### PR TITLE
fix(rewards): allow other pool allocations while a pool claim awaits approval

### DIFF
--- a/custom_components/taskmate/button.py
+++ b/custom_components/taskmate/button.py
@@ -186,11 +186,15 @@ class ClaimRewardButton(TaskMateBaseButton):
         return reward.icon if reward else "mdi:gift"
 
     def _get_committed_points(self, child_id: str) -> int:
-        """Calculate points committed by pending reward claims for a child."""
+        """Calculate points committed by pending reward claims for a child.
+
+        Pool-mode pending claims are skipped because their cost was already
+        deducted from child.points at allocation time.
+        """
         pending_claims = self.coordinator.data.get("pending_reward_claims", [])
         committed = 0
         for c in pending_claims:
-            if c.child_id == child_id:
+            if c.child_id == child_id and not self.coordinator.is_pool_mode_claim(c):
                 reward = self.coordinator.get_reward(c.reward_id)
                 if reward:
                     committed += reward.cost

--- a/custom_components/taskmate/coordinator.py
+++ b/custom_components/taskmate/coordinator.py
@@ -380,6 +380,20 @@ class TaskMateCoordinator(DataUpdateCoordinator):
         """Get a reward by ID."""
         return self.storage.get_reward(reward_id)
 
+    def is_pool_mode_claim(self, claim: "RewardClaim") -> bool:
+        """True if the claim is covered by pool allocations (points already deducted).
+
+        Pool-mode claims must NOT be counted against a child's spendable balance,
+        because their cost was already removed from child.points at allocation time.
+        """
+        reward = self.get_reward(claim.reward_id)
+        if not reward:
+            return False
+        if getattr(reward, "is_jackpot", False):
+            return self.storage.get_total_allocated_for_reward(claim.reward_id) >= reward.cost
+        alloc = self.storage.get_pool_allocation(claim.child_id, claim.reward_id)
+        return bool(alloc and alloc.allocated_points >= reward.cost)
+
     # ── Chore completion operations ───────────────────────────────────────────
 
     def _is_visibility_entity_active(
@@ -927,12 +941,12 @@ class TaskMateCoordinator(DataUpdateCoordinator):
 
         if not pool_filled:
             # Wallet mode: verify child has enough uncommitted points.
-            # Pool allocations are already deducted from child.points at allocation time,
-            # so they don't need to be subtracted again here.
+            # Pool-mode pending claims already had their cost deducted at allocation time,
+            # so they are skipped here to avoid double-counting against the wallet.
             pending_claims = self.storage.get_pending_reward_claims()
             committed = 0
             for c in pending_claims:
-                if c.child_id == child_id:
+                if c.child_id == child_id and not self.is_pool_mode_claim(c):
                     pending_reward = self.get_reward(c.reward_id)
                     if pending_reward:
                         committed += pending_reward.cost
@@ -1049,10 +1063,13 @@ class TaskMateCoordinator(DataUpdateCoordinator):
         # Spendable balance = child.points − points committed to other pending claims.
         # (Already-allocated points are no longer part of child.points, so we do NOT
         # subtract total_allocated here — they've been deducted at allocation time.)
+        # Pool-mode pending claims are also skipped — their cost was already removed
+        # from child.points at allocation time, so counting it again would block the
+        # child from allocating to any other pool reward while one awaits approval.
         pending_claims = self.storage.get_pending_reward_claims()
         committed = 0
         for c in pending_claims:
-            if c.child_id == child_id:
+            if c.child_id == child_id and not self.is_pool_mode_claim(c):
                 pending_reward = self.get_reward(c.reward_id)
                 if pending_reward:
                     committed += pending_reward.cost

--- a/custom_components/taskmate/sensor.py
+++ b/custom_components/taskmate/sensor.py
@@ -189,10 +189,15 @@ class TaskMateOverallStatsSensor(TaskMateBaseSensor):
             if chore:
                 pending_points_by_child[child_id] = pending_points_by_child.get(child_id, 0) + chore.points
 
-        # Calculate committed points per child (reward claims awaiting approval = points reserved)
+        # Calculate committed points per child (reward claims awaiting approval = points reserved).
+        # Pool-mode pending claims are skipped because their cost was already deducted
+        # from child.points at allocation time — counting them here would drive
+        # spendable_balance to zero and prevent allocating to other pool rewards.
         committed_points_by_child = {}
         pending_reward_claim_objs = data.get("pending_reward_claims", [])
         for rc in pending_reward_claim_objs:
+            if self.coordinator.is_pool_mode_claim(rc):
+                continue
             reward = next((r for r in rewards if r.id == rc.reward_id), None)
             if reward:
                 # All reward costs are static

--- a/tests/test_coordinator_rewards.py
+++ b/tests/test_coordinator_rewards.py
@@ -281,3 +281,90 @@ class TestPoolModeApproval:
         assert child.points == 50
         # Allocation is cleared
         coord.storage.remove_pool_allocation.assert_called_once()
+
+
+class TestPoolClaimDoesNotBlockOtherAllocations:
+    """A pending claim on a filled pool reward must not stop the child from
+    allocating points to other pool rewards. The pool claim's cost was already
+    deducted from child.points at allocation time, so counting it again as
+    "committed" would drive spendable to zero."""
+
+    def test_allocation_to_other_pool_reward_while_first_awaits_approval(self):
+        import datetime as dt
+        # Child started with 100; 50 already allocated to reward1 (pool-filled).
+        # Visible points dropped to 50, and reward1 is claimed but unapproved.
+        child = _child(points=50)
+        reward1 = Reward(name="Movie", cost=50, id="reward1")
+        reward2 = Reward(name="Toy", cost=50, id="reward2")
+        filled_alloc = PoolAllocation(
+            child_id="kid1", reward_id="reward1", allocated_points=50
+        )
+        claim = RewardClaim(
+            reward_id="reward1", child_id="kid1",
+            claimed_at=dt.datetime.now(dt.timezone.utc), id="claim1",
+        )
+        coord = _make_coord(children=[child], rewards=[reward1, reward2], claims=[claim])
+
+        def _get_alloc(child_id, reward_id):
+            if reward_id == "reward1":
+                return filled_alloc
+            return None
+        coord.storage.get_pool_allocation = MagicMock(side_effect=_get_alloc)
+
+        # Allocating to a different pool reward should succeed — the pending
+        # pool-mode claim on reward1 must not be counted as committed wallet points.
+        alloc = run(coord.async_allocate_points_to_pool("kid1", "reward2", 20))
+        assert alloc.reward_id == "reward2"
+        assert alloc.allocated_points == 20
+        assert child.points == 30  # 50 − 20
+
+    def test_wallet_claim_still_blocks_pool_allocation(self):
+        """Sanity check: a non-pool-mode pending claim should still reserve points."""
+        import datetime as dt
+        child = _child(points=50)
+        reward1 = Reward(name="Movie", cost=40, id="reward1")
+        reward2 = Reward(name="Toy", cost=30, id="reward2")
+        # No allocation → claim is wallet-mode and its cost IS committed.
+        claim = RewardClaim(
+            reward_id="reward1", child_id="kid1",
+            claimed_at=dt.datetime.now(dt.timezone.utc), id="claim1",
+        )
+        coord = _make_coord(children=[child], rewards=[reward1, reward2], claims=[claim])
+        # spendable = 50 − 40 = 10, so requesting 30 is capped to 10.
+        alloc = run(coord.async_allocate_points_to_pool("kid1", "reward2", 30))
+        assert alloc.allocated_points == 10
+        assert child.points == 40
+
+    def test_is_pool_mode_claim_detects_filled_allocation(self):
+        import datetime as dt
+        reward = _reward(cost=50)
+        coord = _make_coord(rewards=[reward])
+        filled = PoolAllocation(child_id="kid1", reward_id="reward1", allocated_points=50)
+        coord.storage.get_pool_allocation = MagicMock(return_value=filled)
+        claim = RewardClaim(
+            reward_id="reward1", child_id="kid1",
+            claimed_at=dt.datetime.now(dt.timezone.utc), id="claim1",
+        )
+        assert coord.is_pool_mode_claim(claim) is True
+
+    def test_is_pool_mode_claim_false_for_partial_allocation(self):
+        import datetime as dt
+        reward = _reward(cost=50)
+        coord = _make_coord(rewards=[reward])
+        partial = PoolAllocation(child_id="kid1", reward_id="reward1", allocated_points=20)
+        coord.storage.get_pool_allocation = MagicMock(return_value=partial)
+        claim = RewardClaim(
+            reward_id="reward1", child_id="kid1",
+            claimed_at=dt.datetime.now(dt.timezone.utc), id="claim1",
+        )
+        assert coord.is_pool_mode_claim(claim) is False
+
+    def test_is_pool_mode_claim_false_without_allocation(self):
+        import datetime as dt
+        reward = _reward(cost=50)
+        coord = _make_coord(rewards=[reward])
+        claim = RewardClaim(
+            reward_id="reward1", child_id="kid1",
+            claimed_at=dt.datetime.now(dt.timezone.utc), id="claim1",
+        )
+        assert coord.is_pool_mode_claim(claim) is False


### PR DESCRIPTION
## Summary

Fixes a bug where a child with a pending pool-reward claim could not allocate points to any other pool reward until the pending claim was approved or rejected. The +1/+5/+10 deposit buttons on all other pool rewards were disabled.

## Root cause

Pool allocations deduct points from `child.points` at allocation time. When a filled pool reward was then claimed, the resulting pending `RewardClaim` had its cost counted *again* as "committed" wallet points in:

- `sensor.py` — `committed_points_by_child` → drove `spendable_balance` to 0
- `coordinator.async_claim_reward` — wallet-mode commit check
- `coordinator.async_allocate_points_to_pool` — spendable computation that the deposit buttons gate on
- `button.py::_get_committed_points` — reward-claim button availability

With `spendable_balance = 0`, the frontend disables deposit buttons on every other pool reward.

## Fix

Added `TaskMateCoordinator.is_pool_mode_claim(claim)` which returns `True` when a claim is covered by pool allocations (jackpot pool meets cost, or per-child allocation fills the cost). All four committed-points computations now skip pool-mode claims, since their cost was already removed from `child.points`.

## Test plan

- [x] New `TestPoolClaimDoesNotBlockOtherAllocations` test class covering the regression scenario and the `is_pool_mode_claim` helper
- [x] Sanity test that wallet-mode pending claims still commit points correctly
- [x] Existing pool-mode approval test still passes (no double deduction)
- [x] Full suite: 165 passed
- [x] `ruff check` on modified modules passes