### PR TITLE
ci: add HACS validation workflow

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,17 @@
+name: HACS Validation
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  hacs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: HACS validation
+        uses: hacs/action@main
+        with:
+          category: integration


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/validate.yml` running `hacs/action@main` with `category: integration`
- Triggers on push, PR, and a daily cron — matches the cadence of the existing hassfest workflow
- Required green check before submitting the integration to the HACS default repository

## Test plan
- [ ] Workflow appears under Actions and runs on this PR
- [ ] HACS validation passes
- [ ] hassfest continues to pass
