### PR TITLE
chore: bump version to 2.4.3-beta2

### DIFF
--- a/custom_components/taskmate/manifest.json
+++ b/custom_components/taskmate/manifest.json
@@ -15,5 +15,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/tempus2016/taskmate/issues",
   "requirements": [],
-  "version": "2.4.3-beta1"
+  "version": "2.4.3-beta2"
 }


### PR DESCRIPTION
## Summary

- Bumps `custom_components/taskmate/manifest.json` from `2.4.3-beta1` → `2.4.3-beta2`.
- Release over beta1 adds the bonuses-card save fix (#74).

https://claude.ai/code/session_01RMe1Fk2EXLCo6u6MNEMeWf