### PR TITLE
fix(rewards): refund pool over-allocations and tidy spendable banner

### DIFF
--- a/custom_components/taskmate/coordinator.py
+++ b/custom_components/taskmate/coordinator.py
@@ -823,10 +823,82 @@ class TaskMateCoordinator(DataUpdateCoordinator):
         return reward
 
     async def async_update_reward(self, reward: Reward) -> None:
-        """Update a reward."""
+        """Update a reward.
+
+        If the cost is reduced below any existing pool allocation, the excess is
+        refunded to the contributing children's wallets so over-allocated pools
+        can't appear as e.g. 11/10.
+        """
+        old = self.get_reward(reward.id)
         self.storage.update_reward(reward)
+        if old and reward.cost < old.cost:
+            self._refund_pool_excess(reward, "Pool refund (reward cost reduced)")
         await self.storage.async_save()
         await self.async_refresh()
+
+    def _refund_pool_excess(self, reward: Reward, reason: str) -> None:
+        """Trim any pool allocations on `reward` that exceed its cost.
+
+        Non-jackpot: each allocation is capped at the reward's cost individually.
+        Jackpot: allocations are trimmed starting from the newest contributor
+        until the combined total matches the cost.
+        """
+        allocations = [
+            a for a in self.storage.get_pool_allocations()
+            if a.reward_id == reward.id and a.allocated_points > 0
+        ]
+        if not allocations:
+            return
+
+        if reward.is_jackpot:
+            overshoot = sum(a.allocated_points for a in allocations) - reward.cost
+            if overshoot <= 0:
+                return
+            for alloc in sorted(allocations, key=lambda a: a.id, reverse=True):
+                if overshoot <= 0:
+                    break
+                refund = min(alloc.allocated_points, overshoot)
+                self._apply_pool_refund(alloc, refund, reward, reason)
+                overshoot -= refund
+        else:
+            for alloc in allocations:
+                if alloc.allocated_points > reward.cost:
+                    self._apply_pool_refund(
+                        alloc, alloc.allocated_points - reward.cost, reward, reason
+                    )
+
+    def _apply_pool_refund(
+        self, allocation: "PoolAllocation", refund: int, reward: Reward, reason: str
+    ) -> None:
+        """Refund `refund` points from `allocation` back to the child's wallet.
+
+        Updates or removes the allocation record and writes an audit transaction.
+        """
+        if refund <= 0:
+            return
+        child = self.get_child(allocation.child_id)
+        if not child:
+            return
+        child.points += refund
+        self.storage.update_child(child)
+
+        remaining = allocation.allocated_points - refund
+        if remaining <= 0:
+            self.storage.remove_pool_allocation(allocation.child_id, allocation.reward_id)
+        else:
+            self.storage.upsert_pool_allocation(PoolAllocation(
+                child_id=allocation.child_id,
+                reward_id=allocation.reward_id,
+                allocated_points=remaining,
+                id=allocation.id,
+            ))
+
+        self.storage.add_points_transaction(PointsTransaction(
+            child_id=allocation.child_id,
+            points=refund,
+            reason=f"{reason}: {reward.name}",
+            created_at=dt_util.now(),
+        ))
 
     async def async_remove_reward(self, reward_id: str) -> None:
         """Remove a reward and clean up any pending claims and pool allocations referencing it."""
@@ -1006,6 +1078,9 @@ class TaskMateCoordinator(DataUpdateCoordinator):
                 if is_pool_mode:
                     # Pool mode: points were already deducted from child.points at allocation
                     # time — approving the redeem just clears the allocation record(s).
+                    # Refund any over-allocation first (e.g. left over from a prior cost reduction)
+                    # so the child doesn't lose points beyond the reward's actual cost.
+                    self._refund_pool_excess(reward, "Pool refund on redeem")
                     if reward.is_jackpot:
                         jackpot_allocs = [
                             a for a in self.storage.get_pool_allocations()

--- a/custom_components/taskmate/www/taskmate-rewards-card.js
+++ b/custom_components/taskmate/www/taskmate-rewards-card.js
@@ -881,13 +881,17 @@ class TaskMateRewardsCard extends LitElement {
   _renderSpendableBanner(child, pointsIcon, pointsName) {
     const spendable = typeof child.spendable_balance === 'number' ? child.spendable_balance : (child.points || 0);
     const gross = child.points || 0;
+    // Only show "/ gross" when points are reserved by a pending claim.
+    const detail = spendable !== gross
+      ? html`<span class="spendable-of">/ ${gross} ${pointsName}</span>`
+      : html`<span class="spendable-of">${pointsName}</span>`;
     return html`
       <div class="spendable-banner">
         <ha-icon icon="${pointsIcon}"></ha-icon>
         <span class="spendable-label">${this._t('rewards.spendable_balance')}</span>
         <span class="spendable-value">
           ${spendable}
-          <span class="spendable-of">/ ${gross} ${pointsName}</span>
+          ${detail}
         </span>
       </div>
     `;

--- a/tests/test_coordinator_rewards.py
+++ b/tests/test_coordinator_rewards.py
@@ -368,3 +368,109 @@ class TestPoolClaimDoesNotBlockOtherAllocations:
             claimed_at=dt.datetime.now(dt.timezone.utc), id="claim1",
         )
         assert coord.is_pool_mode_claim(claim) is False
+
+
+class TestPoolOverallocationRefund:
+    """When a reward's cost is reduced (or when an over-allocated pool is
+    redeemed) any pool allocation that exceeds the reward's cost must be
+    trimmed and the excess refunded to the contributing child's wallet."""
+
+    def test_update_reward_refunds_excess_when_cost_reduced(self):
+        # Child started with 100, allocated 10 to a reward originally costing 10.
+        child = _child(points=90)
+        old_reward = Reward(name="Test", cost=10, id="reward1")
+        existing = PoolAllocation(child_id="kid1", reward_id="reward1", allocated_points=10)
+        coord = _make_coord(children=[child], rewards=[old_reward])
+        coord.storage.get_pool_allocation = MagicMock(return_value=existing)
+        coord.storage.get_pool_allocations = MagicMock(return_value=[existing])
+
+        # Parent edits the cost down to 5 — 5 points should refund.
+        new_reward = Reward(name="Test", cost=5, id="reward1")
+        run(coord.async_update_reward(new_reward))
+
+        assert child.points == 95  # 90 + 5 refunded
+        # Allocation trimmed to the new cost
+        upsert_args = coord.storage.upsert_pool_allocation.call_args[0][0]
+        assert upsert_args.allocated_points == 5
+        # Audit transaction recorded
+        coord.storage.add_points_transaction.assert_called_once()
+        txn = coord.storage.add_points_transaction.call_args[0][0]
+        assert txn.points == 5
+        assert "cost reduced" in txn.reason.lower()
+
+    def test_update_reward_no_refund_when_cost_unchanged(self):
+        child = _child(points=90)
+        reward = Reward(name="Test", cost=10, id="reward1")
+        existing = PoolAllocation(child_id="kid1", reward_id="reward1", allocated_points=10)
+        coord = _make_coord(children=[child], rewards=[reward])
+        coord.storage.get_pool_allocation = MagicMock(return_value=existing)
+        coord.storage.get_pool_allocations = MagicMock(return_value=[existing])
+
+        run(coord.async_update_reward(Reward(name="Test renamed", cost=10, id="reward1")))
+
+        assert child.points == 90  # No refund
+        coord.storage.add_points_transaction.assert_not_called()
+
+    def test_update_reward_no_refund_when_cost_increased(self):
+        child = _child(points=90)
+        reward = Reward(name="Test", cost=10, id="reward1")
+        existing = PoolAllocation(child_id="kid1", reward_id="reward1", allocated_points=10)
+        coord = _make_coord(children=[child], rewards=[reward])
+        coord.storage.get_pool_allocation = MagicMock(return_value=existing)
+        coord.storage.get_pool_allocations = MagicMock(return_value=[existing])
+
+        run(coord.async_update_reward(Reward(name="Test", cost=20, id="reward1")))
+
+        assert child.points == 90
+        coord.storage.add_points_transaction.assert_not_called()
+
+    def test_update_reward_removes_allocation_when_cost_drops_to_zero(self):
+        child = _child(points=90)
+        reward = Reward(name="Test", cost=10, id="reward1")
+        existing = PoolAllocation(child_id="kid1", reward_id="reward1", allocated_points=10)
+        coord = _make_coord(children=[child], rewards=[reward])
+        coord.storage.get_pool_allocation = MagicMock(return_value=existing)
+        coord.storage.get_pool_allocations = MagicMock(return_value=[existing])
+
+        run(coord.async_update_reward(Reward(name="Test", cost=0, id="reward1")))
+
+        assert child.points == 100  # all 10 refunded
+        coord.storage.remove_pool_allocation.assert_called_once_with("kid1", "reward1")
+
+    def test_jackpot_cost_reduction_refunds_newest_first(self):
+        # Two children each contributed to a 100-point jackpot. Newer allocation
+        # (id sorts later) gets trimmed first when cost drops to 60 (overshoot 20).
+        child_a = Child(name="A", points=0, id="kidA")
+        child_b = Child(name="B", points=0, id="kidB")
+        old_reward = Reward(name="Jackpot", cost=100, is_jackpot=True, id="rewardJ")
+        alloc_a = PoolAllocation(child_id="kidA", reward_id="rewardJ", allocated_points=50, id="alloc_aaa")
+        alloc_b = PoolAllocation(child_id="kidB", reward_id="rewardJ", allocated_points=30, id="alloc_zzz")
+        coord = _make_coord(children=[child_a, child_b], rewards=[old_reward])
+        coord.storage.get_pool_allocations = MagicMock(return_value=[alloc_a, alloc_b])
+
+        run(coord.async_update_reward(Reward(name="Jackpot", cost=60, is_jackpot=True, id="rewardJ")))
+
+        # Total was 80, cost dropped to 60 → overshoot 20 refunded from kidB (newer id).
+        assert child_b.points == 20  # full refund of 20
+        assert child_a.points == 0   # untouched
+
+    def test_approve_refunds_overshoot_on_redeem(self):
+        # Pre-existing over-allocation: child put 11 into a pool that costs 10.
+        # On approval, the 1-point overshoot must be refunded to the wallet.
+        import datetime as dt
+        child = _child(points=89)  # 100 earned − 11 allocated = 89
+        reward = _reward(cost=10)
+        over_alloc = PoolAllocation(child_id="kid1", reward_id="reward1", allocated_points=11)
+        claim = RewardClaim(
+            reward_id="reward1", child_id="kid1",
+            claimed_at=dt.datetime.now(dt.timezone.utc), id="claim1",
+        )
+        coord = _make_coord(children=[child], rewards=[reward], claims=[claim])
+        coord.storage.get_pool_allocation = MagicMock(return_value=over_alloc)
+        coord.storage.get_pool_allocations = MagicMock(return_value=[over_alloc])
+
+        run(coord.async_approve_reward("claim1"))
+
+        # 1 point refunded back to the wallet on redeem
+        assert child.points == 90
+        coord.storage.remove_pool_allocation.assert_called()


### PR DESCRIPTION
## Summary

- **Refund pool over-allocations.** When a reward's cost is reduced below an existing allocation (or an over-allocated pool is redeemed), the excess points are now refunded to the contributing children's wallets. Fixes the `11/10` and `10/5` states visible in the rewards card.
- **Tidy the Spendable banner.** Hides `/ gross` when it equals spendable, so a fully-available wallet shows `10 Points` instead of the redundant `10 / 10 Points`. The `/ gross` form still appears whenever a pending claim has reserved points (e.g. `5 / 10 Points`).

## Behaviour

- `async_update_reward` — if `new_cost < old_cost`, trims allocations:
  - Per-child rewards: each child's allocation capped at the new cost.
  - Jackpots: trims newest-first until the combined total fits.
- `async_approve_reward` — calls the same trim before clearing allocations on redeem (defensive net for any leftover overshoot).
- Each refund writes a `PointsTransaction` (`"Pool refund (reward cost reduced): <name>"` or `"Pool refund on redeem: <name>"`) for the audit trail.

## Test plan

- [x] 6 new tests covering: cost reduction refund, no-op when cost unchanged/increased, allocation removed when cost drops to 0, jackpot newest-first refund, redeem-time refund of pre-existing overshoot.
- [x] Full suite: 171 passed.
- [x] Ruff clean.
- [ ] Manually: edit a reward's cost down below an allocation, confirm wallet refund and bar redraws as `cost/cost`.
- [ ] Manually: confirm Spendable banner shows just `N Points` normally and `N / M Points` once a pending reward claim exists.