### PR TITLE
chore: bump manifest to 3.0.1

### DIFF
--- a/custom_components/taskmate/manifest.json
+++ b/custom_components/taskmate/manifest.json
@@ -15,5 +15,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/tempus2016/taskmate/issues",
   "requirements": [],
-  "version": "3.0.0"
+  "version": "3.0.1"
 }


### PR DESCRIPTION
## Summary
- Bumps `custom_components/taskmate/manifest.json` version from `3.0.0` to `3.0.1`
- Prepares main for the next patch release tag

## Test plan
- [ ] hassfest passes
- [ ] HACS validation passes
