### PR TITLE
feat(rewards-card): contextual tooltips on disabled pool deposit buttons

### DIFF
--- a/custom_components/taskmate/www/locales/en-GB.json
+++ b/custom_components/taskmate/www/locales/en-GB.json
@@ -366,6 +366,9 @@
   "rewards.deposit_points": "Deposit {amount}",
   "rewards.add_all": "All",
   "rewards.pool_locked_note": "Allocations are locked — they can only be spent on this goal",
+  "rewards.deposit_disabled_no_child": "Select a child to deposit",
+  "rewards.deposit_disabled_insufficient": "Not enough spendable ({spendable} available)",
+  "rewards.deposit_disabled_loading": "Depositing…",
 
   "streak.card_name": "TaskMate Streaks & Achievements",
   "streak.card_description": "Consecutive day streaks and milestone badges for each child",

--- a/custom_components/taskmate/www/locales/en.json
+++ b/custom_components/taskmate/www/locales/en.json
@@ -366,6 +366,9 @@
   "rewards.deposit_points": "Deposit {amount}",
   "rewards.add_all": "All",
   "rewards.pool_locked_note": "Allocations are locked — they can only be spent on this goal",
+  "rewards.deposit_disabled_no_child": "Select a child to deposit",
+  "rewards.deposit_disabled_insufficient": "Not enough spendable ({spendable} available)",
+  "rewards.deposit_disabled_loading": "Depositing…",
 
   "streak.card_name": "TaskMate Streaks & Achievements",
   "streak.card_description": "Consecutive day streaks and milestone badges for each child",

--- a/custom_components/taskmate/www/taskmate-rewards-card.js
+++ b/custom_components/taskmate/www/taskmate-rewards-card.js
@@ -4,7 +4,7 @@
  * Shows rewards in a vertical list with star cost, name, description, and progress gauges.
  * Supports regular rewards, Jackpot rewards, and (v3.0+) Pool Mode "savings jar" rewards.
  *
- * Version: 0.0.8
+ * Version: 0.0.9
  * Last Updated: 2026-04-17
  */
 
@@ -1062,16 +1062,30 @@ class TaskMateRewardsCard extends LitElement {
     const amounts = [1, 5, 10];
     return html`
       <div class="allocation-controls">
-        ${amounts.map((amt) => html`
-          <button
-            class="alloc-btn"
-            ?disabled="${!child || spendable < amt || isAllocLoading}"
-            @click="${(e) => { e.stopPropagation(); this._handleAllocate(reward, child, amt); }}"
-            title="${this._t('rewards.deposit_points', { amount: amt })}"
-          >+${amt}</button>
-        `)}
+        ${amounts.map((amt) => {
+          const disabled = !child || spendable < amt || isAllocLoading;
+          const tooltip = this._depositTooltip({ child, spendable, amt, isAllocLoading });
+          return html`
+            <button
+              class="alloc-btn"
+              ?disabled="${disabled}"
+              @click="${(e) => { e.stopPropagation(); this._handleAllocate(reward, child, amt); }}"
+              title="${tooltip}"
+              aria-label="${tooltip}"
+            >+${amt}</button>
+          `;
+        })}
       </div>
     `;
+  }
+
+  _depositTooltip({ child, spendable, amt, isAllocLoading }) {
+    if (isAllocLoading) return this._t('rewards.deposit_disabled_loading');
+    if (!child) return this._t('rewards.deposit_disabled_no_child');
+    if (spendable < amt) {
+      return this._t('rewards.deposit_disabled_insufficient', { spendable });
+    }
+    return this._t('rewards.deposit_points', { amount: amt });
   }
 
   async _handleClaim(reward, child) {


### PR DESCRIPTION
## Summary

Each pool-mode `[+N]` deposit button now explains *why* it's disabled via a native `title` tooltip (and mirrored `aria-label` for screen readers):

- `"Select a child to deposit"` — no active child context
- `"Not enough spendable (X available)"` — child's spendable balance below the deposit amount
- `"Depositing…"` — previous allocation service call still in flight

Enabled buttons keep the existing `"Deposit {amount}"` tooltip. Logic is extracted into `_depositTooltip(...)` so the same rule drives both `title` and `aria-label` without duplication.

Follow-up to the v3.0.0-beta1 Pool Mode launch — addresses UX feedback that kids couldn't tell whether a greyed button meant "not enough points" or "something's broken."

## Changes

- `taskmate-rewards-card.js` — `_renderPoolControls` computes per-button tooltip; new `_depositTooltip` helper
- `locales/en.json` + `en-GB.json` — three new keys: `deposit_disabled_no_child`, `deposit_disabled_insufficient`, `deposit_disabled_loading`
- Card banner version bumped `0.0.8` → `0.0.9` for cache busting

No model, storage, coordinator, sensor, or service changes — pure frontend.

## Test plan

- [ ] Card with `enable_pool_mode: true` and no `child_id` → hover a deposit button → "Select a child to deposit"
- [ ] Child has 3 spendable points → hover `+5` → "Not enough spendable (3 available)"; hover `+1` → normal tooltip; `+1` clickable
- [ ] Click `+5` while service is running → momentarily shows "Depositing…"
- [ ] Screen reader announces the same message via `aria-label`
