### PR TITLE
feat(editors): ha-form + improved colour picker for 4 card editors

### DIFF
--- a/custom_components/taskmate/www/taskmate-approvals-card.js
+++ b/custom_components/taskmate/www/taskmate-approvals-card.js
@@ -760,33 +760,21 @@ class TaskMateApprovalsCardEditor extends LitElement {
 
   static get styles() {
     return css`
-      .form-group {
-        margin-bottom: 16px;
-      }
-
-      .form-group label {
-        display: block;
-        margin-bottom: 4px;
-        font-weight: 500;
-      }
-
-      .form-group input,
-      .form-group select {
-        width: 100%;
-        padding: 8px;
-        border: 1px solid var(--divider-color);
-        border-radius: 4px;
-        background: var(--card-background-color);
-        color: var(--primary-text-color);
-        font-size: 1em;
-      }
-
-      .form-group small {
-        display: block;
-        margin-top: 4px;
-        color: var(--secondary-text-color);
-        font-size: 0.85em;
-      }
+      :host { display: block; }
+      ha-form { display: block; margin-bottom: 16px; }
+      .colour-field { display: flex; flex-direction: column; gap: 8px; padding: 12px 16px; border: 1px solid var(--outline-color, var(--divider-color, #e0e0e0)); border-radius: 4px; background: var(--mdc-text-field-fill-color, var(--card-background-color)); }
+      .colour-field-label { font-size: 0.82rem; color: var(--primary-color); font-weight: 500; }
+      .colour-field-body { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }
+      .colour-swatch-wrapper { position: relative; width: 36px; height: 36px; border-radius: 50%; overflow: hidden; cursor: pointer; border: 2px solid var(--divider-color, #e0e0e0); flex-shrink: 0; }
+      .colour-swatch-wrapper input[type="color"] { position: absolute; inset: 0; opacity: 0; cursor: pointer; border: 0; padding: 0; }
+      .colour-swatch-preview { position: absolute; inset: 0; pointer-events: none; }
+      .colour-hex { font-family: var(--code-font-family, monospace); font-size: 0.85rem; color: var(--secondary-text-color); min-width: 70px; }
+      .colour-presets { display: flex; gap: 6px; flex-wrap: wrap; }
+      .preset-swatch { width: 22px; height: 22px; border-radius: 50%; cursor: pointer; border: 2px solid var(--divider-color, #e0e0e0); transition: transform 0.1s; padding: 0; }
+      .preset-swatch:hover { transform: scale(1.15); }
+      .preset-swatch.active { border-color: var(--primary-text-color); box-shadow: 0 0 0 2px var(--primary-color); }
+      .colour-reset { font-size: 0.78rem; color: var(--secondary-text-color); background: none; border: 1px solid var(--divider-color, #e0e0e0); border-radius: 4px; padding: 4px 10px; cursor: pointer; margin-left: auto; }
+      .colour-helper { color: var(--secondary-text-color); font-size: 0.82rem; line-height: 1.3; }
     `;
   }
 
@@ -794,75 +782,111 @@ class TaskMateApprovalsCardEditor extends LitElement {
     this.config = config;
   }
 
+  _buildSchema() {
+    const overviewEntity = this.config?.entity
+      ? this.hass?.states?.[this.config.entity]
+      : null;
+    const children = overviewEntity?.attributes?.children || [];
+    return [
+      { name: 'entity', selector: { entity: { domain: 'sensor' } } },
+      { name: 'title', selector: { text: {} } },
+      {
+        name: 'child_id',
+        selector: {
+          select: {
+            options: [
+              { value: '', label: this._t('common.editor.filter_by_child_all') },
+              ...children.map((c) => ({ value: c.id, label: c.name })),
+            ],
+            mode: 'dropdown',
+          },
+        },
+      },
+    ];
+  }
+
+  _computeLabel = (entry) => {
+    const labels = {
+      entity: this._t('common.entity'),
+      title: this._t('common.title'),
+      child_id: this._t('approvals.editor.child_id'),
+    };
+    return labels[entry.name] ?? entry.name;
+  };
+
+  _computeHelper = (entry) => {
+    const helpers = {
+      entity: this._t('approvals.editor.entity_helper'),
+      child_id: this._t('approvals.editor.child_id_helper'),
+    };
+    return helpers[entry.name] ?? '';
+  };
+
   render() {
-    if (!this.hass || !this.config) {
-      return html``;
-    }
-
+    if (!this.hass || !this.config) return html``;
+    const data = {
+      entity: this.config.entity || '',
+      title: this.config.title || '',
+      child_id: this.config.child_id || '',
+    };
     return html`
-      <div class="form-group">
-        <label>${this._t('common.entity')}</label>
-        <input
-          type="text"
-          .value="${this.config.entity || ""}"
-          @input="${this._entityChanged}"
-          placeholder="sensor.pending_approvals"
-        />
-        <small>${this._t('approvals.editor.entity_helper')}</small>
-      </div>
+      <ha-form
+        .hass=${this.hass}
+        .data=${data}
+        .schema=${this._buildSchema()}
+        .computeLabel=${this._computeLabel}
+        .computeHelper=${this._computeHelper}
+        @value-changed=${this._formChanged}
+      ></ha-form>
+      ${this._renderColourPicker('header_color', '#27ae60')}
+    `;
+  }
 
-      <div class="form-group">
-        <label>${this._t('common.title')}</label>
-        <input
-          type="text"
-          .value="${this.config.title || ""}"
-          @input="${this._titleChanged}"
-          placeholder="${this._t('approvals.default_title')}"
-        />
-      </div>
-
-      <div class="form-group">
-        <label>${this._t('approvals.editor.child_id')}</label>
-        <input
-          type="text"
-          .value="${this.config.child_id || ""}"
-          @input="${this._childIdChanged}"
-          placeholder="${this._t('approvals.editor.child_id_placeholder')}"
-        />
-        <small>${this._t('approvals.editor.child_id_helper')}</small>
-      </div>
-        <small>${this._t('common.editor.header_colour_helper')}</small>
-      </div>
-      <div class="field-row">
-        <label class="field-label">${this._t('common.editor.header_colour')}</label>
-        <div style="display:flex;align-items:center;gap:10px;">
-          <input
-            type="color"
-            .value=${this.config.header_color || '#27ae60'}
-            @input=${e => this._updateConfig('header_color', e.target.value)}
-            style="width:48px;height:36px;padding:2px;border:1px solid var(--divider-color,#e0e0e0);border-radius:6px;cursor:pointer;"
-          />
-          <span style="font-size:13px;color:var(--secondary-text-color);">${this.config.header_color || '#27ae60'}</span>
-          <button
-            style="font-size:11px;color:var(--secondary-text-color);background:none;border:1px solid var(--divider-color,#e0e0e0);border-radius:4px;padding:3px 8px;cursor:pointer;"
-            @click=${() => this._updateConfig('header_color', '#27ae60')}
+  _renderColourPicker(key, defaultValue) {
+    const current = this.config[key] || defaultValue;
+    const presets = [defaultValue, '#e67e22', '#3498db', '#9b59b6', '#f1c40f', '#e74c3c', '#34495e'];
+    const isActive = (c) => c.toLowerCase() === current.toLowerCase();
+    return html`
+      <div class="colour-field">
+        <span class="colour-field-label">${this._t('common.editor.header_colour')}</span>
+        <div class="colour-field-body">
+          <label class="colour-swatch-wrapper">
+            <input type="color" .value=${current}
+              @input=${(e) => this._updateConfig(key, e.target.value)} />
+            <span class="colour-swatch-preview" style="background:${current}"></span>
+          </label>
+          <span class="colour-hex">${current}</span>
+          <div class="colour-presets">
+            ${presets.map((p) => html`
+              <button class="preset-swatch ${isActive(p) ? 'active' : ''}"
+                style="background:${p}"
+                title=${p}
+                @click=${(e) => { e.preventDefault(); this._updateConfig(key, p); }}
+              ></button>
+            `)}
+          </div>
+          <button class="colour-reset"
+            @click=${(e) => { e.preventDefault(); this._updateConfig(key, defaultValue); }}
           >${this._t('common.reset')}</button>
         </div>
-        <span class="field-helper">${this._t('common.editor.header_colour_helper')}</span>
+        <div class="colour-helper">${this._t('common.editor.header_colour_helper')}</div>
       </div>
     `;
   }
 
-  _entityChanged(e) {
-    this._updateConfig("entity", e.target.value);
-  }
-
-  _titleChanged(e) {
-    this._updateConfig("title", e.target.value);
-  }
-
-  _childIdChanged(e) {
-    this._updateConfig("child_id", e.target.value || undefined);
+  _formChanged(e) {
+    const newValues = e.detail.value || {};
+    const newConfig = { ...this.config };
+    for (const [key, value] of Object.entries(newValues)) {
+      if (value === '' || value === null || value === undefined) {
+        delete newConfig[key];
+      } else {
+        newConfig[key] = value;
+      }
+    }
+    this.dispatchEvent(new CustomEvent('config-changed', {
+      detail: { config: newConfig }, bubbles: true, composed: true,
+    }));
   }
 
   _updateConfig(key, value) {

--- a/custom_components/taskmate/www/taskmate-child-card.js
+++ b/custom_components/taskmate/www/taskmate-child-card.js
@@ -1976,90 +1976,82 @@ class TaskMateChildCardEditor extends LitElement {
   static get styles() {
     return css`
       :host { display: block; padding: 4px 0; }
+      ha-form { display: block; margin-bottom: 16px; }
 
-      ha-textfield { width: 100%; margin-bottom: 8px; }
-
-      .field-row { margin-bottom: 16px; }
-
-      .field-label {
-        display: block;
-        font-size: 12px;
-        font-weight: 500;
-        color: var(--secondary-text-color);
-        text-transform: uppercase;
-        letter-spacing: 0.08em;
-        margin-bottom: 6px;
-        padding: 0 4px;
-      }
-
-      .field-select {
-        display: block;
-        width: 100%;
-        padding: 10px 12px;
-        border: 1px solid var(--divider-color, #e0e0e0);
+      .colour-field {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+        padding: 12px 16px;
+        border: 1px solid var(--outline-color, var(--divider-color, #e0e0e0));
         border-radius: 4px;
-        background: var(--card-background-color, #fff);
-        color: var(--primary-text-color);
-        font-size: 14px;
-        font-family: var(--mdc-typography-body1-font-family, Roboto, sans-serif);
-        box-sizing: border-box;
-        cursor: pointer;
-        appearance: auto;
-        transition: border-color 0.15s;
+        background: var(--mdc-text-field-fill-color, var(--card-background-color));
       }
-
-      .field-select:focus {
-        outline: none;
-        border-color: var(--primary-color, #3498db);
-        border-width: 2px;
+      .colour-field-label {
+        font-size: 0.82rem;
+        color: var(--primary-color);
+        font-weight: 500;
       }
-
-      .field-helper {
-        display: block;
-        font-size: 11px;
-        color: var(--secondary-text-color);
-        margin-top: 5px;
-        padding: 0 4px;
-        line-height: 1.4;
-      }
-
-      .check-row {
+      .colour-field-body {
         display: flex;
         align-items: center;
         gap: 12px;
-        padding: 10px 12px;
+        flex-wrap: wrap;
+      }
+      .colour-swatch-wrapper {
+        position: relative;
+        width: 36px;
+        height: 36px;
+        border-radius: 50%;
+        overflow: hidden;
+        cursor: pointer;
+        border: 2px solid var(--divider-color, #e0e0e0);
+        flex-shrink: 0;
+      }
+      .colour-swatch-wrapper input[type="color"] {
+        position: absolute;
+        inset: 0;
+        opacity: 0;
+        cursor: pointer;
+        border: 0;
+        padding: 0;
+      }
+      .colour-swatch-preview { position: absolute; inset: 0; pointer-events: none; }
+      .colour-hex {
+        font-family: var(--code-font-family, monospace);
+        font-size: 0.85rem;
+        color: var(--secondary-text-color);
+        min-width: 70px;
+      }
+      .colour-presets { display: flex; gap: 6px; flex-wrap: wrap; }
+      .preset-swatch {
+        width: 22px;
+        height: 22px;
+        border-radius: 50%;
+        cursor: pointer;
+        border: 2px solid var(--divider-color, #e0e0e0);
+        transition: transform 0.1s;
+        padding: 0;
+      }
+      .preset-swatch:hover { transform: scale(1.15); }
+      .preset-swatch.active {
+        border-color: var(--primary-text-color);
+        box-shadow: 0 0 0 2px var(--primary-color);
+      }
+      .colour-reset {
+        font-size: 0.78rem;
+        color: var(--secondary-text-color);
+        background: none;
         border: 1px solid var(--divider-color, #e0e0e0);
         border-radius: 4px;
-        background: var(--card-background-color, #fff);
+        padding: 4px 10px;
         cursor: pointer;
-        user-select: none;
-        margin-bottom: 4px;
-        transition: background 0.15s;
+        margin-left: auto;
       }
-
-      .check-row:hover { background: var(--secondary-background-color, #f5f5f5); }
-
-      .check-row input[type="checkbox"] {
-        width: 18px;
-        height: 18px;
-        cursor: pointer;
-        flex-shrink: 0;
-        accent-color: var(--primary-color, #3498db);
-        margin: 0;
-      }
-
-      .check-label {
-        font-size: 14px;
-        color: var(--primary-text-color);
-        font-family: var(--mdc-typography-body1-font-family, Roboto, sans-serif);
-        flex: 1;
+      .colour-helper {
+        color: var(--secondary-text-color);
+        font-size: 0.82rem;
         line-height: 1.3;
-      }
-
-      .section-divider {
-        height: 1px;
-        background: var(--divider-color, #e0e0e0);
-        margin: 16px 0;
       }
     `;
   }
@@ -2068,153 +2060,204 @@ class TaskMateChildCardEditor extends LitElement {
     this.config = config;
   }
 
-  render() {
-    if (!this.hass || !this.config) {
-      return html``;
-    }
-
-    // Get children from overview entity
-    const overviewEntity = this.hass.states[this.config.entity];
+  _buildSchema() {
+    const overviewEntity = this.config?.entity
+      ? this.hass?.states?.[this.config.entity]
+      : null;
     const children = overviewEntity?.attributes?.children || [];
 
+    return [
+      { name: 'entity', selector: { entity: { domain: 'sensor' } } },
+      {
+        name: 'child_id',
+        selector: {
+          select: {
+            options: [
+              { value: '', label: this._t('child.editor.select_child') },
+              ...children.map((c) => ({ value: c.id, label: c.name })),
+            ],
+            mode: 'dropdown',
+          },
+        },
+      },
+      {
+        name: 'time_category',
+        selector: {
+          select: {
+            options: [
+              { value: 'morning', label: this._t('child.editor.time_category_morning') },
+              { value: 'afternoon', label: this._t('child.editor.time_category_afternoon') },
+              { value: 'evening', label: this._t('child.editor.time_category_evening') },
+              { value: 'night', label: this._t('child.editor.time_category_night') },
+              { value: 'anytime', label: this._t('child.editor.time_category_anytime') },
+              { value: 'all', label: this._t('child.editor.time_category_all') },
+            ],
+            mode: 'dropdown',
+          },
+        },
+      },
+      {
+        name: 'due_days_mode',
+        selector: {
+          select: {
+            options: [
+              { value: 'hide', label: this._t('child.editor.due_days_hide') },
+              { value: 'dim', label: this._t('child.editor.due_days_dim') },
+              { value: 'show', label: this._t('child.editor.due_days_show') },
+            ],
+            mode: 'dropdown',
+          },
+        },
+      },
+      {
+        name: 'recurrence_done_mode',
+        selector: {
+          select: {
+            options: [
+              { value: 'dim', label: this._t('child.editor.recurrence_dim') },
+              { value: 'hide', label: this._t('child.editor.recurrence_hide') },
+              { value: 'show', label: this._t('child.editor.recurrence_show') },
+            ],
+            mode: 'dropdown',
+          },
+        },
+      },
+      {
+        name: 'elapsed_time_mode',
+        selector: {
+          select: {
+            options: [
+              { value: 'dim', label: this._t('child.editor.elapsed_dim') },
+              { value: 'hide', label: this._t('child.editor.elapsed_hide') },
+              { value: 'show', label: this._t('child.editor.elapsed_show') },
+            ],
+            mode: 'dropdown',
+          },
+        },
+      },
+      { name: 'show_countdown', selector: { boolean: {} } },
+      { name: 'show_description', selector: { boolean: {} } },
+      { name: 'debug', selector: { boolean: {} } },
+    ];
+  }
+
+  _computeLabel = (entry) => {
+    const labels = {
+      entity: this._t('common.editor.overview_entity'),
+      child_id: this._t('child.editor.child'),
+      time_category: this._t('child.editor.time_category'),
+      due_days_mode: this._t('child.editor.chores_not_due_today'),
+      recurrence_done_mode: this._t('child.editor.recurring_when_completed'),
+      elapsed_time_mode: this._t('child.editor.missed_time_chores'),
+      show_countdown: this._t('child.editor.show_countdown'),
+      show_description: this._t('child.editor.show_description'),
+      debug: this._t('child.editor.show_debug'),
+    };
+    return labels[entry.name] ?? entry.name;
+  };
+
+  _computeHelper = (entry) => {
+    const helpers = {
+      entity: this._t('common.editor.overview_entity_helper'),
+      child_id: this._t('child.editor.child_helper'),
+      time_category: this._t('child.editor.time_category_helper'),
+      due_days_mode: this._t('child.editor.due_days_helper'),
+      recurrence_done_mode: this._t('child.editor.recurrence_helper'),
+      elapsed_time_mode: this._t('child.editor.elapsed_helper'),
+    };
+    return helpers[entry.name] ?? '';
+  };
+
+  render() {
+    if (!this.hass || !this.config) return html``;
+
+    const data = {
+      entity: this.config.entity || '',
+      child_id: this.config.child_id || '',
+      time_category: this.config.time_category || 'morning',
+      due_days_mode: this.config.due_days_mode || 'hide',
+      recurrence_done_mode: this.config.recurrence_done_mode || 'dim',
+      elapsed_time_mode: this.config.elapsed_time_mode || 'dim',
+      show_countdown: this.config.show_countdown !== false,
+      show_description: this.config.show_description === true,
+      debug: this.config.debug === true,
+    };
+
     return html`
-      <ha-textfield
-        label="${this._t('common.editor.overview_entity')}"
-        .value="${this.config.entity || ''}"
-        @change="${this._entityChanged}"
-        helper="${this._t('common.editor.overview_entity_helper')}"
-        helperPersistent
-        placeholder="sensor.taskmate_overview"
-      ></ha-textfield>
+      <ha-form
+        .hass=${this.hass}
+        .data=${data}
+        .schema=${this._buildSchema()}
+        .computeLabel=${this._computeLabel}
+        .computeHelper=${this._computeHelper}
+        @value-changed=${this._formChanged}
+      ></ha-form>
+      ${this._renderColourPicker('header_color', '#9b59b6')}
+    `;
+  }
 
-      <div class="field-row">
-        <label class="field-label">${this._t('child.editor.child')}</label>
-        <select class="field-select" @change="${this._childIdChanged}">
-          <option value="">${this._t('child.editor.select_child')}</option>
-          ${children.map(child => html`
-            <option value="${child.id}" ?selected="${this.config.child_id === child.id}">${child.name}</option>
-          `)}
-        </select>
-        <span class="field-helper">${this._t('child.editor.child_helper')}</span>
-      </div>
-
-      <div class="field-row">
-        <label class="field-label">${this._t('child.editor.time_category')}</label>
-        <select class="field-select" @change="${this._timeCategoryChanged}">
-          <option value="morning" ?selected="${this.config.time_category === 'morning'}">${this._t('child.editor.time_category_morning')}</option>
-          <option value="afternoon" ?selected="${this.config.time_category === 'afternoon'}">${this._t('child.editor.time_category_afternoon')}</option>
-          <option value="evening" ?selected="${this.config.time_category === 'evening'}">${this._t('child.editor.time_category_evening')}</option>
-          <option value="night" ?selected="${this.config.time_category === 'night'}">${this._t('child.editor.time_category_night')}</option>
-          <option value="anytime" ?selected="${this.config.time_category === 'anytime'}">${this._t('child.editor.time_category_anytime')}</option>
-          <option value="all" ?selected="${this.config.time_category === 'all'}">${this._t('child.editor.time_category_all')}</option>
-        </select>
-        <span class="field-helper">${this._t('child.editor.time_category_helper')}</span>
-      </div>
-
-      <div class="field-row">
-        <label class="field-label">${this._t('child.editor.chores_not_due_today')}</label>
-        <select class="field-select" @change="${e => this._updateConfig('due_days_mode', e.target.value)}">
-          <option value="hide" ?selected="${(this.config.due_days_mode || 'hide') === 'hide'}">${this._t('child.editor.due_days_hide')}</option>
-          <option value="dim" ?selected="${this.config.due_days_mode === 'dim'}">${this._t('child.editor.due_days_dim')}</option>
-          <option value="show" ?selected="${this.config.due_days_mode === 'show'}">${this._t('child.editor.due_days_show')}</option>
-        </select>
-        <span class="field-helper">${this._t('child.editor.due_days_helper')}</span>
-      </div>
-
-      <div class="field-row">
-        <label class="field-label">${this._t('child.editor.recurring_when_completed')}</label>
-        <select class="field-select" @change="${e => this._updateConfig('recurrence_done_mode', e.target.value)}">
-          <option value="dim" ?selected="${(this.config.recurrence_done_mode || 'dim') === 'dim'}">${this._t('child.editor.recurrence_dim')}</option>
-          <option value="hide" ?selected="${this.config.recurrence_done_mode === 'hide'}">${this._t('child.editor.recurrence_hide')}</option>
-          <option value="show" ?selected="${this.config.recurrence_done_mode === 'show'}">${this._t('child.editor.recurrence_show')}</option>
-        </select>
-        <span class="field-helper">${this._t('child.editor.recurrence_helper')}</span>
-      </div>
-
-      <div class="field-row">
-        <label class="field-label">${this._t('child.editor.missed_time_chores')}</label>
-        <select class="field-select" @change="${e => this._updateConfig('elapsed_time_mode', e.target.value)}">
-          <option value="dim" ?selected="${(this.config.elapsed_time_mode || 'dim') === 'dim'}">${this._t('child.editor.elapsed_dim')}</option>
-          <option value="hide" ?selected="${this.config.elapsed_time_mode === 'hide'}">${this._t('child.editor.elapsed_hide')}</option>
-          <option value="show" ?selected="${this.config.elapsed_time_mode === 'show'}">${this._t('child.editor.elapsed_show')}</option>
-        </select>
-        <span class="field-helper">${this._t('child.editor.elapsed_helper')}</span>
-      </div>
-
-      <div class="section-divider"></div>
-
-      <label class="check-row">
-        <input type="checkbox"
-          ?checked="${this.config.show_countdown !== false}"
-          @change="${e => this._updateConfig('show_countdown', e.target.checked)}"
-        />
-        <span class="check-label">${this._t('child.editor.show_countdown')}</span>
-      </label>
-
-      <label class="check-row">
-        <input type="checkbox"
-          ?checked="${this.config.show_description === true}"
-          @change="${e => this._updateConfig('show_description', e.target.checked)}"
-        />
-        <span class="check-label">${this._t('child.editor.show_description')}</span>
-      </label>
-
-      <label class="check-row">
-        <input type="checkbox"
-          ?checked="${this.config.debug === true}"
-          @change="${this._debugChanged}"
-        />
-        <span class="check-label">${this._t('child.editor.show_debug')}</span>
-      </label>
-        <span class="field-helper">${this._t('common.editor.header_colour_helper')}</span>
-      </div>
-      <div class="field-row">
-        <label class="field-label">${this._t('common.editor.header_colour')}</label>
-        <div style="display:flex;align-items:center;gap:10px;">
-          <input
-            type="color"
-            .value=${this.config.header_color || '#9b59b6'}
-            @input=${e => this._updateConfig('header_color', e.target.value)}
-            style="width:48px;height:36px;padding:2px;border:1px solid var(--divider-color,#e0e0e0);border-radius:6px;cursor:pointer;"
-          />
-          <span style="font-size:13px;color:var(--secondary-text-color);">${this.config.header_color || '#9b59b6'}</span>
-          <button
-            style="font-size:11px;color:var(--secondary-text-color);background:none;border:1px solid var(--divider-color,#e0e0e0);border-radius:4px;padding:3px 8px;cursor:pointer;"
-            @click=${() => this._updateConfig('header_color', '#9b59b6')}
+  _renderColourPicker(key, defaultValue) {
+    const current = this.config[key] || defaultValue;
+    const presets = ['#9b59b6', '#e67e22', '#27ae60', '#3498db', '#f1c40f', '#e74c3c', '#34495e'];
+    const isActive = (c) => c.toLowerCase() === current.toLowerCase();
+    return html`
+      <div class="colour-field">
+        <span class="colour-field-label">${this._t('common.editor.header_colour')}</span>
+        <div class="colour-field-body">
+          <label class="colour-swatch-wrapper">
+            <input type="color" .value=${current}
+              @input=${(e) => this._updateConfig(key, e.target.value)} />
+            <span class="colour-swatch-preview" style="background:${current}"></span>
+          </label>
+          <span class="colour-hex">${current}</span>
+          <div class="colour-presets">
+            ${presets.map((p) => html`
+              <button class="preset-swatch ${isActive(p) ? 'active' : ''}"
+                style="background:${p}"
+                title=${p}
+                @click=${(e) => { e.preventDefault(); this._updateConfig(key, p); }}
+              ></button>
+            `)}
+          </div>
+          <button class="colour-reset"
+            @click=${(e) => { e.preventDefault(); this._updateConfig(key, defaultValue); }}
           >${this._t('common.reset')}</button>
         </div>
-        <span class="field-helper">${this._t('common.editor.header_colour_helper')}</span>
+        <div class="colour-helper">${this._t('common.editor.header_colour_helper')}</div>
       </div>
     `;
   }
 
-  _entityChanged(e) {
-    this._updateConfig("entity", e.target.value);
-  }
-
-  _childIdChanged(e) {
-    this._updateConfig("child_id", e.target.value);
-  }
-
-  _timeCategoryChanged(e) {
-    this._updateConfig("time_category", e.target.value);
-  }
-
-  _debugChanged(e) {
-    this._updateConfig("debug", e.target.checked);
+  _formChanged(e) {
+    const newValues = e.detail.value || {};
+    const newConfig = { ...this.config };
+    for (const [key, value] of Object.entries(newValues)) {
+      const defaults = {
+        show_countdown: true, show_description: false, debug: false,
+        time_category: 'morning', due_days_mode: 'hide',
+        recurrence_done_mode: 'dim', elapsed_time_mode: 'dim',
+      };
+      if (value === '' || value === null || value === undefined) {
+        delete newConfig[key];
+      } else if (defaults[key] !== undefined && value === defaults[key]) {
+        delete newConfig[key];
+      } else {
+        newConfig[key] = value;
+      }
+    }
+    this._dispatchConfig(newConfig);
   }
 
   _updateConfig(key, value) {
     const newConfig = { ...this.config, [key]: value };
-    if (value === undefined || value === "") {
-      delete newConfig[key];
-    }
-    const event = new CustomEvent("config-changed", {
-      detail: { config: newConfig },
-      bubbles: true,
-      composed: true,
-    });
-    this.dispatchEvent(event);
+    if (value === undefined || value === '') delete newConfig[key];
+    this._dispatchConfig(newConfig);
+  }
+
+  _dispatchConfig(newConfig) {
+    this.dispatchEvent(new CustomEvent('config-changed', {
+      detail: { config: newConfig }, bubbles: true, composed: true,
+    }));
   }
 }
 

--- a/custom_components/taskmate/www/taskmate-points-card.js
+++ b/custom_components/taskmate/www/taskmate-points-card.js
@@ -947,18 +947,24 @@ class TaskMatePointsCardEditor extends LitElement {
   static get styles() {
     return css`
       :host { display: block; padding: 4px 0; }
-      ha-textfield { width: 100%; margin-bottom: 8px; }
-      .field-row { margin-bottom: 16px; }
-      .field-label { display: block; font-size: 12px; font-weight: 500; color: var(--secondary-text-color); text-transform: uppercase; letter-spacing: 0.08em; margin-bottom: 6px; padding: 0 4px; }
-      .field-helper { display: block; font-size: 11px; color: var(--secondary-text-color); margin-top: 5px; padding: 0 4px; line-height: 1.4; }
-      .section-divider { height: 1px; background: var(--divider-color, #e0e0e0); margin: 16px 0; }
-      .check-row { display: flex; align-items: center; gap: 12px; padding: 10px 12px; border: 1px solid var(--divider-color, #e0e0e0); border-radius: 4px; background: var(--card-background-color, #fff); cursor: pointer; user-select: none; margin-bottom: 4px; }
-      .check-row input[type="checkbox"] { width: 18px; height: 18px; cursor: pointer; flex-shrink: 0; accent-color: var(--primary-color, #3498db); margin: 0; }
-      .check-label { font-size: 14px; color: var(--primary-text-color); flex: 1; }
-      .amounts-preview { display: flex; flex-wrap: wrap; gap: 5px; margin-top: 8px; }
+      ha-form { display: block; margin-bottom: 16px; }
+      .amounts-preview { display: flex; flex-wrap: wrap; gap: 5px; margin: 4px 0 16px; }
       .preview-btn { padding: 3px 9px; border-radius: 6px; font-size: 0.8rem; font-weight: 700; border: none; }
       .preview-btn.add { background: #43a047; color: white; }
       .preview-btn.remove { background: #e53935; color: white; }
+      .colour-field { display: flex; flex-direction: column; gap: 8px; padding: 12px 16px; border: 1px solid var(--outline-color, var(--divider-color, #e0e0e0)); border-radius: 4px; background: var(--mdc-text-field-fill-color, var(--card-background-color)); }
+      .colour-field-label { font-size: 0.82rem; color: var(--primary-color); font-weight: 500; }
+      .colour-field-body { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }
+      .colour-swatch-wrapper { position: relative; width: 36px; height: 36px; border-radius: 50%; overflow: hidden; cursor: pointer; border: 2px solid var(--divider-color, #e0e0e0); flex-shrink: 0; }
+      .colour-swatch-wrapper input[type="color"] { position: absolute; inset: 0; opacity: 0; cursor: pointer; border: 0; padding: 0; }
+      .colour-swatch-preview { position: absolute; inset: 0; pointer-events: none; }
+      .colour-hex { font-family: var(--code-font-family, monospace); font-size: 0.85rem; color: var(--secondary-text-color); min-width: 70px; }
+      .colour-presets { display: flex; gap: 6px; flex-wrap: wrap; }
+      .preset-swatch { width: 22px; height: 22px; border-radius: 50%; cursor: pointer; border: 2px solid var(--divider-color, #e0e0e0); transition: transform 0.1s; padding: 0; }
+      .preset-swatch:hover { transform: scale(1.15); }
+      .preset-swatch.active { border-color: var(--primary-text-color); box-shadow: 0 0 0 2px var(--primary-color); }
+      .colour-reset { font-size: 0.78rem; color: var(--secondary-text-color); background: none; border: 1px solid var(--divider-color, #e0e0e0); border-radius: 4px; padding: 4px 10px; cursor: pointer; margin-left: auto; }
+      .colour-helper { color: var(--secondary-text-color); font-size: 0.82rem; line-height: 1.3; }
     `;
   }
 
@@ -973,89 +979,118 @@ class TaskMatePointsCardEditor extends LitElement {
     return Array.isArray(arr) ? arr.join(', ') : '';
   }
 
+  _buildSchema() {
+    return [
+      { name: 'entity', selector: { entity: { domain: 'sensor' } } },
+      { name: 'title', selector: { text: {} } },
+      { name: 'quick_add_amounts', selector: { text: {} } },
+      { name: 'quick_remove_amounts', selector: { text: {} } },
+      { name: 'show_dialog', selector: { boolean: {} } },
+    ];
+  }
+
+  _computeLabel = (entry) => {
+    const labels = {
+      entity: this._t('points_card.editor.entity_label'),
+      title: this._t('points_card.editor.title_label'),
+      quick_add_amounts: this._t('points_card.editor.add_buttons_label'),
+      quick_remove_amounts: this._t('points_card.editor.remove_buttons_label'),
+      show_dialog: this._t('points_card.editor.show_dialog_label'),
+    };
+    return labels[entry.name] ?? entry.name;
+  };
+
+  _computeHelper = (entry) => {
+    const helpers = {
+      entity: this._t('points_card.editor.entity_helper'),
+      quick_add_amounts: this._t('points_card.editor.add_buttons_helper'),
+      quick_remove_amounts: this._t('points_card.editor.remove_buttons_helper'),
+    };
+    return helpers[entry.name] ?? '';
+  };
+
   render() {
     if (!this.hass || !this.config) return html``;
 
     const addAmounts = this.config.quick_add_amounts || [1, 5, 10];
     const removeAmounts = this.config.quick_remove_amounts || [1, 5, 10];
 
+    const data = {
+      entity: this.config.entity || '',
+      title: this.config.title || '',
+      quick_add_amounts: this._amountsToString(addAmounts),
+      quick_remove_amounts: this._amountsToString(removeAmounts),
+      show_dialog: this.config.show_dialog !== false,
+    };
+
     return html`
-      <ha-textfield
-        label="${this._t('points_card.editor.entity_label')}"
-        .value="${this.config.entity || ''}"
-        @change="${e => this._updateConfig('entity', e.target.value)}"
-        helper="${this._t('points_card.editor.entity_helper')}"
-        helperPersistent
-        placeholder="sensor.taskmate_overview"
-      ></ha-textfield>
-
-      <ha-textfield
-        label="${this._t('points_card.editor.title_label')}"
-        .value="${this.config.title || ''}"
-        @change="${e => this._updateConfig('title', e.target.value)}"
-        placeholder="Manage Points"
-      ></ha-textfield>
-
-      <div class="section-divider"></div>
-
-      <div class="field-row">
-        <label class="field-label">${this._t('points_card.editor.add_buttons_label')}</label>
-        <ha-textfield
-          .value="${this._amountsToString(addAmounts)}"
-          @change="${e => this._updateConfig('quick_add_amounts', this._parseAmounts(e.target.value, [1,5,10]))}"
-          helper="${this._t('points_card.editor.add_buttons_helper')}"
-          helperPersistent
-          placeholder="1, 5, 10"
-          style="width:100%;"
-        ></ha-textfield>
-        <div class="amounts-preview">
-          ${addAmounts.map(a => html`<span class="preview-btn add">+${a}</span>`)}
-        </div>
+      <ha-form
+        .hass=${this.hass}
+        .data=${data}
+        .schema=${this._buildSchema()}
+        .computeLabel=${this._computeLabel}
+        .computeHelper=${this._computeHelper}
+        @value-changed=${this._formChanged}
+      ></ha-form>
+      <div class="amounts-preview">
+        ${addAmounts.map(a => html`<span class="preview-btn add">+${a}</span>`)}
+        ${removeAmounts.map(a => html`<span class="preview-btn remove">−${a}</span>`)}
       </div>
+      ${this._renderColourPicker('header_color', '#2980b9')}
+    `;
+  }
 
-      <div class="field-row">
-        <label class="field-label">${this._t('points_card.editor.remove_buttons_label')}</label>
-        <ha-textfield
-          .value="${this._amountsToString(removeAmounts)}"
-          @change="${e => this._updateConfig('quick_remove_amounts', this._parseAmounts(e.target.value, [1,5,10]))}"
-          helper="${this._t('points_card.editor.remove_buttons_helper')}"
-          helperPersistent
-          placeholder="1, 5, 10"
-          style="width:100%;"
-        ></ha-textfield>
-        <div class="amounts-preview">
-          ${removeAmounts.map(a => html`<span class="preview-btn remove">−${a}</span>`)}
-        </div>
-      </div>
-
-      <label class="check-row">
-        <input type="checkbox"
-          ?checked="${this.config.show_dialog !== false}"
-          @change="${e => this._updateConfig('show_dialog', e.target.checked)}"
-        />
-        <span class="check-label">${this._t('points_card.editor.show_dialog_label')}</span>
-      </label>
-
-      <div class="section-divider"></div>
-
-      <div class="field-row">
-        <label class="field-label">${this._t('points_card.editor.header_colour_label')}</label>
-        <div style="display:flex;align-items:center;gap:10px;">
-          <input
-            type="color"
-            .value=${this.config.header_color || '#2980b9'}
-            @input=${e => this._updateConfig('header_color', e.target.value)}
-            style="width:48px;height:36px;padding:2px;border:1px solid var(--divider-color,#e0e0e0);border-radius:6px;cursor:pointer;"
-          />
-          <span style="font-size:13px;color:var(--secondary-text-color);">${this.config.header_color || '#2980b9'}</span>
-          <button
-            style="font-size:11px;color:var(--secondary-text-color);background:none;border:1px solid var(--divider-color,#e0e0e0);border-radius:4px;padding:3px 8px;cursor:pointer;"
-            @click=${() => this._updateConfig('header_color', '#2980b9')}
+  _renderColourPicker(key, defaultValue) {
+    const current = this.config[key] || defaultValue;
+    const presets = [defaultValue, '#e67e22', '#27ae60', '#9b59b6', '#f1c40f', '#e74c3c', '#34495e'];
+    const isActive = (c) => c.toLowerCase() === current.toLowerCase();
+    return html`
+      <div class="colour-field">
+        <span class="colour-field-label">${this._t('common.editor.header_colour')}</span>
+        <div class="colour-field-body">
+          <label class="colour-swatch-wrapper">
+            <input type="color" .value=${current}
+              @input=${(e) => this._updateConfig(key, e.target.value)} />
+            <span class="colour-swatch-preview" style="background:${current}"></span>
+          </label>
+          <span class="colour-hex">${current}</span>
+          <div class="colour-presets">
+            ${presets.map((p) => html`
+              <button class="preset-swatch ${isActive(p) ? 'active' : ''}"
+                style="background:${p}"
+                title=${p}
+                @click=${(e) => { e.preventDefault(); this._updateConfig(key, p); }}
+              ></button>
+            `)}
+          </div>
+          <button class="colour-reset"
+            @click=${(e) => { e.preventDefault(); this._updateConfig(key, defaultValue); }}
           >${this._t('common.reset')}</button>
         </div>
-        <span class="field-helper">${this._t('points_card.editor.header_colour_helper')}</span>
+        <div class="colour-helper">${this._t('common.editor.header_colour_helper')}</div>
       </div>
     `;
+  }
+
+  _formChanged(e) {
+    const newValues = e.detail.value || {};
+    const newConfig = { ...this.config };
+    for (const [key, value] of Object.entries(newValues)) {
+      if (value === '' || value === null || value === undefined) {
+        delete newConfig[key];
+      } else if (key === 'show_dialog' && value === true) {
+        delete newConfig[key];
+      } else if (key === 'quick_add_amounts' || key === 'quick_remove_amounts') {
+        const parsed = this._parseAmounts(value, null);
+        if (parsed && parsed.length) newConfig[key] = parsed;
+        else delete newConfig[key];
+      } else {
+        newConfig[key] = value;
+      }
+    }
+    this.dispatchEvent(new CustomEvent('config-changed', {
+      detail: { config: newConfig }, bubbles: true, composed: true,
+    }));
   }
 
   _t(key, params) {

--- a/custom_components/taskmate/www/taskmate-rewards-card.js
+++ b/custom_components/taskmate/www/taskmate-rewards-card.js
@@ -1271,38 +1271,70 @@ class TaskMateRewardsCardEditor extends LitElement {
 
   static get styles() {
     return css`
-      :host {
-        display: block;
-      }
-      ha-form {
-        display: block;
-      }
-      .colour-row {
+      :host { display: block; }
+      ha-form { display: block; margin-bottom: 16px; }
+
+      .colour-field {
         display: flex;
         flex-direction: column;
-        gap: 6px;
-        margin-top: 12px;
+        gap: 8px;
+        padding: 12px 16px;
+        border: 1px solid var(--outline-color, var(--divider-color, #e0e0e0));
+        border-radius: 4px;
+        background: var(--mdc-text-field-fill-color, var(--card-background-color));
       }
-      .colour-row-inner {
+      .colour-field-label {
+        font-size: 0.82rem;
+        color: var(--primary-color);
+        font-weight: 500;
+      }
+      .colour-field-body {
         display: flex;
         align-items: center;
         gap: 12px;
+        flex-wrap: wrap;
       }
-      .colour-row-inner input[type="color"] {
-        width: 42px;
+      .colour-swatch-wrapper {
+        position: relative;
+        width: 36px;
         height: 36px;
-        padding: 2px;
-        border: 1px solid var(--divider-color, #e0e0e0);
-        border-radius: 6px;
+        border-radius: 50%;
+        overflow: hidden;
         cursor: pointer;
-        background: transparent;
+        border: 2px solid var(--divider-color, #e0e0e0);
+        flex-shrink: 0;
       }
-      .colour-value {
+      .colour-swatch-wrapper input[type="color"] {
+        position: absolute;
+        inset: 0;
+        opacity: 0;
+        cursor: pointer;
+        border: 0;
+        padding: 0;
+      }
+      .colour-swatch-preview { position: absolute; inset: 0; pointer-events: none; }
+      .colour-hex {
         font-family: var(--code-font-family, monospace);
         font-size: 0.85rem;
         color: var(--secondary-text-color);
+        min-width: 70px;
       }
-      .reset-btn {
+      .colour-presets { display: flex; gap: 6px; flex-wrap: wrap; }
+      .preset-swatch {
+        width: 22px;
+        height: 22px;
+        border-radius: 50%;
+        cursor: pointer;
+        border: 2px solid var(--divider-color, #e0e0e0);
+        transition: transform 0.1s;
+        padding: 0;
+      }
+      .preset-swatch:hover { transform: scale(1.15); }
+      .preset-swatch.active {
+        border-color: var(--primary-text-color);
+        box-shadow: 0 0 0 2px var(--primary-color);
+      }
+      .colour-reset {
         font-size: 0.78rem;
         color: var(--secondary-text-color);
         background: none;
@@ -1310,10 +1342,7 @@ class TaskMateRewardsCardEditor extends LitElement {
         border-radius: 4px;
         padding: 4px 10px;
         cursor: pointer;
-      }
-      .colour-label {
-        font-size: 0.95rem;
-        color: var(--primary-text-color);
+        margin-left: auto;
       }
       .colour-helper {
         color: var(--secondary-text-color);
@@ -1387,7 +1416,6 @@ class TaskMateRewardsCardEditor extends LitElement {
     if (!this.hass || !this.config) {
       return html``;
     }
-    const headerColour = this.config.header_color || '#e67e22';
     // ha-form treats missing keys as empty; normalise for consistent values.
     const data = {
       entity: this.config.entity || '',
@@ -1406,24 +1434,38 @@ class TaskMateRewardsCardEditor extends LitElement {
         .computeHelper=${this._computeHelper}
         @value-changed=${this._formChanged}
       ></ha-form>
+      ${this._renderColourPicker('header_color', '#e67e22')}
+    `;
+  }
 
-      <div class="colour-row">
-        <span class="colour-label">${this._t('common.editor.header_colour')}</span>
-        <div class="colour-row-inner">
-          <input
-            type="color"
-            .value="${headerColour}"
-            @input="${(e) => this._updateConfig('header_color', e.target.value)}"
-          />
-          <span class="colour-value">${headerColour}</span>
-          <button
-            class="reset-btn"
-            @click="${() => this._updateConfig('header_color', '#e67e22')}"
+  _renderColourPicker(key, defaultValue) {
+    const current = this.config[key] || defaultValue;
+    const presets = ['#e67e22', '#27ae60', '#3498db', '#9b59b6', '#f1c40f', '#e74c3c', '#34495e'];
+    const isActive = (c) => c.toLowerCase() === current.toLowerCase();
+    return html`
+      <div class="colour-field">
+        <span class="colour-field-label">${this._t('common.editor.header_colour')}</span>
+        <div class="colour-field-body">
+          <label class="colour-swatch-wrapper">
+            <input type="color" .value=${current}
+              @input=${(e) => this._updateConfig(key, e.target.value)} />
+            <span class="colour-swatch-preview" style="background:${current}"></span>
+          </label>
+          <span class="colour-hex">${current}</span>
+          <div class="colour-presets">
+            ${presets.map((p) => html`
+              <button class="preset-swatch ${isActive(p) ? 'active' : ''}"
+                style="background:${p}"
+                title=${p}
+                @click=${(e) => { e.preventDefault(); this._updateConfig(key, p); }}
+              ></button>
+            `)}
+          </div>
+          <button class="colour-reset"
+            @click=${(e) => { e.preventDefault(); this._updateConfig(key, defaultValue); }}
           >${this._t('common.reset')}</button>
         </div>
-        <div class="colour-helper">
-          ${this._t('common.editor.header_colour_helper')}
-        </div>
+        <div class="colour-helper">${this._t('common.editor.header_colour_helper')}</div>
       </div>
     `;
   }


### PR DESCRIPTION
## Summary

Two improvements to card editors:

1. **Rolls out the `ha-form` pattern** from the rewards card to three more editors: **child**, **points**, **approvals**. These now render with native HA styling (floating labels, toggle switches, HA dropdowns showing child names instead of raw IDs).
2. **Replaces the plain `<input type="color">` colour picker** with a better-designed one that matches HA's field aesthetic and offers preset swatches.

## New colour picker

Each card editor now has a labelled outlined container with:

- A round **colour swatch** (36px) that opens the native picker when clicked
- The **hex value** in monospace
- A row of **7 preset swatches** covering the card's default + common TaskMate accent colours (orange / green / blue / purple / gold / red / slate)
- The **active preset** is highlighted with a primary-coloured ring
- A **Reset** button anchored on the right
- Helper text below

This is inlined into each editor class since each card loads independently. Can be extracted into a shared module later.

## Covered in this PR

- `taskmate-rewards-card.js` — existing ha-form editor gains the new picker
- `taskmate-child-card.js` — full refactor (10 fields, dropdowns + toggles)
- `taskmate-points-card.js` — full refactor, keeps the +/- amount preview chips
- `taskmate-approvals-card.js` — full refactor, child filter becomes a dropdown populated from the overview sensor

## Follow-up

10 editors still on the old pattern — will be done in separate PRs so the diff stays reviewable:

`parent-dashboard`, `leaderboard`, `activity`, `graph`, `overview`, `reorder`, `reward-progress`, `streak`, `weekly`, `points-display`.

## Test plan

- [ ] 160 tests pass; ruff clean
- [ ] Open each of the 4 cards in edit mode → form renders with HA styling, no ugly black checkboxes
- [ ] Colour picker: click swatch → native picker opens; click a preset → colour applies and preset gets highlighted; Reset → default returns
- [ ] Child card's "Child" dropdown shows child names (not IDs)
- [ ] Approvals card's "Child ID" filter becomes a dropdown of children
- [ ] Save + reload — all config values persist
