### PR TITLE
fix(approvals): show reward claims + notify on claim — v3.0.0-beta4

### DIFF
--- a/custom_components/taskmate/coordinator.py
+++ b/custom_components/taskmate/coordinator.py
@@ -821,13 +821,35 @@ class TaskMateCoordinator(DataUpdateCoordinator):
     async def _async_notify_pending_approval(
         self, child_name: str, chore_name: str, points: int
     ) -> None:
-        """Fire a persistent notification and optional notify service when approval is needed."""
+        """Fire a persistent notification and optional notify service when a chore needs approval."""
         points_name = self.storage.get_points_name()
         message = (
             f"{child_name} completed '{chore_name}' (+{points} {points_name}) "
             f"and is waiting for your approval."
         )
+        notification_id = (
+            f"taskmate_approval_{child_name}_{chore_name}".replace(" ", "_").lower()
+        )
+        await self._async_fire_approval_notification(message, notification_id)
 
+    async def _async_notify_pending_reward_claim(
+        self, child_name: str, reward_name: str, cost: int
+    ) -> None:
+        """Fire a persistent notification and optional notify service when a reward claim needs approval."""
+        points_name = self.storage.get_points_name()
+        message = (
+            f"{child_name} claimed '{reward_name}' ({cost} {points_name}) "
+            f"and is waiting for your approval."
+        )
+        notification_id = (
+            f"taskmate_reward_claim_{child_name}_{reward_name}".replace(" ", "_").lower()
+        )
+        await self._async_fire_approval_notification(message, notification_id)
+
+    async def _async_fire_approval_notification(
+        self, message: str, notification_id: str
+    ) -> None:
+        """Shared helper: create a persistent notification and (optionally) call a notify.* service."""
         self.hass.async_create_task(
             self.hass.services.async_call(
                 "persistent_notification",
@@ -835,10 +857,7 @@ class TaskMateCoordinator(DataUpdateCoordinator):
                 {
                     "title": "TaskMate — Approval Needed",
                     "message": message,
-                    "notification_id": (
-                        f"taskmate_approval_{child_name}_{chore_name}"
-                        .replace(" ", "_").lower()
-                    ),
+                    "notification_id": notification_id,
                 },
                 blocking=False,
             )
@@ -929,6 +948,9 @@ class TaskMateCoordinator(DataUpdateCoordinator):
         self.storage.add_reward_claim(claim)
         await self.storage.async_save()
         await self.async_refresh()
+        await self._async_notify_pending_reward_claim(
+            child.name, reward.name, reward.cost
+        )
         return claim
 
     async def async_approve_reward(self, claim_id: str) -> None:

--- a/custom_components/taskmate/manifest.json
+++ b/custom_components/taskmate/manifest.json
@@ -15,5 +15,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/tempus2016/taskmate/issues",
   "requirements": [],
-  "version": "3.0.0-beta3"
+  "version": "3.0.0-beta4"
 }

--- a/custom_components/taskmate/www/locales/en-GB.json
+++ b/custom_components/taskmate/www/locales/en-GB.json
@@ -65,6 +65,7 @@
   "approvals.please_define_entity": "Please define an entity (pending_approvals sensor)",
   "approvals.all_caught_up": "All caught up!",
   "approvals.no_pending_approvals": "No pending approvals",
+  "approvals.reward_claims_section": "Reward claims",
   "approvals.approve": "Approve",
   "approvals.reject": "Reject",
   "approvals.error_title": "TaskMate Error",

--- a/custom_components/taskmate/www/locales/en.json
+++ b/custom_components/taskmate/www/locales/en.json
@@ -65,6 +65,7 @@
   "approvals.please_define_entity": "Please define an entity (pending_approvals sensor)",
   "approvals.all_caught_up": "All caught up!",
   "approvals.no_pending_approvals": "No pending approvals",
+  "approvals.reward_claims_section": "Reward claims",
   "approvals.approve": "Approve",
   "approvals.reject": "Reject",
   "approvals.error_title": "TaskMate Error",

--- a/custom_components/taskmate/www/taskmate-approvals-card.js
+++ b/custom_components/taskmate/www/taskmate-approvals-card.js
@@ -350,7 +350,16 @@ class TaskMateApprovalsCard extends LitElement {
     }
     const filteredCompletions = this._filterByChild(completions);
     const groupedByDay = this._groupByDay(filteredCompletions);
-    const totalPending = filteredCompletions.length;
+
+    // Pending reward claims: supported via either the pending_approvals sensor
+    // (reward_claims attribute) or the overview sensor (pending_reward_claims).
+    let rewardClaims =
+      entity.attributes.reward_claims ||
+      entity.attributes.pending_reward_claims ||
+      [];
+    const filteredClaims = this._filterClaimsByChild(rewardClaims);
+
+    const totalPending = filteredCompletions.length + filteredClaims.length;
 
     return html`
       <ha-card>
@@ -366,7 +375,10 @@ class TaskMateApprovalsCard extends LitElement {
         <div class="card-content">
           ${totalPending === 0
             ? this._renderEmptyState()
-            : this._renderApprovals(groupedByDay)}
+            : html`
+                ${filteredClaims.length > 0 ? this._renderRewardClaims(filteredClaims) : ''}
+                ${filteredCompletions.length > 0 ? this._renderApprovals(groupedByDay) : ''}
+              `}
         </div>
       </ha-card>
     `;
@@ -379,6 +391,103 @@ class TaskMateApprovalsCard extends LitElement {
     return completions.filter(
       (c) => c.child_id === this.config.child_id
     );
+  }
+
+  _filterClaimsByChild(claims) {
+    if (!this.config.child_id) return claims;
+    return claims.filter((c) => c.child_id === this.config.child_id);
+  }
+
+  _renderRewardClaims(claims) {
+    return html`
+      <div class="day-group">
+        <div class="day-header">
+          <ha-icon icon="mdi:gift-outline" style="--mdc-icon-size: 18px; vertical-align: -3px; margin-right: 6px;"></ha-icon>
+          ${this._t('approvals.reward_claims_section') || 'Reward claims'}
+        </div>
+        ${claims.map((claim) => this._renderClaimItem(claim))}
+      </div>
+    `;
+  }
+
+  _renderClaimItem(claim) {
+    const claimId = claim.claim_id || claim.id;
+    const isLoading = this._loading[claimId];
+    const rewardName = claim.reward_name || '';
+    const childName = claim.child_name || '';
+    const cost = claim.cost ?? 0;
+
+    return html`
+      <div class="approval-item ${isLoading ? 'loading' : ''}">
+        <div class="action-buttons left">
+          <button
+            class="action-button reject ${isLoading ? 'loading' : ''}"
+            @click="${() => this._handleRejectReward(claimId)}"
+            title="${this._t('approvals.reject')}"
+            ?disabled="${isLoading}"
+          >
+            <ha-icon icon="mdi:close"></ha-icon>
+          </button>
+        </div>
+        <div class="item-info">
+          <span class="chore-name">
+            <ha-icon icon="${claim.reward_icon || 'mdi:gift'}" style="--mdc-icon-size: 16px; vertical-align: -3px; margin-right: 4px;"></ha-icon>
+            ${rewardName}
+          </span>
+          <div class="item-details">
+            <span class="child-name">
+              <ha-icon icon="mdi:account"></ha-icon>
+              ${childName}
+            </span>
+            <span class="points-badge">
+              <ha-icon icon="mdi:star"></ha-icon>
+              ${cost}
+            </span>
+          </div>
+        </div>
+        <div class="action-buttons right">
+          <button
+            class="action-button approve ${isLoading ? 'loading' : ''}"
+            @click="${() => this._handleApproveReward(claimId)}"
+            title="${this._t('approvals.approve')}"
+            ?disabled="${isLoading}"
+          >
+            <ha-icon icon="mdi:check"></ha-icon>
+          </button>
+        </div>
+      </div>
+    `;
+  }
+
+  async _handleApproveReward(claimId) {
+    await this._callClaimService('approve_reward', claimId);
+  }
+
+  async _handleRejectReward(claimId) {
+    await this._callClaimService('reject_reward', claimId);
+  }
+
+  async _callClaimService(service, claimId) {
+    this._loading = { ...this._loading, [claimId]: true };
+    this.requestUpdate();
+    try {
+      await this.hass.callService('taskmate', service, { claim_id: claimId });
+    } catch (error) {
+      console.error(`Failed to call ${service}:`, error);
+      if (this.hass.callService) {
+        this.hass.callService('persistent_notification', 'create', {
+          title: this._t('approvals.error_title'),
+          message: this._t('approvals.error_failed_service', {
+            service: service.replace('_', ' '),
+            message: error.message,
+          }),
+          notification_id: `taskmate_error_${claimId}`,
+        });
+      }
+    } finally {
+      this._loading = { ...this._loading, [claimId]: false };
+      this.requestUpdate();
+    }
   }
 
   _groupByDay(completions) {


### PR DESCRIPTION
## Summary

Fixes two bugs the user reported against pool-mode redeems in v3.0.0-beta3:

1. **Pending Approvals card missed reward claims.** When a child tapped Redeem on a full pool (or Claim on a wallet reward), the pending claim never appeared in the TaskMate Approvals card — only in the separate Claims tab. Parents could easily miss it.
2. **No notification on claim.** `async_claim_reward` didn't fire any `persistent_notification` or `notify.*` call, so parents weren't alerted at all when a child tapped Redeem.

## Changes

### Approvals card (`taskmate-approvals-card.js`)

- Now renders a **"Reward claims"** section above the chore groups
- Pulls from `entity.attributes.reward_claims` (pending_approvals sensor) or `pending_reward_claims` (overview sensor)
- Same approve/reject UX as chore rows, but wires up the `approve_reward` / `reject_reward` services
- Pending count in the header reflects both chores and claims
- Child filter applies to both

### Coordinator (`coordinator.py`)

Split the notification helper so reward claims get the same treatment as chore approvals:
- `_async_fire_approval_notification(message, notification_id)` — shared transport
- `_async_notify_pending_approval(...)` — chore (unchanged public signature)
- `_async_notify_pending_reward_claim(child_name, reward_name, cost)` — **new**

Called at the end of `async_claim_reward`.

### Other

- `approvals.reward_claims_section` translation key (en, en-GB)
- `manifest.json`: `3.0.0-beta3` → `3.0.0-beta4`

## Test plan

- [ ] 160 tests pass; ruff clean
- [ ] Kid taps Redeem on a full pool → Pending Approvals card shows the claim with reward icon + name + child + cost + ✓/✗ buttons
- [ ] Same card still shows chore completions underneath
- [ ] Parent receives a `persistent_notification` *"X claimed 'Y' (Z points) and is waiting for your approval"*
- [ ] If `notify_service` is configured, that notification also fires
- [ ] Approve via the card → claim disappears, child points reconcile correctly (wallet or pool mode)
- [ ] Reject via the card → claim disappears, no point changes
- [ ] Child filter: card filtered to one child only shows that child's claims and chores
