### PR TITLE
chore: bump version to 2.4.3-beta3

### DIFF
--- a/custom_components/taskmate/manifest.json
+++ b/custom_components/taskmate/manifest.json
@@ -15,5 +15,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/tempus2016/taskmate/issues",
   "requirements": [],
-  "version": "2.4.3-beta2"
+  "version": "2.4.3-beta3"
 }


### PR DESCRIPTION
Single-file change: `manifest.json` version `2.4.3-beta2` → `2.4.3-beta3`.

Rolls up this session's merged PRs:

- #81 — critical bug fixes (Graph-card XSS, dead `SERVICE_RESET_DAILY`, silent service-call errors, `config-sounds` poll leak, `.github/.DS_Store` removed)
- #82 — Should Fix items (config-flow coordinator guard, narrowed translation-load error handling, Ruff CI + `pyproject.toml`, README image URLs, HA version sync, stale `translation_files/` deleted, issue-template wiki links repointed)
- #83 — Nice to Have items (Dependabot for Actions, `hassfest` action pinned, README Requirements + Privacy, `generate_id` rationale)
- #88 — console version banner added to Bonuses, Penalties, Points Display cards

`frontend.py` reads `manifest.json` at runtime to stamp `?v=…` on every card URL, so bumping just the manifest is enough — the per-card header comments (`* Version: 1.0.0` etc.) are historical notes, not a source of truth, and previous version bumps didn't touch them.

Tests: ruff clean; pytest 146 passed.

Release notes drafted separately for the GitHub release UI.

https://claude.ai/code/session_01B6mqdPJok57Chm1c5PnB1L