### PR TITLE
docs: Add wiki sections for v2.4.3 changes

### DIFF
--- a/docs/wiki/Bonuses.md
+++ b/docs/wiki/Bonuses.md
@@ -1,0 +1,171 @@
+# Bonuses
+
+Bonuses are a point-awarding system that complements the Penalties system. While Penalties deduct points for negative behaviors, Bonuses award points for positive achievements and special occasions.
+
+## Overview
+
+The Bonuses feature allows you to:
+- **Create custom bonuses** that award points to children
+- **Manage bonuses** through the Bonuses card in your dashboard
+- **Apply bonuses** instantly via the UI or services
+- **Assign bonuses** to specific children or all children
+- **Categorize bonuses** with icons and descriptions
+
+## How Bonuses Work
+
+1. **Create a Bonus** - Define a bonus with a name, point value, optional description, and icon
+2. **Assign It** - Choose which children the bonus applies to (or leave empty for all)
+3. **Apply the Bonus** - Award the points to a child through the Bonuses card or via service call
+4. **Points Awarded** - The child receives the bonus points immediately in their account
+
+### Bonuses vs Penalties
+
+| Aspect | Bonuses | Penalties |
+|--------|---------|-----------|
+| **Purpose** | Reward positive behaviors | Discourage negative behaviors |
+| **Point Effect** | Awards points (+) | Deducts points (-) |
+| **Common Use Cases** | Perfect week, good report card, extra chores | Rule breaking, incomplete chores, screen time violations |
+| **Trigger** | Parent recognition, special events | Behavioral issues, incomplete tasks |
+
+## The Bonuses Card
+
+The Bonuses Card provides a green-themed interface for managing all your bonuses. Key features:
+
+- **List of Bonuses** - View all defined bonuses with their point values
+- **Add New Bonus** - Create a new bonus definition directly from the card
+- **Apply Bonus** - Select a child and click the bonus to award points
+- **Edit/Delete** - Manage existing bonuses
+- **Visual Indicators** - Color-coded icons help distinguish different bonus types
+
+### Lovelace Configuration
+
+Add the Bonuses Card to your dashboard:
+
+```yaml
+type: custom:taskmate-bonuses-card
+entity: sensor.taskmate_overview
+title: Bonuses
+```
+
+## Creating and Managing Bonuses
+
+### Create a Bonus
+
+1. Open the Bonuses Card on your dashboard
+2. Click "Add Bonus" or the **+** button
+3. Fill in the bonus details:
+   - **Name** - The bonus title (e.g., "Perfect Week")
+   - **Points** - Points awarded when applied (1-10000)
+   - **Description** (optional) - Details about when to use this bonus
+   - **Icon** (optional) - MDI icon for visual identification
+   - **Assigned To** (optional) - Specific children (leave empty for all)
+4. Click Save
+
+### Update a Bonus
+
+1. In the Bonuses Card, click the **edit** icon on the bonus
+2. Modify the desired fields
+3. Click Save
+
+### Remove a Bonus
+
+1. In the Bonuses Card, click the **delete** icon on the bonus
+2. Confirm the deletion
+
+### Apply a Bonus
+
+1. In the Bonuses Card, select a child from the dropdown
+2. Click the bonus you want to apply
+3. The points are instantly awarded to that child
+
+## Services
+
+The Bonuses system provides four services for advanced automation:
+
+### taskmate.add_bonus
+Create a new bonus definition.
+
+### taskmate.update_bonus
+Update an existing bonus definition.
+
+### taskmate.remove_bonus
+Remove a bonus definition.
+
+### taskmate.apply_bonus
+Award bonus points to a child (calls the internal `add_points` service).
+
+See the [Services](Services) page for detailed parameter documentation and YAML examples.
+
+## Common Use Cases
+
+### Perfect Week Bonus
+Award extra points when a child completes all assigned chores in a week.
+
+**Bonus Details:**
+- Name: "Perfect Week"
+- Points: 25
+- Description: "Completed all chores for the week"
+- Icon: `mdi:star`
+
+### Report Card Bonus
+Reward good grades or school achievements.
+
+**Bonus Details:**
+- Name: "Great Grades"
+- Points: 50
+- Description: "Honor roll or excellent report card"
+- Icon: `mdi:school`
+
+### Special Event Bonus
+Celebrate birthdays, holidays, or milestones.
+
+**Bonus Details:**
+- Name: "Birthday Bonus"
+- Points: 100
+- Description: "Happy Birthday!"
+- Icon: `mdi:birthday-cake`
+
+### Chore Motivation Bonus
+Quick bonuses for exceeding expectations.
+
+**Bonus Details:**
+- Name: "Extra Effort"
+- Points: 10
+- Description: "Completed a chore ahead of schedule"
+- Icon: `mdi:lightning-bolt`
+
+## Tips & Best Practices
+
+**Start Simple** - Begin with a few bonuses (Perfect Week, Good Grades, Birthday) and expand based on your family's needs.
+
+**Balance Your Economy** - Keep bonus point values reasonable compared to chore rewards to maintain motivation balance. Example: If chores award 5-20 points, bonuses might award 10-50 points.
+
+**Use Icons Consistently** - Choose recognizable MDI icons that make bonuses instantly identifiable on the card.
+
+**Assign Strategically** - Use assignment to create age-appropriate bonuses. Younger children might have simpler bonus criteria.
+
+**Celebrate Often** - Bonuses are more effective when applied promptly and for genuine achievements. Don't overuse them.
+
+**Combine with Automations** - Use the `apply_bonus` service in automations to award bonuses based on Home Assistant sensor values (e.g., door lock, presence, weather).
+
+## Troubleshooting
+
+**Bonus Not Appearing on Card**
+- Verify the bonus was saved (check the card's bonus list)
+- Refresh your dashboard (F5 or hard refresh)
+- Check that the `sensor.taskmate_overview` entity is available
+
+**Can't Apply Bonus**
+- Ensure a child is selected from the dropdown
+- Verify the bonus is assigned to that child (or assigned to all if "Assigned To" is empty)
+- Check Home Assistant logs for errors
+
+**Points Not Awarded**
+- Confirm the child's point balance increased after applying the bonus
+- Verify the `apply_bonus` service is properly configured (if using automations)
+- Check that the bonus points value is correctly set
+
+**Service Call Fails**
+- Verify the `bonus_id` and `child_id` are correct (use Developer Tools to find IDs)
+- Ensure the bonus and child still exist
+- Check Home Assistant logs for detailed error messages

--- a/docs/wiki/Services.md
+++ b/docs/wiki/Services.md
@@ -1,0 +1,492 @@
+# Services
+
+TaskMate provides a comprehensive set of services that can be called from Home Assistant automations, scripts, and other integrations. All services are under the `taskmate` domain.
+
+## Chore Management
+
+### taskmate.complete_chore
+Mark a chore as completed by a child.
+
+**Parameters:**
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `chore_id` | String | Yes | The ID of the chore to complete |
+| `child_id` | String | Yes | The ID of the child completing the chore |
+
+**Example:**
+```yaml
+service: taskmate.complete_chore
+data:
+  chore_id: "chore_123"
+  child_id: "child_456"
+```
+
+**Notes:** Points are held until approved if approval is required. The chore will enter a pending state awaiting parent review.
+
+---
+
+### taskmate.approve_chore
+Approve a completed chore and award points to the child.
+
+**Parameters:**
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `completion_id` | String | Yes | The ID of the chore completion to approve |
+
+**Example:**
+```yaml
+service: taskmate.approve_chore
+data:
+  completion_id: "completion_789"
+```
+
+---
+
+### taskmate.reject_chore
+Reject a completed chore without awarding points.
+
+**Parameters:**
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `completion_id` | String | Yes | The ID of the chore completion to reject |
+
+**Example:**
+```yaml
+service: taskmate.reject_chore
+data:
+  completion_id: "completion_789"
+```
+
+---
+
+## Reward System
+
+### taskmate.claim_reward
+Allow a child to claim a reward using their points.
+
+**Parameters:**
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `reward_id` | String | Yes | The ID of the reward to claim |
+| `child_id` | String | Yes | The ID of the child claiming the reward |
+
+**Example:**
+```yaml
+service: taskmate.claim_reward
+data:
+  reward_id: "reward_123"
+  child_id: "child_456"
+```
+
+**Notes:** Points are not deducted until the claim is approved by a parent.
+
+---
+
+### taskmate.approve_reward
+Approve a pending reward claim and deduct points from the child.
+
+**Parameters:**
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `claim_id` | String | Yes | The ID of the reward claim to approve |
+
+**Example:**
+```yaml
+service: taskmate.approve_reward
+data:
+  claim_id: "claim_789"
+```
+
+---
+
+### taskmate.reject_reward
+Reject a pending reward claim without deducting points.
+
+**Parameters:**
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `claim_id` | String | Yes | The ID of the reward claim to reject |
+
+**Example:**
+```yaml
+service: taskmate.reject_reward
+data:
+  claim_id: "claim_789"
+```
+
+---
+
+## Point Adjustments
+
+### taskmate.add_points
+Award bonus points to a child.
+
+**Parameters:**
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `child_id` | String | Yes | The ID of the child to add points to |
+| `points` | Number | Yes | The number of points to add (1-10000) |
+| `reason` | String | No | Optional reason for the bonus |
+
+**Example:**
+```yaml
+service: taskmate.add_points
+data:
+  child_id: "child_456"
+  points: 25
+  reason: "Helped with yard work"
+```
+
+---
+
+### taskmate.remove_points
+Remove points from a child (penalty).
+
+**Parameters:**
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `child_id` | String | Yes | The ID of the child to remove points from |
+| `points` | Number | Yes | The number of points to remove (1-10000) |
+| `reason` | String | No | Optional reason for the penalty |
+
+**Example:**
+```yaml
+service: taskmate.remove_points
+data:
+  child_id: "child_456"
+  points: 10
+  reason: "Did not complete chore on time"
+```
+
+---
+
+## Chore Display Configuration
+
+### taskmate.set_chore_order
+Set the display order of chores for a specific child.
+
+**Parameters:**
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `child_id` | String | Yes | The ID of the child to set chore order for |
+| `chore_order` | Object | Yes | Ordered list of chore IDs |
+
+**Example:**
+```yaml
+service: taskmate.set_chore_order
+data:
+  child_id: "child_456"
+  chore_order:
+    - "chore_001"
+    - "chore_002"
+    - "chore_003"
+```
+
+---
+
+## Audio Preview
+
+### taskmate.preview_sound
+Preview a completion sound effect in the browser (useful for testing sounds).
+
+**Parameters:**
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `sound` | Select | Yes | The sound effect to preview |
+
+**Available Sounds:**
+- `none` - No sound
+- `coin` - Coin collection sound
+- `levelup` - Level up sound
+- `fanfare` - Fanfare trumpet sound
+- `chime` - Bell chime sound
+- `powerup` - Power-up sound
+- `undo` - Undo/retract sound
+- `fart1` through `fart10` - Various fart sound effects
+- `fart_random` - Random fart sound
+
+**Example:**
+```yaml
+service: taskmate.preview_sound
+data:
+  sound: "coin"
+```
+
+---
+
+## Penalty Management
+
+### taskmate.add_penalty
+Create a new penalty definition.
+
+**Parameters:**
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | String | Yes | The name of the penalty |
+| `points` | Number | Yes | Points deducted when applied (1-10000) |
+| `description` | String | No | Optional description of the penalty |
+| `icon` | String | No | MDI icon for the penalty |
+| `assigned_to` | Object | No | List of child IDs this penalty applies to (empty for all) |
+
+**Example:**
+```yaml
+service: taskmate.add_penalty
+data:
+  name: "Backtalk"
+  points: 5
+  description: "Talking back to parent"
+  icon: "mdi:close-circle"
+  assigned_to:
+    - "child_001"
+    - "child_002"
+```
+
+---
+
+### taskmate.update_penalty
+Update an existing penalty definition.
+
+**Parameters:**
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `penalty_id` | String | Yes | The ID of the penalty to update |
+| `name` | String | No | New name for the penalty |
+| `points` | Number | No | New points value |
+| `description` | String | No | New description |
+| `icon` | String | No | New icon |
+| `assigned_to` | Object | No | New list of assigned child IDs |
+
+**Example:**
+```yaml
+service: taskmate.update_penalty
+data:
+  penalty_id: "penalty_123"
+  points: 10
+  description: "Updated description for backtalk penalty"
+```
+
+---
+
+### taskmate.remove_penalty
+Remove a penalty definition.
+
+**Parameters:**
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `penalty_id` | String | Yes | The ID of the penalty to remove |
+
+**Example:**
+```yaml
+service: taskmate.remove_penalty
+data:
+  penalty_id: "penalty_123"
+```
+
+---
+
+### taskmate.apply_penalty
+Apply a penalty to a child, deducting points.
+
+**Parameters:**
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `penalty_id` | String | Yes | The ID of the penalty to apply |
+| `child_id` | String | Yes | The ID of the child to apply the penalty to |
+
+**Example:**
+```yaml
+service: taskmate.apply_penalty
+data:
+  penalty_id: "penalty_123"
+  child_id: "child_456"
+```
+
+---
+
+## Bonus Management
+
+### taskmate.add_bonus
+Create a new bonus definition.
+
+**Parameters:**
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | String | Yes | The name of the bonus |
+| `points` | Number | Yes | Points awarded when applied (1-10000) |
+| `description` | String | No | Optional description of the bonus |
+| `icon` | String | No | MDI icon for the bonus |
+| `assigned_to` | Object | No | List of child IDs this bonus applies to (empty for all) |
+
+**Example:**
+```yaml
+service: taskmate.add_bonus
+data:
+  name: "Perfect Week"
+  points: 25
+  description: "Completed all chores for the week"
+  icon: "mdi:star"
+  assigned_to:
+    - "child_001"
+    - "child_002"
+```
+
+---
+
+### taskmate.update_bonus
+Update an existing bonus definition.
+
+**Parameters:**
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `bonus_id` | String | Yes | The ID of the bonus to update |
+| `name` | String | No | New name for the bonus |
+| `points` | Number | No | New points value |
+| `description` | String | No | New description |
+| `icon` | String | No | New icon |
+| `assigned_to` | Object | No | New list of assigned child IDs |
+
+**Example:**
+```yaml
+service: taskmate.update_bonus
+data:
+  bonus_id: "bonus_123"
+  points: 50
+  description: "Updated to higher reward"
+```
+
+---
+
+### taskmate.remove_bonus
+Remove a bonus definition.
+
+**Parameters:**
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `bonus_id` | String | Yes | The ID of the bonus to remove |
+
+**Example:**
+```yaml
+service: taskmate.remove_bonus
+data:
+  bonus_id: "bonus_123"
+```
+
+---
+
+### taskmate.apply_bonus
+Apply a bonus to a child, awarding points.
+
+**Parameters:**
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `bonus_id` | String | Yes | The ID of the bonus to apply |
+| `child_id` | String | Yes | The ID of the child to apply the bonus to |
+
+**Example:**
+```yaml
+service: taskmate.apply_bonus
+data:
+  bonus_id: "bonus_123"
+  child_id: "child_456"
+```
+
+---
+
+## Dynamic Chore Creation
+
+### taskmate.add_chore
+Create a new chore dynamically from an automation or script. This is useful for creating just-in-time chores in response to Home Assistant events.
+
+**Parameters:**
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `name` | String | Yes | - | The name of the chore |
+| `description` | String | No | - | Optional description of the chore |
+| `points` | Number | No | 10 | Points awarded when completed (1-10000) |
+| `assigned_to` | Object | No | - | List of child IDs to assign to (empty assigns to all) |
+| `time_category` | Select | No | anytime | When the chore should be completed: `morning`, `afternoon`, `evening`, `night`, `anytime` |
+| `one_shot` | Boolean | No | false | If true, this is a one-time chore that expires after completion or at end of day |
+| `requires_approval` | Boolean | No | true | If true, a parent must approve completion before points are awarded |
+
+**Example - Simple Chore:**
+```yaml
+service: taskmate.add_chore
+data:
+  name: "Water the plants"
+  points: 15
+```
+
+**Example - One-Shot Chore:**
+```yaml
+service: taskmate.add_chore
+data:
+  name: "Pick up package at front door"
+  description: "Amazon delivery has arrived"
+  points: 20
+  one_shot: true
+  requires_approval: false
+  assigned_to:
+    - "child_001"
+```
+
+**Example - Time-Specific Chore:**
+```yaml
+service: taskmate.add_chore
+data:
+  name: "Pack lunch for school"
+  time_category: "morning"
+  points: 10
+  requires_approval: false
+```
+
+**Use Cases:**
+- Create a chore when a door sensor opens (packages have arrived)
+- Dynamic chores based on weather (water lawn only when temperature is moderate)
+- Time-limited chores for appointments or events
+- Chores triggered by presence changes (someone left home)
+- One-time urgent tasks as they arise
+
+---
+
+## Accessing Services
+
+### Home Assistant Developer Tools
+
+1. Go to **Developer Tools** > **Services** in Home Assistant
+2. Search for a service starting with `taskmate.`
+3. Fill in the parameters using the form or YAML editor
+4. Click **Call Service**
+
+### Automations and Scripts
+
+Include service calls in your automations or scripts:
+
+```yaml
+automation:
+  - alias: "Award bonus for early completion"
+    trigger:
+      platform: template
+      value_template: "{{ states('sensor.chore_completion_time') | int < 300 }}"
+    action:
+      service: taskmate.apply_bonus
+      data:
+        bonus_id: "bonus_speed"
+        child_id: "{{ states('input_select.current_child') }}"
+```
+
+### Button Entities
+
+Create automation-triggering buttons in Home Assistant for quick service calls:
+
+```yaml
+button:
+  - platform: template
+    buttons:
+      award_perfect_week:
+        friendly_name: "Award Perfect Week Bonus"
+        press:
+          service: taskmate.apply_bonus
+          data:
+            bonus_id: "bonus_perfect_week"
+            child_id: "{{ states('input_select.selected_child') }}"
+```


### PR DESCRIPTION
## Summary
- Add new **Bonuses** wiki page documenting the point-awarding system (mirrors Penalties) with overview, card configuration, management steps, use cases, and troubleshooting
- Update **Services** wiki page with 5 new services: `add_bonus`, `update_bonus`, `remove_bonus`, `apply_bonus`, and `add_chore` (dynamic chore creation)
- Covers all changes from v2.4.2 → v2.4.3-beta2

## Test plan
- [ ] Verify `docs/wiki/Bonuses.md` renders correctly on GitHub
- [ ] Verify `docs/wiki/Services.md` renders correctly on GitHub
- [ ] Confirm YAML examples for all new services are valid
- [ ] Sync `Bonuses.md` content to the GitHub wiki as a new "Bonuses" page
- [ ] Sync updated `Services.md` content to the existing "Services" wiki page

https://claude.ai/code/session_01TDSBsdL9r7X3V4aPyy5Zkn