### PR TITLE
fix: Correct not_equals operator for string visibility matching

### DIFF
--- a/custom_components/taskmate/www/taskmate-child-card.js
+++ b/custom_components/taskmate/www/taskmate-child-card.js
@@ -1369,12 +1369,19 @@ class TaskMateChildCard extends LitElement {
           }
 
           if (!matched) {
-            // Check state (case-insensitive exact match)
-            if (state.toLowerCase() === visibilityState.toLowerCase()) {
-              visibilityOK = true;
+            // Check state (case-insensitive matching)
+            const stateMatches = state.toLowerCase() === visibilityState.toLowerCase();
+
+            // For not_equals, we want the opposite of equality
+            if (visibilityOperator === 'not_equals') {
+              visibilityOK = !stateMatches;
             } else {
-              // Check attributes for a matching value
-              visibilityOK = false;
+              // For equals and other operators, match is success
+              visibilityOK = stateMatches;
+            }
+
+            if (!visibilityOK && visibilityOperator !== 'not_equals') {
+              // Check attributes for a matching value (only for equals operator)
               if (entityState.attributes) {
                 for (const attrValue of Object.values(entityState.attributes)) {
                   if (String(attrValue).toLowerCase() === visibilityState.toLowerCase()) {


### PR DESCRIPTION
## Summary
Fixed the `!=` (not_equals) operator for string-based visibility matching. Previously it only worked for numeric comparisons.

## Issue
When using `!=` operator with string states (e.g., "on", "off"), the visibility check was incorrectly matching equality instead of inequality.

Example:
- Operator: `!=`
- State: `on`  
- Entity state: `off`
- Expected: Chore shows (because off ≠ on)
- Actual: Chore didn't show (bug)

## Fix
Updated the string matching logic to explicitly handle `not_equals` by inverting the equality check.