### PR TITLE
feat(pool-mode): per-reward pool flag from the admin area — v3.0.0-beta3

### DIFF
--- a/custom_components/taskmate/config_flow.py
+++ b/custom_components/taskmate/config_flow.py
@@ -993,6 +993,7 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
                     icon=user_input.get("icon", "mdi:gift"),
                     assigned_to=user_input.get("assigned_to", []),
                     is_jackpot=user_input.get("is_jackpot", False),
+                    pool_enabled=user_input.get("pool_enabled", False),
                 )
                 return await self.async_step_manage_rewards()
 
@@ -1014,6 +1015,7 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
                 )
             ),
             vol.Optional("is_jackpot", default=False): selector.BooleanSelector(),
+            vol.Optional("pool_enabled", default=False): selector.BooleanSelector(),
             vol.Required("cost", default=50): selector.NumberSelector(
                 selector.NumberSelectorConfig(min=1, max=10000, mode=selector.NumberSelectorMode.BOX)
             ),
@@ -1057,6 +1059,9 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
                 reward.icon = user_input.get("icon", reward.icon)
                 reward.assigned_to = user_input.get("assigned_to", reward.assigned_to)
                 reward.is_jackpot = user_input.get("is_jackpot", reward.is_jackpot)
+                reward.pool_enabled = user_input.get(
+                    "pool_enabled", getattr(reward, "pool_enabled", False)
+                )
                 await self.coordinator.async_update_reward(reward)
                 return await self.async_step_manage_rewards()
 
@@ -1078,6 +1083,7 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
                 )
             ),
             vol.Optional("is_jackpot", default=getattr(reward, 'is_jackpot', False)): selector.BooleanSelector(),
+            vol.Optional("pool_enabled", default=getattr(reward, 'pool_enabled', False)): selector.BooleanSelector(),
             vol.Optional("cost", default=reward.cost): selector.NumberSelector(
                 selector.NumberSelectorConfig(min=1, max=10000, mode=selector.NumberSelectorMode.BOX)
             ),

--- a/custom_components/taskmate/coordinator.py
+++ b/custom_components/taskmate/coordinator.py
@@ -787,6 +787,7 @@ class TaskMateCoordinator(DataUpdateCoordinator):
         icon: str = "mdi:gift",
         assigned_to: list[str] | None = None,
         is_jackpot: bool = False,
+        pool_enabled: bool = False,
     ) -> Reward:
         """Add a new reward."""
         reward = Reward(
@@ -796,6 +797,7 @@ class TaskMateCoordinator(DataUpdateCoordinator):
             icon=icon,
             assigned_to=assigned_to or [],
             is_jackpot=is_jackpot,
+            pool_enabled=pool_enabled,
         )
         self.storage.add_reward(reward)
         await self.storage.async_save()

--- a/custom_components/taskmate/manifest.json
+++ b/custom_components/taskmate/manifest.json
@@ -15,5 +15,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/tempus2016/taskmate/issues",
   "requirements": [],
-  "version": "3.0.0-beta2"
+  "version": "3.0.0-beta3"
 }

--- a/custom_components/taskmate/models.py
+++ b/custom_components/taskmate/models.py
@@ -220,6 +220,7 @@ class Reward:
     icon: str = "mdi:gift"
     assigned_to: list[str] = field(default_factory=list)  # List of child IDs, empty means all children
     is_jackpot: bool = False  # If True, pool stars from all assigned children together
+    pool_enabled: bool = False  # If True, this reward uses pool-mode (savings jar) semantics
     id: str = field(default_factory=generate_id)
 
     @classmethod
@@ -232,6 +233,7 @@ class Reward:
             icon=data.get("icon", "mdi:gift"),
             assigned_to=list(data.get("assigned_to", [])),
             is_jackpot=data.get("is_jackpot", False),
+            pool_enabled=data.get("pool_enabled", False),
             id=data.get("id", generate_id()),
         )
 
@@ -244,6 +246,7 @@ class Reward:
             "icon": self.icon,
             "assigned_to": self.assigned_to,
             "is_jackpot": self.is_jackpot,
+            "pool_enabled": self.pool_enabled,
             "id": self.id,
         }
 

--- a/custom_components/taskmate/sensor.py
+++ b/custom_components/taskmate/sensor.py
@@ -274,6 +274,7 @@ class TaskMateOverallStatsSensor(TaskMateBaseSensor):
                 "icon": r.icon,
                 "assigned_to": r.assigned_to if isinstance(r.assigned_to, list) else [],
                 "is_jackpot": getattr(r, 'is_jackpot', False),
+                "pool_enabled": getattr(r, 'pool_enabled', False),
                 "calculated_costs": calculated_costs,
                 "pool_allocations": reward_pool_allocations,
                 "jackpot_pool_total": jackpot_pool_total,

--- a/custom_components/taskmate/strings.json
+++ b/custom_components/taskmate/strings.json
@@ -160,10 +160,12 @@
           "cost": "Points Cost (fixed)",
           "icon": "Icon",
           "assigned_to": "Assigned To (leave empty for all children)",
-          "is_jackpot": "Is Jackpot"
+          "is_jackpot": "Is Jackpot",
+          "pool_enabled": "Pool Reward (Savings Jar)"
         },
         "data_description": {
           "is_jackpot": "Pool points from all assigned children toward one shared reward",
+          "pool_enabled": "Children deposit points into this reward's dedicated pool rather than spending from their global balance. Good for long-term savings goals.",
           "cost": "Number of points required to claim this reward"
         }
       },
@@ -177,10 +179,12 @@
           "icon": "Icon",
           "assigned_to": "Assigned To",
           "is_jackpot": "Is Jackpot",
+          "pool_enabled": "Pool Reward (Savings Jar)",
           "action": "Action"
         },
         "data_description": {
           "is_jackpot": "Pool points from all assigned children toward one shared reward",
+          "pool_enabled": "Children deposit points into this reward's dedicated pool rather than spending from their global balance. Good for long-term savings goals.",
           "cost": "Number of points required to claim this reward"
         }
       },

--- a/custom_components/taskmate/translations/en-GB.json
+++ b/custom_components/taskmate/translations/en-GB.json
@@ -160,10 +160,12 @@
           "cost": "Points Cost (fixed)",
           "icon": "Icon",
           "assigned_to": "Assigned To (leave empty for all children)",
-          "is_jackpot": "Is Jackpot"
+          "is_jackpot": "Is Jackpot",
+          "pool_enabled": "Pool Reward (Savings Jar)"
         },
         "data_description": {
           "is_jackpot": "Pool points from all assigned children toward one shared reward",
+          "pool_enabled": "Children deposit points into this reward's dedicated pool rather than spending from their global balance. Good for long-term savings goals.",
           "cost": "Number of points required to claim this reward"
         }
       },
@@ -177,10 +179,12 @@
           "icon": "Icon",
           "assigned_to": "Assigned To",
           "is_jackpot": "Is Jackpot",
+          "pool_enabled": "Pool Reward (Savings Jar)",
           "action": "Action"
         },
         "data_description": {
           "is_jackpot": "Pool points from all assigned children toward one shared reward",
+          "pool_enabled": "Children deposit points into this reward's dedicated pool rather than spending from their global balance. Good for long-term savings goals.",
           "cost": "Number of points required to claim this reward"
         }
       },

--- a/custom_components/taskmate/translations/en.json
+++ b/custom_components/taskmate/translations/en.json
@@ -160,10 +160,12 @@
           "cost": "Points Cost (fixed)",
           "icon": "Icon",
           "assigned_to": "Assigned To (leave empty for all children)",
-          "is_jackpot": "Is Jackpot"
+          "is_jackpot": "Is Jackpot",
+          "pool_enabled": "Pool Reward (Savings Jar)"
         },
         "data_description": {
           "is_jackpot": "Pool points from all assigned children toward one shared reward",
+          "pool_enabled": "Children deposit points into this reward's dedicated pool rather than spending from their global balance. Good for long-term savings goals.",
           "cost": "Number of points required to claim this reward"
         }
       },
@@ -177,10 +179,12 @@
           "icon": "Icon",
           "assigned_to": "Assigned To",
           "is_jackpot": "Is Jackpot",
+          "pool_enabled": "Pool Reward (Savings Jar)",
           "action": "Action"
         },
         "data_description": {
           "is_jackpot": "Pool points from all assigned children toward one shared reward",
+          "pool_enabled": "Children deposit points into this reward's dedicated pool rather than spending from their global balance. Good for long-term savings goals.",
           "cost": "Number of points required to claim this reward"
         }
       },

--- a/custom_components/taskmate/www/taskmate-rewards-card.js
+++ b/custom_components/taskmate/www/taskmate-rewards-card.js
@@ -4,7 +4,7 @@
  * Shows rewards in a vertical list with star cost, name, description, and progress gauges.
  * Supports regular rewards, Jackpot rewards, and (v3.0+) Pool Mode "savings jar" rewards.
  *
- * Version: 0.1.1
+ * Version: 0.1.2
  * Last Updated: 2026-04-17
  */
 
@@ -844,9 +844,15 @@ class TaskMateRewardsCard extends LitElement {
       childMap[child.id] = child.name;
     });
 
-    const enablePoolMode = this.config.enable_pool_mode === true;
+    // Card-level override: when true, every reward on this card is treated as a pool reward.
+    // Otherwise each reward decides for itself via reward.pool_enabled.
+    const cardForcesPool = this.config.enable_pool_mode === true;
     const activeChildId = this.config.child_id || this._selectedChildId;
     const activeChild = activeChildId ? children.find((c) => c.id === activeChildId) : null;
+    // Show the spendable banner when any visible reward is in pool mode
+    const anyPoolReward = sortedRewards.some(
+      (r) => cardForcesPool || r.pool_enabled === true
+    );
 
     return html`
       <ha-card>
@@ -861,7 +867,7 @@ class TaskMateRewardsCard extends LitElement {
             : ""}
         </div>
 
-        ${enablePoolMode && activeChild ? this._renderSpendableBanner(activeChild, pointsIcon, pointsName) : ''}
+        ${anyPoolReward && activeChild ? this._renderSpendableBanner(activeChild, pointsIcon, pointsName) : ''}
 
         <div class="card-content">
           ${sortedRewards.length === 0
@@ -903,7 +909,9 @@ class TaskMateRewardsCard extends LitElement {
     const assignedTo = reward.assigned_to || [];
     const showChildBadges = this.config.show_child_badges !== false;
     const isJackpot = reward.is_jackpot || false;
-    const enablePoolMode = this.config.enable_pool_mode === true;
+    // Pool mode is enabled per-reward (reward.pool_enabled) OR forced on via card config.
+    const cardForcesPool = this.config.enable_pool_mode === true;
+    const enablePoolMode = cardForcesPool || reward.pool_enabled === true;
     // All costs are static — just use reward.cost
     const displayCost = this._getDisplayCost(reward, children);
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -209,6 +209,7 @@ class TestReward:
         assert reward.icon == "mdi:gift"
         assert reward.assigned_to == []
         assert reward.is_jackpot is False
+        assert reward.pool_enabled is False
 
     def test_roundtrip(self):
         reward = Reward(
@@ -218,13 +219,20 @@ class TestReward:
             icon="mdi:pizza",
             assigned_to=["child1"],
             is_jackpot=True,
+            pool_enabled=True,
             id="reward01",
         )
         restored = Reward.from_dict(reward.to_dict())
         assert restored.name == reward.name
         assert restored.cost == reward.cost
         assert restored.is_jackpot == reward.is_jackpot
+        assert restored.pool_enabled is True
         assert restored.id == reward.id
+
+    def test_legacy_missing_pool_enabled_defaults_to_false(self):
+        legacy = {"name": "Old reward", "cost": 20, "id": "r1"}
+        reward = Reward.from_dict(legacy)
+        assert reward.pool_enabled is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds a per-reward **Pool Reward (Savings Jar)** toggle in the admin area (Settings → Manage Rewards → Add/Edit Reward). Lets parents mark *individual* rewards as pool-mode, so "instant buy" treats and "savings goals" can coexist on the same rewards card.

Previously, pool mode was card-level only — enabling it on a card forced every reward into savings-jar behaviour. This didn't match the real-world mental model where a 10pt candy is an impulse buy and a 500pt LEGO set is a long-term goal.

## Changes

| File | Change |
| --- | --- |
| `models.py` | New `Reward.pool_enabled: bool = False` field |
| `coordinator.py` | `async_add_reward` accepts `pool_enabled` param |
| `config_flow.py` | Add/Edit Reward forms include a `BooleanSelector` with helper text |
| `sensor.py` | `rewards_list` entries expose `pool_enabled` |
| `taskmate-rewards-card.js` | Pool-mode decision made per reward; card-level `enable_pool_mode` still acts as an override |
| `strings.json` + `translations/en.json` + `en-GB.json` | New "Pool Reward (Savings Jar)" label and description |
| `tests/test_models.py` | Round-trip coverage for the new field (+1 test) |

## Backward compatibility

- **Existing rewards:** load with `pool_enabled=False` → continue as wallet-mode (unchanged behaviour)
- **Cards with `enable_pool_mode: true`:** still force ALL their rewards into pool mode (useful as a card-level preset)
- No storage version bump; no migration needed — missing field defaults to `False`

## Versions

- `manifest.json`: `3.0.0-beta2` → `3.0.0-beta3`
- rewards-card banner: `0.1.1` → `0.1.2`

## Test plan

- [ ] 160 tests pass (+1 new); ruff clean
- [ ] Admin → Manage Rewards → Add Reward → toggle "Pool Reward (Savings Jar)" → save. The new reward appears with deposit buttons on any rewards card (not just cards with `enable_pool_mode: true`).
- [ ] Edit an existing wallet reward → toggle on → save → it now shows deposit buttons; existing progress preserved
- [ ] Same card showing mixed rewards: pool-flagged reward shows deposit buttons + spendable banner; wallet reward shows Claim button. Both work correctly.
- [ ] Card-level `enable_pool_mode: true` still forces ALL rewards into pool mode
