### PR TITLE
chore: add console version banner to bonuses, penalties, points-display cards

### DIFF
--- a/custom_components/taskmate/www/taskmate-bonuses-card.js
+++ b/custom_components/taskmate/www/taskmate-bonuses-card.js
@@ -681,3 +681,14 @@ window.customCards.push({
   description: "Apply point-awarding bonuses to children",
   preview: false,
 });
+
+// Version is injected by the HA resource URL (?v=x.x.x) and read from the DOM
+const _tmVersion = new URLSearchParams(
+  Array.from(document.querySelectorAll('script[src*="/taskmate-bonuses-card.js"]'))
+    .map(s => s.src.split("?")[1]).find(Boolean) || ""
+).get("v") || "?";
+console.info(
+  "%c TASKMATE BONUSES CARD %c v" + _tmVersion + " ",
+  "background:#f39c12;color:white;font-weight:bold;padding:2px 4px;border-radius:4px 0 0 4px;",
+  "background:#2c3e50;color:white;font-weight:bold;padding:2px 4px;border-radius:0 4px 4px 0;"
+);

--- a/custom_components/taskmate/www/taskmate-penalties-card.js
+++ b/custom_components/taskmate/www/taskmate-penalties-card.js
@@ -679,3 +679,14 @@ window.customCards.push({
   description: "Apply point-deduction penalties to children",
   preview: false,
 });
+
+// Version is injected by the HA resource URL (?v=x.x.x) and read from the DOM
+const _tmVersion = new URLSearchParams(
+  Array.from(document.querySelectorAll('script[src*="/taskmate-penalties-card.js"]'))
+    .map(s => s.src.split("?")[1]).find(Boolean) || ""
+).get("v") || "?";
+console.info(
+  "%c TASKMATE PENALTIES CARD %c v" + _tmVersion + " ",
+  "background:#922b21;color:white;font-weight:bold;padding:2px 4px;border-radius:4px 0 0 4px;",
+  "background:#2c3e50;color:white;font-weight:bold;padding:2px 4px;border-radius:0 4px 4px 0;"
+);

--- a/custom_components/taskmate/www/taskmate-points-display-card.js
+++ b/custom_components/taskmate/www/taskmate-points-display-card.js
@@ -988,3 +988,14 @@ window.customCards.push({
   preview:     true,
   configElement: "taskmate-points-display-card-editor",
 });
+
+// Version is injected by the HA resource URL (?v=x.x.x) and read from the DOM
+const _tmVersion = new URLSearchParams(
+  Array.from(document.querySelectorAll('script[src*="/taskmate-points-display-card.js"]'))
+    .map(s => s.src.split("?")[1]).find(Boolean) || ""
+).get("v") || "?";
+console.info(
+  "%c TASKMATE POINTS DISPLAY CARD %c v" + _tmVersion + " ",
+  "background:#566573;color:white;font-weight:bold;padding:2px 4px;border-radius:4px 0 0 4px;",
+  "background:#2c3e50;color:white;font-weight:bold;padding:2px 4px;border-radius:0 4px 4px 0;"
+);


### PR DESCRIPTION
## Summary

13 of 16 TaskMate cards print a coloured "TASKMATE <NAME> CARD v<x>" banner to the browser console on load — useful for confirming which version is cached. Three cards were missing it: **Bonuses**, **Penalties**, **Points Display**.

Added the same pattern to those three, with fresh accent colours not already used by the other 13:

| Card | Accent colour |
|------|---------------|
| `taskmate-bonuses-card.js` | `#f39c12` (gold) |
| `taskmate-penalties-card.js` | `#922b21` (deep red) |
| `taskmate-points-display-card.js` | `#566573` (steel grey) |

## Verification

- `node --check` on all three — parses.
- `ruff check` — clean.
- `pytest` — 146 passed.
- After loading the dashboard, every card (including the three that were silent before) will show its name + version in DevTools → Console, matching the screenshot behaviour.

https://claude.ai/code/session_01B6mqdPJok57Chm1c5PnB1L