### PR TITLE
feat: add one-shot (non-recurring) chore support

### DIFF
--- a/custom_components/taskmate/config_flow.py
+++ b/custom_components/taskmate/config_flow.py
@@ -308,7 +308,8 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
 
         for chore in chores:
             time_label = f" [{chore.time_category}]" if chore.time_category != "anytime" else ""
-            menu_options[f"edit_chore_{chore.id}"] = f"{chore.name} ({chore.points} pts){time_label}"
+            disabled_label = " (disabled)" if (not getattr(chore, 'enabled', True) or getattr(chore, 'disabled_for', [])) else ""
+            menu_options[f"edit_chore_{chore.id}"] = f"{chore.name} ({chore.points} pts){time_label}{disabled_label}"
 
         menu_options["init"] = _m("init", "Back to Main Menu")
 
@@ -334,6 +335,8 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
                 schedule_mode = user_input.get("schedule_mode", "specific_days")
                 if schedule_mode == "specific_days":
                     return await self.async_step_chore_schedule_specific()
+                elif schedule_mode == "one_shot":
+                    return await self.async_step_chore_schedule_one_shot()
                 else:
                     return await self.async_step_chore_schedule_recurring()
 
@@ -356,7 +359,7 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
             ),
             vol.Required("schedule_mode", default="specific_days"): selector.SelectSelector(
                 selector.SelectSelectorConfig(
-                    options=["specific_days", "recurring"],
+                    options=["specific_days", "recurring", "one_shot"],
                     translation_key="schedule_mode",
                     mode=selector.SelectSelectorMode.LIST,
                 )
@@ -427,6 +430,26 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
                 ),
             }),
         )
+
+    async def async_step_chore_schedule_one_shot(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Add chore — one-shot (no schedule config needed)."""
+        s1 = self._chore_step1_data or {}
+        await self.coordinator.async_add_chore(
+            name=s1.get("name", "").strip(),
+            points=int(s1.get("points", 10)),
+            description=s1.get("description", ""),
+            assigned_to=s1.get("assigned_to", []),
+            requires_approval=s1.get("requires_approval", True),
+            time_category=s1.get("time_category", "anytime"),
+            daily_limit=1,
+            completion_sound=s1.get("completion_sound", DEFAULT_COMPLETION_SOUND),
+            schedule_mode="one_shot",
+            visibility_entity=s1.get("visibility_entity", ""),
+        )
+        self._chore_step1_data = None
+        return await self.async_step_manage_chores()
 
     async def async_step_chore_schedule_recurring(
         self, user_input: dict[str, Any] | None = None
@@ -615,6 +638,14 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
             if action == "delete":
                 await self.coordinator.async_remove_chore(chore_id)
                 return await self.async_step_manage_chores()
+            if action == "re_enable":
+                chore.enabled = True
+                chore.disabled_for = []
+                if getattr(chore, 'schedule_mode', 'specific_days') == 'one_shot':
+                    from homeassistant.util import dt as dt_util
+                    chore.created_date = dt_util.as_local(dt_util.now()).date().isoformat()
+                await self.coordinator.async_update_chore(chore)
+                return await self.async_step_manage_chores()
 
             name = user_input.get("name", "").strip()
             if not name:
@@ -641,6 +672,8 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
                 schedule_mode = user_input.get("schedule_mode", "specific_days")
                 if schedule_mode == "specific_days":
                     return await self.async_step_edit_chore_schedule_specific()
+                elif schedule_mode == "one_shot":
+                    return await self.async_step_edit_chore_schedule_one_shot()
                 else:
                     return await self.async_step_edit_chore_schedule_recurring()
 
@@ -668,7 +701,7 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
             ),
             vol.Required("schedule_mode", default=current_schedule_mode): selector.SelectSelector(
                 selector.SelectSelectorConfig(
-                    options=["specific_days", "recurring"],
+                    options=["specific_days", "recurring", "one_shot"],
                     translation_key="schedule_mode",
                     mode=selector.SelectSelectorMode.LIST,
                 )
@@ -703,7 +736,11 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
             vol.Optional("visibility_state", default=getattr(chore, 'visibility_state', "on")): str,
             vol.Required("action", default="save"): selector.SelectSelector(
                 selector.SelectSelectorConfig(
-                    options=["save", "delete"],
+                    options=(
+                        ["save", "re_enable", "delete"]
+                        if (not getattr(chore, 'enabled', True) or getattr(chore, 'disabled_for', []))
+                        else ["save", "delete"]
+                    ),
                     translation_key="chore_action",
                     mode=selector.SelectSelectorMode.LIST,
                 )
@@ -770,6 +807,32 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
             }),
             description_placeholders={"chore_name": chore.name},
         )
+
+    async def async_step_edit_chore_schedule_one_shot(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Edit chore — one-shot schedule (save immediately)."""
+        chore = self._edited_chore
+        if not chore:
+            chore_id = self._selected_chore_id
+            chore = self.coordinator.get_chore(chore_id)
+        if not chore:
+            return await self.async_step_manage_chores()
+
+        chore.schedule_mode = "one_shot"
+        chore.daily_limit = 1
+        chore.due_days = []
+        chore.recurrence = "weekly"
+        chore.recurrence_day = ""
+        chore.recurrence_start = ""
+        chore.first_occurrence_mode = "available_immediately"
+        if not chore.created_date:
+            from homeassistant.util import dt as dt_util
+            chore.created_date = dt_util.as_local(dt_util.now()).date().isoformat()
+        await self.coordinator.async_update_chore(chore)
+        self._chore_step1_data = None
+        self._edited_chore = None
+        return await self.async_step_manage_chores()
 
     async def async_step_edit_chore_schedule_recurring(
         self, user_input: dict[str, Any] | None = None

--- a/custom_components/taskmate/const.py
+++ b/custom_components/taskmate/const.py
@@ -67,7 +67,7 @@ RECURRENCE_LABELS: Final = {
 }
 
 # Schedule modes
-SCHEDULE_MODES: Final = ["specific_days", "recurring"]
+SCHEDULE_MODES: Final = ["specific_days", "recurring", "one_shot"]
 
 # First occurrence modes
 FIRST_OCCURRENCE_MODES: Final = ["available_immediately", "wait_for_first_occurrence"]

--- a/custom_components/taskmate/coordinator.py
+++ b/custom_components/taskmate/coordinator.py
@@ -59,6 +59,7 @@ class TaskMateCoordinator(DataUpdateCoordinator):
     def _async_midnight_streak_check(self, now: datetime) -> None:
         """Scheduled callback at midnight to check and reset streaks if needed."""
         self.hass.async_create_task(self._async_check_streaks())
+        self.hass.async_create_task(self._async_expire_one_shot_chores())
         # Check for perfect week bonus every Monday at midnight
         if now.weekday() == 0:
             self.hass.async_create_task(self._async_check_perfect_week())
@@ -263,8 +264,15 @@ class TaskMateCoordinator(DataUpdateCoordinator):
         visibility_entity: str = "",
         visibility_state: str = "on",
         visibility_operator: str = "equals",
+        created_date: str = "",
     ) -> Chore:
         """Add a new chore."""
+        # One-shot chores: force daily_limit=1, set created_date to today
+        if schedule_mode == "one_shot":
+            daily_limit = 1
+            if not created_date:
+                created_date = dt_util.as_local(dt_util.now()).date().isoformat()
+
         chore = Chore(
             name=name,
             points=points,
@@ -283,6 +291,7 @@ class TaskMateCoordinator(DataUpdateCoordinator):
             visibility_entity=visibility_entity,
             visibility_state=visibility_state,
             visibility_operator=visibility_operator,
+            created_date=created_date,
         )
         self.storage.add_chore(chore)
         await self.storage.async_save()
@@ -455,6 +464,15 @@ class TaskMateCoordinator(DataUpdateCoordinator):
 
         Both modes also check visibility_entity if configured.
         """
+        # Check if chore is globally disabled (soft-disabled one-shot chores)
+        if not getattr(chore, 'enabled', True):
+            return False
+
+        # Check per-child disabling (one-shot chores completed by this child)
+        disabled_for = getattr(chore, 'disabled_for', [])
+        if child_id in disabled_for:
+            return False
+
         # Check visibility entity first — if not visible, chore is not available
         visibility_entity = getattr(chore, 'visibility_entity', '')
         visibility_state = getattr(chore, 'visibility_state', 'on')
@@ -463,6 +481,19 @@ class TaskMateCoordinator(DataUpdateCoordinator):
             return False
 
         schedule_mode = getattr(chore, 'schedule_mode', 'specific_days')
+
+        # One-shot chores: only available on the day they were created
+        if schedule_mode == 'one_shot':
+            created_date = getattr(chore, 'created_date', '')
+            if created_date:
+                today = dt_util.as_local(dt_util.now()).date()
+                try:
+                    if date.fromisoformat(created_date) != today:
+                        return False
+                except ValueError:
+                    pass
+            return True
+
         if schedule_mode != 'recurring':
             return True
 
@@ -559,6 +590,13 @@ class TaskMateCoordinator(DataUpdateCoordinator):
                     f"Recurrence: {recurrence.replace('_', ' ')}."
                 )
 
+        # Check availability for one-shot chores
+        if getattr(chore, 'schedule_mode', 'specific_days') == 'one_shot':
+            if not self.is_chore_available_for_child(chore, child_id):
+                raise ValueError(
+                    f"Chore '{chore.name}' is not available (one-shot chore already completed or expired)."
+                )
+
         # Check daily limit
         all_completions = self.storage.get_completions()
         todays_completions_count = 0
@@ -597,6 +635,13 @@ class TaskMateCoordinator(DataUpdateCoordinator):
         # Update last_completed store (window starts at completion time, midnight-rounded)
         self.storage.set_last_completed(chore_id, child_id, now.isoformat())
 
+        # One-shot: if auto-approved (no approval needed), disable for this child immediately
+        if getattr(chore, 'schedule_mode', 'specific_days') == 'one_shot' and not chore.requires_approval:
+            if child_id not in chore.disabled_for:
+                chore.disabled_for.append(child_id)
+            self._check_one_shot_fully_disabled(chore)
+            self.storage.update_chore(chore)
+
         await self.storage.async_save()
 
         # Fire approval notification if chore requires parent sign-off
@@ -621,6 +666,14 @@ class TaskMateCoordinator(DataUpdateCoordinator):
                     completion.approved_at = dt_util.now()
                     completion.points_awarded = total_awarded
                     self.storage.update_completion(completion)
+
+                    # One-shot: disable for this child on approval
+                    if getattr(chore, 'schedule_mode', 'specific_days') == 'one_shot':
+                        if completion.child_id not in chore.disabled_for:
+                            chore.disabled_for.append(completion.child_id)
+                        self._check_one_shot_fully_disabled(chore)
+                        self.storage.update_chore(chore)
+
                     await self.storage.async_save()
                     await self.async_refresh()
                 else:
@@ -658,9 +711,57 @@ class TaskMateCoordinator(DataUpdateCoordinator):
                 target_completion.chore_id, target_completion.child_id
             )
 
+            # One-shot: re-enable for this child on rejection
+            chore = self.get_chore(target_completion.chore_id)
+            if chore and getattr(chore, 'schedule_mode', 'specific_days') == 'one_shot':
+                if target_completion.child_id in chore.disabled_for:
+                    chore.disabled_for.remove(target_completion.child_id)
+                chore.enabled = True
+                self.storage.update_chore(chore)
+
         self.storage.remove_completion(completion_id)
         await self.storage.async_save()
         await self.async_refresh()
+
+    def _check_one_shot_fully_disabled(self, chore) -> None:
+        """Check if a one-shot chore should be fully disabled (all children done)."""
+        if chore.assigned_to:
+            target_children = set(chore.assigned_to)
+        else:
+            # assigned_to=[] means all children
+            target_children = {c.id for c in self.storage.get_children()}
+
+        if target_children and target_children.issubset(set(chore.disabled_for)):
+            chore.enabled = False
+
+    async def _async_expire_one_shot_chores(self) -> None:
+        """Soft-disable one-shot chores whose created_date is before today."""
+        today = dt_util.as_local(dt_util.now()).date()
+        changed = False
+
+        for chore in self.storage.get_chores():
+            if getattr(chore, 'schedule_mode', 'specific_days') != 'one_shot':
+                continue
+            if not getattr(chore, 'enabled', True):
+                continue
+            created_date = getattr(chore, 'created_date', '')
+            if not created_date:
+                continue
+            try:
+                if date.fromisoformat(created_date) < today:
+                    chore.enabled = False
+                    self.storage.update_chore(chore)
+                    changed = True
+                    _LOGGER.info(
+                        "One-shot chore '%s' expired (created %s, today %s)",
+                        chore.name, created_date, today.isoformat(),
+                    )
+            except ValueError:
+                continue
+
+        if changed:
+            await self.storage.async_save()
+            await self.async_refresh()
 
     # ── Reward operations ─────────────────────────────────────────────────────
 

--- a/custom_components/taskmate/models.py
+++ b/custom_components/taskmate/models.py
@@ -136,6 +136,10 @@ class Chore:
     visibility_entity: str = ""  # optional: entity_id to check for visibility
     visibility_state: str = "on"  # state/value that makes chore visible (e.g. "on", "true", "123")
     visibility_operator: str = "equals"  # equals, gte, lte, gt, lt, not_equals
+    # One-shot chore fields
+    enabled: bool = True  # False = soft-disabled (completed or expired)
+    disabled_for: list[str] = field(default_factory=list)  # Child IDs this chore is disabled for
+    created_date: str = ""  # ISO date for one-shot expiry, e.g. "2026-04-16"
     id: str = field(default_factory=generate_id)
 
     @classmethod
@@ -166,6 +170,9 @@ class Chore:
             visibility_entity=data.get("visibility_entity", ""),
             visibility_state=data.get("visibility_state", "on"),
             visibility_operator=data.get("visibility_operator", "equals"),
+            enabled=data.get("enabled", True),
+            disabled_for=list(data.get("disabled_for", [])),
+            created_date=data.get("created_date", ""),
             id=data.get("id", generate_id()),
         )
 
@@ -189,6 +196,9 @@ class Chore:
             "visibility_entity": self.visibility_entity,
             "visibility_state": self.visibility_state,
             "visibility_operator": self.visibility_operator,
+            "enabled": self.enabled,
+            "disabled_for": self.disabled_for,
+            "created_date": self.created_date,
             "id": self.id,
         }
 

--- a/custom_components/taskmate/sensor.py
+++ b/custom_components/taskmate/sensor.py
@@ -234,6 +234,9 @@ class TaskMateOverallStatsSensor(TaskMateBaseSensor):
                 "visibility_entity": getattr(c, 'visibility_entity', ''),
                 "visibility_operator": getattr(c, 'visibility_operator', 'equals'),
                 "visibility_state": getattr(c, 'visibility_state', 'on'),
+                "enabled": getattr(c, 'enabled', True),
+                "disabled_for": getattr(c, 'disabled_for', []),
+                "created_date": getattr(c, 'created_date', ''),
                 "last_completed_at": last_completed_at,
                 "is_available": is_available,
             })

--- a/custom_components/taskmate/strings.json
+++ b/custom_components/taskmate/strings.json
@@ -278,6 +278,7 @@
     "chore_action": {
       "options": {
         "save": "Save Changes",
+        "re_enable": "Re-enable Chore",
         "delete": "Delete This Chore"
       }
     },
@@ -299,7 +300,8 @@
     "schedule_mode": {
       "options": {
         "specific_days": "Specific days of the week",
-        "recurring": "Recurring (every N days/weeks/months)"
+        "recurring": "Recurring (every N days/weeks/months)",
+        "one_shot": "One-time task (single day)"
       }
     },
     "due_days_option": {

--- a/custom_components/taskmate/translations/en-GB.json
+++ b/custom_components/taskmate/translations/en-GB.json
@@ -278,6 +278,7 @@
     "chore_action": {
       "options": {
         "save": "Save Changes",
+        "re_enable": "Re-enable Chore",
         "delete": "Delete This Chore"
       }
     },
@@ -299,7 +300,8 @@
     "schedule_mode": {
       "options": {
         "specific_days": "Specific days of the week",
-        "recurring": "Recurring (every N days/weeks/months)"
+        "recurring": "Recurring (every N days/weeks/months)",
+        "one_shot": "One-time task (single day)"
       }
     },
     "due_days_option": {

--- a/custom_components/taskmate/translations/en.json
+++ b/custom_components/taskmate/translations/en.json
@@ -278,6 +278,7 @@
     "chore_action": {
       "options": {
         "save": "Save Changes",
+        "re_enable": "Re-enable Chore",
         "delete": "Delete This Chore"
       }
     },
@@ -299,7 +300,8 @@
     "schedule_mode": {
       "options": {
         "specific_days": "Specific days of the week",
-        "recurring": "Recurring (every N days/weeks/months)"
+        "recurring": "Recurring (every N days/weeks/months)",
+        "one_shot": "One-time task (single day)"
       }
     },
     "due_days_option": {

--- a/custom_components/taskmate/translations/fr.json
+++ b/custom_components/taskmate/translations/fr.json
@@ -278,6 +278,7 @@
     "chore_action": {
       "options": {
         "save": "Enregistrer les modifications",
+        "re_enable": "Réactiver la corvée",
         "delete": "Supprimer cette corvée"
       }
     },
@@ -299,7 +300,8 @@
     "schedule_mode": {
       "options": {
         "specific_days": "Jours spécifiques de la semaine",
-        "recurring": "Récurrent (tous les N jours/semaines/mois)"
+        "recurring": "Récurrent (tous les N jours/semaines/mois)",
+        "one_shot": "Tâche unique (un seul jour)"
       }
     },
     "due_days_option": {

--- a/custom_components/taskmate/translations/nb.json
+++ b/custom_components/taskmate/translations/nb.json
@@ -278,6 +278,7 @@
     "chore_action": {
       "options": {
         "save": "Lagre endringer",
+        "re_enable": "Reaktiver oppgave",
         "delete": "Slett denne oppgaven"
       }
     },
@@ -299,7 +300,8 @@
     "schedule_mode": {
       "options": {
         "specific_days": "Bestemte ukedager",
-        "recurring": "Gjentakende (hver N dag/uke/måned)"
+        "recurring": "Gjentakende (hver N dag/uke/måned)",
+        "one_shot": "Engangsoppgave (én dag)"
       }
     },
     "due_days_option": {

--- a/custom_components/taskmate/translations/nn.json
+++ b/custom_components/taskmate/translations/nn.json
@@ -278,6 +278,7 @@
     "chore_action": {
       "options": {
         "save": "Lagre endringar",
+        "re_enable": "Reaktiver oppgåve",
         "delete": "Slett denne oppgåva"
       }
     },
@@ -299,7 +300,8 @@
     "schedule_mode": {
       "options": {
         "specific_days": "Bestemte vekedagar",
-        "recurring": "Gjentakande (kvar N dag/veke/månad)"
+        "recurring": "Gjentakande (kvar N dag/veke/månad)",
+        "one_shot": "Eingongsoppgåve (éin dag)"
       }
     },
     "due_days_option": {

--- a/custom_components/taskmate/translations/pt-BR.json
+++ b/custom_components/taskmate/translations/pt-BR.json
@@ -278,6 +278,7 @@
     "chore_action": {
       "options": {
         "save": "Guardar alterações",
+        "re_enable": "Reativar tarefa",
         "delete": "Eliminar esta tarefa"
       }
     },
@@ -299,7 +300,8 @@
     "schedule_mode": {
       "options": {
         "specific_days": "Dias específicos da semana",
-        "recurring": "Recorrente (a cada N dias/semanas/meses)"
+        "recurring": "Recorrente (a cada N dias/semanas/meses)",
+        "one_shot": "Tarefa única (um dia)"
       }
     },
     "due_days_option": {

--- a/custom_components/taskmate/translations/pt.json
+++ b/custom_components/taskmate/translations/pt.json
@@ -278,6 +278,7 @@
     "chore_action": {
       "options": {
         "save": "Guardar alterações",
+        "re_enable": "Reativar tarefa",
         "delete": "Eliminar esta tarefa"
       }
     },
@@ -299,7 +300,8 @@
     "schedule_mode": {
       "options": {
         "specific_days": "Dias específicos da semana",
-        "recurring": "Recorrente (a cada N dias/semanas/meses)"
+        "recurring": "Recorrente (a cada N dias/semanas/meses)",
+        "one_shot": "Tarefa única (um dia)"
       }
     },
     "due_days_option": {

--- a/custom_components/taskmate/www/taskmate-child-card.js
+++ b/custom_components/taskmate/www/taskmate-child-card.js
@@ -1325,6 +1325,11 @@ class TaskMateChildCard extends LitElement {
 
     // First, filter chores for this child and time category
     const filteredChores = chores.filter(chore => {
+      // Check if chore is disabled (one-shot chores that are completed or expired)
+      if (chore.enabled === false) return false;
+      const disabledFor = chore.disabled_for || [];
+      if (disabledFor.includes(childId)) return false;
+
       // Check time category
       const matchesTime =
         this.config.time_category === "all" ||

--- a/custom_components/taskmate/www/taskmate-parent-dashboard-card.js
+++ b/custom_components/taskmate/www/taskmate-parent-dashboard-card.js
@@ -439,11 +439,20 @@ class TaskMateParentDashboardCard extends LitElement {
     return html`
       ${children.map(child => {
         const childChores = chores.filter(c => {
+          // Skip disabled chores (one-shot completed or expired)
+          if (c.enabled === false) return false;
+          if ((c.disabled_for || []).includes(child.id)) return false;
+
           const at = c.assigned_to || [];
           const assigned = at.length === 0 || at.includes(child.id);
           if (!assigned) return false;
+          // One-shot: use is_available check (same as recurring)
+          if (c.schedule_mode === 'one_shot') {
+            const isAvailable = c.is_available && c.is_available[child.id];
+            if (isAvailable === false) return false;
+          }
           // Mode A: due days check
-          if (c.schedule_mode !== 'recurring') {
+          if (c.schedule_mode === 'specific_days') {
             const dueDays = Array.isArray(c.due_days) ? c.due_days : [];
             if (dueDays.length > 0 && !dueDays.includes(todayDow)) return false;
           }

--- a/tests/test_coordinator_logic.py
+++ b/tests/test_coordinator_logic.py
@@ -780,3 +780,168 @@ class TestChoreAvailability:
         )
         now = _date(2024, 3, 20)
         assert self._run(coord, chore, "kid1", now) is True
+
+
+# ---------------------------------------------------------------------------
+# One-Shot Chore Tests
+# ---------------------------------------------------------------------------
+
+class TestOneShotChores:
+    """Tests for one-shot (non-recurring) chore functionality."""
+
+    def _run(self, coord, chore, child_id, now_dt):
+        import custom_components.taskmate.coordinator as _mod
+        with patch.object(_mod.dt_util, "now", return_value=now_dt):
+            return coord.is_chore_available_for_child(chore, child_id)
+
+    def _make_one_shot_chore(self, created_date: str = "2024-03-20", **kwargs) -> Chore:
+        return Chore(
+            name="One-shot chore",
+            schedule_mode="one_shot",
+            daily_limit=1,
+            created_date=created_date,
+            **kwargs,
+        )
+
+    def test_one_shot_available_on_creation_day(self):
+        coord = _make_coord()
+        coord.storage.get_last_completed = MagicMock(return_value={})
+        chore = self._make_one_shot_chore(created_date="2024-03-20")
+        now = _date(2024, 3, 20)  # Same day as created_date
+        assert self._run(coord, chore, "kid1", now) is True
+
+    def test_one_shot_not_available_next_day(self):
+        coord = _make_coord()
+        coord.storage.get_last_completed = MagicMock(return_value={})
+        chore = self._make_one_shot_chore(created_date="2024-03-20")
+        now = _date(2024, 3, 21)  # Day after created_date
+        assert self._run(coord, chore, "kid1", now) is False
+
+    def test_one_shot_disabled_for_child_not_available(self):
+        coord = _make_coord()
+        coord.storage.get_last_completed = MagicMock(return_value={})
+        chore = self._make_one_shot_chore(disabled_for=["kid1"])
+        now = _date(2024, 3, 20)
+        assert self._run(coord, chore, "kid1", now) is False
+
+    def test_one_shot_disabled_for_other_child_still_available(self):
+        coord = _make_coord()
+        coord.storage.get_last_completed = MagicMock(return_value={})
+        chore = self._make_one_shot_chore(disabled_for=["kid1"])
+        now = _date(2024, 3, 20)
+        assert self._run(coord, chore, "kid2", now) is True
+
+    def test_one_shot_globally_disabled_not_available(self):
+        coord = _make_coord()
+        coord.storage.get_last_completed = MagicMock(return_value={})
+        chore = self._make_one_shot_chore(enabled=False)
+        now = _date(2024, 3, 20)
+        assert self._run(coord, chore, "kid1", now) is False
+
+    def test_one_shot_no_created_date_always_available(self):
+        """If created_date is empty, one-shot chore is available (backwards compat)."""
+        coord = _make_coord()
+        coord.storage.get_last_completed = MagicMock(return_value={})
+        chore = self._make_one_shot_chore(created_date="")
+        now = _date(2024, 3, 20)
+        assert self._run(coord, chore, "kid1", now) is True
+
+    def test_check_one_shot_fully_disabled_all_assigned(self):
+        """When all assigned children are in disabled_for, chore becomes globally disabled."""
+        kid1 = _make_child()
+        kid1._id = "kid1"
+        kid1.id = "kid1"
+        kid2 = _make_child()
+        kid2._id = "kid2"
+        kid2.id = "kid2"
+        coord = _make_coord(children=[kid1, kid2])
+        chore = self._make_one_shot_chore(
+            assigned_to=["kid1", "kid2"],
+            disabled_for=["kid1", "kid2"],
+        )
+        coord._check_one_shot_fully_disabled(chore)
+        assert chore.enabled is False
+
+    def test_check_one_shot_partially_disabled(self):
+        """When only some assigned children are in disabled_for, chore stays enabled."""
+        kid1 = _make_child()
+        kid1.id = "kid1"
+        kid2 = _make_child()
+        kid2.id = "kid2"
+        coord = _make_coord(children=[kid1, kid2])
+        chore = self._make_one_shot_chore(
+            assigned_to=["kid1", "kid2"],
+            disabled_for=["kid1"],
+        )
+        coord._check_one_shot_fully_disabled(chore)
+        assert chore.enabled is True
+
+    def test_check_one_shot_fully_disabled_all_children(self):
+        """When assigned_to is empty (all children), check against all system children."""
+        kid1 = _make_child()
+        kid1.id = "kid1"
+        kid2 = _make_child()
+        kid2.id = "kid2"
+        coord = _make_coord(children=[kid1, kid2])
+        chore = self._make_one_shot_chore(
+            assigned_to=[],
+            disabled_for=["kid1", "kid2"],
+        )
+        coord._check_one_shot_fully_disabled(chore)
+        assert chore.enabled is False
+
+    def test_midnight_expiry(self):
+        """Midnight callback should disable one-shot chores from previous days."""
+        import custom_components.taskmate.coordinator as _mod
+
+        chore = self._make_one_shot_chore(created_date="2024-03-19")  # Yesterday
+        coord = _make_coord()
+        coord.storage.get_chores = MagicMock(return_value=[chore])
+        coord.storage.update_chore = MagicMock()
+        coord.async_refresh = AsyncMock()
+
+        now = _date(2024, 3, 20)  # Today
+        with patch.object(_mod.dt_util, "now", return_value=now):
+            asyncio.get_event_loop().run_until_complete(
+                coord._async_expire_one_shot_chores()
+            )
+
+        assert chore.enabled is False
+        coord.storage.update_chore.assert_called_once_with(chore)
+
+    def test_midnight_expiry_skips_current_day(self):
+        """Midnight callback should NOT disable one-shot chores created today."""
+        import custom_components.taskmate.coordinator as _mod
+
+        chore = self._make_one_shot_chore(created_date="2024-03-20")  # Today
+        coord = _make_coord()
+        coord.storage.get_chores = MagicMock(return_value=[chore])
+        coord.storage.update_chore = MagicMock()
+        coord.async_refresh = AsyncMock()
+
+        now = _date(2024, 3, 20)
+        with patch.object(_mod.dt_util, "now", return_value=now):
+            asyncio.get_event_loop().run_until_complete(
+                coord._async_expire_one_shot_chores()
+            )
+
+        assert chore.enabled is True
+        coord.storage.update_chore.assert_not_called()
+
+    def test_midnight_expiry_skips_already_disabled(self):
+        """Midnight callback should skip already-disabled one-shot chores."""
+        import custom_components.taskmate.coordinator as _mod
+
+        chore = self._make_one_shot_chore(created_date="2024-03-18", enabled=False)
+        coord = _make_coord()
+        coord.storage.get_chores = MagicMock(return_value=[chore])
+        coord.storage.update_chore = MagicMock()
+        coord.async_refresh = AsyncMock()
+
+        now = _date(2024, 3, 20)
+        with patch.object(_mod.dt_util, "now", return_value=now):
+            asyncio.get_event_loop().run_until_complete(
+                coord._async_expire_one_shot_chores()
+            )
+
+        coord.storage.update_chore.assert_not_called()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -338,3 +338,61 @@ class TestPointsTransaction:
         )
         restored = PointsTransaction.from_dict(tx.to_dict())
         assert restored.points == -10
+
+
+# ---------------------------------------------------------------------------
+# Chore one-shot fields
+# ---------------------------------------------------------------------------
+
+class TestChoreOneShotFields:
+    def test_new_fields_defaults(self):
+        chore = Chore(name="Test")
+        assert chore.enabled is True
+        assert chore.disabled_for == []
+        assert chore.created_date == ""
+
+    def test_one_shot_roundtrip(self):
+        chore = Chore(
+            name="Wash car",
+            schedule_mode="one_shot",
+            daily_limit=1,
+            enabled=True,
+            disabled_for=["kid1"],
+            created_date="2024-03-20",
+        )
+        d = chore.to_dict()
+        assert d["enabled"] is True
+        assert d["disabled_for"] == ["kid1"]
+        assert d["created_date"] == "2024-03-20"
+        assert d["schedule_mode"] == "one_shot"
+
+        restored = Chore.from_dict(d)
+        assert restored.enabled is True
+        assert restored.disabled_for == ["kid1"]
+        assert restored.created_date == "2024-03-20"
+        assert restored.schedule_mode == "one_shot"
+
+    def test_legacy_chore_missing_new_fields(self):
+        """Old chore dicts without enabled/disabled_for/created_date should load with defaults."""
+        legacy = {
+            "name": "Old chore",
+            "points": 5,
+            "schedule_mode": "specific_days",
+            "id": "legacy123",
+        }
+        chore = Chore.from_dict(legacy)
+        assert chore.enabled is True
+        assert chore.disabled_for == []
+        assert chore.created_date == ""
+
+    def test_disabled_chore_roundtrip(self):
+        chore = Chore(
+            name="Expired task",
+            schedule_mode="one_shot",
+            enabled=False,
+            disabled_for=["kid1", "kid2"],
+            created_date="2024-03-19",
+        )
+        restored = Chore.from_dict(chore.to_dict())
+        assert restored.enabled is False
+        assert restored.disabled_for == ["kid1", "kid2"]


### PR DESCRIPTION
## Summary

- Add `schedule_mode="one_shot"` as a third scheduling mode for single-use tasks (e.g. "wash the car", "big bedroom declutter")
- One-shot chores are valid only for the day they are created and soft-disable after completion+approval or at midnight if not completed
- Per-child disabling: each assigned child gets their own shot; chore fully disables when all children are done
- Parents can re-enable disabled one-shot chores from the edit flow, which resets the expiry window to today

## Changes

- **Model**: Add `enabled`, `disabled_for`, `created_date` fields to `Chore` (backwards-compatible via `.get()` defaults)
- **Coordinator**: Availability checks, auto-disable on approve, re-enable on reject, midnight expiry callback
- **Config flow**: New creation/edit steps for one-shot chores, "Re-enable Chore" action for disabled chores
- **Sensor**: Expose new fields to frontend cards
- **Frontend**: Child card and parent dashboard filter out disabled chores
- **Translations**: All 7 language files updated (en, en-GB, fr, pt, pt-BR, nb, nn)
- **Tests**: 16 new tests covering one-shot lifecycle (143 total, all passing)

## Test plan

- [x] All 143 tests pass (`pytest tests/ -v`)
- [ ] Create a one-shot chore via config flow, verify it appears for children
- [ ] Complete and approve it, verify it disappears from active list
- [ ] Reject a one-shot completion, verify it reappears
- [ ] Assign to multiple children, verify per-child disabling
- [ ] Wait past midnight (or mock), verify auto-expiry
- [ ] Re-enable a disabled chore, verify it reappears with today's date

https://claude.ai/code/session_011khQPbiEFaBGiUzZqgcM65