### PR TITLE
chore: roll manifest back to 3.0.0-beta4

### DIFF
--- a/custom_components/taskmate/manifest.json
+++ b/custom_components/taskmate/manifest.json
@@ -15,5 +15,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/tempus2016/taskmate/issues",
   "requirements": [],
-  "version": "3.0.0-beta5"
+  "version": "3.0.0-beta4"
 }


### PR DESCRIPTION
Superseded by #105 (manifest bumped to 3.0.1 directly). Closing as obsolete.