### PR TITLE
chore: Nice to Have items (action pinning, Dependabot, README)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "ci"

--- a/.github/workflows/hassfest.yaml
+++ b/.github/workflows/hassfest.yaml
@@ -10,5 +10,5 @@ jobs:
   validate:
     runs-on: "ubuntu-latest"
     steps:
-      - uses: "actions/checkout@v3"
+      - uses: "actions/checkout@v4"
       - uses: home-assistant/actions/hassfest@master

--- a/README.md
+++ b/README.md
@@ -68,6 +68,15 @@ TaskMate is not yet in the HACS default store. Add it as a custom repository:
 2. Copy the `taskmate` folder to `/config/custom_components/taskmate/`
 3. **Restart Home Assistant**
  
+### Requirements
+
+- **Home Assistant** 2024.1 or newer
+- A modern browser for the dashboard cards: current Chrome, Firefox, Edge, or Safari. The cards use Web Components, Web Audio, and ES2020 features and will not work in Internet Explorer or pre-2022 browsers.
+
+### Privacy
+
+All TaskMate data — children, chores, points, reward claims, completion history — is stored inside your Home Assistant instance via HA's native storage helpers. Nothing is sent to any external service.
+
 ---
  
 ## Setup

--- a/custom_components/taskmate/models.py
+++ b/custom_components/taskmate/models.py
@@ -8,7 +8,13 @@ import uuid
 
 
 def generate_id() -> str:
-    """Generate a unique ID."""
+    """Generate a unique ID.
+
+    Returns the first 16 hex chars of a UUID4 (64 bits). Short enough to
+    use in dotted HA keys and service-call payloads without being unwieldy;
+    still provides ~1.8e19 values, far more than the entities a household
+    will ever create.
+    """
     return str(uuid.uuid4()).replace("-", "")[:16]
 
 


### PR DESCRIPTION
Batch 3 of 3: Nice to Have items from local review.

## Changes

- **Action pinning**: bumped `hassfest.yaml` from `actions/checkout@v3` → `@v4` so all three workflows are on the same major.
- **Dependabot**: added `.github/dependabot.yml` with a weekly `github-actions` update job so action versions don't drift again.
- **README**: added a Requirements section (HA 2024.1+, modern browser note — Web Components / Web Audio / ES2020) and a short Privacy callout stating data stays inside the HA instance.
- **Model docs**: `models.generate_id` now documents why the UUID is truncated to 16 hex chars (short enough for dotted HA keys and service payloads; still ~1.8e19 values).

## Verification
- `ruff check custom_components/taskmate tests` — clean.
- `pytest` — 146 passed.

## Items intentionally skipped from the Nice to Have list
- **Theme tokens / palette refactor** (#23) — skipped at your request.
- Typography / spacing harmonisation (#22), coordinator split (#24), lazy sound loading (#25), `will-change` hints (#26), global contrast sweep (#27), aria-live toast region (#28) — all subjective, invasive, or better done with live UI testing than static patching.
- Penalty/bonus screenshots (#32) — needs fresh screenshots I can't capture.

https://claude.ai/code/session_01B6mqdPJok57Chm1c5PnB1L