### PR TITLE
Fix visibility form validation and restore entity dropdown

### DIFF
--- a/custom_components/taskmate/config_flow.py
+++ b/custom_components/taskmate/config_flow.py
@@ -377,7 +377,9 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
                     mode=selector.SelectSelectorMode.DROPDOWN,
                 )
             ),
-            vol.Optional("visibility_entity", default=""): str,
+            vol.Optional("visibility_entity", default=""): selector.EntitySelector(
+                selector.EntitySelectorConfig()
+            ),
         }
         if child_options:
             schema_dict[vol.Optional("assigned_to", default=[])] = selector.SelectSelector(
@@ -412,7 +414,7 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
                 completion_sound=s1.get("completion_sound", DEFAULT_COMPLETION_SOUND),
                 schedule_mode="specific_days",
                 due_days=user_input.get("due_days", []),
-                visibility_entity=s1.get("visibility_entity", ""),
+                visibility_entity=s1.get("visibility_entity") or "",
             )
             self._chore_step1_data = None
             return await self.async_step_manage_chores()
@@ -446,7 +448,7 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
             daily_limit=1,
             completion_sound=s1.get("completion_sound", DEFAULT_COMPLETION_SOUND),
             schedule_mode="one_shot",
-            visibility_entity=s1.get("visibility_entity", ""),
+            visibility_entity=s1.get("visibility_entity") or "",
         )
         self._chore_step1_data = None
         return await self.async_step_manage_chores()
@@ -485,7 +487,7 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
                 recurrence_day=recurrence_day,
                 recurrence_start=recurrence_start,
                 first_occurrence_mode=first_occurrence_mode,
-                visibility_entity=s1.get("visibility_entity", ""),
+                visibility_entity=s1.get("visibility_entity") or "",
             )
             self._chore_step1_data = None
             return await self.async_step_manage_chores()
@@ -553,7 +555,7 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
                         daily_limit=int(user_input.get("daily_limit", 1)),
                         schedule_mode="specific_days",
                         completion_sound=user_input.get("completion_sound", DEFAULT_COMPLETION_SOUND),
-                        visibility_entity=user_input.get("visibility_entity", ""),
+                        visibility_entity=user_input.get("visibility_entity") or "",
                     )
                     return await self.async_step_manage_chores()
 
@@ -600,7 +602,9 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
                     mode=selector.SelectSelectorMode.DROPDOWN,
                 )
             ),
-            vol.Optional("visibility_entity", default=""): str,
+            vol.Optional("visibility_entity", default=""): selector.EntitySelector(
+                selector.EntitySelectorConfig()
+            ),
         }
 
         if child_options:
@@ -660,9 +664,9 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
                 chore.time_category = user_input.get("time_category", chore.time_category)
                 chore.daily_limit = int(user_input.get("daily_limit", chore.daily_limit))
                 chore.completion_sound = user_input.get("completion_sound", getattr(chore, 'completion_sound', DEFAULT_COMPLETION_SOUND))
-                chore.visibility_entity = user_input.get("visibility_entity", "")
-                chore.visibility_state = user_input.get("visibility_state", "on")
-                chore.visibility_operator = user_input.get("visibility_operator", "equals")
+                chore.visibility_entity = user_input.get("visibility_entity") or ""
+                chore.visibility_state = user_input.get("visibility_state") or "on"
+                chore.visibility_operator = user_input.get("visibility_operator") or "equals"
                 self._edited_chore = chore
                 _LOGGER.debug(
                     "Edit chore step 1 - saved visibility fields: entity=%s, operator=%s, state=%s",
@@ -719,8 +723,10 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
                     mode=selector.SelectSelectorMode.DROPDOWN,
                 )
             ),
-            vol.Optional("visibility_entity", default=getattr(chore, 'visibility_entity', "")): str,
-            vol.Optional("visibility_operator", default=getattr(chore, 'visibility_operator', "equals")): selector.SelectSelector(
+            vol.Optional("visibility_entity", default=getattr(chore, 'visibility_entity', "")): selector.EntitySelector(
+                selector.EntitySelectorConfig()
+            ),
+            vol.Required("visibility_operator", default=getattr(chore, 'visibility_operator', "equals")): selector.SelectSelector(
                 selector.SelectSelectorConfig(
                     options=[
                         selector.SelectOptionDict(value="equals", label="Equals (exact match)"),


### PR DESCRIPTION
## Summary

- **Restore entity dropdown**: Replace plain `str` field with `EntitySelector` for `visibility_entity` in add_chore, add_chores_bulk, and edit_chore forms — restores the autocomplete dropdown of all HA entities
- **Fix form validation blocking save**: Change `visibility_operator` from `vol.Optional` to `vol.Required` in edit_chore so it always has a valid default and the clear (X) button is removed, preventing form submission failures when cleared
- **Handle None from EntitySelector**: Use `or ""` fallback when reading `visibility_entity` from form input, since `EntitySelector` may return `None` when cleared

## Test plan
- [ ] Edit an existing chore — verify the entity field shows a dropdown of sensors/entities
- [ ] Edit a chore with visibility fields blank — verify the form saves successfully
- [ ] Add a new chore — verify the entity field shows a dropdown
- [ ] Edit a chore, clear the entity field, and save — verify it saves without errors
- [ ] Verify operator dropdown cannot be accidentally cleared in edit form

https://claude.ai/code/session_01NeDThCcdAGQbRPLSk7ZSbK