### PR TITLE
feat: add manual disable/re-enable for one-shot chores

### DIFF
--- a/custom_components/taskmate/config_flow.py
+++ b/custom_components/taskmate/config_flow.py
@@ -625,6 +625,22 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
             },
         )
 
+    @staticmethod
+    def _get_chore_action_options(chore) -> list[str]:
+        """Build the action options list for the chore edit form."""
+        is_one_shot = getattr(chore, 'schedule_mode', 'specific_days') == 'one_shot'
+        is_disabled = not getattr(chore, 'enabled', True) or getattr(chore, 'disabled_for', [])
+
+        if is_one_shot:
+            if is_disabled:
+                return ["save", "re_enable", "delete"]
+            else:
+                return ["save", "disable", "delete"]
+        elif is_disabled:
+            return ["save", "re_enable", "delete"]
+        else:
+            return ["save", "delete"]
+
     async def async_step_edit_chore(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
@@ -648,6 +664,10 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
                 if getattr(chore, 'schedule_mode', 'specific_days') == 'one_shot':
                     from homeassistant.util import dt as dt_util
                     chore.created_date = dt_util.as_local(dt_util.now()).date().isoformat()
+                await self.coordinator.async_update_chore(chore)
+                return await self.async_step_manage_chores()
+            if action == "disable":
+                chore.enabled = False
                 await self.coordinator.async_update_chore(chore)
                 return await self.async_step_manage_chores()
 
@@ -742,11 +762,7 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
             vol.Optional("visibility_state", default=getattr(chore, 'visibility_state', "on")): str,
             vol.Required("action", default="save"): selector.SelectSelector(
                 selector.SelectSelectorConfig(
-                    options=(
-                        ["save", "re_enable", "delete"]
-                        if (not getattr(chore, 'enabled', True) or getattr(chore, 'disabled_for', []))
-                        else ["save", "delete"]
-                    ),
+                    options=self._get_chore_action_options(chore),
                     translation_key="chore_action",
                     mode=selector.SelectSelectorMode.LIST,
                 )

--- a/custom_components/taskmate/strings.json
+++ b/custom_components/taskmate/strings.json
@@ -279,6 +279,7 @@
       "options": {
         "save": "Save Changes",
         "re_enable": "Re-enable Chore",
+        "disable": "Disable Chore",
         "delete": "Delete This Chore"
       }
     },

--- a/custom_components/taskmate/translations/en-GB.json
+++ b/custom_components/taskmate/translations/en-GB.json
@@ -279,6 +279,7 @@
       "options": {
         "save": "Save Changes",
         "re_enable": "Re-enable Chore",
+        "disable": "Disable Chore",
         "delete": "Delete This Chore"
       }
     },

--- a/custom_components/taskmate/translations/en.json
+++ b/custom_components/taskmate/translations/en.json
@@ -279,6 +279,7 @@
       "options": {
         "save": "Save Changes",
         "re_enable": "Re-enable Chore",
+        "disable": "Disable Chore",
         "delete": "Delete This Chore"
       }
     },

--- a/custom_components/taskmate/translations/fr.json
+++ b/custom_components/taskmate/translations/fr.json
@@ -279,6 +279,7 @@
       "options": {
         "save": "Enregistrer les modifications",
         "re_enable": "Réactiver la corvée",
+        "disable": "Désactiver la corvée",
         "delete": "Supprimer cette corvée"
       }
     },

--- a/custom_components/taskmate/translations/nb.json
+++ b/custom_components/taskmate/translations/nb.json
@@ -279,6 +279,7 @@
       "options": {
         "save": "Lagre endringer",
         "re_enable": "Reaktiver oppgave",
+        "disable": "Deaktiver oppgave",
         "delete": "Slett denne oppgaven"
       }
     },

--- a/custom_components/taskmate/translations/nn.json
+++ b/custom_components/taskmate/translations/nn.json
@@ -279,6 +279,7 @@
       "options": {
         "save": "Lagre endringar",
         "re_enable": "Reaktiver oppgåve",
+        "disable": "Deaktiver oppgåve",
         "delete": "Slett denne oppgåva"
       }
     },

--- a/custom_components/taskmate/translations/pt-BR.json
+++ b/custom_components/taskmate/translations/pt-BR.json
@@ -279,6 +279,7 @@
       "options": {
         "save": "Guardar alterações",
         "re_enable": "Reativar tarefa",
+        "disable": "Desativar tarefa",
         "delete": "Eliminar esta tarefa"
       }
     },

--- a/custom_components/taskmate/translations/pt.json
+++ b/custom_components/taskmate/translations/pt.json
@@ -279,6 +279,7 @@
       "options": {
         "save": "Guardar alterações",
         "re_enable": "Reativar tarefa",
+        "disable": "Desativar tarefa",
         "delete": "Eliminar esta tarefa"
       }
     },


### PR DESCRIPTION
## Summary\n\n- Active one-shot chores now show a **\"Disable Chore\"** action in the edit flow\n- Disabled one-shot chores show **\"Re-enable Chore\"** to reactivate with today's date\n- Gives parents full manual control over the one-shot lifecycle without waiting for midnight expiry\n- Translations added for all 7 languages\n\n## Test plan\n\n- [x] All 143 tests pass\n- [ ] Create a one-shot chore, edit it, verify \"Disable Chore\" action appears\n- [ ] Disable it, verify it shows \"(disabled)\" in the chore list\n- [ ] Edit it again, verify \"Re-enable Chore\" action appears\n- [ ] Re-enable it, verify it reappears on child cards\n\nhttps://claude.ai/code/session_011khQPbiEFaBGiUzZqgcM65