### PR TITLE
Add dynamic chore visibility based on Home Assistant entities

### DIFF
--- a/custom_components/taskmate/config_flow.py
+++ b/custom_components/taskmate/config_flow.py
@@ -373,6 +373,11 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
                     mode=selector.SelectSelectorMode.DROPDOWN,
                 )
             ),
+            vol.Optional("visibility_entity", default=""): selector.EntitySelector(
+                selector.EntitySelectorConfig(
+                    domain=["binary_sensor", "input_boolean", "switch", "sensor"],
+                )
+            ),
         }
         if child_options:
             schema_dict[vol.Optional("assigned_to", default=[])] = selector.SelectSelector(
@@ -407,6 +412,7 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
                 completion_sound=s1.get("completion_sound", DEFAULT_COMPLETION_SOUND),
                 schedule_mode="specific_days",
                 due_days=user_input.get("due_days", []),
+                visibility_entity=s1.get("visibility_entity", ""),
             )
             self._chore_step1_data = None
             return await self.async_step_manage_chores()
@@ -459,6 +465,7 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
                 recurrence_day=recurrence_day,
                 recurrence_start=recurrence_start,
                 first_occurrence_mode=first_occurrence_mode,
+                visibility_entity=s1.get("visibility_entity", ""),
             )
             self._chore_step1_data = None
             return await self.async_step_manage_chores()
@@ -526,6 +533,7 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
                         daily_limit=int(user_input.get("daily_limit", 1)),
                         schedule_mode="specific_days",
                         completion_sound=user_input.get("completion_sound", DEFAULT_COMPLETION_SOUND),
+                        visibility_entity=user_input.get("visibility_entity", ""),
                     )
                     return await self.async_step_manage_chores()
 
@@ -570,6 +578,11 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
                         for sound in COMPLETION_SOUND_OPTIONS
                     ],
                     mode=selector.SelectSelectorMode.DROPDOWN,
+                )
+            ),
+            vol.Optional("visibility_entity", default=""): selector.EntitySelector(
+                selector.EntitySelectorConfig(
+                    domain=["binary_sensor", "input_boolean", "switch", "sensor"],
                 )
             ),
         }
@@ -663,6 +676,11 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
                     mode=selector.SelectSelectorMode.DROPDOWN,
                 )
             ),
+            vol.Optional("visibility_entity", default=getattr(chore, 'visibility_entity', "")): selector.EntitySelector(
+                selector.EntitySelectorConfig(
+                    domain=["binary_sensor", "input_boolean", "switch", "sensor"],
+                )
+            ),
             vol.Required("action", default="save"): selector.SelectSelector(
                 selector.SelectSelectorConfig(
                     options=["save", "delete"],
@@ -706,6 +724,7 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
             chore.time_category = s1.get("time_category", chore.time_category)
             chore.daily_limit = int(s1.get("daily_limit", chore.daily_limit))
             chore.completion_sound = s1.get("completion_sound", getattr(chore, 'completion_sound', DEFAULT_COMPLETION_SOUND))
+            chore.visibility_entity = s1.get("visibility_entity", "")
             chore.schedule_mode = "specific_days"
             chore.due_days = user_input.get("due_days", [])
             # Clear recurring fields
@@ -751,6 +770,7 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
             chore.time_category = s1.get("time_category", chore.time_category)
             chore.daily_limit = int(s1.get("daily_limit", chore.daily_limit))
             chore.completion_sound = s1.get("completion_sound", getattr(chore, 'completion_sound', DEFAULT_COMPLETION_SOUND))
+            chore.visibility_entity = s1.get("visibility_entity", "")
             chore.schedule_mode = "recurring"
             chore.due_days = []
             recurrence = user_input.get("recurrence", "weekly")

--- a/custom_components/taskmate/coordinator.py
+++ b/custom_components/taskmate/coordinator.py
@@ -260,6 +260,7 @@ class TaskMateCoordinator(DataUpdateCoordinator):
         recurrence_day: str = "",
         recurrence_start: str = "",
         first_occurrence_mode: str = "available_immediately",
+        visibility_entity: str = "",
     ) -> Chore:
         """Add a new chore."""
         chore = Chore(
@@ -277,6 +278,7 @@ class TaskMateCoordinator(DataUpdateCoordinator):
             recurrence_day=recurrence_day,
             recurrence_start=recurrence_start,
             first_occurrence_mode=first_occurrence_mode,
+            visibility_entity=visibility_entity,
         )
         self.storage.add_chore(chore)
         await self.storage.async_save()
@@ -295,6 +297,7 @@ class TaskMateCoordinator(DataUpdateCoordinator):
         daily_limit: int = 1,
         schedule_mode: str = "specific_days",
         completion_sound: str = "coin",
+        visibility_entity: str = "",
             ) -> list[Chore]:
         """Add multiple chores at once with shared settings."""
         chores = []
@@ -313,6 +316,7 @@ class TaskMateCoordinator(DataUpdateCoordinator):
                 daily_limit=daily_limit,
                 schedule_mode=schedule_mode,
                 completion_sound=completion_sound,
+                visibility_entity=visibility_entity,
                             )
             self.storage.add_chore(chore)
             chores.append(chore)
@@ -353,15 +357,40 @@ class TaskMateCoordinator(DataUpdateCoordinator):
 
     # ── Chore completion operations ───────────────────────────────────────────
 
+    def _is_visibility_entity_active(self, visibility_entity: str) -> bool:
+        """Check if a visibility entity is active (state is 'on').
+
+        Returns True if entity is not set, entity doesn't exist, or entity is 'on'.
+        Returns False only if entity is explicitly 'off'.
+        """
+        if not visibility_entity:
+            return True
+
+        # Get entity state from Home Assistant
+        state = self.hass.states.get(visibility_entity)
+        if state is None:
+            # Entity doesn't exist, treat as visible
+            _LOGGER.debug(f"Visibility entity '{visibility_entity}' not found, defaulting to visible")
+            return True
+
+        # For binary_sensor, input_boolean, switch, etc., check if state is 'on'
+        return state.state == 'on'
+
     def is_chore_available_for_child(self, chore, child_id: str) -> bool:
         """Check if a recurring chore is available for a child to complete.
 
-        Mode A (specific_days): always returns True — day filtering is handled
-        by the child card, not the coordinator.
+        Mode A (specific_days): day filtering is handled by the child card.
 
         Mode B (recurring): checks rolling window from last completion date
         (midnight-rounded). Window lengths in days per recurrence type.
+
+        Both modes also check visibility_entity if configured.
         """
+        # Check visibility entity first — if not visible, chore is not available
+        visibility_entity = getattr(chore, 'visibility_entity', '')
+        if not self._is_visibility_entity_active(visibility_entity):
+            return False
+
         schedule_mode = getattr(chore, 'schedule_mode', 'specific_days')
         if schedule_mode != 'recurring':
             return True

--- a/custom_components/taskmate/models.py
+++ b/custom_components/taskmate/models.py
@@ -132,6 +132,8 @@ class Chore:
     recurrence_day: str = ""    # optional: which day of week for weekly/every_2_weeks
     recurrence_start: str = ""  # optional: ISO date anchor for every_2_days
     first_occurrence_mode: str = "available_immediately"  # available_immediately | wait_for_first_occurrence
+    # Dynamic visibility
+    visibility_entity: str = ""  # optional: entity_id (binary_sensor, input_boolean, etc) for dynamic visibility
     id: str = field(default_factory=generate_id)
 
     @classmethod
@@ -159,6 +161,7 @@ class Chore:
             recurrence_day=data.get("recurrence_day", ""),
             recurrence_start=data.get("recurrence_start", ""),
             first_occurrence_mode=data.get("first_occurrence_mode", "available_immediately"),
+            visibility_entity=data.get("visibility_entity", ""),
             id=data.get("id", generate_id()),
         )
 
@@ -179,6 +182,7 @@ class Chore:
             "recurrence_day": self.recurrence_day,
             "recurrence_start": self.recurrence_start,
             "first_occurrence_mode": self.first_occurrence_mode,
+            "visibility_entity": self.visibility_entity,
             "id": self.id,
         }
 

--- a/custom_components/taskmate/strings.json
+++ b/custom_components/taskmate/strings.json
@@ -74,11 +74,15 @@
           "assigned_to": "Assigned To (leave empty for all children)",
           "requires_approval": "Requires Parent Approval",
           "daily_limit": "Daily Completion Limit",
-          "schedule_mode": "Scheduling Mode"
+          "schedule_mode": "Scheduling Mode",
+          "completion_sound": "Completion Sound",
+          "visibility_entity": "Visibility Entity (optional)"
         },
         "data_description": {
           "daily_limit": "How many times per day this chore can be completed",
-          "schedule_mode": "Choose how this chore is scheduled — specific days of the week, or a repeating interval. The scheduling options will be configured on the next page."
+          "schedule_mode": "Choose how this chore is scheduled — specific days of the week, or a repeating interval. The scheduling options will be configured on the next page.",
+          "completion_sound": "Sound to play when this chore is completed",
+          "visibility_entity": "Entity that controls when this chore is visible (e.g., binary_sensor.dishwasher_running). Chore only appears when entity is 'on'."
         }
       },
       "add_chores_bulk": {
@@ -92,11 +96,15 @@
           "assigned_to": "Assigned To (leave empty for all children)",
           "requires_approval": "Requires Parent Approval",
           "daily_limit": "Daily Completion Limit",
-          "schedule_mode": "Scheduling Mode"
+          "schedule_mode": "Scheduling Mode",
+          "completion_sound": "Completion Sound",
+          "visibility_entity": "Visibility Entity (optional)"
         },
         "data_description": {
           "daily_limit": "How many times per day this chore can be completed",
-          "schedule_mode": "Choose how this chore is scheduled"
+          "schedule_mode": "Choose how this chore is scheduled",
+          "completion_sound": "Sound to play when chores are completed",
+          "visibility_entity": "Entity that controls when chores are visible (e.g., binary_sensor.dishwasher_running). Chores only appear when entity is 'on'."
         }
       },
       "edit_chore": {
@@ -112,11 +120,15 @@
           "requires_approval": "Requires Parent Approval",
           "daily_limit": "Daily Completion Limit",
           "action": "Action",
-          "schedule_mode": "Scheduling Mode"
+          "schedule_mode": "Scheduling Mode",
+          "completion_sound": "Completion Sound",
+          "visibility_entity": "Visibility Entity (optional)"
         },
         "data_description": {
           "daily_limit": "How many times per day this chore can be completed",
-          "schedule_mode": "Choose how this chore is scheduled — specific days of the week, or a repeating interval. The scheduling options will be configured on the next page."
+          "schedule_mode": "Choose how this chore is scheduled — specific days of the week, or a repeating interval. The scheduling options will be configured on the next page.",
+          "completion_sound": "Sound to play when this chore is completed",
+          "visibility_entity": "Entity that controls when this chore is visible (e.g., binary_sensor.dishwasher_running). Chore only appears when entity is 'on'."
         }
       },
       "manage_rewards": {

--- a/custom_components/taskmate/www/taskmate-child-card.js
+++ b/custom_components/taskmate/www/taskmate-child-card.js
@@ -1338,6 +1338,17 @@ class TaskMateChildCard extends LitElement {
       const isAssignedToAll = assignedToStrings.length === 0;
       const isAssignedToChild = isAssignedToAll || assignedToStrings.includes(childId);
 
+      // Check visibility_entity — if set, chore is only visible if entity is 'on'
+      const visibilityEntity = chore.visibility_entity || '';
+      let visibilityOK = true;
+      if (visibilityEntity) {
+        const entityState = this.hass?.states?.[visibilityEntity];
+        // Chore is only visible if entity state is 'on'
+        visibilityOK = entityState?.state === 'on';
+      }
+      chore._visibilityEntity = visibilityEntity;
+      chore._visibilityOK = visibilityOK;
+
       // Check due_days — if chore has due_days set and today isn't one of them
       const dueDays = chore.due_days || [];
       const hasDueDays = dueDays.length > 0;
@@ -1361,7 +1372,8 @@ class TaskMateChildCard extends LitElement {
         return false;
       }
 
-      return matchesTime && isAssignedToChild;
+      // Only return chore if visibility entity allows it
+      return matchesTime && isAssignedToChild && visibilityOK;
     });
 
     // Debug: Log the filtered results

--- a/tests/test_coordinator_logic.py
+++ b/tests/test_coordinator_logic.py
@@ -672,3 +672,47 @@ class TestChoreAvailability:
         chore = self._make_recurring_chore(recurrence="every_2_days")
         now = _date(2024, 3, 20)  # only 1 day since last — not available yet
         assert self._run(coord, chore, "kid1", now) is False
+
+    def test_visibility_entity_on_chore_available(self):
+        coord = _make_coord()
+        chore = Chore(
+            name="Visibility chore",
+            schedule_mode="specific_days",
+            visibility_entity="binary_sensor.dishwasher_running"
+        )
+        coord.storage.get_last_completed = MagicMock(return_value={})
+        # Mock entity state as 'on'
+        coord.hass.states.get = MagicMock(
+            return_value=MagicMock(state='on')
+        )
+        now = _date(2024, 3, 20)
+        assert self._run(coord, chore, "kid1", now) is True
+
+    def test_visibility_entity_off_chore_not_available(self):
+        coord = _make_coord()
+        chore = Chore(
+            name="Visibility chore",
+            schedule_mode="specific_days",
+            visibility_entity="binary_sensor.dishwasher_running"
+        )
+        coord.storage.get_last_completed = MagicMock(return_value={})
+        # Mock entity state as 'off'
+        coord.hass.states.get = MagicMock(
+            return_value=MagicMock(state='off')
+        )
+        now = _date(2024, 3, 20)
+        assert self._run(coord, chore, "kid1", now) is False
+
+    def test_visibility_entity_missing_chore_available(self):
+        coord = _make_coord()
+        chore = Chore(
+            name="Visibility chore",
+            schedule_mode="specific_days",
+            visibility_entity="binary_sensor.nonexistent"
+        )
+        coord.storage.get_last_completed = MagicMock(return_value={})
+        # Mock entity doesn't exist (get returns None)
+        coord.hass.states.get = MagicMock(return_value=None)
+        now = _date(2024, 3, 20)
+        # Should be available (defaults to visible if entity doesn't exist)
+        assert self._run(coord, chore, "kid1", now) is True


### PR DESCRIPTION
## Summary

Implement automation-triggered chore visibility feature that allows chores to be displayed dynamically based on external Home Assistant state.

- Add optional `visibility_entity` field to control chore visibility
- Chore only appears when the entity state is 'on'
- Supports binary_sensor, input_boolean, switch, and sensor domains
- Integrates with Home Assistant automations for smart home workflows

## Use Cases

- "Empty Dishwasher" only appears when dishwasher cycle is complete
- "Bring in the Mail" appears when mailbox sensor is triggered
- "Clean Litter Box" appears after counter reaches threshold
- Custom automations for any smart home scenario

## Changes

- Updated Chore model with visibility_entity field
- Coordinator checks entity state before marking chore as available
- Config UI allows setting visibility_entity for chores
- Frontend filters chores based on entity state
- Added comprehensive tests