### PR TITLE
feat(activity): distinguish 'spent' (rewards/pool) from 'lost' (penalty)

### DIFF
--- a/custom_components/taskmate/www/locales/en-GB.json
+++ b/custom_components/taskmate/www/locales/en-GB.json
@@ -48,6 +48,7 @@
   "activity.unknown_child": "Unknown",
   "activity.received": "received",
   "activity.lost": "lost",
+  "activity.spent": "spent",
   "activity.points_manually": "points manually",
   "activity.claimed": "claimed",
   "activity.redeemed": "redeemed",

--- a/custom_components/taskmate/www/locales/en.json
+++ b/custom_components/taskmate/www/locales/en.json
@@ -48,6 +48,7 @@
   "activity.unknown_child": "Unknown",
   "activity.received": "received",
   "activity.lost": "lost",
+  "activity.spent": "spent",
   "activity.points_manually": "points manually",
   "activity.claimed": "claimed",
   "activity.redeemed": "redeemed",

--- a/custom_components/taskmate/www/locales/fr.json
+++ b/custom_components/taskmate/www/locales/fr.json
@@ -48,6 +48,7 @@
   "activity.unknown_child": "Inconnu",
   "activity.received": "reçu",
   "activity.lost": "perdu",
+  "activity.spent": "dépensé",
   "activity.points_manually": "points manuellement",
   "activity.claimed": "réclamé",
   "activity.redeemed": "échangé",

--- a/custom_components/taskmate/www/locales/nb.json
+++ b/custom_components/taskmate/www/locales/nb.json
@@ -48,6 +48,7 @@
   "activity.unknown_child": "Ukjent",
   "activity.received": "mottatt",
   "activity.lost": "mistet",
+  "activity.spent": "brukte",
   "activity.points_manually": "poeng manuelt",
   "activity.claimed": "krevde",
   "activity.redeemed": "innløste",

--- a/custom_components/taskmate/www/locales/nn.json
+++ b/custom_components/taskmate/www/locales/nn.json
@@ -48,6 +48,7 @@
   "activity.unknown_child": "Ukjend",
   "activity.received": "motteke",
   "activity.lost": "mista",
+  "activity.spent": "brukte",
   "activity.points_manually": "poeng manuelt",
   "activity.claimed": "kravde",
   "activity.redeemed": "løyste inn",

--- a/custom_components/taskmate/www/locales/pt.json
+++ b/custom_components/taskmate/www/locales/pt.json
@@ -48,6 +48,7 @@
   "activity.unknown_child": "Desconhecido",
   "activity.received": "recebeu",
   "activity.lost": "perdeu",
+  "activity.spent": "gastou",
   "activity.points_manually": "pontos manualmente",
   "activity.claimed": "reclamou",
   "activity.redeemed": "resgatou",

--- a/custom_components/taskmate/www/taskmate-activity-card.js
+++ b/custom_components/taskmate/www/taskmate-activity-card.js
@@ -324,6 +324,25 @@ class TaskMateActivityCard extends LitElement {
     if (type === "points_added" || type === "points_removed") {
       const isAdd = type === "points_added";
       const pts = Math.abs(item.points || 0);
+      // Distinguish "spent" (rewards/pool) from "lost" (penalty) for negative txns
+      // so a child sees a celebration of spending instead of a punishment colour.
+      const reason = item.reason || '';
+      const isPenalty = reason.startsWith('Penalty:');
+      const isSpend = !isAdd && !isPenalty && (
+        reason.startsWith('Allocated to pool:')
+      );
+      let verb;
+      let pointsColour;
+      if (isAdd) {
+        verb = this._t('activity.received');
+        pointsColour = '';
+      } else if (isSpend) {
+        verb = this._t('activity.spent');
+        pointsColour = 'color: var(--act-orange);';
+      } else {
+        verb = this._t('activity.lost');
+        pointsColour = 'color: var(--act-red);';
+      }
       return html`
         <div class="activity-item">
           <div class="activity-icon ${type}">
@@ -332,13 +351,13 @@ class TaskMateActivityCard extends LitElement {
           <div class="activity-body">
             <div class="activity-title">
               <strong>${childName}</strong>
-              ${isAdd ? ` ${this._t('activity.received')}` : ` ${this._t('activity.lost')}`}
+              ${' '}${verb}
               <strong> ${pts}</strong>
               ${item.reason ? html` — <em>${item.reason}</em>` : ` ${this._t('activity.points_manually')}`}
             </div>
             <div class="activity-meta">
               <span class="activity-time">${time}</span>
-              <span class="activity-points" style="${isAdd ? '' : 'color: var(--act-red);'}">
+              <span class="activity-points" style="${pointsColour}">
                 <ha-icon icon="${pointsIcon}"></ha-icon>
                 ${isAdd ? '+' : '-'}${pts}
               </span>
@@ -348,7 +367,8 @@ class TaskMateActivityCard extends LitElement {
       `;
     }
 
-    // Reward claim events
+    // Reward claim events — these are purchases, not losses, so render in
+    // the "spent" colour even though points are deducted.
     if (type === "reward_claimed" || type === "reward_approved") {
       const pts = Math.abs(item.points || 0);
       const isPending = type === "reward_claimed" && !item.approved;
@@ -366,7 +386,7 @@ class TaskMateActivityCard extends LitElement {
             <div class="activity-meta">
               <span class="activity-time">${time}</span>
               ${pts ? html`
-                <span class="activity-points" style="color: var(--act-red);">
+                <span class="activity-points" style="color: var(--act-orange);">
                   <ha-icon icon="${pointsIcon}"></ha-icon>
                   -${pts}
                 </span>


### PR DESCRIPTION
## Summary

The activity feed coloured every point deduction red and labelled it "lost", which made claiming a reward feel like a punishment. Now the feed differentiates by the kind of deduction so kids see a celebration when they spend, and the punishment colour is reserved for actual penalties.

## Behaviour

| Action | Verb | Points colour |
|---|---|---|
| Penalty (`reason: "Penalty: …"`) | "lost" | red |
| Pool allocation (`reason: "Allocated to pool: …"`) | "spent" | orange |
| Reward claim / redeem (`reward_claimed` / `reward_approved`) | "claimed" / "redeemed" | orange |
| Other manual removals | "lost" | red (default) |
| Manual additions | "received" | default |

## Localisation

Added `activity.spent` in all six locales:
- en / en-GB: `"spent"`
- fr: `"dépensé"`
- nb: `"brukte"`
- nn: `"brukte"`
- pt: `"gastou"`

## Test plan

- [x] Locale parity preserved (465 keys each, no missing/extras)
- [x] Python suite passes (165)
- [x] Ruff clean
- [ ] Manually: claim a reward, confirm `-N ★` shows orange in the activity feed
- [ ] Manually: apply a penalty, confirm `-N ★` shows red and verb is "lost"
- [ ] Manually: deposit to a pool reward, confirm verb is "spent" and colour is orange