### PR TITLE
fix: expose bonuses on overview sensor so new bonuses appear in card

### DIFF
--- a/custom_components/taskmate/sensor.py
+++ b/custom_components/taskmate/sensor.py
@@ -326,6 +326,14 @@ class TaskMateOverallStatsSensor(TaskMateBaseSensor):
                 "icon": p.icon,
                 "assigned_to": p.assigned_to or [],
             } for p in data.get("penalties", [])],
+            "bonuses": [{
+                "id": b.id,
+                "name": b.name,
+                "points": b.points,
+                "description": b.description,
+                "icon": b.icon,
+                "assigned_to": b.assigned_to or [],
+            } for b in data.get("bonuses", [])],
         }
 
     @property

--- a/custom_components/taskmate/www/locales/en-GB.json
+++ b/custom_components/taskmate/www/locales/en-GB.json
@@ -240,6 +240,7 @@
   "bonuses.applying_to": "Applying to {childName} — current balance: {points} {pointsName}",
   "bonuses.toast_applied": "+{points} {pointsName} to {childName}",
   "bonuses.toast_apply_failed": "Failed to apply bonus",
+  "bonuses.toast_saved": "Bonus saved",
   "bonuses.toast_save_failed": "Failed to save changes",
   "bonuses.toast_delete_failed": "Failed to delete bonus",
   "bonuses.toast_add_failed": "Failed to add bonus",

--- a/custom_components/taskmate/www/locales/en.json
+++ b/custom_components/taskmate/www/locales/en.json
@@ -240,6 +240,7 @@
   "bonuses.applying_to": "Applying to {childName} — current balance: {points} {pointsName}",
   "bonuses.toast_applied": "+{points} {pointsName} to {childName}",
   "bonuses.toast_apply_failed": "Failed to apply bonus",
+  "bonuses.toast_saved": "Bonus saved",
   "bonuses.toast_save_failed": "Failed to save changes",
   "bonuses.toast_delete_failed": "Failed to delete bonus",
   "bonuses.toast_add_failed": "Failed to add bonus",

--- a/custom_components/taskmate/www/taskmate-bonuses-card.js
+++ b/custom_components/taskmate/www/taskmate-bonuses-card.js
@@ -468,6 +468,8 @@ class TaskMateBonusesCard extends LitElement {
         icon: this._newForm.icon || "mdi:star-circle-outline",
       });
       this._showNewForm = false;
+      this._newForm = { name: "", points: "", description: "", icon: "mdi:star-circle-outline" };
+      this._showToast(this._t('bonuses.toast_saved'));
     } catch (e) {
       this._showToast(this._t('bonuses.toast_add_failed'));
     }
@@ -597,7 +599,7 @@ class TaskMateBonusesCard extends LitElement {
         <div class="form-row full">
           <div class="form-field">
             <label>${this._t('bonuses.form_description_label')}</label>
-            <input type="text" placeholder="${this._t('bonuses.form_description_placeholder')}"
+            <input type="text" placeholder="${this._t('bonuses.form_description_placeholder')}" .value=${f.description}
               @input=${e => this._newForm = { ...f, description: e.target.value }} />
           </div>
         </div>


### PR DESCRIPTION
## Summary

- Bonuses created via the card were persisted to storage correctly but never appeared on the UI, making "add bonus" look broken.
- Root cause: `TaskMateOverallStatsSensor._build_attributes` in `sensor.py` returned `children`, `chores`, `rewards`, `penalties`, etc. — but **not** `bonuses`. The frontend reads the list from `sensor.taskmate_overview.attributes.bonuses`, which was always `undefined`.
- Fix: add a `bonuses` block alongside `penalties`, mirroring the same shape. `coordinator.data["bonuses"]` was already populated (`coordinator.py:211`), so nothing else on the backend needs to change.
- Also tidy the new-bonus form UX: reset `_newForm` after a successful save, show a success toast (`bonuses.toast_saved`), and add the missing `.value=${f.description}` binding so the description input clears consistently with the other fields.

## Test plan

- [ ] Restart Home Assistant; confirm `sensor.taskmate_overview.attributes.bonuses` is present (Developer Tools → States).
- [ ] Open the Bonuses card, click "New", enter name + points, click Save — new bonus should appear immediately, form clears, success toast shows.
- [ ] Edit an existing bonus — still works.
- [ ] Delete a bonus — still works.
- [ ] Apply a bonus to a child — points still award correctly.

https://claude.ai/code/session_01RMe1Fk2EXLCo6u6MNEMeWf