### PR TITLE
Add visibility feature translations to frontend locale files

### DIFF
--- a/custom_components/taskmate/www/locales/en-GB.json
+++ b/custom_components/taskmate/www/locales/en-GB.json
@@ -425,5 +425,17 @@
   "points_display.editor.stats_to_show": "Stats to Show",
   "points_display.editor.show_weekly": "This week's points",
   "points_display.editor.show_streak": "Streak",
-  "points_display.editor.show_rank": "Rank medals"
+  "points_display.editor.show_rank": "Rank medals",
+
+  "visibility.label_entity": "Visibility Entity",
+  "visibility.label_operator": "Visibility Operator",
+  "visibility.label_state": "Visibility State",
+  "visibility.operator_equals": "Equals",
+  "visibility.operator_not_equals": "Not Equal",
+  "visibility.operator_gte": "Greater than or equal (≥)",
+  "visibility.operator_lte": "Less than or equal (≤)",
+  "visibility.operator_gt": "Greater than (>)",
+  "visibility.operator_lt": "Less than (<)",
+  "visibility.description_hidden": "Hidden by visibility condition",
+  "visibility.description_shown": "Shown by visibility condition"
 }

--- a/custom_components/taskmate/www/locales/en.json
+++ b/custom_components/taskmate/www/locales/en.json
@@ -425,5 +425,17 @@
   "points_display.editor.stats_to_show": "Stats to Show",
   "points_display.editor.show_weekly": "This week's points",
   "points_display.editor.show_streak": "Streak",
-  "points_display.editor.show_rank": "Rank medals"
+  "points_display.editor.show_rank": "Rank medals",
+
+  "visibility.label_entity": "Visibility Entity",
+  "visibility.label_operator": "Visibility Operator",
+  "visibility.label_state": "Visibility State",
+  "visibility.operator_equals": "Equals",
+  "visibility.operator_not_equals": "Not Equal",
+  "visibility.operator_gte": "Greater than or equal (≥)",
+  "visibility.operator_lte": "Less than or equal (≤)",
+  "visibility.operator_gt": "Greater than (>)",
+  "visibility.operator_lt": "Less than (<)",
+  "visibility.description_hidden": "Hidden by visibility condition",
+  "visibility.description_shown": "Shown by visibility condition"
 }

--- a/custom_components/taskmate/www/locales/fr.json
+++ b/custom_components/taskmate/www/locales/fr.json
@@ -425,5 +425,17 @@
   "points_display.editor.stats_to_show": "Stats à afficher",
   "points_display.editor.show_weekly": "Points de cette semaine",
   "points_display.editor.show_streak": "Série",
-  "points_display.editor.show_rank": "Médailles de rang"
+  "points_display.editor.show_rank": "Médailles de rang",
+
+  "visibility.label_entity": "Entité de visibilité",
+  "visibility.label_operator": "Opérateur de visibilité",
+  "visibility.label_state": "État de visibilité",
+  "visibility.operator_equals": "Égal à",
+  "visibility.operator_not_equals": "Non égal à",
+  "visibility.operator_gte": "Supérieur ou égal à (≥)",
+  "visibility.operator_lte": "Inférieur ou égal à (≤)",
+  "visibility.operator_gt": "Supérieur à (>)",
+  "visibility.operator_lt": "Inférieur à (<)",
+  "visibility.description_hidden": "Masqué par la condition de visibilité",
+  "visibility.description_shown": "Affiché par la condition de visibilité"
 }

--- a/custom_components/taskmate/www/locales/nb.json
+++ b/custom_components/taskmate/www/locales/nb.json
@@ -425,5 +425,17 @@
   "points_display.editor.stats_to_show": "Statistikk å vise",
   "points_display.editor.show_weekly": "Denne ukens poeng",
   "points_display.editor.show_streak": "Rekke",
-  "points_display.editor.show_rank": "Rangmedaljer"
+  "points_display.editor.show_rank": "Rangmedaljer",
+
+  "visibility.label_entity": "Synlighetsentitet",
+  "visibility.label_operator": "Synlighetsoperator",
+  "visibility.label_state": "Synlighetstilstand",
+  "visibility.operator_equals": "Lik",
+  "visibility.operator_not_equals": "Ikke lik",
+  "visibility.operator_gte": "Større enn eller lik (≥)",
+  "visibility.operator_lte": "Mindre enn eller lik (≤)",
+  "visibility.operator_gt": "Større enn (>)",
+  "visibility.operator_lt": "Mindre enn (<)",
+  "visibility.description_hidden": "Skjult av synlighetsbetingelse",
+  "visibility.description_shown": "Vist av synlighetsbetingelse"
 }

--- a/custom_components/taskmate/www/locales/nn.json
+++ b/custom_components/taskmate/www/locales/nn.json
@@ -425,5 +425,17 @@
   "points_display.editor.stats_to_show": "Statistikk å vise",
   "points_display.editor.show_weekly": "Denne veka sine poeng",
   "points_display.editor.show_streak": "Rekke",
-  "points_display.editor.show_rank": "Rangmedaljar"
+  "points_display.editor.show_rank": "Rangmedaljar",
+
+  "visibility.label_entity": "Synlegheitsentitet",
+  "visibility.label_operator": "Synleghetsoperator",
+  "visibility.label_state": "Synlegheitstilstand",
+  "visibility.operator_equals": "Lik",
+  "visibility.operator_not_equals": "Ikkje lik",
+  "visibility.operator_gte": "Større eller lik (≥)",
+  "visibility.operator_lte": "Mindre eller lik (≤)",
+  "visibility.operator_gt": "Større enn (>)",
+  "visibility.operator_lt": "Mindre enn (<)",
+  "visibility.description_hidden": "Skjult av synlegheitskondisjon",
+  "visibility.description_shown": "Vist av synlegheitskondisjon"
 }

--- a/custom_components/taskmate/www/locales/pt.json
+++ b/custom_components/taskmate/www/locales/pt.json
@@ -425,5 +425,17 @@
   "points_display.editor.stats_to_show": "Estatísticas a Mostrar",
   "points_display.editor.show_weekly": "Pontos desta semana",
   "points_display.editor.show_streak": "Sequência",
-  "points_display.editor.show_rank": "Medalhas de posição"
+  "points_display.editor.show_rank": "Medalhas de posição",
+
+  "visibility.label_entity": "Entidade de Visibilidade",
+  "visibility.label_operator": "Operador de Visibilidade",
+  "visibility.label_state": "Estado de Visibilidade",
+  "visibility.operator_equals": "Igual a",
+  "visibility.operator_not_equals": "Não igual a",
+  "visibility.operator_gte": "Maior ou igual a (≥)",
+  "visibility.operator_lte": "Menor ou igual a (≤)",
+  "visibility.operator_gt": "Maior que (>)",
+  "visibility.operator_lt": "Menor que (<)",
+  "visibility.description_hidden": "Ocultado por condição de visibilidade",
+  "visibility.description_shown": "Mostrado por condição de visibilidade"
 }


### PR DESCRIPTION
## Summary

Complete the translation support for the dynamic chore visibility feature by adding frontend locale translations.

**Changes:**
- Add visibility field labels and operator translations to all 6 frontend locale files
- Include visibility status message translations for hidden/shown states
- Complete support for all 6 comparison operators in 6 languages

**Languages Updated:**
- English (US & British variants)
- French
- Norwegian (Bokmål & Nynorsk)
- Portuguese

**Translation Keys Added:**
- `visibility.label_entity` - Entity field label
- `visibility.label_operator` - Operator field label  
- `visibility.label_state` - State field label
- `visibility.operator_equals` - Equals operator
- `visibility.operator_not_equals` - Not equal operator
- `visibility.operator_gte` - Greater than or equal operator
- `visibility.operator_lte` - Less than or equal operator
- `visibility.operator_gt` - Greater than operator
- `visibility.operator_lt` - Less than operator
- `visibility.description_hidden` - Hidden state message
- `visibility.description_shown` - Shown state message

https://claude.ai/code/session_012DMemxJ6M2ag7yHihxNgHe