### PR TITLE
chore(release): bump version to 3.1.1

### DIFF
--- a/custom_components/taskmate/manifest.json
+++ b/custom_components/taskmate/manifest.json
@@ -15,5 +15,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/tempus2016/taskmate/issues",
   "requirements": [],
-  "version": "3.1.0"
+  "version": "3.1.1"
 }


### PR DESCRIPTION
## Summary

Bumps the integration manifest version from `3.1.0` to `3.1.1` to cover the fixes and translations landed since the last release:

- PR #124 — pool-reward pending claim no longer blocks other pool allocations
- PR #125 — graph card title reflects child filter, `All Children` selectable in all card editors
- PR #127 — missing `rewards.redeem` and 15 other pool-mode strings added to fr/nb/nn/pt