### PR TITLE
feat(editors): ha-form + improved colour picker for remaining 10 editors

### DIFF
--- a/custom_components/taskmate/www/taskmate-activity-card.js
+++ b/custom_components/taskmate/www/taskmate-activity-card.js
@@ -463,83 +463,134 @@ class TaskMateActivityCardEditor extends LitElement {
   static get styles() {
     return css`
       :host { display: block; }
-      ha-textfield { width: 100%; margin-bottom: 16px; }
-      .form-row { margin-bottom: 16px; }
-      .form-label {
-        display: block; font-size: 0.85rem; font-weight: 500;
-        color: var(--primary-text-color); margin-bottom: 6px; padding: 0 2px;
-      }
-      .form-select {
-        width: 100%; padding: 10px 12px;
-        border: 1px solid var(--divider-color, #e0e0e0);
-        border-radius: 4px;
-        background: var(--card-background-color, #fff);
-        color: var(--primary-text-color);
-        font-size: 1rem; box-sizing: border-box; cursor: pointer; appearance: auto;
-      }
-      .form-select:focus { outline: none; border-color: var(--primary-color); }
-      .form-helper { display: block; font-size: 0.78rem; color: var(--secondary-text-color); margin-top: 4px; padding: 0 2px; }
+      ha-form { display: block; margin-bottom: 16px; }
+      .colour-field { display: flex; flex-direction: column; gap: 8px; padding: 12px 16px; border: 1px solid var(--outline-color, var(--divider-color, #e0e0e0)); border-radius: 4px; background: var(--mdc-text-field-fill-color, var(--card-background-color)); }
+      .colour-field-label { font-size: 0.82rem; color: var(--primary-color); font-weight: 500; }
+      .colour-field-body { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }
+      .colour-swatch-wrapper { position: relative; width: 36px; height: 36px; border-radius: 50%; overflow: hidden; cursor: pointer; border: 2px solid var(--divider-color, #e0e0e0); flex-shrink: 0; }
+      .colour-swatch-wrapper input[type="color"] { position: absolute; inset: 0; opacity: 0; cursor: pointer; border: 0; padding: 0; }
+      .colour-swatch-preview { position: absolute; inset: 0; pointer-events: none; }
+      .colour-hex { font-family: var(--code-font-family, monospace); font-size: 0.85rem; color: var(--secondary-text-color); min-width: 70px; }
+      .colour-presets { display: flex; gap: 6px; flex-wrap: wrap; }
+      .preset-swatch { width: 22px; height: 22px; border-radius: 50%; cursor: pointer; border: 2px solid var(--divider-color, #e0e0e0); transition: transform 0.1s; padding: 0; }
+      .preset-swatch:hover { transform: scale(1.15); }
+      .preset-swatch.active { border-color: var(--primary-text-color); box-shadow: 0 0 0 2px var(--primary-color); }
+      .colour-reset { font-size: 0.78rem; color: var(--secondary-text-color); background: none; border: 1px solid var(--divider-color, #e0e0e0); border-radius: 4px; padding: 4px 10px; cursor: pointer; margin-left: auto; }
+      .colour-helper { color: var(--secondary-text-color); font-size: 0.82rem; line-height: 1.3; }
     `;
   }
 
   setConfig(config) { this.config = config; }
 
+  _buildSchema() {
+    const entity = this.config?.entity ? this.hass?.states?.[this.config.entity] : null;
+    const children = entity?.attributes?.children || [];
+    return [
+      { name: 'entity', selector: { entity: { domain: 'sensor' } } },
+      { name: 'title', selector: { text: {} } },
+      {
+        name: 'child_id',
+        selector: {
+          select: {
+            options: [
+              { value: '', label: this._t('common.editor.filter_by_child_all') },
+              ...children.map((c) => ({ value: c.id, label: c.name })),
+            ],
+            mode: 'dropdown',
+          },
+        },
+      },
+      { name: 'max_items', selector: { number: { min: 5, max: 200, mode: 'box' } } },
+    ];
+  }
+
+  _computeLabel = (entry) => {
+    const labels = {
+      entity: this._t('common.editor.overview_entity'),
+      title: this._t('common.editor.card_title'),
+      child_id: this._t('common.editor.filter_by_child'),
+      max_items: this._t('activity.editor.max_items'),
+    };
+    return labels[entry.name] ?? entry.name;
+  };
+
+  _computeHelper = (entry) => {
+    const helpers = {
+      entity: this._t('common.editor.overview_entity_helper'),
+      child_id: this._t('activity.editor.filter_child_helper'),
+      max_items: this._t('activity.editor.max_items_helper'),
+    };
+    return helpers[entry.name] ?? '';
+  };
+
   render() {
     if (!this.hass || !this.config) return html``;
-    const entity = this.config.entity ? this.hass.states[this.config.entity] : null;
-    const children = entity?.attributes?.children || [];
-
+    const data = {
+      entity: this.config.entity || '',
+      title: this.config.title || '',
+      child_id: this.config.child_id || '',
+      max_items: this.config.max_items || 30,
+    };
     return html`
-      <ha-textfield
-        label="${this._t('common.editor.overview_entity')}"
-        .value="${this.config.entity || ""}"
-        @change="${e => this._updateConfig('entity', e.target.value)}"
-        helper="${this._t('common.editor.overview_entity_helper')}"
-        helperPersistent
-        placeholder="sensor.taskmate_overview"
-      ></ha-textfield>
-      <ha-textfield
-        label="${this._t('common.editor.card_title')}"
-        .value="${this.config.title || ""}"
-        @change="${e => this._updateConfig('title', e.target.value)}"
-        placeholder="${this._t('activity.default_title')}"
-      ></ha-textfield>
-      <div class="form-row">
-        <label class="form-label">${this._t('common.editor.filter_by_child')}</label>
-        <select class="form-select" @change="${e => this._updateConfig('child_id', e.target.value || null)}">
-          <option value="" ?selected="${!this.config.child_id}">${this._t('common.editor.filter_by_child_all')}</option>
-          ${children.map(c => html`<option value="${c.id}" ?selected="${this.config.child_id === c.id}">${c.name}</option>`)}
-        </select>
-        <span class="form-helper">${this._t('activity.editor.filter_child_helper')}</span>
-      </div>
-      <ha-textfield
-        label="${this._t('activity.editor.max_items')}"
-        type="number"
-        .value="${String(this.config.max_items || 30)}"
-        @change="${e => this._updateConfig('max_items', parseInt(e.target.value) || 30)}"
-        helper="${this._t('activity.editor.max_items_helper')}"
-        helperPersistent
-      ></ha-textfield>
-        <span class="field-helper">${this._t('common.editor.header_colour_helper')}</span>
-      </div>
-      <div class="field-row">
-        <label class="field-label">${this._t('common.editor.header_colour')}</label>
-        <div style="display:flex;align-items:center;gap:10px;">
-          <input
-            type="color"
-            .value=${this.config.header_color || '#2471a3'}
-            @input=${e => this._updateConfig('header_color', e.target.value)}
-            style="width:48px;height:36px;padding:2px;border:1px solid var(--divider-color,#e0e0e0);border-radius:6px;cursor:pointer;"
-          />
-          <span style="font-size:13px;color:var(--secondary-text-color);">${this.config.header_color || '#2471a3'}</span>
-          <button
-            style="font-size:11px;color:var(--secondary-text-color);background:none;border:1px solid var(--divider-color,#e0e0e0);border-radius:4px;padding:3px 8px;cursor:pointer;"
-            @click=${() => this._updateConfig('header_color', '#2471a3')}
+      <ha-form
+        .hass=${this.hass}
+        .data=${data}
+        .schema=${this._buildSchema()}
+        .computeLabel=${this._computeLabel}
+        .computeHelper=${this._computeHelper}
+        @value-changed=${this._formChanged}
+      ></ha-form>
+      ${this._renderColourPicker('header_color', '#2471a3')}
+    `;
+  }
+
+  _renderColourPicker(key, defaultValue) {
+    const current = this.config[key] || defaultValue;
+    const presets = [defaultValue, '#e67e22', '#27ae60', '#9b59b6', '#f1c40f', '#e74c3c', '#34495e'];
+    const isActive = (c) => c.toLowerCase() === current.toLowerCase();
+    return html`
+      <div class="colour-field">
+        <span class="colour-field-label">${this._t('common.editor.header_colour')}</span>
+        <div class="colour-field-body">
+          <label class="colour-swatch-wrapper">
+            <input type="color" .value=${current}
+              @input=${(e) => this._updateConfig(key, e.target.value)} />
+            <span class="colour-swatch-preview" style="background:${current}"></span>
+          </label>
+          <span class="colour-hex">${current}</span>
+          <div class="colour-presets">
+            ${presets.map((p) => html`
+              <button class="preset-swatch ${isActive(p) ? 'active' : ''}"
+                style="background:${p}"
+                title=${p}
+                @click=${(e) => { e.preventDefault(); this._updateConfig(key, p); }}
+              ></button>
+            `)}
+          </div>
+          <button class="colour-reset"
+            @click=${(e) => { e.preventDefault(); this._updateConfig(key, defaultValue); }}
           >${this._t('common.reset')}</button>
         </div>
-        <span class="field-helper">${this._t('common.editor.header_colour_helper')}</span>
+        <div class="colour-helper">${this._t('common.editor.header_colour_helper')}</div>
       </div>
     `;
+  }
+
+  _formChanged(e) {
+    const newValues = e.detail.value || {};
+    const newConfig = { ...this.config };
+    for (const [key, value] of Object.entries(newValues)) {
+      if (value === '' || value === null || value === undefined) {
+        delete newConfig[key];
+      } else if (key === 'max_items' && value === 30) {
+        delete newConfig[key];
+      } else {
+        newConfig[key] = value;
+      }
+    }
+    this.dispatchEvent(new CustomEvent('config-changed', {
+      detail: { config: newConfig }, bubbles: true, composed: true,
+    }));
   }
 
   _updateConfig(key, value) {

--- a/custom_components/taskmate/www/taskmate-graph-card.js
+++ b/custom_components/taskmate/www/taskmate-graph-card.js
@@ -642,109 +642,134 @@ class TaskMateGraphCardEditor extends LitElement {
   static get styles() {
     return css`
       :host { display: block; }
-      ha-textfield { width: 100%; margin-bottom: 16px; }
-      .form-row { margin-bottom: 16px; }
-      .form-label {
-        display: block;
-        font-size: 0.85rem;
-        font-weight: 500;
-        color: var(--primary-text-color);
-        margin-bottom: 6px;
-        padding: 0 2px;
-      }
-      .form-select {
-        width: 100%;
-        padding: 10px 12px;
-        border: 1px solid var(--divider-color, #e0e0e0);
-        border-radius: 4px;
-        background: var(--card-background-color, #fff);
-        color: var(--primary-text-color);
-        font-size: 1rem;
-        box-sizing: border-box;
-        cursor: pointer;
-        appearance: auto;
-      }
-      .form-select:focus {
-        outline: none;
-        border-color: var(--primary-color);
-      }
-      .form-helper {
-        display: block;
-        font-size: 0.78rem;
-        color: var(--secondary-text-color);
-        margin-top: 4px;
-        padding: 0 2px;
-      }
+      ha-form { display: block; margin-bottom: 16px; }
+      .colour-field { display: flex; flex-direction: column; gap: 8px; padding: 12px 16px; border: 1px solid var(--outline-color, var(--divider-color, #e0e0e0)); border-radius: 4px; background: var(--mdc-text-field-fill-color, var(--card-background-color)); }
+      .colour-field-label { font-size: 0.82rem; color: var(--primary-color); font-weight: 500; }
+      .colour-field-body { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }
+      .colour-swatch-wrapper { position: relative; width: 36px; height: 36px; border-radius: 50%; overflow: hidden; cursor: pointer; border: 2px solid var(--divider-color, #e0e0e0); flex-shrink: 0; }
+      .colour-swatch-wrapper input[type="color"] { position: absolute; inset: 0; opacity: 0; cursor: pointer; border: 0; padding: 0; }
+      .colour-swatch-preview { position: absolute; inset: 0; pointer-events: none; }
+      .colour-hex { font-family: var(--code-font-family, monospace); font-size: 0.85rem; color: var(--secondary-text-color); min-width: 70px; }
+      .colour-presets { display: flex; gap: 6px; flex-wrap: wrap; }
+      .preset-swatch { width: 22px; height: 22px; border-radius: 50%; cursor: pointer; border: 2px solid var(--divider-color, #e0e0e0); transition: transform 0.1s; padding: 0; }
+      .preset-swatch:hover { transform: scale(1.15); }
+      .preset-swatch.active { border-color: var(--primary-text-color); box-shadow: 0 0 0 2px var(--primary-color); }
+      .colour-reset { font-size: 0.78rem; color: var(--secondary-text-color); background: none; border: 1px solid var(--divider-color, #e0e0e0); border-radius: 4px; padding: 4px 10px; cursor: pointer; margin-left: auto; }
+      .colour-helper { color: var(--secondary-text-color); font-size: 0.82rem; line-height: 1.3; }
     `;
   }
 
   setConfig(config) { this.config = config; }
 
+  _buildSchema() {
+    const entity = this.config?.entity ? this.hass?.states?.[this.config.entity] : null;
+    const children = entity?.attributes?.children || [];
+    return [
+      { name: 'entity', selector: { entity: { domain: 'sensor' } } },
+      { name: 'title', selector: { text: {} } },
+      { name: 'days', selector: { number: { min: 3, max: 90, mode: 'box' } } },
+      {
+        name: 'child_id',
+        selector: {
+          select: {
+            options: [
+              { value: '', label: this._t('common.editor.filter_by_child_all') },
+              ...children.map((c) => ({ value: c.id, label: c.name })),
+            ],
+            mode: 'dropdown',
+          },
+        },
+      },
+    ];
+  }
+
+  _computeLabel = (entry) => {
+    const labels = {
+      entity: this._t('common.editor.overview_entity'),
+      title: this._t('common.editor.card_title'),
+      days: this._t('graph.editor.days_to_show'),
+      child_id: this._t('common.editor.filter_by_child'),
+    };
+    return labels[entry.name] ?? entry.name;
+  };
+
+  _computeHelper = (entry) => {
+    const helpers = {
+      entity: this._t('common.editor.overview_entity_helper'),
+      days: this._t('graph.editor.days_helper'),
+      child_id: this._t('graph.editor.child_filter_helper'),
+    };
+    return helpers[entry.name] ?? '';
+  };
+
   render() {
     if (!this.hass || !this.config) return html``;
-    const entity = this.config.entity ? this.hass.states[this.config.entity] : null;
-    const children = entity?.attributes?.children || [];
-
+    const data = {
+      entity: this.config.entity || '',
+      title: this.config.title || '',
+      days: this.config.days || 14,
+      child_id: this.config.child_id || '',
+    };
     return html`
-      <ha-textfield
-        label="${this._t('common.editor.overview_entity')}"
-        .value="${this.config.entity || ""}"
-        @change="${e => this._updateConfig('entity', e.target.value)}"
-        helper="${this._t('common.editor.overview_entity_helper')}"
-        helperPersistent
-        placeholder="sensor.taskmate_overview"
-      ></ha-textfield>
+      <ha-form
+        .hass=${this.hass}
+        .data=${data}
+        .schema=${this._buildSchema()}
+        .computeLabel=${this._computeLabel}
+        .computeHelper=${this._computeHelper}
+        @value-changed=${this._formChanged}
+      ></ha-form>
+      ${this._renderColourPicker('header_color', '#d35400')}
+    `;
+  }
 
-      <ha-textfield
-        label="${this._t('common.editor.card_title')}"
-        .value="${this.config.title || ""}"
-        @change="${e => this._updateConfig('title', e.target.value)}"
-        placeholder="${this._t('graph.default_title')}"
-      ></ha-textfield>
-
-      <ha-textfield
-        label="${this._t('graph.editor.days_to_show')}"
-        type="number"
-        .value="${String(this.config.days || 14)}"
-        @change="${e => this._updateConfig('days', parseInt(e.target.value) || 14)}"
-        helper="${this._t('graph.editor.days_helper')}"
-        helperPersistent
-      ></ha-textfield>
-
-      <div class="form-row">
-        <label class="form-label">${this._t('common.editor.filter_by_child')}</label>
-        <select
-          class="form-select"
-          .value="${this.config.child_id || ""}"
-          @change="${e => this._updateConfig('child_id', e.target.value || null)}"
-        >
-          <option value="" ?selected="${!this.config.child_id}">${this._t('common.editor.filter_by_child_all')}</option>
-          ${children.map(c => html`
-            <option value="${c.id}" ?selected="${this.config.child_id === c.id}">${c.name}</option>
-          `)}
-        </select>
-        <span class="form-helper">${this._t('graph.editor.child_filter_helper')}</span>
-      </div>
-        <span class="field-helper">${this._t('common.editor.header_colour_helper')}</span>
-      </div>
-      <div class="field-row">
-        <label class="field-label">${this._t('common.editor.header_colour')}</label>
-        <div style="display:flex;align-items:center;gap:10px;">
-          <input
-            type="color"
-            .value=${this.config.header_color || '#d35400'}
-            @input=${e => this._updateConfig('header_color', e.target.value)}
-            style="width:48px;height:36px;padding:2px;border:1px solid var(--divider-color,#e0e0e0);border-radius:6px;cursor:pointer;"
-          />
-          <span style="font-size:13px;color:var(--secondary-text-color);">${this.config.header_color || '#d35400'}</span>
-          <button
-            style="font-size:11px;color:var(--secondary-text-color);background:none;border:1px solid var(--divider-color,#e0e0e0);border-radius:4px;padding:3px 8px;cursor:pointer;"
-            @click=${() => this._updateConfig('header_color', '#d35400')}
+  _renderColourPicker(key, defaultValue) {
+    const current = this.config[key] || defaultValue;
+    const presets = [defaultValue, '#27ae60', '#3498db', '#9b59b6', '#f1c40f', '#e74c3c', '#34495e'];
+    const isActive = (c) => c.toLowerCase() === current.toLowerCase();
+    return html`
+      <div class="colour-field">
+        <span class="colour-field-label">${this._t('common.editor.header_colour')}</span>
+        <div class="colour-field-body">
+          <label class="colour-swatch-wrapper">
+            <input type="color" .value=${current}
+              @input=${(e) => this._updateConfig(key, e.target.value)} />
+            <span class="colour-swatch-preview" style="background:${current}"></span>
+          </label>
+          <span class="colour-hex">${current}</span>
+          <div class="colour-presets">
+            ${presets.map((p) => html`
+              <button class="preset-swatch ${isActive(p) ? 'active' : ''}"
+                style="background:${p}"
+                title=${p}
+                @click=${(e) => { e.preventDefault(); this._updateConfig(key, p); }}
+              ></button>
+            `)}
+          </div>
+          <button class="colour-reset"
+            @click=${(e) => { e.preventDefault(); this._updateConfig(key, defaultValue); }}
           >${this._t('common.reset')}</button>
         </div>
-        <span class="field-helper">${this._t('common.editor.header_colour_helper')}</span>
+        <div class="colour-helper">${this._t('common.editor.header_colour_helper')}</div>
       </div>
     `;
+  }
+
+  _formChanged(e) {
+    const newValues = e.detail.value || {};
+    const newConfig = { ...this.config };
+    for (const [key, value] of Object.entries(newValues)) {
+      if (value === '' || value === null || value === undefined) {
+        delete newConfig[key];
+      } else if (key === 'days' && value === 14) {
+        delete newConfig[key];
+      } else {
+        newConfig[key] = value;
+      }
+    }
+    this.dispatchEvent(new CustomEvent('config-changed', {
+      detail: { config: newConfig }, bubbles: true, composed: true,
+    }));
   }
 
   _updateConfig(key, value) {

--- a/custom_components/taskmate/www/taskmate-leaderboard-card.js
+++ b/custom_components/taskmate/www/taskmate-leaderboard-card.js
@@ -461,93 +461,143 @@ class TaskMateLeaderboardCardEditor extends LitElement {
 
   static get styles() {
     return css`
-      :host { display: block; padding: 4px 0; }
-      ha-textfield { width: 100%; margin-bottom: 8px; }
-      .field-row { margin-bottom: 16px; }
-      .field-label { display: block; font-size: 12px; font-weight: 500; color: var(--secondary-text-color); text-transform: uppercase; letter-spacing: 0.08em; margin-bottom: 6px; padding: 0 4px; }
-      .field-select { display: block; width: 100%; padding: 10px 12px; border: 1px solid var(--divider-color, #e0e0e0); border-radius: 4px; background: var(--card-background-color, #fff); color: var(--primary-text-color); font-size: 14px; box-sizing: border-box; cursor: pointer; appearance: auto; }
-      .field-select:focus { outline: none; border-color: var(--primary-color); border-width: 2px; }
-      .field-helper { display: block; font-size: 11px; color: var(--secondary-text-color); margin-top: 5px; padding: 0 4px; }
-      .check-row { display: flex; align-items: center; gap: 12px; padding: 10px 12px; border: 1px solid var(--divider-color, #e0e0e0); border-radius: 4px; background: var(--card-background-color, #fff); cursor: pointer; user-select: none; margin-bottom: 8px; }
-      .check-row input[type="checkbox"] { width: 18px; height: 18px; cursor: pointer; flex-shrink: 0; accent-color: var(--primary-color); margin: 0; }
-      .check-label { font-size: 14px; color: var(--primary-text-color); flex: 1; }
+      :host { display: block; }
+      ha-form { display: block; margin-bottom: 16px; }
+      .colour-field { display: flex; flex-direction: column; gap: 8px; padding: 12px 16px; border: 1px solid var(--outline-color, var(--divider-color, #e0e0e0)); border-radius: 4px; background: var(--mdc-text-field-fill-color, var(--card-background-color)); }
+      .colour-field-label { font-size: 0.82rem; color: var(--primary-color); font-weight: 500; }
+      .colour-field-body { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }
+      .colour-swatch-wrapper { position: relative; width: 36px; height: 36px; border-radius: 50%; overflow: hidden; cursor: pointer; border: 2px solid var(--divider-color, #e0e0e0); flex-shrink: 0; }
+      .colour-swatch-wrapper input[type="color"] { position: absolute; inset: 0; opacity: 0; cursor: pointer; border: 0; padding: 0; }
+      .colour-swatch-preview { position: absolute; inset: 0; pointer-events: none; }
+      .colour-hex { font-family: var(--code-font-family, monospace); font-size: 0.85rem; color: var(--secondary-text-color); min-width: 70px; }
+      .colour-presets { display: flex; gap: 6px; flex-wrap: wrap; }
+      .preset-swatch { width: 22px; height: 22px; border-radius: 50%; cursor: pointer; border: 2px solid var(--divider-color, #e0e0e0); transition: transform 0.1s; padding: 0; }
+      .preset-swatch:hover { transform: scale(1.15); }
+      .preset-swatch.active { border-color: var(--primary-text-color); box-shadow: 0 0 0 2px var(--primary-color); }
+      .colour-reset { font-size: 0.78rem; color: var(--secondary-text-color); background: none; border: 1px solid var(--divider-color, #e0e0e0); border-radius: 4px; padding: 4px 10px; cursor: pointer; margin-left: auto; }
+      .colour-helper { color: var(--secondary-text-color); font-size: 0.82rem; line-height: 1.3; }
     `;
   }
 
   setConfig(config) { this.config = config; }
 
+  _buildSchema() {
+    return [
+      { name: 'entity', selector: { entity: { domain: 'sensor' } } },
+      { name: 'title', selector: { text: {} } },
+      {
+        name: 'sort_by',
+        selector: {
+          select: {
+            options: [
+              { value: 'points', label: this._t('leaderboard.editor.sort_option_points') },
+              { value: 'streak', label: this._t('leaderboard.editor.sort_option_streak') },
+              { value: 'weekly', label: this._t('leaderboard.editor.sort_option_weekly') },
+            ],
+            mode: 'dropdown',
+          },
+        },
+      },
+      { name: 'show_streak', selector: { boolean: {} } },
+      { name: 'show_weekly', selector: { boolean: {} } },
+    ];
+  }
+
+  _computeLabel = (entry) => {
+    const labels = {
+      entity: this._t('leaderboard.editor.entity_label'),
+      title: this._t('leaderboard.editor.title_label'),
+      sort_by: this._t('leaderboard.editor.rank_by_label'),
+      show_streak: this._t('leaderboard.editor.show_streak'),
+      show_weekly: this._t('leaderboard.editor.show_weekly'),
+    };
+    return labels[entry.name] ?? entry.name;
+  };
+
+  _computeHelper = (entry) => {
+    const helpers = {
+      entity: this._t('leaderboard.editor.entity_helper'),
+      sort_by: this._t('leaderboard.editor.rank_by_helper'),
+    };
+    return helpers[entry.name] ?? '';
+  };
+
   render() {
     if (!this.hass || !this.config) return html``;
+    const data = {
+      entity: this.config.entity || '',
+      title: this.config.title || '',
+      sort_by: this.config.sort_by || 'points',
+      show_streak: this.config.show_streak !== false,
+      show_weekly: this.config.show_weekly !== false,
+    };
     return html`
-      <ha-textfield
-        label="${this._t('leaderboard.editor.entity_label')}"
-        .value="${this.config.entity || ''}"
-        @change="${e => this._update('entity', e.target.value)}"
-        helper="${this._t('leaderboard.editor.entity_helper')}"
-        helperPersistent
-        placeholder="sensor.taskmate_overview"
-      ></ha-textfield>
+      <ha-form
+        .hass=${this.hass}
+        .data=${data}
+        .schema=${this._buildSchema()}
+        .computeLabel=${this._computeLabel}
+        .computeHelper=${this._computeHelper}
+        @value-changed=${this._formChanged}
+      ></ha-form>
+      ${this._renderColourPicker('header_color', '#b7950b')}
+    `;
+  }
 
-      <ha-textfield
-        label="${this._t('leaderboard.editor.title_label')}"
-        .value="${this.config.title || ''}"
-        @change="${e => this._update('title', e.target.value)}"
-        placeholder="${this._t('leaderboard.default_title')}"
-      ></ha-textfield>
-
-      <div class="field-row">
-        <label class="field-label">${this._t('leaderboard.editor.rank_by_label')}</label>
-        <select class="field-select" @change="${e => this._update('sort_by', e.target.value)}">
-          <option value="points" ?selected="${(this.config.sort_by || 'points') === 'points'}">${this._t('leaderboard.editor.sort_option_points')}</option>
-          <option value="streak" ?selected="${this.config.sort_by === 'streak'}">${this._t('leaderboard.editor.sort_option_streak')}</option>
-          <option value="weekly" ?selected="${this.config.sort_by === 'weekly'}">${this._t('leaderboard.editor.sort_option_weekly')}</option>
-        </select>
-        <span class="field-helper">${this._t('leaderboard.editor.rank_by_helper')}</span>
-      </div>
-
-      <label class="check-row">
-        <input type="checkbox"
-          ?checked="${this.config.show_streak !== false}"
-
-          @change="${e => this._update('show_streak', e.target.checked)}"
-        />
-        <span class="check-label">${this._t('leaderboard.editor.show_streak')}</span>
-      </label>
-
-      <label class="check-row">
-        <input type="checkbox"
-          ?checked="${this.config.show_weekly !== false}"
-
-          @change="${e => this._update('show_weekly', e.target.checked)}"
-        />
-        <span class="check-label">${this._t('leaderboard.editor.show_weekly')}</span>
-      </label>
-        <span class="field-helper">${this._t('leaderboard.editor.header_colour_helper')}</span>
-      </div>
-    
-      <div class="field-row">
-        <label class="field-label">${this._t('leaderboard.editor.header_colour_label')}</label>
-        <div style="display:flex;align-items:center;gap:10px;">
-          <input
-            type="color"
-            .value=${this.config.header_color || '#b7950b'}
-            @input=${e => this._update('header_color', e.target.value)}
-            style="width:48px;height:36px;padding:2px;border:1px solid var(--divider-color,#e0e0e0);border-radius:6px;cursor:pointer;"
-          />
-          <span style="font-size:13px;color:var(--secondary-text-color);">${this.config.header_color || '#b7950b'}</span>
-          <button
-            style="font-size:11px;color:var(--secondary-text-color);background:none;border:1px solid var(--divider-color,#e0e0e0);border-radius:4px;padding:3px 8px;cursor:pointer;"
-            @click=${() => this._update('header_color', '#b7950b')}
+  _renderColourPicker(key, defaultValue) {
+    const current = this.config[key] || defaultValue;
+    const presets = [defaultValue, '#e67e22', '#27ae60', '#3498db', '#9b59b6', '#e74c3c', '#34495e'];
+    const isActive = (c) => c.toLowerCase() === current.toLowerCase();
+    return html`
+      <div class="colour-field">
+        <span class="colour-field-label">${this._t('common.editor.header_colour')}</span>
+        <div class="colour-field-body">
+          <label class="colour-swatch-wrapper">
+            <input type="color" .value=${current}
+              @input=${(e) => this._update(key, e.target.value)} />
+            <span class="colour-swatch-preview" style="background:${current}"></span>
+          </label>
+          <span class="colour-hex">${current}</span>
+          <div class="colour-presets">
+            ${presets.map((p) => html`
+              <button class="preset-swatch ${isActive(p) ? 'active' : ''}"
+                style="background:${p}"
+                title=${p}
+                @click=${(e) => { e.preventDefault(); this._update(key, p); }}
+              ></button>
+            `)}
+          </div>
+          <button class="colour-reset"
+            @click=${(e) => { e.preventDefault(); this._update(key, defaultValue); }}
           >${this._t('common.reset')}</button>
         </div>
-        <span class="field-helper">${this._t('leaderboard.editor.header_colour_helper')}</span>
+        <div class="colour-helper">${this._t('common.editor.header_colour_helper')}</div>
       </div>
     `;
   }
 
+  _formChanged(e) {
+    const newValues = e.detail.value || {};
+    const newConfig = { ...this.config };
+    for (const [key, value] of Object.entries(newValues)) {
+      if (value === '' || value === null || value === undefined) {
+        delete newConfig[key];
+      } else if ((key === 'show_streak' || key === 'show_weekly') && value === true) {
+        delete newConfig[key];
+      } else if (key === 'sort_by' && value === 'points') {
+        delete newConfig[key];
+      } else {
+        newConfig[key] = value;
+      }
+    }
+    this.dispatchEvent(new CustomEvent('config-changed', {
+      detail: { config: newConfig }, bubbles: true, composed: true,
+    }));
+  }
+
   _update(key, value) {
     const cfg = { ...this.config, [key]: value };
-    this.dispatchEvent(new CustomEvent("config-changed", { detail: { config: cfg }, bubbles: true, composed: true }));
+    this.dispatchEvent(new CustomEvent('config-changed', { detail: { config: cfg }, bubbles: true, composed: true }));
   }
 }
 

--- a/custom_components/taskmate/www/taskmate-overview-card.js
+++ b/custom_components/taskmate/www/taskmate-overview-card.js
@@ -472,68 +472,123 @@ class TaskMateOverviewCardEditor extends LitElement {
   static get styles() {
     return css`
       :host { display: block; }
-      ha-textfield { width: 100%; margin-bottom: 16px; }
+      ha-form { display: block; margin-bottom: 16px; }
+      .colour-field { display: flex; flex-direction: column; gap: 8px; padding: 12px 16px; border: 1px solid var(--outline-color, var(--divider-color, #e0e0e0)); border-radius: 4px; background: var(--mdc-text-field-fill-color, var(--card-background-color)); }
+      .colour-field-label { font-size: 0.82rem; color: var(--primary-color); font-weight: 500; }
+      .colour-field-body { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }
+      .colour-swatch-wrapper { position: relative; width: 36px; height: 36px; border-radius: 50%; overflow: hidden; cursor: pointer; border: 2px solid var(--divider-color, #e0e0e0); flex-shrink: 0; }
+      .colour-swatch-wrapper input[type="color"] { position: absolute; inset: 0; opacity: 0; cursor: pointer; border: 0; padding: 0; }
+      .colour-swatch-preview { position: absolute; inset: 0; pointer-events: none; }
+      .colour-hex { font-family: var(--code-font-family, monospace); font-size: 0.85rem; color: var(--secondary-text-color); min-width: 70px; }
+      .colour-presets { display: flex; gap: 6px; flex-wrap: wrap; }
+      .preset-swatch { width: 22px; height: 22px; border-radius: 50%; cursor: pointer; border: 2px solid var(--divider-color, #e0e0e0); transition: transform 0.1s; padding: 0; }
+      .preset-swatch:hover { transform: scale(1.15); }
+      .preset-swatch.active { border-color: var(--primary-text-color); box-shadow: 0 0 0 2px var(--primary-color); }
+      .colour-reset { font-size: 0.78rem; color: var(--secondary-text-color); background: none; border: 1px solid var(--divider-color, #e0e0e0); border-radius: 4px; padding: 4px 10px; cursor: pointer; margin-left: auto; }
+      .colour-helper { color: var(--secondary-text-color); font-size: 0.82rem; line-height: 1.3; }
     `;
   }
 
   setConfig(config) { this.config = config; }
-
-  render() {
-    if (!this.hass || !this.config) return html``;
-    return html`
-      <ha-textfield
-        label="${this._t('overview.editor.entity_label')}"
-        .value="${this.config.entity || ""}"
-        @change="${e => this._updateConfig('entity', e.target.value)}"
-        helper="${this._t('overview.editor.entity_helper')}"
-        helperPersistent
-        placeholder="sensor.taskmate_overview"
-      ></ha-textfield>
-      <ha-textfield
-        label="${this._t('overview.editor.title_label')}"
-        .value="${this.config.title || ""}"
-        @change="${e => this._updateConfig('title', e.target.value)}"
-        placeholder="TaskMate"
-      ></ha-textfield>
-      <ha-textfield
-        label="${this._t('overview.editor.approvals_entity_label')}"
-        .value="${this.config.approvals_entity || ""}"
-        @change="${e => this._updateConfig('approvals_entity', e.target.value)}"
-        helper="${this._t('overview.editor.approvals_entity_helper')}"
-        helperPersistent
-        placeholder="sensor.pending_approvals"
-      ></ha-textfield>
-        <span class="field-helper">${this._t('overview.editor.header_colour_helper')}</span>
-      </div>
-      <div class="field-row">
-        <label class="field-label">${this._t('overview.editor.header_colour_label')}</label>
-        <div style="display:flex;align-items:center;gap:10px;">
-          <input
-            type="color"
-            .value=${this.config.header_color || '#8e44ad'}
-            @input=${e => this._updateConfig('header_color', e.target.value)}
-            style="width:48px;height:36px;padding:2px;border:1px solid var(--divider-color,#e0e0e0);border-radius:6px;cursor:pointer;"
-          />
-          <span style="font-size:13px;color:var(--secondary-text-color);">${this.config.header_color || '#8e44ad'}</span>
-          <button
-            style="font-size:11px;color:var(--secondary-text-color);background:none;border:1px solid var(--divider-color,#e0e0e0);border-radius:4px;padding:3px 8px;cursor:pointer;"
-            @click=${() => this._updateConfig('header_color', '#8e44ad')}
-          >${this._t('common.reset')}</button>
-        </div>
-        <span class="field-helper">${this._t('overview.editor.header_colour_helper')}</span>
-      </div>
-    `;
-  }
 
   _t(key, params) {
     const fn = window.__taskmate_localize;
     return fn ? fn(this.hass, key, params) : key;
   }
 
+  _buildSchema() {
+    return [
+      { name: 'entity', selector: { entity: { domain: 'sensor' } } },
+      { name: 'title', selector: { text: {} } },
+      { name: 'approvals_entity', selector: { entity: { domain: 'sensor' } } },
+    ];
+  }
+
+  _computeLabel = (entry) => {
+    const labels = {
+      entity: this._t('overview.editor.entity_label'),
+      title: this._t('overview.editor.title_label'),
+      approvals_entity: this._t('overview.editor.approvals_entity_label'),
+    };
+    return labels[entry.name] ?? entry.name;
+  };
+
+  _computeHelper = (entry) => {
+    const helpers = {
+      entity: this._t('overview.editor.entity_helper'),
+      approvals_entity: this._t('overview.editor.approvals_entity_helper'),
+    };
+    return helpers[entry.name] ?? '';
+  };
+
+  render() {
+    if (!this.hass || !this.config) return html``;
+    const data = {
+      entity: this.config.entity || '',
+      title: this.config.title || '',
+      approvals_entity: this.config.approvals_entity || '',
+    };
+    return html`
+      <ha-form
+        .hass=${this.hass}
+        .data=${data}
+        .schema=${this._buildSchema()}
+        .computeLabel=${this._computeLabel}
+        .computeHelper=${this._computeHelper}
+        @value-changed=${this._formChanged}
+      ></ha-form>
+      ${this._renderColourPicker('header_color', '#8e44ad')}
+    `;
+  }
+
+  _renderColourPicker(key, defaultValue) {
+    const current = this.config[key] || defaultValue;
+    const presets = [defaultValue, '#e67e22', '#27ae60', '#3498db', '#f1c40f', '#e74c3c', '#34495e'];
+    const isActive = (c) => c.toLowerCase() === current.toLowerCase();
+    return html`
+      <div class="colour-field">
+        <span class="colour-field-label">${this._t('common.editor.header_colour')}</span>
+        <div class="colour-field-body">
+          <label class="colour-swatch-wrapper">
+            <input type="color" .value=${current}
+              @input=${(e) => this._updateConfig(key, e.target.value)} />
+            <span class="colour-swatch-preview" style="background:${current}"></span>
+          </label>
+          <span class="colour-hex">${current}</span>
+          <div class="colour-presets">
+            ${presets.map((p) => html`
+              <button class="preset-swatch ${isActive(p) ? 'active' : ''}"
+                style="background:${p}"
+                title=${p}
+                @click=${(e) => { e.preventDefault(); this._updateConfig(key, p); }}
+              ></button>
+            `)}
+          </div>
+          <button class="colour-reset"
+            @click=${(e) => { e.preventDefault(); this._updateConfig(key, defaultValue); }}
+          >${this._t('common.reset')}</button>
+        </div>
+        <div class="colour-helper">${this._t('common.editor.header_colour_helper')}</div>
+      </div>
+    `;
+  }
+
+  _formChanged(e) {
+    const newValues = e.detail.value || {};
+    const newConfig = { ...this.config };
+    for (const [key, value] of Object.entries(newValues)) {
+      if (value === '' || value === null || value === undefined) delete newConfig[key];
+      else newConfig[key] = value;
+    }
+    this.dispatchEvent(new CustomEvent('config-changed', {
+      detail: { config: newConfig }, bubbles: true, composed: true,
+    }));
+  }
+
   _updateConfig(key, value) {
     const newConfig = { ...this.config, [key]: value };
     if (!value) delete newConfig[key];
-    this.dispatchEvent(new CustomEvent("config-changed", {
+    this.dispatchEvent(new CustomEvent('config-changed', {
       detail: { config: newConfig }, bubbles: true, composed: true,
     }));
   }

--- a/custom_components/taskmate/www/taskmate-parent-dashboard-card.js
+++ b/custom_components/taskmate/www/taskmate-parent-dashboard-card.js
@@ -707,86 +707,133 @@ class TaskMateParentDashboardCardEditor extends LitElement {
 
   static get styles() {
     return css`
-      :host { display: block; padding: 4px 0; }
-      ha-textfield { width: 100%; margin-bottom: 8px; }
-      .field-row { margin-bottom: 16px; }
-      .field-label { display: block; font-size: 12px; font-weight: 500; color: var(--secondary-text-color); text-transform: uppercase; letter-spacing: 0.08em; margin-bottom: 6px; padding: 0 4px; }
-      .field-helper { display: block; font-size: 11px; color: var(--secondary-text-color); margin-top: 5px; padding: 0 4px; }
-      .check-row { display: flex; align-items: center; gap: 12px; padding: 10px 12px; border: 1px solid var(--divider-color, #e0e0e0); border-radius: 4px; background: var(--card-background-color, #fff); cursor: pointer; user-select: none; margin-bottom: 8px; }
-      .check-row input[type="checkbox"] { width: 18px; height: 18px; cursor: pointer; flex-shrink: 0; accent-color: var(--primary-color); margin: 0; }
-      .check-label { font-size: 14px; color: var(--primary-text-color); flex: 1; }
+      :host { display: block; }
+      ha-form { display: block; margin-bottom: 16px; }
+      .colour-field { display: flex; flex-direction: column; gap: 8px; padding: 12px 16px; border: 1px solid var(--outline-color, var(--divider-color, #e0e0e0)); border-radius: 4px; background: var(--mdc-text-field-fill-color, var(--card-background-color)); }
+      .colour-field-label { font-size: 0.82rem; color: var(--primary-color); font-weight: 500; }
+      .colour-field-body { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }
+      .colour-swatch-wrapper { position: relative; width: 36px; height: 36px; border-radius: 50%; overflow: hidden; cursor: pointer; border: 2px solid var(--divider-color, #e0e0e0); flex-shrink: 0; }
+      .colour-swatch-wrapper input[type="color"] { position: absolute; inset: 0; opacity: 0; cursor: pointer; border: 0; padding: 0; }
+      .colour-swatch-preview { position: absolute; inset: 0; pointer-events: none; }
+      .colour-hex { font-family: var(--code-font-family, monospace); font-size: 0.85rem; color: var(--secondary-text-color); min-width: 70px; }
+      .colour-presets { display: flex; gap: 6px; flex-wrap: wrap; }
+      .preset-swatch { width: 22px; height: 22px; border-radius: 50%; cursor: pointer; border: 2px solid var(--divider-color, #e0e0e0); transition: transform 0.1s; padding: 0; }
+      .preset-swatch:hover { transform: scale(1.15); }
+      .preset-swatch.active { border-color: var(--primary-text-color); box-shadow: 0 0 0 2px var(--primary-color); }
+      .colour-reset { font-size: 0.78rem; color: var(--secondary-text-color); background: none; border: 1px solid var(--divider-color, #e0e0e0); border-radius: 4px; padding: 4px 10px; cursor: pointer; margin-left: auto; }
+      .colour-helper { color: var(--secondary-text-color); font-size: 0.82rem; line-height: 1.3; }
     `;
   }
 
   setConfig(config) { this.config = config; }
-
-  render() {
-    if (!this.hass || !this.config) return html``;
-    return html`
-      <ha-textfield
-        label="${this._t('dashboard.editor.entity_label')}"
-        .value="${this.config.entity || ''}"
-        @change="${e => this._update('entity', e.target.value)}"
-        helper="${this._t('dashboard.editor.entity_helper')}"
-        helperPersistent
-        placeholder="sensor.taskmate_overview"
-      ></ha-textfield>
-
-      <ha-textfield
-        label="${this._t('dashboard.editor.title_label')}"
-        .value="${this.config.title || ''}"
-        @change="${e => this._update('title', e.target.value)}"
-        placeholder="Parent Dashboard"
-      ></ha-textfield>
-
-      <ha-textfield
-        label="${this._t('dashboard.editor.quick_points_label')}"
-        type="number"
-        .value="${String(this.config.quick_points_amount || 5)}"
-        @change="${e => this._update('quick_points_amount', parseInt(e.target.value) || 5)}"
-        helper="${this._t('dashboard.editor.quick_points_helper')}"
-        helperPersistent
-      ></ha-textfield>
-
-      <label class="check-row">
-        <input type="checkbox"
-          ?checked="${this.config.show_claims !== false}"
-
-          @change="${e => this._update('show_claims', e.target.checked)}"
-        />
-        <span class="check-label">${this._t('dashboard.editor.show_claims')}</span>
-      </label>
-        <span class="field-helper">${this._t('dashboard.editor.header_colour_helper')}</span>
-      </div>
-
-      <div class="field-row">
-        <label class="field-label">${this._t('dashboard.editor.header_colour_label')}</label>
-        <div style="display:flex;align-items:center;gap:10px;">
-          <input
-            type="color"
-            .value=${this.config.header_color || '#c0392b'}
-            @input=${e => this._update('header_color', e.target.value)}
-            style="width:48px;height:36px;padding:2px;border:1px solid var(--divider-color,#e0e0e0);border-radius:6px;cursor:pointer;"
-          />
-          <span style="font-size:13px;color:var(--secondary-text-color);">${this.config.header_color || '#c0392b'}</span>
-          <button
-            style="font-size:11px;color:var(--secondary-text-color);background:none;border:1px solid var(--divider-color,#e0e0e0);border-radius:4px;padding:3px 8px;cursor:pointer;"
-            @click=${() => this._update('header_color', '#c0392b')}
-          >${this._t('common.reset')}</button>
-        </div>
-        <span class="field-helper">${this._t('dashboard.editor.header_colour_helper')}</span>
-      </div>
-    `;
-  }
 
   _t(key, params) {
     const fn = window.__taskmate_localize;
     return fn ? fn(this.hass, key, params) : key;
   }
 
+  _buildSchema() {
+    return [
+      { name: 'entity', selector: { entity: { domain: 'sensor' } } },
+      { name: 'title', selector: { text: {} } },
+      { name: 'quick_points_amount', selector: { number: { min: 1, max: 100, mode: 'box' } } },
+      { name: 'show_claims', selector: { boolean: {} } },
+    ];
+  }
+
+  _computeLabel = (entry) => {
+    const labels = {
+      entity: this._t('dashboard.editor.entity_label'),
+      title: this._t('dashboard.editor.title_label'),
+      quick_points_amount: this._t('dashboard.editor.quick_points_label'),
+      show_claims: this._t('dashboard.editor.show_claims'),
+    };
+    return labels[entry.name] ?? entry.name;
+  };
+
+  _computeHelper = (entry) => {
+    const helpers = {
+      entity: this._t('dashboard.editor.entity_helper'),
+      quick_points_amount: this._t('dashboard.editor.quick_points_helper'),
+    };
+    return helpers[entry.name] ?? '';
+  };
+
+  render() {
+    if (!this.hass || !this.config) return html``;
+    const data = {
+      entity: this.config.entity || '',
+      title: this.config.title || '',
+      quick_points_amount: this.config.quick_points_amount || 5,
+      show_claims: this.config.show_claims !== false,
+    };
+    return html`
+      <ha-form
+        .hass=${this.hass}
+        .data=${data}
+        .schema=${this._buildSchema()}
+        .computeLabel=${this._computeLabel}
+        .computeHelper=${this._computeHelper}
+        @value-changed=${this._formChanged}
+      ></ha-form>
+      ${this._renderColourPicker('header_color', '#c0392b')}
+    `;
+  }
+
+  _renderColourPicker(key, defaultValue) {
+    const current = this.config[key] || defaultValue;
+    const presets = [defaultValue, '#e67e22', '#27ae60', '#3498db', '#9b59b6', '#f1c40f', '#34495e'];
+    const isActive = (c) => c.toLowerCase() === current.toLowerCase();
+    return html`
+      <div class="colour-field">
+        <span class="colour-field-label">${this._t('common.editor.header_colour')}</span>
+        <div class="colour-field-body">
+          <label class="colour-swatch-wrapper">
+            <input type="color" .value=${current}
+              @input=${(e) => this._update(key, e.target.value)} />
+            <span class="colour-swatch-preview" style="background:${current}"></span>
+          </label>
+          <span class="colour-hex">${current}</span>
+          <div class="colour-presets">
+            ${presets.map((p) => html`
+              <button class="preset-swatch ${isActive(p) ? 'active' : ''}"
+                style="background:${p}"
+                title=${p}
+                @click=${(e) => { e.preventDefault(); this._update(key, p); }}
+              ></button>
+            `)}
+          </div>
+          <button class="colour-reset"
+            @click=${(e) => { e.preventDefault(); this._update(key, defaultValue); }}
+          >${this._t('common.reset')}</button>
+        </div>
+        <div class="colour-helper">${this._t('common.editor.header_colour_helper')}</div>
+      </div>
+    `;
+  }
+
+  _formChanged(e) {
+    const newValues = e.detail.value || {};
+    const newConfig = { ...this.config };
+    for (const [key, value] of Object.entries(newValues)) {
+      if (value === '' || value === null || value === undefined) {
+        delete newConfig[key];
+      } else if (key === 'show_claims' && value === true) {
+        delete newConfig[key];
+      } else if (key === 'quick_points_amount' && value === 5) {
+        delete newConfig[key];
+      } else {
+        newConfig[key] = value;
+      }
+    }
+    this.dispatchEvent(new CustomEvent('config-changed', {
+      detail: { config: newConfig }, bubbles: true, composed: true,
+    }));
+  }
+
   _update(key, value) {
     const cfg = { ...this.config, [key]: value };
-    this.dispatchEvent(new CustomEvent("config-changed", { detail: { config: cfg }, bubbles: true, composed: true }));
+    this.dispatchEvent(new CustomEvent('config-changed', { detail: { config: cfg }, bubbles: true, composed: true }));
   }
 }
 

--- a/custom_components/taskmate/www/taskmate-points-display-card.js
+++ b/custom_components/taskmate/www/taskmate-points-display-card.js
@@ -742,105 +742,21 @@ class TaskMatePointsDisplayCardEditor extends LitElement {
 
   static get styles() {
     return css`
-      .editor-wrap { padding: 16px; display: flex; flex-direction: column; gap: 14px; }
-
-      .field-row { display: flex; flex-direction: column; gap: 4px; }
-      .field-label {
-        font-size: 0.78rem;
-        font-weight: 600;
-        color: var(--secondary-text-color);
-        text-transform: uppercase;
-        letter-spacing: 0.06em;
-      }
-
-      .segment-row { display: flex; gap: 8px; flex-wrap: wrap; }
-      .segment-btn {
-        flex: 1;
-        min-width: 80px;
-        padding: 8px 10px;
-        border-radius: 10px;
-        border: 2px solid var(--divider-color, #ddd);
-        background: var(--card-background-color, #fff);
-        cursor: pointer;
-        font-size: 0.85rem;
-        font-weight: 600;
-        color: var(--primary-text-color);
-        text-align: center;
-        transition: border-color 0.15s, background 0.15s;
-      }
-      .segment-btn.active {
-        border-color: var(--primary-color, #3498db);
-        background: var(--primary-color, #3498db);
-        color: white;
-      }
-
-      select, input[type="text"] {
-        width: 100%;
-        padding: 9px 12px;
-        border-radius: 10px;
-        border: 1px solid var(--divider-color, #ccc);
-        background: var(--card-background-color, #fff);
-        color: var(--primary-text-color);
-        font-size: 0.9rem;
-        box-sizing: border-box;
-      }
-      select:focus, input[type="text"]:focus {
-        outline: none;
-        border-color: var(--primary-color, #3498db);
-      }
-
-      .toggle-row {
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        gap: 10px;
-      }
-      .toggle-label {
-        font-size: 0.88rem;
-        font-weight: 500;
-        color: var(--primary-text-color);
-      }
-
-      .colour-row { display: flex; align-items: center; gap: 10px; }
-      .colour-swatch {
-        width: 36px; height: 36px; border-radius: 8px;
-        border: 2px solid var(--divider-color, #ddd);
-        flex-shrink: 0;
-        cursor: pointer;
-        overflow: hidden;
-        position: relative;
-      }
-      .colour-swatch input[type="color"] {
-        position: absolute; inset: 0; width: 100%; height: 100%;
-        border: none; padding: 0; margin: 0; cursor: pointer; opacity: 0;
-      }
-      .colour-hex {
-        flex: 1; font-size: 0.85rem; font-weight: 600;
-        font-family: monospace; padding: 9px 12px;
-        border-radius: 10px; border: 1px solid var(--divider-color, #ccc);
-        background: var(--card-background-color, #fff);
-        color: var(--primary-text-color);
-      }
-
-      .section-header {
-        font-size: 0.72rem;
-        font-weight: 700;
-        text-transform: uppercase;
-        letter-spacing: 0.1em;
-        color: var(--secondary-text-color);
-        border-bottom: 1px solid var(--divider-color, #e0e0e0);
-        padding-bottom: 6px;
-        margin-top: 4px;
-      }
-
-      .info-note {
-        font-size: 0.8rem;
-        color: var(--secondary-text-color);
-        background: var(--secondary-background-color, #f5f5f5);
-        border-radius: 8px;
-        padding: 8px 12px;
-        line-height: 1.4;
-      }
+      :host { display: block; padding: 8px 0; }
+      ha-form { display: block; margin-bottom: 16px; }
+      .colour-field { display: flex; flex-direction: column; gap: 8px; padding: 12px 16px; border: 1px solid var(--outline-color, var(--divider-color, #e0e0e0)); border-radius: 4px; background: var(--mdc-text-field-fill-color, var(--card-background-color)); }
+      .colour-field-label { font-size: 0.82rem; color: var(--primary-color); font-weight: 500; }
+      .colour-field-body { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }
+      .colour-swatch-wrapper { position: relative; width: 36px; height: 36px; border-radius: 50%; overflow: hidden; cursor: pointer; border: 2px solid var(--divider-color, #e0e0e0); flex-shrink: 0; }
+      .colour-swatch-wrapper input[type="color"] { position: absolute; inset: 0; opacity: 0; cursor: pointer; border: 0; padding: 0; }
+      .colour-swatch-preview { position: absolute; inset: 0; pointer-events: none; }
+      .colour-hex { font-family: var(--code-font-family, monospace); font-size: 0.85rem; color: var(--secondary-text-color); min-width: 70px; }
+      .colour-presets { display: flex; gap: 6px; flex-wrap: wrap; }
+      .preset-swatch { width: 22px; height: 22px; border-radius: 50%; cursor: pointer; border: 2px solid var(--divider-color, #e0e0e0); transition: transform 0.1s; padding: 0; }
+      .preset-swatch:hover { transform: scale(1.15); }
+      .preset-swatch.active { border-color: var(--primary-text-color); box-shadow: 0 0 0 2px var(--primary-color); }
+      .colour-reset { font-size: 0.78rem; color: var(--secondary-text-color); background: none; border: 1px solid var(--divider-color, #e0e0e0); border-radius: 4px; padding: 4px 10px; cursor: pointer; margin-left: auto; }
+      .colour-helper { color: var(--secondary-text-color); font-size: 0.82rem; line-height: 1.3; }
     `;
   }
 
@@ -849,7 +765,7 @@ class TaskMatePointsDisplayCardEditor extends LitElement {
   }
 
   updated(changed) {
-    if (changed.has("hass") && this.hass && this.config?.entity) {
+    if (changed.has('hass') && this.hass && this.config?.entity) {
       this._loadChildren();
     }
   }
@@ -860,8 +776,140 @@ class TaskMatePointsDisplayCardEditor extends LitElement {
     this._children = getChildren(state);
   }
 
+  _buildSchema() {
+    const mode = this.config.mode || 'single';
+    const schema = [
+      { name: 'entity', selector: { entity: { domain: 'sensor' } } },
+      { name: 'title', selector: { text: {} } },
+      {
+        name: 'mode',
+        selector: {
+          select: {
+            options: [
+              { value: 'single', label: this._t('points_display.editor.mode_single') },
+              { value: 'multi', label: this._t('points_display.editor.mode_multi') },
+              { value: 'cumulative', label: this._t('points_display.editor.mode_cumulative') },
+            ],
+            mode: 'dropdown',
+          },
+        },
+      },
+    ];
+
+    if (mode === 'single') {
+      schema.push({
+        name: 'child_id',
+        selector: {
+          select: {
+            options: [
+              { value: '', label: this._t('points_display.editor.select_child') },
+              ...this._children.map((c) => ({ value: c.id, label: c.name })),
+            ],
+            mode: 'dropdown',
+          },
+        },
+      });
+    }
+
+    schema.push({ name: 'show_weekly', selector: { boolean: {} } });
+    schema.push({ name: 'show_streak', selector: { boolean: {} } });
+    if (mode !== 'single') {
+      schema.push({ name: 'show_rank', selector: { boolean: {} } });
+    }
+    return schema;
+  }
+
+  _computeLabel = (entry) => {
+    const labels = {
+      entity: this._t('points_display.editor.entity_label'),
+      title: this._t('common.editor.card_title'),
+      mode: this._t('points_display.editor.mode_label'),
+      child_id: this._t('points_display.editor.child_label'),
+      show_weekly: this._t('points_display.editor.show_weekly'),
+      show_streak: this._t('points_display.editor.show_streak'),
+      show_rank: this._t('points_display.editor.show_rank'),
+    };
+    return labels[entry.name] ?? entry.name;
+  };
+
+  _computeHelper = () => '';
+
+  render() {
+    if (!this.config) return html``;
+    const mode = this.config.mode || 'single';
+    const data = {
+      entity: this.config.entity || '',
+      title: this.config.title || '',
+      mode,
+      child_id: this.config.child_id || '',
+      show_weekly: this.config.show_weekly !== false,
+      show_streak: this.config.show_streak !== false,
+      show_rank: this.config.show_rank !== false,
+    };
+    return html`
+      <ha-form
+        .hass=${this.hass}
+        .data=${data}
+        .schema=${this._buildSchema()}
+        .computeLabel=${this._computeLabel}
+        .computeHelper=${this._computeHelper}
+        @value-changed=${this._formChanged}
+      ></ha-form>
+      ${this._renderColourPicker('header_color', DEFAULT_HEADER)}
+    `;
+  }
+
+  _renderColourPicker(key, defaultValue) {
+    const current = this.config[key] || defaultValue;
+    const presets = [defaultValue, '#e67e22', '#27ae60', '#3498db', '#f1c40f', '#e74c3c', '#34495e'];
+    const isActive = (c) => c.toLowerCase() === current.toLowerCase();
+    return html`
+      <div class="colour-field">
+        <span class="colour-field-label">${this._t('common.editor.header_colour')}</span>
+        <div class="colour-field-body">
+          <label class="colour-swatch-wrapper">
+            <input type="color" .value=${current}
+              @input=${(e) => this._set(key, e.target.value)} />
+            <span class="colour-swatch-preview" style="background:${current}"></span>
+          </label>
+          <span class="colour-hex">${current}</span>
+          <div class="colour-presets">
+            ${presets.map((p) => html`
+              <button class="preset-swatch ${isActive(p) ? 'active' : ''}"
+                style="background:${p}"
+                title=${p}
+                @click=${(e) => { e.preventDefault(); this._set(key, p); }}
+              ></button>
+            `)}
+          </div>
+          <button class="colour-reset"
+            @click=${(e) => { e.preventDefault(); this._set(key, defaultValue); }}
+          >${this._t('common.reset')}</button>
+        </div>
+        <div class="colour-helper">${this._t('common.editor.header_colour_helper')}</div>
+      </div>
+    `;
+  }
+
+  _formChanged(e) {
+    const newValues = e.detail.value || {};
+    const newConfig = { ...this.config };
+    for (const [key, value] of Object.entries(newValues)) {
+      if (value === '' || value === null || value === undefined) {
+        delete newConfig[key];
+      } else if (key === 'mode' && value === 'single') {
+        delete newConfig[key];
+      } else if ((key === 'show_weekly' || key === 'show_streak' || key === 'show_rank') && value === true) {
+        delete newConfig[key];
+      } else {
+        newConfig[key] = value;
+      }
+    }
+    this._fire(newConfig);
+  }
+
   _fire(config) {
-    this.dispatchEvent(new CustomEvent("config-changed", {
+    this.dispatchEvent(new CustomEvent('config-changed', {
       detail: { config },
       bubbles: true,
       composed: true,
@@ -870,109 +918,6 @@ class TaskMatePointsDisplayCardEditor extends LitElement {
 
   _set(key, value) {
     this._fire({ ...this.config, [key]: value });
-  }
-
-  _toggle(key) {
-    this._set(key, !this.config[key]);
-  }
-
-  _onEntityChange(e) { this._set("entity", e.target.value); }
-  _onTitleChange(e)  { this._set("title",  e.target.value); }
-  _onColourChange(e) { this._set("header_color", e.target.value); }
-  _onHexChange(e)    {
-    const v = e.target.value;
-    if (/^#[0-9a-fA-F]{6}$/.test(v)) this._set("header_color", v);
-  }
-  _onChildChange(e)  { this._set("child_id", e.target.value); }
-  _setMode(m)        { this._set("mode", m); }
-
-  render() {
-    if (!this.config) return html``;
-
-    const mode       = this.config.mode       || "single";
-    const headerCol  = this.config.header_color || DEFAULT_HEADER;
-    const showStreak = this.config.show_streak !== false;
-    const showWeekly = this.config.show_weekly !== false;
-    const showRank   = this.config.show_rank   !== false;
-
-    return html`
-      <div class="editor-wrap">
-
-        <!-- Entity -->
-        <div class="field-row">
-          <div class="field-label">${this._t("points_display.editor.entity_label")}</div>
-          <input type="text" .value="${this.config.entity || ""}"
-            placeholder="sensor.taskmate_overview"
-            @change="${this._onEntityChange}">
-        </div>
-
-        <!-- Display Mode -->
-        <div class="section-header">${this._t("points_display.editor.display_mode")}</div>
-        <div class="field-row">
-          <div class="field-label">${this._t("points_display.editor.mode_label")}</div>
-          <div class="segment-row">
-            ${["single","multi","cumulative"].map(m => html`
-              <button class="segment-btn ${mode === m ? "active" : ""}"
-                      @click="${() => this._setMode(m)}">
-                ${{ single: this._t("points_display.editor.mode_single"), multi: this._t("points_display.editor.mode_multi"), cumulative: this._t("points_display.editor.mode_cumulative") }[m]}
-              </button>`)}
-          </div>
-        </div>
-
-        ${mode === "single" ? html`
-          <div class="field-row">
-            <div class="field-label">${this._t("points_display.editor.child_label")}</div>
-            ${this._children.length ? html`
-              <select .value="${this.config.child_id || ""}" @change="${this._onChildChange}">
-                <option value="">${this._t("points_display.editor.select_child")}</option>
-                ${this._children.map(c => html`
-                  <option value="${c.id}" ?selected="${c.id === this.config.child_id}">${c.name}</option>`)}
-              </select>` : html`
-              <input type="text" .value="${this.config.child_id || ""}"
-                placeholder="${this._t("points_display.editor.child_id_placeholder")}"
-                @change="${this._onChildChange}">
-              <div class="info-note">${this._t("points_display.editor.child_id_note")}</div>`}
-          </div>` : ""}
-
-        <!-- Appearance -->
-        <div class="section-header">${this._t("points_display.editor.appearance")}</div>
-
-        <div class="field-row">
-          <div class="field-label">${this._t("common.editor.header_colour")}</div>
-          <div class="colour-row">
-            <div class="colour-swatch" style="background:${headerCol};">
-              <input type="color" .value="${headerCol}" @input="${this._onColourChange}">
-            </div>
-            <input type="text" class="colour-hex" .value="${headerCol}"
-              maxlength="7" placeholder="#9b59b6" @change="${this._onHexChange}">
-          </div>
-        </div>
-
-        <div class="field-row">
-          <div class="field-label">${this._t("common.editor.card_title")}</div>
-          <input type="text" .value="${this.config.title || ""}"
-            placeholder="${this._t("points_display.editor.title_placeholder")}"
-            @change="${this._onTitleChange}">
-        </div>
-
-        <!-- Stats to show -->
-        <div class="section-header">${this._t("points_display.editor.stats_to_show")}</div>
-
-        <div class="toggle-row">
-          <span class="toggle-label">${this._t("points_display.editor.show_weekly")}</span>
-          <ha-switch ?checked="${showWeekly}" @change="${() => this._toggle("show_weekly")}"></ha-switch>
-        </div>
-        <div class="toggle-row">
-          <span class="toggle-label">${this._t("points_display.editor.show_streak")}</span>
-          <ha-switch ?checked="${showStreak}" @change="${() => this._toggle("show_streak")}"></ha-switch>
-        </div>
-        ${mode !== "single" ? html`
-          <div class="toggle-row">
-            <span class="toggle-label">${this._t("points_display.editor.show_rank")}</span>
-            <ha-switch ?checked="${showRank}" @change="${() => this._toggle("show_rank")}"></ha-switch>
-          </div>` : ""}
-
-      </div>`;
   }
 }
 

--- a/custom_components/taskmate/www/taskmate-reorder-card.js
+++ b/custom_components/taskmate/www/taskmate-reorder-card.js
@@ -894,84 +894,131 @@ class TaskMateReorderCardEditor extends LitElement {
   static get styles() {
     return css`
       :host { display: block; }
-      ha-textfield { width: 100%; margin-bottom: 16px; }
-      .form-row { margin-bottom: 16px; }
-      .form-label {
-        display: block; font-size: 0.85rem; font-weight: 500;
-        color: var(--primary-text-color); margin-bottom: 6px; padding: 0 2px;
-      }
-      .form-select {
-        width: 100%; padding: 10px 12px;
-        border: 1px solid var(--divider-color, #e0e0e0);
-        border-radius: 4px;
-        background: var(--card-background-color, #fff);
-        color: var(--primary-text-color);
-        font-size: 1rem; box-sizing: border-box; cursor: pointer; appearance: auto;
-      }
-      .form-select:focus { outline: none; border-color: var(--primary-color); }
-      .form-helper { display: block; font-size: 0.78rem; color: var(--secondary-text-color); margin-top: 4px; padding: 0 2px; }
+      ha-form { display: block; margin-bottom: 16px; }
+      .colour-field { display: flex; flex-direction: column; gap: 8px; padding: 12px 16px; border: 1px solid var(--outline-color, var(--divider-color, #e0e0e0)); border-radius: 4px; background: var(--mdc-text-field-fill-color, var(--card-background-color)); }
+      .colour-field-label { font-size: 0.82rem; color: var(--primary-color); font-weight: 500; }
+      .colour-field-body { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }
+      .colour-swatch-wrapper { position: relative; width: 36px; height: 36px; border-radius: 50%; overflow: hidden; cursor: pointer; border: 2px solid var(--divider-color, #e0e0e0); flex-shrink: 0; }
+      .colour-swatch-wrapper input[type="color"] { position: absolute; inset: 0; opacity: 0; cursor: pointer; border: 0; padding: 0; }
+      .colour-swatch-preview { position: absolute; inset: 0; pointer-events: none; }
+      .colour-hex { font-family: var(--code-font-family, monospace); font-size: 0.85rem; color: var(--secondary-text-color); min-width: 70px; }
+      .colour-presets { display: flex; gap: 6px; flex-wrap: wrap; }
+      .preset-swatch { width: 22px; height: 22px; border-radius: 50%; cursor: pointer; border: 2px solid var(--divider-color, #e0e0e0); transition: transform 0.1s; padding: 0; }
+      .preset-swatch:hover { transform: scale(1.15); }
+      .preset-swatch.active { border-color: var(--primary-text-color); box-shadow: 0 0 0 2px var(--primary-color); }
+      .colour-reset { font-size: 0.78rem; color: var(--secondary-text-color); background: none; border: 1px solid var(--divider-color, #e0e0e0); border-radius: 4px; padding: 4px 10px; cursor: pointer; margin-left: auto; }
+      .colour-helper { color: var(--secondary-text-color); font-size: 0.82rem; line-height: 1.3; }
     `;
   }
 
   setConfig(config) { this.config = config; }
-
-  render() {
-    if (!this.hass || !this.config) return html``;
-    const entity = this.config.entity ? this.hass.states[this.config.entity] : null;
-    const children = entity?.attributes?.children || [];
-    return html`
-      <ha-textfield
-        label="${this._t('common.editor.overview_entity')}"
-        .value="${this.config.entity || ""}"
-        @change="${this._entityChanged}"
-        helper="${this._t('common.editor.overview_entity_helper')}"
-        helperPersistent
-        placeholder="sensor.taskmate_overview"
-      ></ha-textfield>
-      <div class="form-row">
-        <label class="form-label">${this._t('reorder.editor.child')}</label>
-        <select class="form-select" @change="${this._childIdChanged}">
-          <option value="" ?selected="${!this.config.child_id}">${this._t('reorder.editor.select_child')}</option>
-          ${children.map(c => html`<option value="${c.id}" ?selected="${this.config.child_id === c.id}">${c.name}</option>`)}
-        </select>
-        <span class="form-helper">${this._t('reorder.editor.child_helper')}</span>
-      </div>
-      <ha-textfield
-        label="${this._t('common.editor.card_title')}"
-        .value="${this.config.title || ""}"
-        @change="${this._titleChanged}"
-        placeholder="Reorder Chores"
-      ></ha-textfield>
-        <span class="field-helper">${this._t('common.editor.header_colour_helper')}</span>
-      </div>
-      <div class="field-row">
-        <label class="field-label">${this._t('common.editor.header_colour')}</label>
-        <div style="display:flex;align-items:center;gap:10px;">
-          <input
-            type="color"
-            .value=${this.config.header_color || '#16a085'}
-            @input=${e => this._updateConfig('header_color', e.target.value)}
-            style="width:48px;height:36px;padding:2px;border:1px solid var(--divider-color,#e0e0e0);border-radius:6px;cursor:pointer;"
-          />
-          <span style="font-size:13px;color:var(--secondary-text-color);">${this.config.header_color || '#16a085'}</span>
-          <button
-            style="font-size:11px;color:var(--secondary-text-color);background:none;border:1px solid var(--divider-color,#e0e0e0);border-radius:4px;padding:3px 8px;cursor:pointer;"
-            @click=${() => this._updateConfig('header_color', '#16a085')}
-          >${this._t('common.reset')}</button>
-        </div>
-        <span class="field-helper">${this._t('common.editor.header_colour_helper')}</span>
-      </div>
-    `;
-  }
 
   _t(key, params) {
     const fn = window.__taskmate_localize;
     return fn ? fn(this.hass, key, params) : key;
   }
 
-  _entityChanged(e) { this._updateConfig("entity", e.target.value); }
-  _childIdChanged(e) { this._updateConfig("child_id", e.target.value); }
-  _titleChanged(e) { this._updateConfig("title", e.target.value); }
+  _buildSchema() {
+    const entity = this.config?.entity ? this.hass?.states?.[this.config.entity] : null;
+    const children = entity?.attributes?.children || [];
+    return [
+      { name: 'entity', selector: { entity: { domain: 'sensor' } } },
+      {
+        name: 'child_id',
+        selector: {
+          select: {
+            options: [
+              { value: '', label: this._t('reorder.editor.select_child') },
+              ...children.map((c) => ({ value: c.id, label: c.name })),
+            ],
+            mode: 'dropdown',
+          },
+        },
+      },
+      { name: 'title', selector: { text: {} } },
+    ];
+  }
+
+  _computeLabel = (entry) => {
+    const labels = {
+      entity: this._t('common.editor.overview_entity'),
+      child_id: this._t('reorder.editor.child'),
+      title: this._t('common.editor.card_title'),
+    };
+    return labels[entry.name] ?? entry.name;
+  };
+
+  _computeHelper = (entry) => {
+    const helpers = {
+      entity: this._t('common.editor.overview_entity_helper'),
+      child_id: this._t('reorder.editor.child_helper'),
+    };
+    return helpers[entry.name] ?? '';
+  };
+
+  render() {
+    if (!this.hass || !this.config) return html``;
+    const data = {
+      entity: this.config.entity || '',
+      child_id: this.config.child_id || '',
+      title: this.config.title || '',
+    };
+    return html`
+      <ha-form
+        .hass=${this.hass}
+        .data=${data}
+        .schema=${this._buildSchema()}
+        .computeLabel=${this._computeLabel}
+        .computeHelper=${this._computeHelper}
+        @value-changed=${this._formChanged}
+      ></ha-form>
+      ${this._renderColourPicker('header_color', '#16a085')}
+    `;
+  }
+
+  _renderColourPicker(key, defaultValue) {
+    const current = this.config[key] || defaultValue;
+    const presets = [defaultValue, '#e67e22', '#3498db', '#9b59b6', '#f1c40f', '#e74c3c', '#34495e'];
+    const isActive = (c) => c.toLowerCase() === current.toLowerCase();
+    return html`
+      <div class="colour-field">
+        <span class="colour-field-label">${this._t('common.editor.header_colour')}</span>
+        <div class="colour-field-body">
+          <label class="colour-swatch-wrapper">
+            <input type="color" .value=${current}
+              @input=${(e) => this._updateConfig(key, e.target.value)} />
+            <span class="colour-swatch-preview" style="background:${current}"></span>
+          </label>
+          <span class="colour-hex">${current}</span>
+          <div class="colour-presets">
+            ${presets.map((p) => html`
+              <button class="preset-swatch ${isActive(p) ? 'active' : ''}"
+                style="background:${p}"
+                title=${p}
+                @click=${(e) => { e.preventDefault(); this._updateConfig(key, p); }}
+              ></button>
+            `)}
+          </div>
+          <button class="colour-reset"
+            @click=${(e) => { e.preventDefault(); this._updateConfig(key, defaultValue); }}
+          >${this._t('common.reset')}</button>
+        </div>
+        <div class="colour-helper">${this._t('common.editor.header_colour_helper')}</div>
+      </div>
+    `;
+  }
+
+  _formChanged(e) {
+    const newValues = e.detail.value || {};
+    const newConfig = { ...this.config };
+    for (const [key, value] of Object.entries(newValues)) {
+      if (value === '' || value === null || value === undefined) delete newConfig[key];
+      else newConfig[key] = value;
+    }
+    this.dispatchEvent(new CustomEvent('config-changed', {
+      detail: { config: newConfig }, bubbles: true, composed: true,
+    }));
+  }
 
   _updateConfig(key, value) {
     const newConfig = { ...this.config, [key]: value };

--- a/custom_components/taskmate/www/taskmate-reward-progress-card.js
+++ b/custom_components/taskmate/www/taskmate-reward-progress-card.js
@@ -568,85 +568,148 @@ class TaskMateRewardProgressCardEditor extends LitElement {
 
   static get styles() {
     return css`
-      :host { display: block; padding: 4px 0; }
-      ha-textfield { width: 100%; margin-bottom: 8px; }
-      .field-row { margin-bottom: 16px; }
-      .field-label { display: block; font-size: 12px; font-weight: 500; color: var(--secondary-text-color); text-transform: uppercase; letter-spacing: 0.08em; margin-bottom: 6px; padding: 0 4px; }
-      .field-select { display: block; width: 100%; padding: 10px 12px; border: 1px solid var(--divider-color, #e0e0e0); border-radius: 4px; background: var(--card-background-color, #fff); color: var(--primary-text-color); font-size: 14px; box-sizing: border-box; cursor: pointer; appearance: auto; }
-      .field-select:focus { outline: none; border-color: var(--primary-color); border-width: 2px; }
-      .field-helper { display: block; font-size: 11px; color: var(--secondary-text-color); margin-top: 5px; padding: 0 4px; }
+      :host { display: block; }
+      ha-form { display: block; margin-bottom: 16px; }
+      .colour-field { display: flex; flex-direction: column; gap: 8px; padding: 12px 16px; border: 1px solid var(--outline-color, var(--divider-color, #e0e0e0)); border-radius: 4px; background: var(--mdc-text-field-fill-color, var(--card-background-color)); }
+      .colour-field-label { font-size: 0.82rem; color: var(--primary-color); font-weight: 500; }
+      .colour-field-body { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }
+      .colour-swatch-wrapper { position: relative; width: 36px; height: 36px; border-radius: 50%; overflow: hidden; cursor: pointer; border: 2px solid var(--divider-color, #e0e0e0); flex-shrink: 0; }
+      .colour-swatch-wrapper input[type="color"] { position: absolute; inset: 0; opacity: 0; cursor: pointer; border: 0; padding: 0; }
+      .colour-swatch-preview { position: absolute; inset: 0; pointer-events: none; }
+      .colour-hex { font-family: var(--code-font-family, monospace); font-size: 0.85rem; color: var(--secondary-text-color); min-width: 70px; }
+      .colour-presets { display: flex; gap: 6px; flex-wrap: wrap; }
+      .preset-swatch { width: 22px; height: 22px; border-radius: 50%; cursor: pointer; border: 2px solid var(--divider-color, #e0e0e0); transition: transform 0.1s; padding: 0; }
+      .preset-swatch:hover { transform: scale(1.15); }
+      .preset-swatch.active { border-color: var(--primary-text-color); box-shadow: 0 0 0 2px var(--primary-color); }
+      .colour-reset { font-size: 0.78rem; color: var(--secondary-text-color); background: none; border: 1px solid var(--divider-color, #e0e0e0); border-radius: 4px; padding: 4px 10px; cursor: pointer; margin-left: auto; }
+      .colour-helper { color: var(--secondary-text-color); font-size: 0.82rem; line-height: 1.3; }
     `;
   }
 
   setConfig(config) { this.config = config; }
 
-  render() {
-    if (!this.hass || !this.config) return html``;
-    const entity = this.config.entity ? this.hass.states[this.config.entity] : null;
+  _buildSchema() {
+    const entity = this.config?.entity ? this.hass?.states?.[this.config.entity] : null;
     const rewards = entity?.attributes?.rewards || [];
     const children = entity?.attributes?.children || [];
+    return [
+      { name: 'entity', selector: { entity: { domain: 'sensor' } } },
+      { name: 'title', selector: { text: {} } },
+      {
+        name: 'reward_id',
+        selector: {
+          select: {
+            options: [
+              { value: '', label: this._t('reward_progress.editor.first_available') },
+              ...rewards.map((r) => ({ value: r.id, label: r.name })),
+            ],
+            mode: 'dropdown',
+          },
+        },
+      },
+      {
+        name: 'child_id',
+        selector: {
+          select: {
+            options: [
+              { value: '', label: this._t('reward_progress.editor.child_filter_all') },
+              ...children.map((c) => ({ value: c.id, label: c.name })),
+            ],
+            mode: 'dropdown',
+          },
+        },
+      },
+    ];
+  }
 
+  _computeLabel = (entry) => {
+    const labels = {
+      entity: this._t('common.editor.overview_entity'),
+      title: this._t('common.editor.card_title'),
+      reward_id: this._t('reward_progress.editor.reward_to_display'),
+      child_id: this._t('common.editor.filter_by_child'),
+    };
+    return labels[entry.name] ?? entry.name;
+  };
+
+  _computeHelper = (entry) => {
+    const helpers = {
+      entity: this._t('common.editor.overview_entity_helper'),
+      reward_id: this._t('reward_progress.editor.reward_helper'),
+      child_id: this._t('reward_progress.editor.child_helper'),
+    };
+    return helpers[entry.name] ?? '';
+  };
+
+  render() {
+    if (!this.hass || !this.config) return html``;
+    const data = {
+      entity: this.config.entity || '',
+      title: this.config.title || '',
+      reward_id: this.config.reward_id || '',
+      child_id: this.config.child_id || '',
+    };
     return html`
-      <ha-textfield
-        label="${this._t('common.editor.overview_entity')}"
-        .value="${this.config.entity || ''}"
-        @change="${e => this._update('entity', e.target.value)}"
-        helper="${this._t('common.editor.overview_entity_helper')}"
-        helperPersistent
-        placeholder="sensor.taskmate_overview"
-      ></ha-textfield>
+      <ha-form
+        .hass=${this.hass}
+        .data=${data}
+        .schema=${this._buildSchema()}
+        .computeLabel=${this._computeLabel}
+        .computeHelper=${this._computeHelper}
+        @value-changed=${this._formChanged}
+      ></ha-form>
+      ${this._renderColourPicker('header_color', '#7d3c98')}
+    `;
+  }
 
-      <ha-textfield
-        label="${this._t('common.editor.card_title')}"
-        .value="${this.config.title || ''}"
-        @change="${e => this._update('title', e.target.value)}"
-        placeholder="Reward Goal"
-      ></ha-textfield>
-
-      <div class="field-row">
-        <label class="field-label">${this._t('reward_progress.editor.reward_to_display')}</label>
-        <select class="field-select" @change="${e => this._update('reward_id', e.target.value || null)}">
-          <option value="" ?selected="${!this.config.reward_id}">${this._t('reward_progress.editor.first_available')}</option>
-          ${rewards.map(r => html`<option value="${r.id}" ?selected="${this.config.reward_id === r.id}">${r.name}</option>`)}
-        </select>
-        <span class="field-helper">${this._t('reward_progress.editor.reward_helper')}</span>
-      </div>
-
-      <div class="field-row">
-        <label class="field-label">${this._t('common.editor.filter_by_child')}</label>
-        <select class="field-select" @change="${e => this._update('child_id', e.target.value || null)}">
-          <option value="" ?selected="${!this.config.child_id}">${this._t('reward_progress.editor.child_filter_all')}</option>
-          ${children.map(c => html`<option value="${c.id}" ?selected="${this.config.child_id === c.id}">${c.name}</option>`)}
-        </select>
-        <span class="field-helper">${this._t('reward_progress.editor.child_helper')}</span>
-      </div>
-        <span class="field-helper">${this._t('common.editor.header_colour_helper')}</span>
-      </div>
-
-      <div class="field-row">
-        <label class="field-label">${this._t('common.editor.header_colour')}</label>
-        <div style="display:flex;align-items:center;gap:10px;">
-          <input
-            type="color"
-            .value=${this.config.header_color || '#7d3c98'}
-            @input=${e => this._update('header_color', e.target.value)}
-            style="width:48px;height:36px;padding:2px;border:1px solid var(--divider-color,#e0e0e0);border-radius:6px;cursor:pointer;"
-          />
-          <span style="font-size:13px;color:var(--secondary-text-color);">${this.config.header_color || '#7d3c98'}</span>
-          <button
-            style="font-size:11px;color:var(--secondary-text-color);background:none;border:1px solid var(--divider-color,#e0e0e0);border-radius:4px;padding:3px 8px;cursor:pointer;"
-            @click=${() => this._update('header_color', '#7d3c98')}
+  _renderColourPicker(key, defaultValue) {
+    const current = this.config[key] || defaultValue;
+    const presets = [defaultValue, '#e67e22', '#27ae60', '#3498db', '#f1c40f', '#e74c3c', '#34495e'];
+    const isActive = (c) => c.toLowerCase() === current.toLowerCase();
+    return html`
+      <div class="colour-field">
+        <span class="colour-field-label">${this._t('common.editor.header_colour')}</span>
+        <div class="colour-field-body">
+          <label class="colour-swatch-wrapper">
+            <input type="color" .value=${current}
+              @input=${(e) => this._update(key, e.target.value)} />
+            <span class="colour-swatch-preview" style="background:${current}"></span>
+          </label>
+          <span class="colour-hex">${current}</span>
+          <div class="colour-presets">
+            ${presets.map((p) => html`
+              <button class="preset-swatch ${isActive(p) ? 'active' : ''}"
+                style="background:${p}"
+                title=${p}
+                @click=${(e) => { e.preventDefault(); this._update(key, p); }}
+              ></button>
+            `)}
+          </div>
+          <button class="colour-reset"
+            @click=${(e) => { e.preventDefault(); this._update(key, defaultValue); }}
           >${this._t('common.reset')}</button>
         </div>
-        <span class="field-helper">${this._t('common.editor.header_colour_helper')}</span>
+        <div class="colour-helper">${this._t('common.editor.header_colour_helper')}</div>
       </div>
     `;
+  }
+
+  _formChanged(e) {
+    const newValues = e.detail.value || {};
+    const newConfig = { ...this.config };
+    for (const [key, value] of Object.entries(newValues)) {
+      if (value === '' || value === null || value === undefined) delete newConfig[key];
+      else newConfig[key] = value;
+    }
+    this.dispatchEvent(new CustomEvent('config-changed', {
+      detail: { config: newConfig }, bubbles: true, composed: true,
+    }));
   }
 
   _update(key, value) {
     const cfg = { ...this.config, [key]: value };
     if (!value) delete cfg[key];
-    this.dispatchEvent(new CustomEvent("config-changed", { detail: { config: cfg }, bubbles: true, composed: true }));
+    this.dispatchEvent(new CustomEvent('config-changed', { detail: { config: cfg }, bubbles: true, composed: true }));
   }
 }
 

--- a/custom_components/taskmate/www/taskmate-streak-card.js
+++ b/custom_components/taskmate/www/taskmate-streak-card.js
@@ -413,83 +413,134 @@ class TaskMateStreakCardEditor extends LitElement {
   static get styles() {
     return css`
       :host { display: block; }
-      ha-textfield { width: 100%; margin-bottom: 16px; }
-      .form-row { margin-bottom: 16px; }
-      .form-label {
-        display: block; font-size: 0.85rem; font-weight: 500;
-        color: var(--primary-text-color); margin-bottom: 6px; padding: 0 2px;
-      }
-      .form-select {
-        width: 100%; padding: 10px 12px;
-        border: 1px solid var(--divider-color, #e0e0e0);
-        border-radius: 4px;
-        background: var(--card-background-color, #fff);
-        color: var(--primary-text-color);
-        font-size: 1rem; box-sizing: border-box; cursor: pointer; appearance: auto;
-      }
-      .form-select:focus { outline: none; border-color: var(--primary-color); }
-      .form-helper { display: block; font-size: 0.78rem; color: var(--secondary-text-color); margin-top: 4px; padding: 0 2px; }
+      ha-form { display: block; margin-bottom: 16px; }
+      .colour-field { display: flex; flex-direction: column; gap: 8px; padding: 12px 16px; border: 1px solid var(--outline-color, var(--divider-color, #e0e0e0)); border-radius: 4px; background: var(--mdc-text-field-fill-color, var(--card-background-color)); }
+      .colour-field-label { font-size: 0.82rem; color: var(--primary-color); font-weight: 500; }
+      .colour-field-body { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }
+      .colour-swatch-wrapper { position: relative; width: 36px; height: 36px; border-radius: 50%; overflow: hidden; cursor: pointer; border: 2px solid var(--divider-color, #e0e0e0); flex-shrink: 0; }
+      .colour-swatch-wrapper input[type="color"] { position: absolute; inset: 0; opacity: 0; cursor: pointer; border: 0; padding: 0; }
+      .colour-swatch-preview { position: absolute; inset: 0; pointer-events: none; }
+      .colour-hex { font-family: var(--code-font-family, monospace); font-size: 0.85rem; color: var(--secondary-text-color); min-width: 70px; }
+      .colour-presets { display: flex; gap: 6px; flex-wrap: wrap; }
+      .preset-swatch { width: 22px; height: 22px; border-radius: 50%; cursor: pointer; border: 2px solid var(--divider-color, #e0e0e0); transition: transform 0.1s; padding: 0; }
+      .preset-swatch:hover { transform: scale(1.15); }
+      .preset-swatch.active { border-color: var(--primary-text-color); box-shadow: 0 0 0 2px var(--primary-color); }
+      .colour-reset { font-size: 0.78rem; color: var(--secondary-text-color); background: none; border: 1px solid var(--divider-color, #e0e0e0); border-radius: 4px; padding: 4px 10px; cursor: pointer; margin-left: auto; }
+      .colour-helper { color: var(--secondary-text-color); font-size: 0.82rem; line-height: 1.3; }
     `;
   }
 
   setConfig(config) { this.config = config; }
 
+  _buildSchema() {
+    const entity = this.config?.entity ? this.hass?.states?.[this.config.entity] : null;
+    const children = entity?.attributes?.children || [];
+    return [
+      { name: 'entity', selector: { entity: { domain: 'sensor' } } },
+      { name: 'title', selector: { text: {} } },
+      {
+        name: 'child_id',
+        selector: {
+          select: {
+            options: [
+              { value: '', label: this._t('common.editor.filter_by_child_all') },
+              ...children.map((c) => ({ value: c.id, label: c.name })),
+            ],
+            mode: 'dropdown',
+          },
+        },
+      },
+      { name: 'streak_days_shown', selector: { number: { min: 1, max: 100, mode: 'box' } } },
+    ];
+  }
+
+  _computeLabel = (entry) => {
+    const labels = {
+      entity: this._t('common.editor.overview_entity'),
+      title: this._t('streak.editor.title'),
+      child_id: this._t('common.editor.filter_by_child'),
+      streak_days_shown: this._t('streak.editor.days_shown'),
+    };
+    return labels[entry.name] ?? entry.name;
+  };
+
+  _computeHelper = (entry) => {
+    const helpers = {
+      entity: this._t('common.editor.overview_entity_helper'),
+      child_id: this._t('streak.editor.child_helper'),
+      streak_days_shown: this._t('streak.editor.days_shown_helper'),
+    };
+    return helpers[entry.name] ?? '';
+  };
+
   render() {
     if (!this.hass || !this.config) return html``;
-    const entity = this.config.entity ? this.hass.states[this.config.entity] : null;
-    const children = entity?.attributes?.children || [];
-
+    const data = {
+      entity: this.config.entity || '',
+      title: this.config.title || '',
+      child_id: this.config.child_id || '',
+      streak_days_shown: this.config.streak_days_shown || 14,
+    };
     return html`
-      <ha-textfield
-        label="${this._t('common.editor.overview_entity')}"
-        .value="${this.config.entity || ""}"
-        @change="${e => this._updateConfig('entity', e.target.value)}"
-        helper="${this._t('common.editor.overview_entity_helper')}"
-        helperPersistent
-        placeholder="sensor.taskmate_overview"
-      ></ha-textfield>
-      <ha-textfield
-        label="${this._t('streak.editor.title')}"
-        .value="${this.config.title || ""}"
-        @change="${e => this._updateConfig('title', e.target.value)}"
-        placeholder="Streaks & Achievements"
-      ></ha-textfield>
-      <div class="form-row">
-        <label class="form-label">${this._t('common.editor.filter_by_child')}</label>
-        <select class="form-select" @change="${e => this._updateConfig('child_id', e.target.value || null)}">
-          <option value="" ?selected="${!this.config.child_id}">${this._t('common.editor.filter_by_child_all')}</option>
-          ${children.map(c => html`<option value="${c.id}" ?selected="${this.config.child_id === c.id}">${c.name}</option>`)}
-        </select>
-        <span class="form-helper">${this._t('streak.editor.child_helper')}</span>
-      </div>
-      <ha-textfield
-        label="${this._t('streak.editor.days_shown')}"
-        type="number"
-        .value="${String(this.config.streak_days_shown || 14)}"
-        @change="${e => this._updateConfig('streak_days_shown', parseInt(e.target.value) || 14)}"
-        helper="${this._t('streak.editor.days_shown_helper')}"
-        helperPersistent
-      ></ha-textfield>
-        <span class="field-helper">${this._t('common.editor.header_colour_helper')}</span>
-      </div>
-      <div class="field-row">
-        <label class="field-label">${this._t('common.editor.header_colour')}</label>
-        <div style="display:flex;align-items:center;gap:10px;">
-          <input
-            type="color"
-            .value=${this.config.header_color || '#e74c3c'}
-            @input=${e => this._updateConfig('header_color', e.target.value)}
-            style="width:48px;height:36px;padding:2px;border:1px solid var(--divider-color,#e0e0e0);border-radius:6px;cursor:pointer;"
-          />
-          <span style="font-size:13px;color:var(--secondary-text-color);">${this.config.header_color || '#e74c3c'}</span>
-          <button
-            style="font-size:11px;color:var(--secondary-text-color);background:none;border:1px solid var(--divider-color,#e0e0e0);border-radius:4px;padding:3px 8px;cursor:pointer;"
-            @click=${() => this._updateConfig('header_color', '#e74c3c')}
+      <ha-form
+        .hass=${this.hass}
+        .data=${data}
+        .schema=${this._buildSchema()}
+        .computeLabel=${this._computeLabel}
+        .computeHelper=${this._computeHelper}
+        @value-changed=${this._formChanged}
+      ></ha-form>
+      ${this._renderColourPicker('header_color', '#e74c3c')}
+    `;
+  }
+
+  _renderColourPicker(key, defaultValue) {
+    const current = this.config[key] || defaultValue;
+    const presets = [defaultValue, '#e67e22', '#27ae60', '#3498db', '#9b59b6', '#f1c40f', '#34495e'];
+    const isActive = (c) => c.toLowerCase() === current.toLowerCase();
+    return html`
+      <div class="colour-field">
+        <span class="colour-field-label">${this._t('common.editor.header_colour')}</span>
+        <div class="colour-field-body">
+          <label class="colour-swatch-wrapper">
+            <input type="color" .value=${current}
+              @input=${(e) => this._updateConfig(key, e.target.value)} />
+            <span class="colour-swatch-preview" style="background:${current}"></span>
+          </label>
+          <span class="colour-hex">${current}</span>
+          <div class="colour-presets">
+            ${presets.map((p) => html`
+              <button class="preset-swatch ${isActive(p) ? 'active' : ''}"
+                style="background:${p}"
+                title=${p}
+                @click=${(e) => { e.preventDefault(); this._updateConfig(key, p); }}
+              ></button>
+            `)}
+          </div>
+          <button class="colour-reset"
+            @click=${(e) => { e.preventDefault(); this._updateConfig(key, defaultValue); }}
           >${this._t('common.reset')}</button>
         </div>
-        <span class="field-helper">${this._t('common.editor.header_colour_helper')}</span>
+        <div class="colour-helper">${this._t('common.editor.header_colour_helper')}</div>
       </div>
     `;
+  }
+
+  _formChanged(e) {
+    const newValues = e.detail.value || {};
+    const newConfig = { ...this.config };
+    for (const [key, value] of Object.entries(newValues)) {
+      if (value === '' || value === null || value === undefined) {
+        delete newConfig[key];
+      } else if (key === 'streak_days_shown' && value === 14) {
+        delete newConfig[key];
+      } else {
+        newConfig[key] = value;
+      }
+    }
+    this.dispatchEvent(new CustomEvent('config-changed', {
+      detail: { config: newConfig }, bubbles: true, composed: true,
+    }));
   }
 
   _updateConfig(key, value) {

--- a/custom_components/taskmate/www/taskmate-weekly-card.js
+++ b/custom_components/taskmate/www/taskmate-weekly-card.js
@@ -484,81 +484,131 @@ class TaskMateWeeklyCardEditor extends LitElement {
   static get styles() {
     return css`
       :host { display: block; }
-      ha-textfield { width: 100%; margin-bottom: 16px; }
-      .form-row { margin-bottom: 16px; }
-      .form-label {
-        display: block; font-size: 0.85rem; font-weight: 500;
-        color: var(--primary-text-color); margin-bottom: 6px; padding: 0 2px;
-      }
-      .form-select {
-        width: 100%; padding: 10px 12px;
-        border: 1px solid var(--divider-color, #e0e0e0);
-        border-radius: 4px;
-        background: var(--card-background-color, #fff);
-        color: var(--primary-text-color);
-        font-size: 1rem; box-sizing: border-box; cursor: pointer; appearance: auto;
-      }
-      .form-select:focus { outline: none; border-color: var(--primary-color); }
-      .form-helper { display: block; font-size: 0.78rem; color: var(--secondary-text-color); margin-top: 4px; padding: 0 2px; }
+      ha-form { display: block; margin-bottom: 16px; }
+      .colour-field { display: flex; flex-direction: column; gap: 8px; padding: 12px 16px; border: 1px solid var(--outline-color, var(--divider-color, #e0e0e0)); border-radius: 4px; background: var(--mdc-text-field-fill-color, var(--card-background-color)); }
+      .colour-field-label { font-size: 0.82rem; color: var(--primary-color); font-weight: 500; }
+      .colour-field-body { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }
+      .colour-swatch-wrapper { position: relative; width: 36px; height: 36px; border-radius: 50%; overflow: hidden; cursor: pointer; border: 2px solid var(--divider-color, #e0e0e0); flex-shrink: 0; }
+      .colour-swatch-wrapper input[type="color"] { position: absolute; inset: 0; opacity: 0; cursor: pointer; border: 0; padding: 0; }
+      .colour-swatch-preview { position: absolute; inset: 0; pointer-events: none; }
+      .colour-hex { font-family: var(--code-font-family, monospace); font-size: 0.85rem; color: var(--secondary-text-color); min-width: 70px; }
+      .colour-presets { display: flex; gap: 6px; flex-wrap: wrap; }
+      .preset-swatch { width: 22px; height: 22px; border-radius: 50%; cursor: pointer; border: 2px solid var(--divider-color, #e0e0e0); transition: transform 0.1s; padding: 0; }
+      .preset-swatch:hover { transform: scale(1.15); }
+      .preset-swatch.active { border-color: var(--primary-text-color); box-shadow: 0 0 0 2px var(--primary-color); }
+      .colour-reset { font-size: 0.78rem; color: var(--secondary-text-color); background: none; border: 1px solid var(--divider-color, #e0e0e0); border-radius: 4px; padding: 4px 10px; cursor: pointer; margin-left: auto; }
+      .colour-helper { color: var(--secondary-text-color); font-size: 0.82rem; line-height: 1.3; }
     `;
   }
 
   setConfig(config) { this.config = config; }
 
+  _buildSchema() {
+    const entity = this.config?.entity ? this.hass?.states?.[this.config.entity] : null;
+    const children = entity?.attributes?.children || [];
+    return [
+      { name: 'entity', selector: { entity: { domain: 'sensor' } } },
+      { name: 'title', selector: { text: {} } },
+      {
+        name: 'child_id',
+        selector: {
+          select: {
+            options: [
+              { value: '', label: this._t('common.editor.filter_by_child_all') },
+              ...children.map((c) => ({ value: c.id, label: c.name })),
+            ],
+            mode: 'dropdown',
+          },
+        },
+      },
+    ];
+  }
+
+  _computeLabel = (entry) => {
+    const labels = {
+      entity: this._t('common.editor.overview_entity'),
+      title: this._t('weekly.editor.title'),
+      child_id: this._t('common.editor.filter_by_child'),
+    };
+    return labels[entry.name] ?? entry.name;
+  };
+
+  _computeHelper = (entry) => {
+    const helpers = {
+      entity: this._t('common.editor.overview_entity_helper'),
+      child_id: this._t('weekly.editor.child_helper'),
+    };
+    return helpers[entry.name] ?? '';
+  };
+
   render() {
     if (!this.hass || !this.config) return html``;
-    const entity = this.config.entity ? this.hass.states[this.config.entity] : null;
-    const children = entity?.attributes?.children || [];
-
+    const data = {
+      entity: this.config.entity || '',
+      title: this.config.title || '',
+      child_id: this.config.child_id || '',
+    };
     return html`
-      <ha-textfield
-        label="${this._t('common.editor.overview_entity')}"
-        .value="${this.config.entity || ""}"
-        @change="${e => this._updateConfig('entity', e.target.value)}"
-        helper="${this._t('common.editor.overview_entity_helper')}"
-        helperPersistent
-        placeholder="sensor.taskmate_overview"
-      ></ha-textfield>
-      <ha-textfield
-        label="${this._t('weekly.editor.title')}"
-        .value="${this.config.title || ""}"
-        @change="${e => this._updateConfig('title', e.target.value)}"
-        placeholder="This Week"
-      ></ha-textfield>
-      <div class="form-row">
-        <label class="form-label">${this._t('common.editor.filter_by_child')}</label>
-        <select class="form-select" @change="${e => this._updateConfig('child_id', e.target.value || null)}">
-          <option value="" ?selected="${!this.config.child_id}">${this._t('common.editor.filter_by_child_all')}</option>
-          ${children.map(c => html`<option value="${c.id}" ?selected="${this.config.child_id === c.id}">${c.name}</option>`)}
-        </select>
-        <span class="form-helper">${this._t('weekly.editor.child_helper')}</span>
-      </div>
-        <span class="field-helper">${this._t('common.editor.header_colour_helper')}</span>
-      </div>
-      <div class="field-row">
-        <label class="field-label">${this._t('common.editor.header_colour')}</label>
-        <div style="display:flex;align-items:center;gap:10px;">
-          <input
-            type="color"
-            .value=${this.config.header_color || '#27ae60'}
-            @input=${e => this._updateConfig('header_color', e.target.value)}
-            style="width:48px;height:36px;padding:2px;border:1px solid var(--divider-color,#e0e0e0);border-radius:6px;cursor:pointer;"
-          />
-          <span style="font-size:13px;color:var(--secondary-text-color);">${this.config.header_color || '#27ae60'}</span>
-          <button
-            style="font-size:11px;color:var(--secondary-text-color);background:none;border:1px solid var(--divider-color,#e0e0e0);border-radius:4px;padding:3px 8px;cursor:pointer;"
-            @click=${() => this._updateConfig('header_color', '#27ae60')}
+      <ha-form
+        .hass=${this.hass}
+        .data=${data}
+        .schema=${this._buildSchema()}
+        .computeLabel=${this._computeLabel}
+        .computeHelper=${this._computeHelper}
+        @value-changed=${this._formChanged}
+      ></ha-form>
+      ${this._renderColourPicker('header_color', '#27ae60')}
+    `;
+  }
+
+  _renderColourPicker(key, defaultValue) {
+    const current = this.config[key] || defaultValue;
+    const presets = [defaultValue, '#e67e22', '#3498db', '#9b59b6', '#f1c40f', '#e74c3c', '#34495e'];
+    const isActive = (c) => c.toLowerCase() === current.toLowerCase();
+    return html`
+      <div class="colour-field">
+        <span class="colour-field-label">${this._t('common.editor.header_colour')}</span>
+        <div class="colour-field-body">
+          <label class="colour-swatch-wrapper">
+            <input type="color" .value=${current}
+              @input=${(e) => this._updateConfig(key, e.target.value)} />
+            <span class="colour-swatch-preview" style="background:${current}"></span>
+          </label>
+          <span class="colour-hex">${current}</span>
+          <div class="colour-presets">
+            ${presets.map((p) => html`
+              <button class="preset-swatch ${isActive(p) ? 'active' : ''}"
+                style="background:${p}"
+                title=${p}
+                @click=${(e) => { e.preventDefault(); this._updateConfig(key, p); }}
+              ></button>
+            `)}
+          </div>
+          <button class="colour-reset"
+            @click=${(e) => { e.preventDefault(); this._updateConfig(key, defaultValue); }}
           >${this._t('common.reset')}</button>
         </div>
-        <span class="field-helper">${this._t('common.editor.header_colour_helper')}</span>
+        <div class="colour-helper">${this._t('common.editor.header_colour_helper')}</div>
       </div>
     `;
   }
 
+  _formChanged(e) {
+    const newValues = e.detail.value || {};
+    const newConfig = { ...this.config };
+    for (const [key, value] of Object.entries(newValues)) {
+      if (value === '' || value === null || value === undefined) delete newConfig[key];
+      else newConfig[key] = value;
+    }
+    this.dispatchEvent(new CustomEvent('config-changed', {
+      detail: { config: newConfig }, bubbles: true, composed: true,
+    }));
+  }
+
   _updateConfig(key, value) {
     const newConfig = { ...this.config, [key]: value };
-    if (value === null || value === "" || value === undefined) delete newConfig[key];
-    this.dispatchEvent(new CustomEvent("config-changed", {
+    if (value === null || value === '' || value === undefined) delete newConfig[key];
+    this.dispatchEvent(new CustomEvent('config-changed', {
       detail: { config: newConfig }, bubbles: true, composed: true,
     }));
   }


### PR DESCRIPTION
## Summary

Completes the card-editor refactor started in #108. All remaining 10 card editors are now migrated to `<ha-form>` with selector schemas, and every `<input type="color">` is replaced with the labelled colour-picker component (preset swatches + hex + reset).

Every TaskMate card editor (14 total) now uses the same native HA styling.

## Editors refactored in this PR

| Card | Config fields |
| --- | --- |
| activity-card | entity + title + child_id + max_items |
| graph-card | entity + title + days + child_id |
| leaderboard-card | entity + title + sort_by + show_streak + show_weekly |
| overview-card | entity + title + approvals_entity |
| parent-dashboard-card | entity + title + quick_points_amount + show_claims |
| points-display-card | entity + title + mode + child_id (if single) + show_weekly + show_streak + show_rank (if not single). Conditional schema. |
| reorder-card | entity + child_id + title |
| reward-progress-card | entity + title + reward_id + child_id |
| streak-card | entity + title + child_id + streak_days_shown |
| weekly-card | entity + title + child_id |

## Pattern

Each editor now has:
- `<ha-form>` with a schema built per-card via `_buildSchema()`
- `computeLabel` / `computeHelper` for translation keys
- `_formChanged` emitting `config-changed`; default values pruned from stored YAML so files stay minimal
- The custom labelled colour-field helper from #108

## Cumulative state

| Already landed (#108) | In this PR |
| --- | --- |
| rewards, child, points, approvals | activity, graph, leaderboard, overview, parent-dashboard, points-display, reorder, reward-progress, streak, weekly |

**14 / 14 card editors now use ha-form + the new colour picker.**

## Test plan

- [ ] 160 tests pass; ruff clean (✅ verified locally)
- [ ] Open each refactored editor → form renders with native HA styling
- [ ] Dropdowns show labels (not raw IDs) for child / reward / mode selectors
- [ ] Colour picker: click a preset → picker highlights the active swatch; reset returns to default
- [ ] Save + reload each card → all values persist
- [ ] Points-display mode dropdown: switching to `single` shows child picker; switching to `multi`/`cumulative` shows show_rank toggle
