### PR TITLE
Fix Family Points card not finding children

### DIFF
--- a/custom_components/taskmate/www/taskmate-points-display-card.js
+++ b/custom_components/taskmate/www/taskmate-points-display-card.js
@@ -40,10 +40,7 @@ const RANK_MEDAL = ["\u{1F947}", "\u{1F948}", "\u{1F949}"];
 /* ─── Utility helpers ──────────────────────────────────────────────────── */
 
 function getChildren(state) {
-  try {
-    const d = JSON.parse(state.attributes.data || "{}");
-    return d.children || [];
-  } catch { return []; }
+  return state.attributes.children || [];
 }
 
 function weeklyPoints(child) {


### PR DESCRIPTION
The getChildren() helper was trying to parse state.attributes.data as JSON, but the backend provides children directly at state.attributes.children — matching every other card in the codebase.