### PR TITLE
fix(pool-mode): deduct points from child balance on allocation — v3.0.0-beta2

### DIFF
--- a/custom_components/taskmate/coordinator.py
+++ b/custom_components/taskmate/coordinator.py
@@ -901,7 +901,9 @@ class TaskMateCoordinator(DataUpdateCoordinator):
                 pool_filled = True
 
         if not pool_filled:
-            # Wallet mode: verify child has enough uncommitted points
+            # Wallet mode: verify child has enough uncommitted points.
+            # Pool allocations are already deducted from child.points at allocation time,
+            # so they don't need to be subtracted again here.
             pending_claims = self.storage.get_pending_reward_claims()
             committed = 0
             for c in pending_claims:
@@ -909,8 +911,6 @@ class TaskMateCoordinator(DataUpdateCoordinator):
                     pending_reward = self.get_reward(c.reward_id)
                     if pending_reward:
                         committed += pending_reward.cost
-            # Pool-allocated points are already reserved — count them as committed too
-            committed += self.storage.get_total_allocated_for_child(child_id)
             available_points = child.points - committed
 
             if available_points < effective_cost:
@@ -962,35 +962,17 @@ class TaskMateCoordinator(DataUpdateCoordinator):
                     is_pool_mode = True
 
                 if is_pool_mode:
-                    # Pool mode: each contributing child loses exactly their own allocation
-                    # from gross points. The allocation records are cleared.
+                    # Pool mode: points were already deducted from child.points at allocation
+                    # time — approving the redeem just clears the allocation record(s).
                     if reward.is_jackpot:
                         jackpot_allocs = [
                             a for a in self.storage.get_pool_allocations()
                             if a.reward_id == claim.reward_id and a.allocated_points > 0
                         ]
                         for alloc in jackpot_allocs:
-                            contrib_child = self.get_child(alloc.child_id)
-                            if contrib_child:
-                                contrib_child.points = max(
-                                    0, contrib_child.points - alloc.allocated_points
-                                )
-                                self.storage.update_child(contrib_child)
                             self.storage.remove_pool_allocation(alloc.child_id, alloc.reward_id)
                     else:
-                        # Regular reward: this child loses reward.cost from gross balance,
-                        # allocation is consumed.
-                        if child.points < effective_cost:
-                            raise ValueError(
-                                f"Not enough points to approve. Need {effective_cost}, have {child.points}"
-                            )
-                        child.points -= effective_cost
-                        self.storage.update_child(child)
-                        pool_alloc.allocated_points -= effective_cost
-                        if pool_alloc.allocated_points <= 0:
-                            self.storage.remove_pool_allocation(claim.child_id, claim.reward_id)
-                        else:
-                            self.storage.upsert_pool_allocation(pool_alloc)
+                        self.storage.remove_pool_allocation(claim.child_id, claim.reward_id)
                 else:
                     # Wallet mode: deduct directly from child.points
                     if child.points < effective_cost:
@@ -1019,8 +1001,10 @@ class TaskMateCoordinator(DataUpdateCoordinator):
     ) -> PoolAllocation:
         """Move `points` from a child's spendable balance into a reward pool.
 
-        Spendable balance = child.points − (committed pending claims) − (existing pool allocations).
-        Requested points are capped silently at the pool's remaining capacity.
+        Deducts immediately from child.points so the visible balance reflects the
+        commitment. The matching PoolAllocation record tracks the earmarked total
+        for each (child, reward) pair. Requested points are capped silently at the
+        pool's remaining capacity and the child's spendable balance.
         Allocations are locked — there is no matching "withdraw" operation.
         """
         child = self.get_child(child_id)
@@ -1034,7 +1018,9 @@ class TaskMateCoordinator(DataUpdateCoordinator):
         if points < 1:
             raise ValueError("Points to allocate must be at least 1")
 
-        # Compute this child's spendable balance (uncommitted, unallocated points)
+        # Spendable balance = child.points − points committed to other pending claims.
+        # (Already-allocated points are no longer part of child.points, so we do NOT
+        # subtract total_allocated here — they've been deducted at allocation time.)
         pending_claims = self.storage.get_pending_reward_claims()
         committed = 0
         for c in pending_claims:
@@ -1042,8 +1028,7 @@ class TaskMateCoordinator(DataUpdateCoordinator):
                 pending_reward = self.get_reward(c.reward_id)
                 if pending_reward:
                     committed += pending_reward.cost
-        total_allocated = self.storage.get_total_allocated_for_child(child_id)
-        spendable = child.points - committed - total_allocated
+        spendable = child.points - committed
 
         if spendable < 1:
             raise ValueError(f"No spendable points available for {child.name}")
@@ -1061,6 +1046,10 @@ class TaskMateCoordinator(DataUpdateCoordinator):
 
         capped_points = min(points, spendable, room_left)
 
+        # Deduct from the visible balance; the allocation record holds the earmarked points.
+        child.points -= capped_points
+        self.storage.update_child(child)
+
         allocation = PoolAllocation(
             child_id=child_id,
             reward_id=reward_id,
@@ -1069,7 +1058,7 @@ class TaskMateCoordinator(DataUpdateCoordinator):
         )
         self.storage.upsert_pool_allocation(allocation)
 
-        # Audit trail: negative transaction to show the reservation
+        # Audit trail: negative transaction showing the deduction
         transaction = PointsTransaction(
             child_id=child_id,
             points=-capped_points,

--- a/custom_components/taskmate/manifest.json
+++ b/custom_components/taskmate/manifest.json
@@ -15,5 +15,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/tempus2016/taskmate/issues",
   "requirements": [],
-  "version": "3.0.0-beta1"
+  "version": "3.0.0-beta2"
 }

--- a/custom_components/taskmate/sensor.py
+++ b/custom_components/taskmate/sensor.py
@@ -304,11 +304,11 @@ class TaskMateOverallStatsSensor(TaskMateBaseSensor):
                 "pending_points": pending_points_by_child.get(c.id, 0),
                 "committed_points": committed_points_by_child.get(c.id, 0),
                 "allocated_points": total_allocated_by_child.get(c.id, 0),
+                # Allocations are deducted from child.points at allocation time,
+                # so spendable only needs to account for pending-claim commitments.
                 "spendable_balance": max(
                     0,
-                    c.points
-                    - committed_points_by_child.get(c.id, 0)
-                    - total_allocated_by_child.get(c.id, 0),
+                    c.points - committed_points_by_child.get(c.id, 0),
                 ),
                 "chore_order": c.chore_order,
                 "current_streak": getattr(c, 'current_streak', 0) or 0,

--- a/custom_components/taskmate/storage.py
+++ b/custom_components/taskmate/storage.py
@@ -54,8 +54,53 @@ class TaskMateStorage:
 
         # Run data migrations
         await self._migrate_assigned_to_child_ids()
+        await self._migrate_pool_allocations_v2()
 
         return data
+
+    async def _migrate_pool_allocations_v2(self) -> None:
+        """Migrate beta1 pool allocations to beta2 semantics.
+
+        In v3.0.0-beta1, pool allocations did NOT deduct from child.points (the points
+        stayed in the gross balance until redeem). From beta2 onward, allocations deduct
+        immediately so the visible balance reflects commitment.
+
+        For existing installs: subtract each allocation's allocated_points from the
+        corresponding child's points, once. Guarded by a version flag so it runs only
+        on the first beta2 load.
+        """
+        if self._data.get("_pool_semantics_version", 1) >= 2:
+            return
+
+        allocations = self._data.get("pool_allocations", [])
+        children = self._data.get("children", [])
+        if not allocations or not children:
+            # Mark as migrated even if nothing to do
+            self._data["_pool_semantics_version"] = 2
+            await self.async_save()
+            return
+
+        # Build child lookup keyed by id
+        children_by_id = {c.get("id"): c for c in children}
+        adjusted = 0
+        for alloc in allocations:
+            child_data = children_by_id.get(alloc.get("child_id"))
+            if not child_data:
+                continue
+            allocated = int(alloc.get("allocated_points", 0) or 0)
+            if allocated <= 0:
+                continue
+            current_points = int(child_data.get("points", 0) or 0)
+            child_data["points"] = max(0, current_points - allocated)
+            adjusted += 1
+
+        self._data["_pool_semantics_version"] = 2
+        if adjusted:
+            _LOGGER.info(
+                "TaskMate: migrated %d pool allocation(s) to beta2 semantics "
+                "(points now deducted at allocation time)", adjusted
+            )
+        await self.async_save()
 
     async def _migrate_assigned_to_child_ids(self) -> None:
         """Migrate chore assigned_to from child names to child IDs if needed.

--- a/tests/test_coordinator_rewards.py
+++ b/tests/test_coordinator_rewards.py
@@ -201,7 +201,7 @@ class TestRejectReward:
 
 
 class TestAllocatePointsToPool:
-    def test_allocation_created_with_sufficient_spendable(self):
+    def test_allocation_deducts_from_child_points(self):
         child = _child(points=100)
         reward = _reward(cost=50)
         coord = _make_coord(children=[child], rewards=[reward])
@@ -209,31 +209,39 @@ class TestAllocatePointsToPool:
         assert alloc.child_id == "kid1"
         assert alloc.reward_id == "reward1"
         assert alloc.allocated_points == 30
+        # Child's visible balance drops by the allocated amount
+        assert child.points == 70
         coord.storage.upsert_pool_allocation.assert_called_once()
         coord.storage.add_points_transaction.assert_called_once()
 
-    def test_allocation_raises_when_insufficient_spendable(self):
+    def test_allocation_raises_when_no_spendable(self):
+        child = _child(points=0)
+        reward = _reward(cost=50)
+        coord = _make_coord(children=[child], rewards=[reward])
+        with pytest.raises(ValueError, match="spendable"):
+            run(coord.async_allocate_points_to_pool("kid1", "reward1", 5))
+
+    def test_allocation_capped_at_spendable(self):
+        # Child has 10, requests 30 — capped to 10
         child = _child(points=10)
         reward = _reward(cost=50)
         coord = _make_coord(children=[child], rewards=[reward])
-        # child has 10, but tries to allocate 30 — spendable too low
-        # Actually spendable=10 and we ask for 30 — capped would be 10, so it succeeds.
-        # Test truly-zero spendable: mock get_total_allocated_for_child to return child.points
-        coord.storage.get_total_allocated_for_child = MagicMock(return_value=10)
-        with pytest.raises(ValueError, match="spendable"):
-            run(coord.async_allocate_points_to_pool("kid1", "reward1", 5))
+        alloc = run(coord.async_allocate_points_to_pool("kid1", "reward1", 30))
+        assert alloc.allocated_points == 10
+        assert child.points == 0
 
     def test_allocation_capped_at_pool_capacity(self):
         child = _child(points=100)
         reward = _reward(cost=50)
-        # Existing allocation of 40 — only 10 room left
+        # Existing allocation of 40 — only 10 room left in the pool
         existing = PoolAllocation(child_id="kid1", reward_id="reward1", allocated_points=40)
         coord = _make_coord(children=[child], rewards=[reward])
         coord.storage.get_pool_allocation = MagicMock(return_value=existing)
-        coord.storage.get_total_allocated_for_child = MagicMock(return_value=40)
         # Ask for 20 but only 10 room left
         alloc = run(coord.async_allocate_points_to_pool("kid1", "reward1", 20))
         assert alloc.allocated_points == 50  # 40 existing + 10 capped
+        # Child only loses the 10 that actually went in
+        assert child.points == 90
 
     def test_allocation_raises_when_pool_full(self):
         child = _child(points=100)
@@ -241,7 +249,6 @@ class TestAllocatePointsToPool:
         existing = PoolAllocation(child_id="kid1", reward_id="reward1", allocated_points=50)
         coord = _make_coord(children=[child], rewards=[reward])
         coord.storage.get_pool_allocation = MagicMock(return_value=existing)
-        coord.storage.get_total_allocated_for_child = MagicMock(return_value=50)
         with pytest.raises(ValueError, match="already full"):
             run(coord.async_allocate_points_to_pool("kid1", "reward1", 5))
 
@@ -254,9 +261,13 @@ class TestAllocatePointsToPool:
 
 
 class TestPoolModeApproval:
-    def test_approval_in_pool_mode_deducts_from_gross_and_clears_allocation(self):
+    def test_approval_in_pool_mode_clears_allocation_without_double_deduction(self):
+        """In beta2, allocations already deducted points at allocation time, so approval
+        should NOT reduce child.points again — it only clears the allocation."""
         import datetime as dt
-        child = _child(points=100)
+        # Simulate the state AFTER allocation: child.points already dropped to 50,
+        # the allocation holds the 50 earmarked points.
+        child = _child(points=50)
         reward = _reward(cost=50)
         existing = PoolAllocation(child_id="kid1", reward_id="reward1", allocated_points=50)
         claim = RewardClaim(
@@ -266,7 +277,7 @@ class TestPoolModeApproval:
         coord = _make_coord(children=[child], rewards=[reward], claims=[claim])
         coord.storage.get_pool_allocation = MagicMock(return_value=existing)
         run(coord.async_approve_reward("claim1"))
-        # Child's gross balance drops by reward.cost
+        # Child's balance stays at 50 — no double deduction
         assert child.points == 50
-        # Allocation is cleared (fully consumed)
+        # Allocation is cleared
         coord.storage.remove_pool_allocation.assert_called_once()

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -362,3 +362,85 @@ class TestSettings:
         assert storage.get_points_icon() == "mdi:star"
         storage.set_points_icon("mdi:coin")
         assert storage.get_points_icon() == "mdi:coin"
+
+
+class TestPoolSemanticsV2Migration:
+    """Migration from v3.0.0-beta1 to beta2 pool allocation semantics.
+
+    In beta1, allocations did not deduct from child.points. In beta2, they do.
+    The migration subtracts each existing allocation from the corresponding child's
+    points once on first load.
+    """
+
+    def test_beta1_install_has_points_adjusted_on_upgrade(self):
+        existing = {
+            "children": [
+                {"id": "kid1", "name": "Alice", "points": 31,
+                 "total_points_earned": 100, "total_chores_completed": 5,
+                 "current_streak": 0, "best_streak": 0, "avatar": "mdi:account-circle",
+                 "pending_rewards": [], "chore_order": [],
+                 "last_completion_date": None, "streak_paused": False,
+                 "streak_milestones_achieved": [], "awarded_perfect_weeks": []},
+            ],
+            "chores": [],
+            "rewards": [],
+            "completions": [],
+            "reward_claims": [],
+            "points_transactions": [],
+            "pool_allocations": [
+                {"id": "a1", "child_id": "kid1", "reward_id": "r1", "allocated_points": 20},
+                {"id": "a2", "child_id": "kid1", "reward_id": "r2", "allocated_points": 5},
+            ],
+            "points_name": "Stars", "points_icon": "mdi:star",
+        }
+        storage = _make_storage(initial_data=existing)
+        run(storage.async_load())
+
+        # 31 − 20 − 5 = 6
+        assert storage._data["children"][0]["points"] == 6
+        assert storage._data["_pool_semantics_version"] == 2
+
+    def test_already_migrated_is_idempotent(self):
+        existing = {
+            "children": [
+                {"id": "kid1", "name": "Alice", "points": 10,
+                 "total_points_earned": 100, "total_chores_completed": 5,
+                 "current_streak": 0, "best_streak": 0, "avatar": "mdi:account-circle",
+                 "pending_rewards": [], "chore_order": [],
+                 "last_completion_date": None, "streak_paused": False,
+                 "streak_milestones_achieved": [], "awarded_perfect_weeks": []},
+            ],
+            "chores": [], "rewards": [], "completions": [],
+            "reward_claims": [], "points_transactions": [],
+            "pool_allocations": [
+                {"id": "a1", "child_id": "kid1", "reward_id": "r1", "allocated_points": 20},
+            ],
+            "points_name": "Stars", "points_icon": "mdi:star",
+            "_pool_semantics_version": 2,
+        }
+        storage = _make_storage(initial_data=existing)
+        run(storage.async_load())
+        # Points untouched because migration flag is already set
+        assert storage._data["children"][0]["points"] == 10
+
+    def test_zero_points_does_not_go_negative(self):
+        existing = {
+            "children": [
+                {"id": "kid1", "name": "Alice", "points": 5,
+                 "total_points_earned": 100, "total_chores_completed": 5,
+                 "current_streak": 0, "best_streak": 0, "avatar": "mdi:account-circle",
+                 "pending_rewards": [], "chore_order": [],
+                 "last_completion_date": None, "streak_paused": False,
+                 "streak_milestones_achieved": [], "awarded_perfect_weeks": []},
+            ],
+            "chores": [], "rewards": [], "completions": [],
+            "reward_claims": [], "points_transactions": [],
+            "pool_allocations": [
+                {"id": "a1", "child_id": "kid1", "reward_id": "r1", "allocated_points": 99},
+            ],
+            "points_name": "Stars", "points_icon": "mdi:star",
+        }
+        storage = _make_storage(initial_data=existing)
+        run(storage.async_load())
+        # max(0, 5 - 99) = 0
+        assert storage._data["children"][0]["points"] == 0


### PR DESCRIPTION
## Summary

Fixes confusing UX reported against v3.0.0-beta1: allocating points to a pool did **not** reduce the child's visible balance. The purple "Malia 31" card kept showing 31 points even after all 31 were committed to a pool.

## Semantics change (beta1 → beta2)

- **Allocation now deducts** from `child.points` immediately. The `PoolAllocation` record holds the earmarked total per (child, reward) pair.
- **Approval in pool mode no longer deducts** from `child.points` — the allocation record already accounted for the spent points. Approval just clears the allocation.
- **Wallet-mode approval is unchanged.**

This matches the natural mental model: *"I deposited 10 points into my LEGO jar, so my spendable balance went from 31 down to 21."*

## Migration

Existing beta1 installs get a one-time `_migrate_pool_allocations_v2` on first beta2 load. For each existing allocation it subtracts `allocated_points` from the corresponding `child.points` and stores a `_pool_semantics_version: 2` flag so it never re-runs. Handles edge cases: orphan allocations (child not found), zero allocations, points going below zero are floored at 0.

## Other changes

- Sensor `spendable_balance` no longer subtracts `allocated_points` (they're already out of `child.points`).
- Claim-reward wallet check no longer double-counts allocated points as committed.
- Updated tests for new semantics: **159 passing** (was 155 → +4 new, 2 adjusted).
- Version bumped `3.0.0-beta1` → `3.0.0-beta2`.

## Test plan

- [ ] Upgrade from beta1 with pool allocations → child's `points` drops by total allocated, allocations preserved
- [ ] On fresh beta2 install: deposit 10 into a pool → purple "Malia 31" card drops to 21 immediately, pool shows 10/50
- [ ] Fill a 50-point pool → Redeem → parent approves → allocation clears, `child.points` stays at its (already-reduced) value, no ghost deduction
- [ ] Jackpot flow: two children each deposit → approve → both allocations clear, neither child's points change on approval
- [ ] Wallet-mode cards (without `enable_pool_mode`) unchanged — claim + approve still deducts `reward.cost` from `child.points`
