### PR TITLE
feat(cards): reflect child filter in graph title and fix 'All Children' selector

### DIFF
--- a/custom_components/taskmate/www/locales/en-GB.json
+++ b/custom_components/taskmate/www/locales/en-GB.json
@@ -135,6 +135,7 @@
   "child.editor.show_debug": "Show debug panel",
 
   "graph.default_title": "Points Graph",
+  "graph.all_children": "All Children",
   "graph.daily": "Daily",
   "graph.total": "Total",
   "graph.graph_error": "Graph error: {message}",

--- a/custom_components/taskmate/www/locales/en.json
+++ b/custom_components/taskmate/www/locales/en.json
@@ -135,6 +135,7 @@
   "child.editor.show_debug": "Show debug panel",
 
   "graph.default_title": "Points Graph",
+  "graph.all_children": "All Children",
   "graph.daily": "Daily",
   "graph.total": "Total",
   "graph.graph_error": "Graph error: {message}",

--- a/custom_components/taskmate/www/locales/fr.json
+++ b/custom_components/taskmate/www/locales/fr.json
@@ -134,6 +134,7 @@
   "child.editor.show_debug": "Afficher le panneau de débogage",
 
   "graph.default_title": "Graphique des points",
+  "graph.all_children": "Tous les enfants",
   "graph.daily": "Quotidien",
   "graph.total": "Total",
   "graph.graph_error": "Erreur de graphique : {message}",

--- a/custom_components/taskmate/www/locales/nb.json
+++ b/custom_components/taskmate/www/locales/nb.json
@@ -134,6 +134,7 @@
   "child.editor.show_debug": "Vis feilsøkingspanel",
 
   "graph.default_title": "Poengraf",
+  "graph.all_children": "Alle barn",
   "graph.daily": "Daglig",
   "graph.total": "Totalt",
   "graph.graph_error": "Graffeil: {message}",

--- a/custom_components/taskmate/www/locales/nn.json
+++ b/custom_components/taskmate/www/locales/nn.json
@@ -134,6 +134,7 @@
   "child.editor.show_debug": "Vis feilsøkingspanel",
 
   "graph.default_title": "Poenggraf",
+  "graph.all_children": "Alle born",
   "graph.daily": "Dagleg",
   "graph.total": "Totalt",
   "graph.graph_error": "Graffeil: {message}",

--- a/custom_components/taskmate/www/locales/pt.json
+++ b/custom_components/taskmate/www/locales/pt.json
@@ -134,6 +134,7 @@
   "child.editor.show_debug": "Mostrar painel de depuração",
 
   "graph.default_title": "Gráfico de Pontos",
+  "graph.all_children": "Todas as Crianças",
   "graph.daily": "Diário",
   "graph.total": "Total",
   "graph.graph_error": "Erro no gráfico: {message}",

--- a/custom_components/taskmate/www/taskmate-activity-card.js
+++ b/custom_components/taskmate/www/taskmate-activity-card.js
@@ -493,7 +493,7 @@ class TaskMateActivityCardEditor extends LitElement {
         selector: {
           select: {
             options: [
-              { value: '', label: this._t('common.editor.filter_by_child_all') },
+              { value: '__all__', label: this._t('common.editor.filter_by_child_all') },
               ...children.map((c) => ({ value: c.id, label: c.name })),
             ],
             mode: 'dropdown',
@@ -528,7 +528,7 @@ class TaskMateActivityCardEditor extends LitElement {
     const data = {
       entity: this.config.entity || '',
       title: this.config.title || '',
-      child_id: this.config.child_id || '',
+      child_id: this.config.child_id || '__all__',
       max_items: this.config.max_items || 30,
     };
     return html`
@@ -580,7 +580,10 @@ class TaskMateActivityCardEditor extends LitElement {
     const newValues = e.detail.value || {};
     const newConfig = { ...this.config };
     for (const [key, value] of Object.entries(newValues)) {
-      if (value === '' || value === null || value === undefined) {
+      if (
+        value === '' || value === null || value === undefined
+        || (key === 'child_id' && value === '__all__')
+      ) {
         delete newConfig[key];
       } else if (key === 'max_items' && value === 30) {
         delete newConfig[key];

--- a/custom_components/taskmate/www/taskmate-approvals-card.js
+++ b/custom_components/taskmate/www/taskmate-approvals-card.js
@@ -795,7 +795,7 @@ class TaskMateApprovalsCardEditor extends LitElement {
         selector: {
           select: {
             options: [
-              { value: '', label: this._t('common.editor.filter_by_child_all') },
+              { value: '__all__', label: this._t('common.editor.filter_by_child_all') },
               ...children.map((c) => ({ value: c.id, label: c.name })),
             ],
             mode: 'dropdown',
@@ -827,7 +827,7 @@ class TaskMateApprovalsCardEditor extends LitElement {
     const data = {
       entity: this.config.entity || '',
       title: this.config.title || '',
-      child_id: this.config.child_id || '',
+      child_id: this.config.child_id || '__all__',
     };
     return html`
       <ha-form
@@ -878,7 +878,10 @@ class TaskMateApprovalsCardEditor extends LitElement {
     const newValues = e.detail.value || {};
     const newConfig = { ...this.config };
     for (const [key, value] of Object.entries(newValues)) {
-      if (value === '' || value === null || value === undefined) {
+      if (
+        value === '' || value === null || value === undefined
+        || (key === 'child_id' && value === '__all__')
+      ) {
         delete newConfig[key];
       } else {
         newConfig[key] = value;

--- a/custom_components/taskmate/www/taskmate-graph-card.js
+++ b/custom_components/taskmate/www/taskmate-graph-card.js
@@ -278,13 +278,21 @@ class TaskMateGraphCard extends LitElement {
     const dataKey = this._mode === "daily" ? "dailyPoints" : "cumulativePoints";
     const hasData = series.some(s => s[dataKey].some(v => v > 0));
 
+    const baseTitle = this.config.title || this._t('graph.default_title');
+    const filterLabel = this.config.child_id
+      ? (series[0]?.child?.name || '')
+      : this._t('graph.all_children');
+    const headerTitle = this.config.title
+      ? baseTitle
+      : (filterLabel ? `${baseTitle} — ${filterLabel}` : baseTitle);
+
     return html`
       <ha-card>
         <style>:host { --taskmate-header-bg: ${this.config.header_color || '#d35400'}; }</style>
         <div class="card-header">
           <div class="header-left">
             <ha-icon class="header-icon" icon="mdi:chart-line"></ha-icon>
-            <span class="header-title">${this.config.title || this._t('graph.default_title')}</span>
+            <span class="header-title">${headerTitle}</span>
           </div>
           <div class="mode-toggle">
             <button
@@ -673,7 +681,7 @@ class TaskMateGraphCardEditor extends LitElement {
         selector: {
           select: {
             options: [
-              { value: '', label: this._t('common.editor.filter_by_child_all') },
+              { value: '__all__', label: this._t('common.editor.filter_by_child_all') },
               ...children.map((c) => ({ value: c.id, label: c.name })),
             ],
             mode: 'dropdown',
@@ -708,7 +716,7 @@ class TaskMateGraphCardEditor extends LitElement {
       entity: this.config.entity || '',
       title: this.config.title || '',
       days: this.config.days || 14,
-      child_id: this.config.child_id || '',
+      child_id: this.config.child_id || '__all__',
     };
     return html`
       <ha-form
@@ -759,7 +767,10 @@ class TaskMateGraphCardEditor extends LitElement {
     const newValues = e.detail.value || {};
     const newConfig = { ...this.config };
     for (const [key, value] of Object.entries(newValues)) {
-      if (value === '' || value === null || value === undefined) {
+      if (
+        value === '' || value === null || value === undefined
+        || (key === 'child_id' && value === '__all__')
+      ) {
         delete newConfig[key];
       } else if (key === 'days' && value === 14) {
         delete newConfig[key];

--- a/custom_components/taskmate/www/taskmate-rewards-card.js
+++ b/custom_components/taskmate/www/taskmate-rewards-card.js
@@ -1362,7 +1362,7 @@ class TaskMateRewardsCardEditor extends LitElement {
     const children = entity?.attributes?.children || [];
 
     const childOptions = [
-      { value: '', label: this._t('rewards.editor.filter_by_child_all') },
+      { value: '__all__', label: this._t('rewards.editor.filter_by_child_all') },
       ...children.map((c) => ({ value: c.id, label: c.name })),
     ];
 
@@ -1420,7 +1420,7 @@ class TaskMateRewardsCardEditor extends LitElement {
     const data = {
       entity: this.config.entity || '',
       title: this.config.title || '',
-      child_id: this.config.child_id || '',
+      child_id: this.config.child_id || '__all__',
       show_child_badges: this.config.show_child_badges !== false,
       enable_pool_mode: this.config.enable_pool_mode === true,
     };
@@ -1475,7 +1475,10 @@ class TaskMateRewardsCardEditor extends LitElement {
     // Merge into config, removing keys that are empty/default so the YAML stays clean.
     const newConfig = { ...this.config };
     for (const [key, value] of Object.entries(newValues)) {
-      if (value === '' || value === null || value === undefined) {
+      if (
+        value === '' || value === null || value === undefined
+        || (key === 'child_id' && value === '__all__')
+      ) {
         delete newConfig[key];
       } else if (key === 'show_child_badges' && value === true) {
         // Default is true — omit to keep config minimal

--- a/custom_components/taskmate/www/taskmate-streak-card.js
+++ b/custom_components/taskmate/www/taskmate-streak-card.js
@@ -443,7 +443,7 @@ class TaskMateStreakCardEditor extends LitElement {
         selector: {
           select: {
             options: [
-              { value: '', label: this._t('common.editor.filter_by_child_all') },
+              { value: '__all__', label: this._t('common.editor.filter_by_child_all') },
               ...children.map((c) => ({ value: c.id, label: c.name })),
             ],
             mode: 'dropdown',
@@ -478,7 +478,7 @@ class TaskMateStreakCardEditor extends LitElement {
     const data = {
       entity: this.config.entity || '',
       title: this.config.title || '',
-      child_id: this.config.child_id || '',
+      child_id: this.config.child_id || '__all__',
       streak_days_shown: this.config.streak_days_shown || 14,
     };
     return html`
@@ -530,7 +530,10 @@ class TaskMateStreakCardEditor extends LitElement {
     const newValues = e.detail.value || {};
     const newConfig = { ...this.config };
     for (const [key, value] of Object.entries(newValues)) {
-      if (value === '' || value === null || value === undefined) {
+      if (
+        value === '' || value === null || value === undefined
+        || (key === 'child_id' && value === '__all__')
+      ) {
         delete newConfig[key];
       } else if (key === 'streak_days_shown' && value === 14) {
         delete newConfig[key];

--- a/custom_components/taskmate/www/taskmate-weekly-card.js
+++ b/custom_components/taskmate/www/taskmate-weekly-card.js
@@ -514,7 +514,7 @@ class TaskMateWeeklyCardEditor extends LitElement {
         selector: {
           select: {
             options: [
-              { value: '', label: this._t('common.editor.filter_by_child_all') },
+              { value: '__all__', label: this._t('common.editor.filter_by_child_all') },
               ...children.map((c) => ({ value: c.id, label: c.name })),
             ],
             mode: 'dropdown',
@@ -546,7 +546,7 @@ class TaskMateWeeklyCardEditor extends LitElement {
     const data = {
       entity: this.config.entity || '',
       title: this.config.title || '',
-      child_id: this.config.child_id || '',
+      child_id: this.config.child_id || '__all__',
     };
     return html`
       <ha-form
@@ -597,8 +597,14 @@ class TaskMateWeeklyCardEditor extends LitElement {
     const newValues = e.detail.value || {};
     const newConfig = { ...this.config };
     for (const [key, value] of Object.entries(newValues)) {
-      if (value === '' || value === null || value === undefined) delete newConfig[key];
-      else newConfig[key] = value;
+      if (
+        value === '' || value === null || value === undefined
+        || (key === 'child_id' && value === '__all__')
+      ) {
+        delete newConfig[key];
+      } else {
+        newConfig[key] = value;
+      }
     }
     this.dispatchEvent(new CustomEvent('config-changed', {
       detail: { config: newConfig }, bubbles: true, composed: true,


### PR DESCRIPTION
## Summary

- Points Graph header now shows the active filter — `Points Graph — Malia` when `child_id` is set, or `Points Graph — All Children` when unfiltered. A custom `title:` still overrides.
- Fixes the card editors where **"All Children"** could not be re-selected after choosing a child. The empty-string option wasn't renderable by `ha-form select`; switched to a `__all__` sentinel, normalised back to "key absent" on save.

## Affected cards

Graph, Streak, Weekly, Activity, Approvals, Rewards — all six editors share the pattern.

## Localisation

Added `graph.all_children` to en, en-GB, fr, nb, nn, pt.

## Test plan

- [x] Python test suite: 165 passed
- [ ] In the editor for each card, confirm "All Children" is present and selectable after first choosing a specific child
- [ ] Graph card header updates live when switching between child and "All Children"
- [ ] Custom `title:` still overrides the auto-suffix