### PR TITLE
feat: add taskmate.add_chore service for dynamic chore creation

### DIFF
--- a/custom_components/taskmate/__init__.py
+++ b/custom_components/taskmate/__init__.py
@@ -18,8 +18,15 @@ from .const import (
     ATTR_BONUS_NAME,
     ATTR_BONUS_POINTS,
     ATTR_CHILD_ID,
+    ATTR_CHORE_ASSIGNED_TO,
+    ATTR_CHORE_DESCRIPTION,
     ATTR_CHORE_ID,
+    ATTR_CHORE_NAME,
+    ATTR_CHORE_ONE_SHOT,
     ATTR_CHORE_ORDER,
+    ATTR_CHORE_POINTS,
+    ATTR_CHORE_REQUIRES_APPROVAL,
+    ATTR_CHORE_TIME_CATEGORY,
     ATTR_PENALTY_ASSIGNED_TO,
     ATTR_PENALTY_DESCRIPTION,
     ATTR_PENALTY_ICON,
@@ -33,6 +40,7 @@ from .const import (
     DOMAIN,
     EVENT_PREVIEW_SOUND,
     SERVICE_ADD_BONUS,
+    SERVICE_ADD_CHORE,
     SERVICE_ADD_PENALTY,
     SERVICE_ADD_POINTS,
     SERVICE_APPLY_BONUS,
@@ -50,6 +58,7 @@ from .const import (
     SERVICE_SET_CHORE_ORDER,
     SERVICE_UPDATE_BONUS,
     SERVICE_UPDATE_PENALTY,
+    TIME_CATEGORIES,
 )
 from .coordinator import TaskMateCoordinator
 from .frontend import async_register_cards, async_register_frontend
@@ -325,6 +334,23 @@ async def _async_register_services(hass: HomeAssistant) -> None:
             child_id=call.data[ATTR_CHILD_ID],
         )
 
+    async def handle_add_chore(call: ServiceCall) -> None:
+        """Handle the add_chore service call."""
+        coordinator = _get_coordinator(hass)
+        if not coordinator:
+            _LOGGER.error("No TaskMate coordinator available")
+            return
+        schedule_mode = "one_shot" if call.data.get(ATTR_CHORE_ONE_SHOT, False) else "specific_days"
+        await coordinator.async_add_chore(
+            name=call.data[ATTR_CHORE_NAME],
+            description=call.data.get(ATTR_CHORE_DESCRIPTION, ""),
+            points=call.data.get(ATTR_CHORE_POINTS, 10),
+            assigned_to=call.data.get(ATTR_CHORE_ASSIGNED_TO, []),
+            time_category=call.data.get(ATTR_CHORE_TIME_CATEGORY, "anytime"),
+            requires_approval=call.data.get(ATTR_CHORE_REQUIRES_APPROVAL, True),
+            schedule_mode=schedule_mode,
+        )
+
     # Register all services
     hass.services.async_register(
         DOMAIN,
@@ -532,6 +558,21 @@ async def _async_register_services(hass: HomeAssistant) -> None:
         }),
     )
 
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_ADD_CHORE,
+        handle_add_chore,
+        schema=vol.Schema({
+            vol.Required(ATTR_CHORE_NAME): cv.string,
+            vol.Optional(ATTR_CHORE_DESCRIPTION, default=""): cv.string,
+            vol.Optional(ATTR_CHORE_POINTS, default=10): cv.positive_int,
+            vol.Optional(ATTR_CHORE_ASSIGNED_TO, default=[]): vol.All(cv.ensure_list, [cv.string]),
+            vol.Optional(ATTR_CHORE_TIME_CATEGORY, default="anytime"): vol.In(TIME_CATEGORIES),
+            vol.Optional(ATTR_CHORE_ONE_SHOT, default=False): cv.boolean,
+            vol.Optional(ATTR_CHORE_REQUIRES_APPROVAL, default=True): cv.boolean,
+        }),
+    )
+
 
 def _async_unregister_services(hass: HomeAssistant) -> None:
     """Unregister TaskMate services."""
@@ -554,6 +595,7 @@ def _async_unregister_services(hass: HomeAssistant) -> None:
         SERVICE_UPDATE_BONUS,
         SERVICE_REMOVE_BONUS,
         SERVICE_APPLY_BONUS,
+        SERVICE_ADD_CHORE,
     ]
     for service in services:
         hass.services.async_remove(DOMAIN, service)

--- a/custom_components/taskmate/const.py
+++ b/custom_components/taskmate/const.py
@@ -208,6 +208,7 @@ SERVICE_ADD_BONUS: Final = "add_bonus"
 SERVICE_UPDATE_BONUS: Final = "update_bonus"
 SERVICE_REMOVE_BONUS: Final = "remove_bonus"
 SERVICE_APPLY_BONUS: Final = "apply_bonus"
+SERVICE_ADD_CHORE: Final = "add_chore"
 
 # Events
 EVENT_PREVIEW_SOUND: Final = "taskmate_preview_sound"
@@ -232,6 +233,13 @@ ATTR_BONUS_POINTS: Final = "points"
 ATTR_BONUS_DESCRIPTION: Final = "description"
 ATTR_BONUS_ICON: Final = "icon"
 ATTR_BONUS_ASSIGNED_TO: Final = "assigned_to"
+ATTR_CHORE_NAME: Final = "name"
+ATTR_CHORE_DESCRIPTION: Final = "description"
+ATTR_CHORE_POINTS: Final = "points"
+ATTR_CHORE_ASSIGNED_TO: Final = "assigned_to"
+ATTR_CHORE_TIME_CATEGORY: Final = "time_category"
+ATTR_CHORE_ONE_SHOT: Final = "one_shot"
+ATTR_CHORE_REQUIRES_APPROVAL: Final = "requires_approval"
 
 # States
 STATE_PENDING: Final = "pending"

--- a/custom_components/taskmate/services.yaml
+++ b/custom_components/taskmate/services.yaml
@@ -394,3 +394,63 @@ apply_bonus:
       required: true
       selector:
         text:
+
+add_chore:
+  name: Add Chore
+  description: Create a new chore dynamically, typically from an automation or script
+  fields:
+    name:
+      name: Name
+      description: The name of the chore
+      required: true
+      selector:
+        text:
+    description:
+      name: Description
+      description: Optional description of the chore
+      required: false
+      selector:
+        text:
+    points:
+      name: Points
+      description: Points awarded when this chore is completed
+      required: false
+      default: 10
+      selector:
+        number:
+          min: 1
+          max: 10000
+          mode: box
+    assigned_to:
+      name: Assigned To
+      description: List of child IDs to assign this chore to. Leave empty to assign to all children
+      required: false
+      selector:
+        object:
+    time_category:
+      name: Time Category
+      description: When this chore should be completed
+      required: false
+      default: anytime
+      selector:
+        select:
+          options:
+            - morning
+            - afternoon
+            - evening
+            - night
+            - anytime
+    one_shot:
+      name: One-Shot
+      description: If true, this is a one-time chore that expires after being completed or at the end of the day
+      required: false
+      default: false
+      selector:
+        boolean:
+    requires_approval:
+      name: Requires Approval
+      description: If true, a parent must approve the completion before points are awarded
+      required: false
+      default: true
+      selector:
+        boolean:

--- a/custom_components/taskmate/strings.json
+++ b/custom_components/taskmate/strings.json
@@ -652,6 +652,40 @@
           "description": "The ID of the child to apply the bonus to"
         }
       }
+    },
+    "add_chore": {
+      "name": "Add Chore",
+      "description": "Create a new chore dynamically, typically from an automation or script",
+      "fields": {
+        "name": {
+          "name": "Name",
+          "description": "The name of the chore"
+        },
+        "description": {
+          "name": "Description",
+          "description": "Optional description of the chore"
+        },
+        "points": {
+          "name": "Points",
+          "description": "Points awarded when this chore is completed"
+        },
+        "assigned_to": {
+          "name": "Assigned To",
+          "description": "List of child IDs to assign this chore to. Leave empty to assign to all children"
+        },
+        "time_category": {
+          "name": "Time Category",
+          "description": "When this chore should be completed: morning, afternoon, evening, night, or anytime"
+        },
+        "one_shot": {
+          "name": "One-Shot",
+          "description": "If true, this is a one-time chore that expires after being completed or at the end of the day"
+        },
+        "requires_approval": {
+          "name": "Requires Approval",
+          "description": "If true, a parent must approve the completion before points are awarded"
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
Expose a Home Assistant service (`taskmate.add_chore`) that lets automations and scripts create chores dynamically. Enables just-in-time task creation in response to sensor events, calendar triggers, or presence changes.

## Features
- **Service**: `taskmate.add_chore` accepts parameters: `name` (required), `description`, `points`, `assigned_to`, `time_category`, `one_shot`, `requires_approval`
- **One-shot chores**: Auto-expire single-day tasks
- **Flexible targeting**: Assign to specific children or all children
- **No model changes**: Reuses existing `coordinator.async_add_chore()` method

## Use Cases
- Spill detected by sensor → create high-priority cleanup chore
- Person arrives home → create welcome/greeting task
- Calendar event triggered → create event-related chore
- Complex automation logic → conditional task creation

## Files Modified
- `const.py`: Service and attribute constants
- `__init__.py`: Service handler, registration, unregister list
- `strings.json`: UI metadata for Home Assistant
- `services.yaml`: Automation editor schema

## Testing
Manual testing:
1. Create chore via service call with all parameters
2. Verify chore appears in TaskMate storage with correct attributes
3. Create one-shot chore, verify it expires
4. Create chore assigned to specific child
5. Verify chore visible in TaskMate sensor data
