### PR TITLE
Fix visibility fields: allow clearing and add No Filter option

### DIFF
--- a/custom_components/taskmate/config_flow.py
+++ b/custom_components/taskmate/config_flow.py
@@ -654,7 +654,18 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
             name = user_input.get("name", "").strip()
             if not name:
                 errors["name"] = "name_required"
-            else:
+
+            # Validate visibility: if entity is set, operator and state are required
+            vis_entity = user_input.get("visibility_entity") or ""
+            vis_operator = user_input.get("visibility_operator", "none")
+            vis_state = user_input.get("visibility_state", "")
+            if vis_entity:
+                if not vis_operator or vis_operator == "none":
+                    errors["visibility_operator"] = "operator_required"
+                if not vis_state.strip():
+                    errors["visibility_state"] = "state_required"
+
+            if not errors:
                 # Update the chore object with all Step 1 fields
                 chore.name = name
                 chore.points = int(user_input.get("points", chore.points))
@@ -664,11 +675,11 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
                 chore.time_category = user_input.get("time_category", chore.time_category)
                 chore.daily_limit = int(user_input.get("daily_limit", chore.daily_limit))
                 chore.completion_sound = user_input.get("completion_sound", getattr(chore, 'completion_sound', DEFAULT_COMPLETION_SOUND))
-                chore.visibility_entity = user_input.get("visibility_entity") or ""
-                chore.visibility_operator = user_input.get("visibility_operator", "none")
-                chore.visibility_state = user_input.get("visibility_state", "")
-                # Clear operator/state when entity is blank or operator is "none"
-                if not chore.visibility_entity or chore.visibility_operator == "none":
+                if vis_entity:
+                    chore.visibility_entity = vis_entity
+                    chore.visibility_operator = vis_operator
+                    chore.visibility_state = vis_state
+                else:
                     chore.visibility_entity = ""
                     chore.visibility_operator = ""
                     chore.visibility_state = ""

--- a/custom_components/taskmate/config_flow.py
+++ b/custom_components/taskmate/config_flow.py
@@ -665,8 +665,13 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
                 chore.daily_limit = int(user_input.get("daily_limit", chore.daily_limit))
                 chore.completion_sound = user_input.get("completion_sound", getattr(chore, 'completion_sound', DEFAULT_COMPLETION_SOUND))
                 chore.visibility_entity = user_input.get("visibility_entity") or ""
-                chore.visibility_state = user_input.get("visibility_state") or "on"
-                chore.visibility_operator = user_input.get("visibility_operator") or "equals"
+                chore.visibility_operator = user_input.get("visibility_operator", "none")
+                chore.visibility_state = user_input.get("visibility_state", "")
+                # Clear operator/state when entity is blank or operator is "none"
+                if not chore.visibility_entity or chore.visibility_operator == "none":
+                    chore.visibility_entity = ""
+                    chore.visibility_operator = ""
+                    chore.visibility_state = ""
                 self._edited_chore = chore
                 _LOGGER.debug(
                     "Edit chore step 1 - saved visibility fields: entity=%s, operator=%s, state=%s",
@@ -726,9 +731,10 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
             vol.Optional("visibility_entity", default=getattr(chore, 'visibility_entity', "")): selector.EntitySelector(
                 selector.EntitySelectorConfig()
             ),
-            vol.Required("visibility_operator", default=getattr(chore, 'visibility_operator', "equals")): selector.SelectSelector(
+            vol.Required("visibility_operator", default=getattr(chore, 'visibility_operator', "none") if not getattr(chore, 'visibility_entity', '') else getattr(chore, 'visibility_operator', 'equals')): selector.SelectSelector(
                 selector.SelectSelectorConfig(
                     options=[
+                        selector.SelectOptionDict(value="none", label="No filter (always show)"),
                         selector.SelectOptionDict(value="equals", label="Equals (exact match)"),
                         selector.SelectOptionDict(value="gte", label="Greater than or equal (>=)"),
                         selector.SelectOptionDict(value="lte", label="Less than or equal (<=)"),
@@ -739,7 +745,7 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
                     mode=selector.SelectSelectorMode.DROPDOWN,
                 )
             ),
-            vol.Optional("visibility_state", default=getattr(chore, 'visibility_state', "on")): str,
+            vol.Optional("visibility_state", default=getattr(chore, 'visibility_state', '') if getattr(chore, 'visibility_entity', '') else ""): str,
             vol.Required("action", default="save"): selector.SelectSelector(
                 selector.SelectSelectorConfig(
                     options=(

--- a/custom_components/taskmate/coordinator.py
+++ b/custom_components/taskmate/coordinator.py
@@ -387,8 +387,14 @@ class TaskMateCoordinator(DataUpdateCoordinator):
         Returns True if entity matches visibility_state with the specified operator.
         Defaults to visible if entity doesn't exist.
         """
-        if not visibility_entity:
+        if not visibility_entity or visibility_operator == "none":
             return True
+
+        # Default empty operator/state to sensible values
+        if not visibility_operator:
+            visibility_operator = "equals"
+        if not visibility_state:
+            visibility_state = "on"
 
         # Get entity state from Home Assistant
         state_obj = self.hass.states.get(visibility_entity)

--- a/custom_components/taskmate/strings.json
+++ b/custom_components/taskmate/strings.json
@@ -351,6 +351,7 @@
     },
     "visibility_operator": {
       "options": {
+        "none": "No filter — Always show chore",
         "equals": "Equals — Show when entity state matches exactly",
         "not_equals": "Not Equal — Show when entity state does not match",
         "gte": "Greater than or equal (≥) — Show when numeric value is ≥ target",

--- a/custom_components/taskmate/strings.json
+++ b/custom_components/taskmate/strings.json
@@ -265,7 +265,9 @@
     },
     "error": {
       "name_required": "Name is required",
-      "invalid_milestone_format": "Invalid milestone format — use days:points pairs, e.g. 3:5, 7:10, 14:20"
+      "invalid_milestone_format": "Invalid milestone format — use days:points pairs, e.g. 3:5, 7:10, 14:20",
+      "operator_required": "Operator is required when an entity is set",
+      "state_required": "Value is required when an entity is set"
     }
   },
   "selector": {


### PR DESCRIPTION
## Summary

- Add **"No filter (always show)"** option to the operator dropdown so users can explicitly disable visibility filtering
- Remove `or "default"` pattern in form processing that was restoring previously saved values when fields were intentionally cleared
- **Conditional validation**: if entity is set, operator and state are required; if entity is empty, all visibility fields are cleared
- Operator defaults to "No filter" when entity is blank; state defaults to empty when entity is blank
- Coordinator handles "none" operator and empty state/operator gracefully

## Test plan
- [ ] Edit a chore — set entity but leave operator as "No filter" → should show validation error
- [ ] Edit a chore — set entity but leave state blank → should show validation error
- [ ] Edit a chore — set entity + operator + state → should save successfully
- [ ] Edit a chore — clear entity, save → all visibility fields should be cleared
- [ ] Select "No filter" with no entity set → should save fine (all cleared)

https://claude.ai/code/session_01NeDThCcdAGQbRPLSk7ZSbK