### PR TITLE
ci: auto-label issues with Author/User Reply on comment

### DIFF
--- a/.github/workflows/issue-comment-labels.yml
+++ b/.github/workflows/issue-comment-labels.yml
@@ -1,0 +1,34 @@
+name: Label issues on comment
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  issues: write
+
+jobs:
+  relabel:
+    if: ${{ !github.event.issue.pull_request }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const isOwner = context.payload.comment.author_association === 'OWNER';
+            const addLabel = isOwner ? 'Author Reply' : 'User Reply';
+            const removeLabel = isOwner ? 'User Reply' : 'Author Reply';
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.issue.number;
+
+            await github.rest.issues.addLabels({
+              owner, repo, issue_number, labels: [addLabel],
+            });
+
+            try {
+              await github.rest.issues.removeLabel({
+                owner, repo, issue_number, name: removeLabel,
+              });
+            } catch (err) {
+              if (err.status !== 404) throw err;
+            }


### PR DESCRIPTION
Adds a workflow that labels issues "Author Reply" when the repo owner comments and "User Reply" otherwise, swapping the labels on each new comment.