### PR TITLE
feat(chores): dynamic assignment modes + calendar publishing

### DIFF
--- a/custom_components/taskmate/config_flow.py
+++ b/custom_components/taskmate/config_flow.py
@@ -12,6 +12,7 @@ from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import selector
 
 from .const import (
+    ASSIGNMENT_MODES,
     AVATAR_OPTIONS,
     COMPLETION_SOUND_OPTIONS,
     DAYS_OF_WEEK,
@@ -388,6 +389,19 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
             vol.Optional("visibility_entity"): selector.EntitySelector(
                 selector.EntitySelectorConfig()
             ),
+            vol.Optional("assignment_mode", default="everyone"): selector.SelectSelector(
+                selector.SelectSelectorConfig(
+                    options=list(ASSIGNMENT_MODES),
+                    translation_key="assignment_mode",
+                    mode=selector.SelectSelectorMode.DROPDOWN,
+                )
+            ),
+            vol.Optional("assignment_rotation_anchor", default=""): selector.TextSelector(
+                selector.TextSelectorConfig(type=selector.TextSelectorType.DATE)
+            ),
+            vol.Optional("publish_calendar_entities", default=[]): selector.EntitySelector(
+                selector.EntitySelectorConfig(domain="calendar", multiple=True)
+            ),
         }
         if child_options:
             schema_dict[vol.Optional("assigned_to", default=[])] = selector.SelectSelector(
@@ -424,6 +438,9 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
                 schedule_mode="specific_days",
                 due_days=user_input.get("due_days", []),
                 visibility_entity=s1.get("visibility_entity") or "",
+                assignment_mode=s1.get("assignment_mode", "everyone"),
+                assignment_rotation_anchor=s1.get("assignment_rotation_anchor", "") or "",
+                publish_calendar_entities=list(s1.get("publish_calendar_entities") or []),
             )
             self._chore_step1_data = None
             return await self.async_step_manage_chores()
@@ -459,6 +476,9 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
             completion_sound=s1.get("completion_sound", DEFAULT_COMPLETION_SOUND),
             schedule_mode="one_shot",
             visibility_entity=s1.get("visibility_entity") or "",
+            assignment_mode=s1.get("assignment_mode", "everyone"),
+            assignment_rotation_anchor=s1.get("assignment_rotation_anchor", "") or "",
+            publish_calendar_entities=list(s1.get("publish_calendar_entities") or []),
         )
         self._chore_step1_data = None
         return await self.async_step_manage_chores()
@@ -499,6 +519,9 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
                 recurrence_start=recurrence_start,
                 first_occurrence_mode=first_occurrence_mode,
                 visibility_entity=s1.get("visibility_entity") or "",
+                assignment_mode=s1.get("assignment_mode", "everyone"),
+                assignment_rotation_anchor=s1.get("assignment_rotation_anchor", "") or "",
+                publish_calendar_entities=list(s1.get("publish_calendar_entities") or []),
             )
             self._chore_step1_data = None
             return await self.async_step_manage_chores()
@@ -722,6 +745,10 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
                     chore.visibility_entity = ""
                     chore.visibility_operator = "equals"
                     chore.visibility_state = "on"
+                mode_in = user_input.get("assignment_mode", getattr(chore, "assignment_mode", "everyone"))
+                chore.assignment_mode = mode_in if mode_in in ASSIGNMENT_MODES else "everyone"
+                chore.assignment_rotation_anchor = user_input.get("assignment_rotation_anchor", getattr(chore, "assignment_rotation_anchor", "")) or ""
+                chore.publish_calendar_entities = list(user_input.get("publish_calendar_entities", getattr(chore, "publish_calendar_entities", []) or []))
                 self._edited_chore = chore
                 _LOGGER.debug(
                     "Edit chore step 1 - saved visibility fields: entity=%s, operator=%s, state=%s",
@@ -808,6 +835,25 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
             )
         )
         schema_dict[vol.Optional("visibility_state", default=getattr(chore, 'visibility_state', '') if vis_entity else "")] = str
+        schema_dict[vol.Optional("assignment_mode", default=getattr(chore, "assignment_mode", "everyone"))] = selector.SelectSelector(
+            selector.SelectSelectorConfig(
+                options=list(ASSIGNMENT_MODES),
+                translation_key="assignment_mode",
+                mode=selector.SelectSelectorMode.DROPDOWN,
+            )
+        )
+        schema_dict[vol.Optional("assignment_rotation_anchor", default=getattr(chore, "assignment_rotation_anchor", "") or "")] = selector.TextSelector(
+            selector.TextSelectorConfig(type=selector.TextSelectorType.DATE)
+        )
+        existing_calendars = list(getattr(chore, "publish_calendar_entities", []) or [])
+        if existing_calendars:
+            schema_dict[vol.Optional("publish_calendar_entities", default=existing_calendars)] = selector.EntitySelector(
+                selector.EntitySelectorConfig(domain="calendar", multiple=True)
+            )
+        else:
+            schema_dict[vol.Optional("publish_calendar_entities", default=[])] = selector.EntitySelector(
+                selector.EntitySelectorConfig(domain="calendar", multiple=True)
+            )
         schema_dict[vol.Required("action", default="save")] = selector.SelectSelector(
             selector.SelectSelectorConfig(
                 options=self._get_chore_action_options(chore),

--- a/custom_components/taskmate/const.py
+++ b/custom_components/taskmate/const.py
@@ -26,6 +26,16 @@ CONF_CHORE_ID: Final = "id"
 CONF_CHORE_REQUIRES_APPROVAL: Final = "requires_approval"
 CONF_CLAIM_ALLOWANCE_MINUTES: Final = "claim_allowance_minutes"
 DEFAULT_CLAIM_ALLOWANCE_MINUTES: Final = 0
+CONF_CHORE_ASSIGNMENT_MODE: Final = "assignment_mode"
+CONF_CHORE_ASSIGNMENT_ROTATION_ANCHOR: Final = "assignment_rotation_anchor"
+CONF_CHORE_PUBLISH_CALENDARS: Final = "publish_calendar_entities"
+
+# Assignment modes
+# "everyone"    = visible to every child in assigned_to (or all children if empty) -- existing behavior
+# "alternating" = round-robin through assigned_to (or all children), one child per calendar day
+# "random"      = deterministic per-day random pick from the same pool
+ASSIGNMENT_MODES: Final = ["everyone", "alternating", "random"]
+DEFAULT_ASSIGNMENT_MODE: Final = "everyone"
 
 # Reward keys
 CONF_REWARD_NAME: Final = "name"

--- a/custom_components/taskmate/coordinator.py
+++ b/custom_components/taskmate/coordinator.py
@@ -1,8 +1,10 @@
 """Data coordinator for TaskMate integration."""
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Callable
 from datetime import date, datetime, timedelta
+import hashlib
 import logging
 from typing import Any
 
@@ -61,6 +63,8 @@ class TaskMateCoordinator(DataUpdateCoordinator):
         """Scheduled callback at midnight to check and reset streaks if needed."""
         self.hass.async_create_task(self._async_check_streaks())
         self.hass.async_create_task(self._async_expire_one_shot_chores())
+        # Rotate assignment_current_child_id and publish today's events to every configured calendar
+        self.hass.async_create_task(self._async_refresh_assignments_and_publish())
         # Check for perfect week bonus every Monday at midnight
         if now.weekday() == 0:
             self.hass.async_create_task(self._async_check_perfect_week())
@@ -270,6 +274,9 @@ class TaskMateCoordinator(DataUpdateCoordinator):
         visibility_state: str = "on",
         visibility_operator: str = "equals",
         created_date: str = "",
+        assignment_mode: str = "everyone",
+        assignment_rotation_anchor: str = "",
+        publish_calendar_entities: list[str] | None = None,
     ) -> Chore:
         """Add a new chore."""
         # One-shot chores: force daily_limit=1, set created_date to today
@@ -298,8 +305,18 @@ class TaskMateCoordinator(DataUpdateCoordinator):
             visibility_state=visibility_state,
             visibility_operator=visibility_operator,
             created_date=created_date,
+            assignment_mode=assignment_mode if assignment_mode in ("everyone", "alternating", "random") else "everyone",
+            assignment_rotation_anchor=assignment_rotation_anchor,
+            publish_calendar_entities=list(publish_calendar_entities or []),
         )
+        # Cache today's active child so the card can show it immediately
+        today = dt_util.as_local(dt_util.now()).date()
+        active = self._compute_active_children(chore, today)
+        if active and chore.assignment_mode != "everyone":
+            chore.assignment_current_child_id = active[0]
         self.storage.add_chore(chore)
+        # Publish to any configured calendars ASAP — before save so we persist the last_date stamp
+        await self._publish_chore_to_calendars(chore, today)
         await self.storage.async_save()
         await self.async_refresh()
         return chore
@@ -353,7 +370,29 @@ class TaskMateCoordinator(DataUpdateCoordinator):
 
     async def async_update_chore(self, chore: Chore) -> None:
         """Update a chore."""
+        today = dt_util.as_local(dt_util.now()).date()
+        active = self._compute_active_children(chore, today)
+        if getattr(chore, "assignment_mode", "everyone") != "everyone":
+            chore.assignment_current_child_id = active[0] if active else ""
+        else:
+            chore.assignment_current_child_id = ""
+        # Re-publish on update so a changed name/assignment/calendar list shows up ASAP.
+        # Force a re-publish by clearing the guard if the publish list changed meaningfully;
+        # otherwise the guard keeps us from spamming duplicate events.
+        existing = self.storage.get_chore(chore.id)
+        if existing is not None:
+            prev_entities = set(getattr(existing, "publish_calendar_entities", []) or [])
+            new_entities = set(chore.publish_calendar_entities or [])
+            prev_name = getattr(existing, "name", "")
+            prev_active = getattr(existing, "assignment_current_child_id", "")
+            if (
+                new_entities != prev_entities
+                or chore.name != prev_name
+                or chore.assignment_current_child_id != prev_active
+            ):
+                chore.publish_calendar_last_date = ""
         self.storage.update_chore(chore)
+        await self._publish_chore_to_calendars(chore, today)
         await self.storage.async_save()
         await self.async_refresh()
 
@@ -482,6 +521,132 @@ class TaskMateCoordinator(DataUpdateCoordinator):
 
         return False
 
+    def _chore_assignment_pool(self, chore: Chore) -> list[str]:
+        """Resolve the ordered pool of child IDs this chore rotates through.
+
+        Prefers the chore's `assigned_to` list. When empty, falls back to every
+        stored child so "Everyone"-style chores can still alternate/randomize.
+        """
+        pool = [cid for cid in (chore.assigned_to or []) if self.storage.get_child(cid)]
+        if pool:
+            return pool
+        return [child.id for child in self.storage.get_children()]
+
+    def _compute_active_children(self, chore: Chore, today: date | None = None) -> list[str]:
+        """Return the child IDs the chore is active for today.
+
+        - everyone: whatever `assigned_to` already said (empty = all children).
+        - alternating: one child picked by `(today - anchor).days % len(pool)`.
+        - random: one child picked by a deterministic per-day+chore-id hash.
+        """
+        mode = getattr(chore, "assignment_mode", "everyone")
+        if mode not in ("alternating", "random"):
+            return list(chore.assigned_to or [])
+
+        pool = self._chore_assignment_pool(chore)
+        if not pool:
+            return []
+
+        if today is None:
+            today = dt_util.as_local(dt_util.now()).date()
+
+        if mode == "alternating":
+            anchor_iso = getattr(chore, "assignment_rotation_anchor", "") or ""
+            try:
+                anchor = date.fromisoformat(anchor_iso) if anchor_iso else today
+            except ValueError:
+                anchor = today
+            offset = (today - anchor).days
+            idx = offset % len(pool)
+            return [pool[idx]]
+
+        # random: stable per (chore.id, date) so the frontend and backend agree
+        digest = hashlib.sha256(f"{chore.id}:{today.toordinal()}".encode()).digest()
+        idx = int.from_bytes(digest[:8], "big") % len(pool)
+        return [pool[idx]]
+
+    async def _publish_chore_to_calendars(self, chore: Chore, today: date | None = None) -> None:
+        """Publish today's assignment for `chore` to every entity in publish_calendar_entities.
+
+        Idempotent per calendar-day thanks to `publish_calendar_last_date`. Fans
+        out all create_event service calls via asyncio.gather so N entities per
+        chore scale with the slowest single call, not the sum of them.
+        """
+        entities = list(getattr(chore, "publish_calendar_entities", []) or [])
+        if not entities:
+            return
+
+        if today is None:
+            today = dt_util.as_local(dt_util.now()).date()
+        today_iso = today.isoformat()
+        if getattr(chore, "publish_calendar_last_date", "") == today_iso:
+            return
+
+        active = self._compute_active_children(chore, today)
+        if active:
+            child = self.storage.get_child(active[0])
+            child_name = child.name if child else "Everyone"
+        else:
+            child_name = "Everyone"
+
+        summary = f"{chore.name} — {child_name}"
+        end = today + timedelta(days=1)
+
+        async def _call(entity_id: str) -> None:
+            try:
+                await self.hass.services.async_call(
+                    "calendar",
+                    "create_event",
+                    {
+                        "entity_id": entity_id,
+                        "summary": summary,
+                        "start_date": today_iso,
+                        "end_date": end.isoformat(),
+                    },
+                    blocking=True,
+                )
+            except Exception as err:  # noqa: BLE001 - HA service errors vary
+                _LOGGER.warning(
+                    "TaskMate: failed to publish chore %s to calendar %s: %s",
+                    chore.name,
+                    entity_id,
+                    err,
+                )
+
+        await asyncio.gather(*(_call(e) for e in entities), return_exceptions=True)
+        chore.publish_calendar_last_date = today_iso
+
+    async def _async_refresh_assignments_and_publish(self) -> None:
+        """Recompute today's active child per chore and publish to calendars.
+
+        Runs at midnight. All chores are processed concurrently so the runtime
+        is bounded by the slowest single publish, not the sum across chores.
+        """
+        today = dt_util.as_local(dt_util.now()).date()
+        chores = self.storage.get_chores()
+        if not chores:
+            return
+
+        async def _process(chore: Chore) -> bool:
+            dirty = False
+            active = self._compute_active_children(chore, today)
+            desired = active[0] if active and getattr(chore, "assignment_mode", "everyone") != "everyone" else ""
+            if getattr(chore, "assignment_current_child_id", "") != desired:
+                chore.assignment_current_child_id = desired
+                dirty = True
+            before = getattr(chore, "publish_calendar_last_date", "")
+            await self._publish_chore_to_calendars(chore, today)
+            if getattr(chore, "publish_calendar_last_date", "") != before:
+                dirty = True
+            if dirty:
+                self.storage.update_chore(chore)
+            return dirty
+
+        results = await asyncio.gather(*(_process(c) for c in chores), return_exceptions=True)
+        if any(r is True for r in results):
+            await self.storage.async_save()
+            await self.async_refresh()
+
     def is_chore_available_for_child(self, chore, child_id: str) -> bool:
         """Check if a recurring chore is available for a child to complete.
 
@@ -500,6 +665,12 @@ class TaskMateCoordinator(DataUpdateCoordinator):
         disabled_for = getattr(chore, 'disabled_for', [])
         if child_id in disabled_for:
             return False
+
+        # Dynamic assignment — only the active child(ren) see alternating/random chores
+        if getattr(chore, 'assignment_mode', 'everyone') != 'everyone':
+            active = self._compute_active_children(chore)
+            if child_id not in active:
+                return False
 
         # Check visibility entity first — if not visible, chore is not available
         visibility_entity = getattr(chore, 'visibility_entity', '')

--- a/custom_components/taskmate/manifest.json
+++ b/custom_components/taskmate/manifest.json
@@ -15,5 +15,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/tempus2016/taskmate/issues",
   "requirements": [],
-  "version": "3.1.1"
+  "version": "3.2.0"
 }

--- a/custom_components/taskmate/models.py
+++ b/custom_components/taskmate/models.py
@@ -148,6 +148,13 @@ class Chore:
     enabled: bool = True  # False = soft-disabled (completed or expired)
     disabled_for: list[str] = field(default_factory=list)  # Child IDs this chore is disabled for
     created_date: str = ""  # ISO date for one-shot expiry, e.g. "2026-04-16"
+    # Dynamic assignment (sibling rotation)
+    assignment_mode: str = "everyone"  # everyone | alternating | random
+    assignment_rotation_anchor: str = ""  # ISO date; day-0 of the rotation for alternating
+    assignment_current_child_id: str = ""  # cached active child ID for today (computed at midnight and on create/update)
+    # Calendar publish: list of HA calendar entity ids to mirror the chore to. Any number supported.
+    publish_calendar_entities: list[str] = field(default_factory=list)
+    publish_calendar_last_date: str = ""  # ISO date guarding against duplicate publishes on the same day
     id: str = field(default_factory=generate_id)
 
     @classmethod
@@ -182,6 +189,11 @@ class Chore:
             enabled=data.get("enabled", True),
             disabled_for=list(data.get("disabled_for", [])),
             created_date=data.get("created_date", ""),
+            assignment_mode=data.get("assignment_mode", "everyone"),
+            assignment_rotation_anchor=data.get("assignment_rotation_anchor", ""),
+            assignment_current_child_id=data.get("assignment_current_child_id", ""),
+            publish_calendar_entities=list(data.get("publish_calendar_entities", [])),
+            publish_calendar_last_date=data.get("publish_calendar_last_date", ""),
             id=data.get("id", generate_id()),
         )
 
@@ -209,6 +221,11 @@ class Chore:
             "enabled": self.enabled,
             "disabled_for": self.disabled_for,
             "created_date": self.created_date,
+            "assignment_mode": self.assignment_mode,
+            "assignment_rotation_anchor": self.assignment_rotation_anchor,
+            "assignment_current_child_id": self.assignment_current_child_id,
+            "publish_calendar_entities": self.publish_calendar_entities,
+            "publish_calendar_last_date": self.publish_calendar_last_date,
             "id": self.id,
         }
 

--- a/custom_components/taskmate/sensor.py
+++ b/custom_components/taskmate/sensor.py
@@ -251,6 +251,10 @@ class TaskMateOverallStatsSensor(TaskMateBaseSensor):
                 "enabled": getattr(c, 'enabled', True),
                 "disabled_for": getattr(c, 'disabled_for', []),
                 "created_date": getattr(c, 'created_date', ''),
+                "assignment_mode": getattr(c, 'assignment_mode', 'everyone'),
+                "assignment_rotation_anchor": getattr(c, 'assignment_rotation_anchor', ''),
+                "assignment_current_child_id": getattr(c, 'assignment_current_child_id', ''),
+                "publish_calendar_entities": list(getattr(c, 'publish_calendar_entities', []) or []),
                 "last_completed_at": last_completed_at,
                 "is_available": is_available,
             })
@@ -536,9 +540,16 @@ class ChildStatsSensor(TaskMateBaseSensor):
         if not child:
             return {}
 
-        # Get chores assigned to this child
+        # Get chores assigned to this child. For alternating/random assignment,
+        # only include a chore when this child is the active one today.
         chores = self.coordinator.data.get("chores", [])
-        assigned_chores = [c for c in chores if child.id in c.assigned_to or not c.assigned_to]
+        def _included(c):
+            if not (child.id in c.assigned_to or not c.assigned_to):
+                return False
+            if getattr(c, "assignment_mode", "everyone") != "everyone":
+                return getattr(c, "assignment_current_child_id", "") == child.id
+            return True
+        assigned_chores = [c for c in chores if _included(c)]
 
         return {
             "child_id": child.id,

--- a/custom_components/taskmate/strings.json
+++ b/custom_components/taskmate/strings.json
@@ -79,7 +79,10 @@
           "completion_sound": "Completion Sound",
           "visibility_entity": "Show when entity is (optional)",
           "visibility_operator": "How to compare",
-          "visibility_state": "Value to compare"
+          "visibility_state": "Value to compare",
+          "assignment_mode": "Assignment Mode",
+          "assignment_rotation_anchor": "Rotation start date (alternating only)",
+          "publish_calendar_entities": "Publish to calendars (optional)"
         },
         "data_description": {
           "daily_limit": "How many times per day this chore can be completed",
@@ -88,7 +91,10 @@
           "completion_sound": "Sound to play when this chore is completed",
           "visibility_entity": "Home Assistant entity ID that controls when this chore appears. Leave blank to always show the chore. Examples: binary_sensor.dishwasher, sensor.soil_moisture, input_boolean.guest_mode, switch.laundry_room. The chore only appears on the child card when the visibility condition is met.",
           "visibility_operator": "How to compare the entity's current state with your target value:\n• No filter — always show the chore (ignores entity state)\n• Equals — state exactly matches (e.g., 'on', 'home', 'running')\n• Not Equal — state does not match\n• Greater than or equal (≥) — for numeric values (e.g., 80 for battery ≥ 80%)\n• Less than or equal (≤) — for numeric values (e.g., 30 for moisture ≤ 30%)\n• Greater than (>) — for numeric values\n• Less than (<) — for numeric values",
-          "visibility_state": "The value to compare against. For 'Equals' or 'Not Equal': any text value (e.g., 'on', 'off', 'home', 'away'). For numeric operators (≥, ≤, >, <): enter a number (e.g., 25, 50.5, 100). Example: Entity 'sensor.temperature', Operator '>=', Value '20' shows chore when temperature is 20°C or higher."
+          "visibility_state": "The value to compare against. For 'Equals' or 'Not Equal': any text value (e.g., 'on', 'off', 'home', 'away'). For numeric operators (≥, ≤, >, <): enter a number (e.g., 25, 50.5, 100). Example: Entity 'sensor.temperature', Operator '>=', Value '20' shows chore when temperature is 20°C or higher.",
+          "assignment_mode": "Everyone = every assigned child sees this chore. Alternating = one child at a time, rotating by day. Random = one randomly picked child per day (stable within the day).",
+          "assignment_rotation_anchor": "Day-0 of the alternating rotation. Leave blank to start today. Only used when Assignment Mode is 'Alternating'.",
+          "publish_calendar_entities": "Pick one or more Home Assistant calendar entities. Whenever this chore is created, updated, or rolls over at midnight, today's assigned child is added as a calendar event on each selected calendar. Works with any number of calendars."
         }
       },
       "add_chores_bulk": {
@@ -137,7 +143,10 @@
           "completion_sound": "Completion Sound",
           "visibility_entity": "Show when entity is (optional)",
           "visibility_operator": "How to compare",
-          "visibility_state": "Value to compare"
+          "visibility_state": "Value to compare",
+          "assignment_mode": "Assignment Mode",
+          "assignment_rotation_anchor": "Rotation start date (alternating only)",
+          "publish_calendar_entities": "Publish to calendars (optional)"
         },
         "data_description": {
           "daily_limit": "How many times per day this chore can be completed",
@@ -146,7 +155,10 @@
           "completion_sound": "Sound to play when this chore is completed",
           "visibility_entity": "Home Assistant entity ID that controls when this chore appears. Leave blank to always show the chore. Examples: binary_sensor.dishwasher, sensor.soil_moisture, input_boolean.guest_mode, switch.laundry_room. The chore only appears on the child card when the visibility condition is met.",
           "visibility_operator": "How to compare the entity's current state with your target value:\n• No filter — always show the chore (ignores entity state)\n• Equals — state exactly matches (e.g., 'on', 'home', 'running')\n• Not Equal — state does not match\n• Greater than or equal (≥) — for numeric values (e.g., 80 for battery ≥ 80%)\n• Less than or equal (≤) — for numeric values (e.g., 30 for moisture ≤ 30%)\n• Greater than (>) — for numeric values\n• Less than (<) — for numeric values",
-          "visibility_state": "The value to compare against. For 'Equals' or 'Not Equal': any text value (e.g., 'on', 'off', 'home', 'away'). For numeric operators (≥, ≤, >, <): enter a number (e.g., 25, 50.5, 100). Example: Entity 'sensor.temperature', Operator '>=', Value '20' shows chore when temperature is 20°C or higher."
+          "visibility_state": "The value to compare against. For 'Equals' or 'Not Equal': any text value (e.g., 'on', 'off', 'home', 'away'). For numeric operators (≥, ≤, >, <): enter a number (e.g., 25, 50.5, 100). Example: Entity 'sensor.temperature', Operator '>=', Value '20' shows chore when temperature is 20°C or higher.",
+          "assignment_mode": "Everyone = every assigned child sees this chore. Alternating = one child at a time, rotating by day. Random = one randomly picked child per day (stable within the day).",
+          "assignment_rotation_anchor": "Day-0 of the alternating rotation. Leave blank to start today. Only used when Assignment Mode is 'Alternating'.",
+          "publish_calendar_entities": "Pick one or more Home Assistant calendar entities. Whenever this chore is created, updated, or rolls over at midnight, today's assigned child is added as a calendar event on each selected calendar. Works with any number of calendars."
         }
       },
       "manage_rewards": {
@@ -371,6 +383,13 @@
         "lte": "Less than or equal (≤) — Show when numeric value is ≤ target",
         "gt": "Greater than (>) — Show when numeric value is > target",
         "lt": "Less than (<) — Show when numeric value is < target"
+      }
+    },
+    "assignment_mode": {
+      "options": {
+        "everyone": "Everyone — every assigned child sees the chore",
+        "alternating": "Alternating — rotate through the assigned children, one per day",
+        "random": "Random — pick one assigned child at random each day"
       }
     }
   },

--- a/custom_components/taskmate/translations/en-GB.json
+++ b/custom_components/taskmate/translations/en-GB.json
@@ -79,7 +79,10 @@
           "completion_sound": "Sound to play when this chore is completed",
           "visibility_entity": "Home Assistant entity ID that controls when this chore appears",
           "visibility_operator": "How to compare the entity state",
-          "visibility_state": "The value to compare against"
+          "visibility_state": "The value to compare against",
+          "assignment_mode": "Assignment Mode",
+          "assignment_rotation_anchor": "Rotation start date (alternating only)",
+          "publish_calendar_entities": "Publish to calendars (optional)"
         },
         "data_description": {
           "claim_allowance_minutes": "Extra minutes after this time-of-day window ends during which the chore can still be claimed. 0 disables the grace period. Night chores are always capped at midnight.",
@@ -88,7 +91,10 @@
           "completion_sound": "Sound to play when this chore is completed",
           "visibility_entity": "Home Assistant entity ID that controls when this chore appears. Leave blank to always show the chore. Examples: binary_sensor.dishwasher, sensor.soil_moisture, input_boolean.guest_mode, switch.laundry_room. The chore only appears on the child card when the visibility condition is met.",
           "visibility_operator": "How to compare the entity's current state with your target value:\n• No filter — always show the chore (ignores entity state)\n• Equals — state exactly matches (e.g., 'on', 'home', 'running')\n• Not Equal — state does not match\n• Greater than or equal (≥) — for numeric values (e.g., 80 for battery ≥ 80%)\n• Less than or equal (≤) — for numeric values (e.g., 30 for moisture ≤ 30%)\n• Greater than (>) — for numeric values\n• Less than (<) — for numeric values",
-          "visibility_state": "The value to compare against. For 'Equals' or 'Not Equal': any text value (e.g., 'on', 'off', 'home', 'away'). For numeric operators (≥, ≤, >, <): enter a number (e.g., 25, 50.5, 100). Example: Entity 'sensor.temperature', Operator '≥', Value '20' shows chore when temperature is 20°C or higher."
+          "visibility_state": "The value to compare against. For 'Equals' or 'Not Equal': any text value (e.g., 'on', 'off', 'home', 'away'). For numeric operators (≥, ≤, >, <): enter a number (e.g., 25, 50.5, 100). Example: Entity 'sensor.temperature', Operator '≥', Value '20' shows chore when temperature is 20°C or higher.",
+          "assignment_mode": "Everyone = every assigned child sees this chore. Alternating = one child at a time, rotating by day. Random = one randomly picked child per day (stable within the day).",
+          "assignment_rotation_anchor": "Day-0 of the alternating rotation. Leave blank to start today. Only used when Assignment Mode is 'Alternating'.",
+          "publish_calendar_entities": "Pick one or more Home Assistant calendar entities. Whenever this chore is created, updated, or rolls over at midnight, today's assigned child is added as a calendar event on each selected calendar. Works with any number of calendars."
         }
       },
       "add_chores_bulk": {
@@ -137,7 +143,10 @@
           "completion_sound": "Sound to play when this chore is completed",
           "visibility_entity": "Home Assistant entity ID that controls when this chore appears",
           "visibility_operator": "How to compare the entity state",
-          "visibility_state": "The value to compare against"
+          "visibility_state": "The value to compare against",
+          "assignment_mode": "Assignment Mode",
+          "assignment_rotation_anchor": "Rotation start date (alternating only)",
+          "publish_calendar_entities": "Publish to calendars (optional)"
         },
         "data_description": {
           "claim_allowance_minutes": "Extra minutes after this time-of-day window ends during which the chore can still be claimed. 0 disables the grace period. Night chores are always capped at midnight.",
@@ -146,7 +155,10 @@
           "completion_sound": "Sound to play when this chore is completed",
           "visibility_entity": "Home Assistant entity ID that controls when this chore appears. Leave blank to always show the chore. Examples: binary_sensor.dishwasher, sensor.soil_moisture, input_boolean.guest_mode, switch.laundry_room. The chore only appears on the child card when the visibility condition is met.",
           "visibility_operator": "How to compare the entity's current state with your target value:\n• No filter — always show the chore (ignores entity state)\n• Equals — state exactly matches (e.g., 'on', 'home', 'running')\n• Not Equal — state does not match\n• Greater than or equal (≥) — for numeric values (e.g., 80 for battery ≥ 80%)\n• Less than or equal (≤) — for numeric values (e.g., 30 for moisture ≤ 30%)\n• Greater than (>) — for numeric values\n• Less than (<) — for numeric values",
-          "visibility_state": "The value to compare against. For 'Equals' or 'Not Equal': any text value (e.g., 'on', 'off', 'home', 'away'). For numeric operators (≥, ≤, >, <): enter a number (e.g., 25, 50.5, 100). Example: Entity 'sensor.temperature', Operator '≥', Value '20' shows chore when temperature is 20°C or higher."
+          "visibility_state": "The value to compare against. For 'Equals' or 'Not Equal': any text value (e.g., 'on', 'off', 'home', 'away'). For numeric operators (≥, ≤, >, <): enter a number (e.g., 25, 50.5, 100). Example: Entity 'sensor.temperature', Operator '≥', Value '20' shows chore when temperature is 20°C or higher.",
+          "assignment_mode": "Everyone = every assigned child sees this chore. Alternating = one child at a time, rotating by day. Random = one randomly picked child per day (stable within the day).",
+          "assignment_rotation_anchor": "Day-0 of the alternating rotation. Leave blank to start today. Only used when Assignment Mode is 'Alternating'.",
+          "publish_calendar_entities": "Pick one or more Home Assistant calendar entities. Whenever this chore is created, updated, or rolls over at midnight, today's assigned child is added as a calendar event on each selected calendar. Works with any number of calendars."
         }
       },
       "manage_rewards": {
@@ -368,6 +380,13 @@
         "lte": "Less than or equal (≤) — Show when numeric value is ≤ target",
         "gt": "Greater than (>) — Show when numeric value is > target",
         "lt": "Less than (<) — Show when numeric value is < target"
+      }
+    },
+    "assignment_mode": {
+      "options": {
+        "everyone": "Everyone — every assigned child sees the chore",
+        "alternating": "Alternating — rotate through the assigned children, one per day",
+        "random": "Random — pick one assigned child at random each day"
       }
     }
   },

--- a/custom_components/taskmate/translations/en.json
+++ b/custom_components/taskmate/translations/en.json
@@ -79,7 +79,10 @@
           "completion_sound": "Completion Sound",
           "visibility_entity": "Show when entity is (optional)",
           "visibility_operator": "How to compare",
-          "visibility_state": "Value to compare"
+          "visibility_state": "Value to compare",
+          "assignment_mode": "Assignment Mode",
+          "assignment_rotation_anchor": "Rotation start date (alternating only)",
+          "publish_calendar_entities": "Publish to calendars (optional)"
         },
         "data_description": {
           "claim_allowance_minutes": "Extra minutes after this time-of-day window ends during which the chore can still be claimed. 0 disables the grace period. Night chores are always capped at midnight.",
@@ -88,7 +91,10 @@
           "completion_sound": "Sound to play when this chore is completed",
           "visibility_entity": "Home Assistant entity ID that controls when this chore appears. Leave blank to always show the chore. Examples: binary_sensor.dishwasher, sensor.soil_moisture, input_boolean.guest_mode, switch.laundry_room. The chore only appears on the child card when the visibility condition is met.",
           "visibility_operator": "How to compare the entity's current state with your target value:\n• No filter — always show the chore (ignores entity state)\n• Equals — state exactly matches (e.g., 'on', 'home', 'running')\n• Not Equal — state does not match\n• Greater than or equal (≥) — for numeric values (e.g., 80 for battery ≥ 80%)\n• Less than or equal (≤) — for numeric values (e.g., 30 for moisture ≤ 30%)\n• Greater than (>) — for numeric values\n• Less than (<) — for numeric values",
-          "visibility_state": "The value to compare against. For 'Equals' or 'Not Equal': any text value (e.g., 'on', 'off', 'home', 'away'). For numeric operators (≥, ≤, >, <): enter a number (e.g., 25, 50.5, 100). Example: Entity 'sensor.temperature', Operator '>=', Value '20' shows chore when temperature is 20°C or higher."
+          "visibility_state": "The value to compare against. For 'Equals' or 'Not Equal': any text value (e.g., 'on', 'off', 'home', 'away'). For numeric operators (≥, ≤, >, <): enter a number (e.g., 25, 50.5, 100). Example: Entity 'sensor.temperature', Operator '>=', Value '20' shows chore when temperature is 20°C or higher.",
+          "assignment_mode": "Everyone = every assigned child sees this chore. Alternating = one child at a time, rotating by day. Random = one randomly picked child per day (stable within the day).",
+          "assignment_rotation_anchor": "Day-0 of the alternating rotation. Leave blank to start today. Only used when Assignment Mode is 'Alternating'.",
+          "publish_calendar_entities": "Pick one or more Home Assistant calendar entities. Whenever this chore is created, updated, or rolls over at midnight, today's assigned child is added as a calendar event on each selected calendar. Works with any number of calendars."
         }
       },
       "add_chores_bulk": {
@@ -137,7 +143,10 @@
           "completion_sound": "Completion Sound",
           "visibility_entity": "Show when entity is (optional)",
           "visibility_operator": "How to compare",
-          "visibility_state": "Value to compare"
+          "visibility_state": "Value to compare",
+          "assignment_mode": "Assignment Mode",
+          "assignment_rotation_anchor": "Rotation start date (alternating only)",
+          "publish_calendar_entities": "Publish to calendars (optional)"
         },
         "data_description": {
           "claim_allowance_minutes": "Extra minutes after this time-of-day window ends during which the chore can still be claimed. 0 disables the grace period. Night chores are always capped at midnight.",
@@ -146,7 +155,10 @@
           "completion_sound": "Sound to play when this chore is completed",
           "visibility_entity": "Home Assistant entity ID that controls when this chore appears. Leave blank to always show the chore. Examples: binary_sensor.dishwasher, sensor.soil_moisture, input_boolean.guest_mode, switch.laundry_room. The chore only appears on the child card when the visibility condition is met.",
           "visibility_operator": "How to compare the entity's current state with your target value:\n• No filter — always show the chore (ignores entity state)\n• Equals — state exactly matches (e.g., 'on', 'home', 'running')\n• Not Equal — state does not match\n• Greater than or equal (≥) — for numeric values (e.g., 80 for battery ≥ 80%)\n• Less than or equal (≤) — for numeric values (e.g., 30 for moisture ≤ 30%)\n• Greater than (>) — for numeric values\n• Less than (<) — for numeric values",
-          "visibility_state": "The value to compare against. For 'Equals' or 'Not Equal': any text value (e.g., 'on', 'off', 'home', 'away'). For numeric operators (≥, ≤, >, <): enter a number (e.g., 25, 50.5, 100). Example: Entity 'sensor.temperature', Operator '>=', Value '20' shows chore when temperature is 20°C or higher."
+          "visibility_state": "The value to compare against. For 'Equals' or 'Not Equal': any text value (e.g., 'on', 'off', 'home', 'away'). For numeric operators (≥, ≤, >, <): enter a number (e.g., 25, 50.5, 100). Example: Entity 'sensor.temperature', Operator '>=', Value '20' shows chore when temperature is 20°C or higher.",
+          "assignment_mode": "Everyone = every assigned child sees this chore. Alternating = one child at a time, rotating by day. Random = one randomly picked child per day (stable within the day).",
+          "assignment_rotation_anchor": "Day-0 of the alternating rotation. Leave blank to start today. Only used when Assignment Mode is 'Alternating'.",
+          "publish_calendar_entities": "Pick one or more Home Assistant calendar entities. Whenever this chore is created, updated, or rolls over at midnight, today's assigned child is added as a calendar event on each selected calendar. Works with any number of calendars."
         }
       },
       "manage_rewards": {
@@ -368,6 +380,13 @@
         "lte": "Less than or equal (≤) — Show when numeric value is ≤ target",
         "gt": "Greater than (>) — Show when numeric value is > target",
         "lt": "Less than (<) — Show when numeric value is < target"
+      }
+    },
+    "assignment_mode": {
+      "options": {
+        "everyone": "Everyone — every assigned child sees the chore",
+        "alternating": "Alternating — rotate through the assigned children, one per day",
+        "random": "Random — pick one assigned child at random each day"
       }
     }
   },

--- a/custom_components/taskmate/translations/fr.json
+++ b/custom_components/taskmate/translations/fr.json
@@ -79,7 +79,10 @@
           "completion_sound": "Son de complétion",
           "visibility_entity": "Afficher quand l'entité est (optionnel)",
           "visibility_operator": "Comment comparer",
-          "visibility_state": "Valeur à comparer"
+          "visibility_state": "Valeur à comparer",
+          "assignment_mode": "Mode d'attribution",
+          "assignment_rotation_anchor": "Date de début du roulement (alternance uniquement)",
+          "publish_calendar_entities": "Publier vers les calendriers (optionnel)"
         },
         "data_description": {
           "claim_allowance_minutes": "Minutes supplémentaires après la fin de cette plage horaire pendant lesquelles la corvée peut encore être réclamée. 0 désactive le délai de grâce. Les corvées nocturnes sont toujours limitées à minuit.",
@@ -88,7 +91,10 @@
           "completion_sound": "Son à jouer quand cette corvée est complétée",
           "visibility_entity": "ID d'entité Home Assistant qui contrôle quand cette corvée apparaît. Laissez vide pour toujours afficher la corvée. Exemples : binary_sensor.lave_vaisselle, sensor.humidite_sol, input_boolean.mode_invite, switch.salle_blanchisserie. La corvée n'apparaît sur la carte enfant que quand la condition de visibilité est satisfaite.",
           "visibility_operator": "Comment comparer l'état actuel de l'entité avec votre valeur cible :\n• Aucun filtre — toujours afficher la corvée (ignore l'état de l'entité)\n• Égale — l'état correspond exactement (ex. : 'on', 'home', 'running')\n• Non égale — l'état ne correspond pas\n• Supérieur ou égal (≥) — pour valeurs numériques (ex. : 80 pour batterie ≥ 80%)\n• Inférieur ou égal (≤) — pour valeurs numériques (ex. : 30 pour humidité ≤ 30%)\n• Supérieur (>) — pour valeurs numériques\n• Inférieur (<) — pour valeurs numériques",
-          "visibility_state": "La valeur à comparer. Pour 'Égale' ou 'Non égale' : tout texte (ex. : 'on', 'off', 'home', 'away'). Pour opérateurs numériques (≥, ≤, >, <) : entrez un nombre (ex. : 25, 50.5, 100). Exemple : Entité 'sensor.temperature', Opérateur '>=', Valeur '20' affiche la corvée quand la température est 20°C ou plus."
+          "visibility_state": "La valeur à comparer. Pour 'Égale' ou 'Non égale' : tout texte (ex. : 'on', 'off', 'home', 'away'). Pour opérateurs numériques (≥, ≤, >, <) : entrez un nombre (ex. : 25, 50.5, 100). Exemple : Entité 'sensor.temperature', Opérateur '>=', Valeur '20' affiche la corvée quand la température est 20°C ou plus.",
+          "assignment_mode": "Tout le monde = chaque enfant assigné voit cette tâche. Alternance = un enfant à la fois, rotation par jour. Aléatoire = un enfant choisi au hasard chaque jour (stable dans la journée).",
+          "assignment_rotation_anchor": "Jour 0 du roulement alterné. Laissez vide pour commencer aujourd'hui. Utilisé uniquement avec le mode 'Alternance'.",
+          "publish_calendar_entities": "Choisissez un ou plusieurs calendriers Home Assistant. À chaque création, mise à jour ou passage à minuit, l'enfant attribué du jour est ajouté comme événement sur chaque calendrier sélectionné. Fonctionne avec un nombre illimité de calendriers."
         }
       },
       "add_chores_bulk": {
@@ -137,7 +143,10 @@
           "completion_sound": "Son de complétion",
           "visibility_entity": "Afficher quand l'entité est (optionnel)",
           "visibility_operator": "Comment comparer",
-          "visibility_state": "Valeur à comparer"
+          "visibility_state": "Valeur à comparer",
+          "assignment_mode": "Mode d'attribution",
+          "assignment_rotation_anchor": "Date de début du roulement (alternance uniquement)",
+          "publish_calendar_entities": "Publier vers les calendriers (optionnel)"
         },
         "data_description": {
           "claim_allowance_minutes": "Minutes supplémentaires après la fin de cette plage horaire pendant lesquelles la corvée peut encore être réclamée. 0 désactive le délai de grâce. Les corvées nocturnes sont toujours limitées à minuit.",
@@ -146,7 +155,10 @@
           "completion_sound": "Son à jouer quand cette corvée est complétée",
           "visibility_entity": "ID d'entité Home Assistant qui contrôle quand cette corvée apparaît. Laissez vide pour toujours afficher la corvée. Exemples : binary_sensor.lave_vaisselle, sensor.humidite_sol, input_boolean.mode_invite, switch.salle_blanchisserie. La corvée n'apparaît sur la carte enfant que quand la condition de visibilité est satisfaite.",
           "visibility_operator": "Comment comparer l'état actuel de l'entité avec votre valeur cible :\n• Aucun filtre — toujours afficher la corvée (ignore l'état de l'entité)\n• Égale — l'état correspond exactement (ex. : 'on', 'home', 'running')\n• Non égale — l'état ne correspond pas\n• Supérieur ou égal (≥) — pour valeurs numériques (ex. : 80 pour batterie ≥ 80%)\n• Inférieur ou égal (≤) — pour valeurs numériques (ex. : 30 pour humidité ≤ 30%)\n• Supérieur (>) — pour valeurs numériques\n• Inférieur (<) — pour valeurs numériques",
-          "visibility_state": "La valeur à comparer. Pour 'Égale' ou 'Non égale' : tout texte (ex. : 'on', 'off', 'home', 'away'). Pour opérateurs numériques (≥, ≤, >, <) : entrez un nombre (ex. : 25, 50.5, 100). Exemple : Entité 'sensor.temperature', Opérateur '>=', Valeur '20' affiche la corvée quand la température est 20°C ou plus."
+          "visibility_state": "La valeur à comparer. Pour 'Égale' ou 'Non égale' : tout texte (ex. : 'on', 'off', 'home', 'away'). Pour opérateurs numériques (≥, ≤, >, <) : entrez un nombre (ex. : 25, 50.5, 100). Exemple : Entité 'sensor.temperature', Opérateur '>=', Valeur '20' affiche la corvée quand la température est 20°C ou plus.",
+          "assignment_mode": "Tout le monde = chaque enfant assigné voit cette tâche. Alternance = un enfant à la fois, rotation par jour. Aléatoire = un enfant choisi au hasard chaque jour (stable dans la journée).",
+          "assignment_rotation_anchor": "Jour 0 du roulement alterné. Laissez vide pour commencer aujourd'hui. Utilisé uniquement avec le mode 'Alternance'.",
+          "publish_calendar_entities": "Choisissez un ou plusieurs calendriers Home Assistant. À chaque création, mise à jour ou passage à minuit, l'enfant attribué du jour est ajouté comme événement sur chaque calendrier sélectionné. Fonctionne avec un nombre illimité de calendriers."
         }
       },
       "manage_rewards": {
@@ -364,6 +376,13 @@
         "lte": "Inférieur ou égal (≤) — Afficher quand la valeur est ≤ cible",
         "gt": "Supérieur (>) — Afficher quand la valeur est > cible",
         "lt": "Inférieur (<) — Afficher quand la valeur est < cible"
+      }
+    },
+    "assignment_mode": {
+      "options": {
+        "everyone": "Tout le monde — chaque enfant assigné voit la tâche",
+        "alternating": "Alternance — rotation entre les enfants assignés, un par jour",
+        "random": "Aléatoire — un enfant assigné choisi au hasard chaque jour"
       }
     }
   },

--- a/custom_components/taskmate/translations/nb.json
+++ b/custom_components/taskmate/translations/nb.json
@@ -79,7 +79,10 @@
           "completion_sound": "Lyd når oppgaven fullføres",
           "visibility_entity": "Home Assistant-enhet for synlighet",
           "visibility_operator": "Synlighetsoperatør",
-          "visibility_state": "Synlighetstilstand"
+          "visibility_state": "Synlighetstilstand",
+          "assignment_mode": "Tildelingsmodus",
+          "assignment_rotation_anchor": "Startdato for rotasjon (kun vekslende)",
+          "publish_calendar_entities": "Publiser til kalendere (valgfritt)"
         },
         "data_description": {
           "claim_allowance_minutes": "Extra minutes after this time-of-day window ends during which the chore can still be claimed. 0 disables the grace period. Night chores are always capped at midnight.",
@@ -88,7 +91,10 @@
           "completion_sound": "Lyd som skal spilles når denne oppgaven fullføres",
           "visibility_entity": "Home Assistant-enhets-ID som styrer når denne oppgaven vises. La stå tom for alltid å vise oppgaven. Eksempler: binary_sensor.dishwasher, sensor.soil_moisture, input_boolean.guest_mode, switch.laundry_room. Oppgaven vises kun på barnets kort når synlighetsbetingelsen er oppfylt.",
           "visibility_operator": "Hvordan sammenlignes enhetens nåværende tilstand med målverdien:\n• Ingen filter — vis alltid oppgaven (ignorerer enhetens tilstand)\n• Lik — tilstanden stemmer nøyaktig (f.eks. 'on', 'home', 'running')\n• Ikke lik — tilstanden stemmer ikke\n• Større enn eller lik (≥) — for numeriske verdier (f.eks. 80 for batteri ≥ 80%)\n• Mindre enn eller lik (≤) — for numeriske verdier (f.eks. 30 for fuktighet ≤ 30%)\n• Større enn (>) — for numeriske verdier\n• Mindre enn (<) — for numeriske verdier",
-          "visibility_state": "Verdien som skal sammenlignes. For 'Lik' eller 'Ikke lik': hvilken som helst tekstverdi (f.eks. 'on', 'off', 'home', 'away'). For numeriske operatorer (≥, ≤, >, <): skriv inn et tall (f.eks. 25, 50,5, 100). Eksempel: Enhet 'sensor.temperature', Operatør '≥', Verdi '20' viser oppgaven når temperaturen er 20°C eller høyere."
+          "visibility_state": "Verdien som skal sammenlignes. For 'Lik' eller 'Ikke lik': hvilken som helst tekstverdi (f.eks. 'on', 'off', 'home', 'away'). For numeriske operatorer (≥, ≤, >, <): skriv inn et tall (f.eks. 25, 50,5, 100). Eksempel: Enhet 'sensor.temperature', Operatør '≥', Verdi '20' viser oppgaven når temperaturen er 20°C eller høyere.",
+          "assignment_mode": "Alle = hvert tilknyttet barn ser oppgaven. Vekslende = ett barn om gangen, roterer daglig. Tilfeldig = ett barn plukket tilfeldig hver dag (stabilt gjennom dagen).",
+          "assignment_rotation_anchor": "Dag 0 i den vekslende rotasjonen. La stå tom for å starte i dag. Brukes kun når tildelingsmodus er 'Vekslende'.",
+          "publish_calendar_entities": "Velg én eller flere Home Assistant-kalenderentiteter. Hver gang oppgaven opprettes, oppdateres eller bytter ved midnatt legges dagens tildelte barn til som en kalenderoppføring i hver valgte kalender. Fungerer med et hvilket som helst antall kalendere."
         }
       },
       "add_chores_bulk": {
@@ -137,7 +143,10 @@
           "completion_sound": "Lyd når oppgaven fullføres",
           "visibility_entity": "Home Assistant-enhet for synlighet",
           "visibility_operator": "Synlighetsoperatør",
-          "visibility_state": "Synlighetstilstand"
+          "visibility_state": "Synlighetstilstand",
+          "assignment_mode": "Tildelingsmodus",
+          "assignment_rotation_anchor": "Startdato for rotasjon (kun vekslende)",
+          "publish_calendar_entities": "Publiser til kalendere (valgfritt)"
         },
         "data_description": {
           "claim_allowance_minutes": "Extra minutes after this time-of-day window ends during which the chore can still be claimed. 0 disables the grace period. Night chores are always capped at midnight.",
@@ -146,7 +155,10 @@
           "completion_sound": "Lyd som skal spilles når denne oppgaven fullføres",
           "visibility_entity": "Home Assistant-enhets-ID som styrer når denne oppgaven vises. La stå tom for alltid å vise oppgaven. Eksempler: binary_sensor.dishwasher, sensor.soil_moisture, input_boolean.guest_mode, switch.laundry_room. Oppgaven vises kun på barnets kort når synlighetsbetingelsen er oppfylt.",
           "visibility_operator": "Hvordan sammenlignes enhetens nåværende tilstand med målverdien:\n• Ingen filter — vis alltid oppgaven (ignorerer enhetens tilstand)\n• Lik — tilstanden stemmer nøyaktig (f.eks. 'on', 'home', 'running')\n• Ikke lik — tilstanden stemmer ikke\n• Større enn eller lik (≥) — for numeriske verdier (f.eks. 80 for batteri ≥ 80%)\n• Mindre enn eller lik (≤) — for numeriske verdier (f.eks. 30 for fuktighet ≤ 30%)\n• Større enn (>) — for numeriske verdier\n• Mindre enn (<) — for numeriske verdier",
-          "visibility_state": "Verdien som skal sammenlignes. For 'Lik' eller 'Ikke lik': hvilken som helst tekstverdi (f.eks. 'on', 'off', 'home', 'away'). For numeriske operatorer (≥, ≤, >, <): skriv inn et tall (f.eks. 25, 50,5, 100). Eksempel: Enhet 'sensor.temperature', Operatør '≥', Verdi '20' viser oppgaven når temperaturen er 20°C eller høyere."
+          "visibility_state": "Verdien som skal sammenlignes. For 'Lik' eller 'Ikke lik': hvilken som helst tekstverdi (f.eks. 'on', 'off', 'home', 'away'). For numeriske operatorer (≥, ≤, >, <): skriv inn et tall (f.eks. 25, 50,5, 100). Eksempel: Enhet 'sensor.temperature', Operatør '≥', Verdi '20' viser oppgaven når temperaturen er 20°C eller høyere.",
+          "assignment_mode": "Alle = hvert tilknyttet barn ser oppgaven. Vekslende = ett barn om gangen, roterer daglig. Tilfeldig = ett barn plukket tilfeldig hver dag (stabilt gjennom dagen).",
+          "assignment_rotation_anchor": "Dag 0 i den vekslende rotasjonen. La stå tom for å starte i dag. Brukes kun når tildelingsmodus er 'Vekslende'.",
+          "publish_calendar_entities": "Velg én eller flere Home Assistant-kalenderentiteter. Hver gang oppgaven opprettes, oppdateres eller bytter ved midnatt legges dagens tildelte barn til som en kalenderoppføring i hver valgte kalender. Fungerer med et hvilket som helst antall kalendere."
         }
       },
       "manage_rewards": {
@@ -364,6 +376,13 @@
         "lte": "Mindre enn eller lik (≤) — Vis når numerisk verdi er ≤ målverdien",
         "gt": "Større enn (>) — Vis når numerisk verdi er > målverdien",
         "lt": "Mindre enn (<) — Vis når numerisk verdi er < målverdien"
+      }
+    },
+    "assignment_mode": {
+      "options": {
+        "everyone": "Alle — hvert tildelt barn ser oppgaven",
+        "alternating": "Vekslende — roter mellom de tildelte barna, ett per dag",
+        "random": "Tilfeldig — plukk ett tildelt barn tilfeldig hver dag"
       }
     }
   },

--- a/custom_components/taskmate/translations/nn.json
+++ b/custom_components/taskmate/translations/nn.json
@@ -79,7 +79,10 @@
           "completion_sound": "Lyd når oppgåva vert fullført",
           "visibility_entity": "Home Assistant-eining for synlegheit",
           "visibility_operator": "Synlegheitsoperator",
-          "visibility_state": "Synlegheitstilstand"
+          "visibility_state": "Synlegheitstilstand",
+          "assignment_mode": "Tildelingsmodus",
+          "assignment_rotation_anchor": "Startdato for rotasjon (berre vekslande)",
+          "publish_calendar_entities": "Publiser til kalendrar (valfritt)"
         },
         "data_description": {
           "claim_allowance_minutes": "Extra minutes after this time-of-day window ends during which the chore can still be claimed. 0 disables the grace period. Night chores are always capped at midnight.",
@@ -88,7 +91,10 @@
           "completion_sound": "Lyd som skal spelast når denne oppgåva vert fullført",
           "visibility_entity": "Home Assistant-eining-ID som styr når denne oppgåva vert viste. Lat stå tom for alltid å vise oppgåva. Døme: binary_sensor.dishwasher, sensor.soil_moisture, input_boolean.guest_mode, switch.laundry_room. Oppgåva vert berre viste på bornekortet når synlegheitsbetingelsen er oppfylt.",
           "visibility_operator": "Korleis samanliknast eininga si noverande tilstand med målverdien:\n• Ingen filter — vis alltid oppgåva (ignorerer eininga si tilstand)\n• Lik — tilstanden stemmer nøyaktig (t.d. 'on', 'home', 'running')\n• Ikkje lik — tilstanden stemmer ikkje\n• Større enn eller lik (≥) — for numeriske verdiar (t.d. 80 for batteri ≥ 80%)\n• Mindre enn eller lik (≤) — for numeriske verdiar (t.d. 30 for fukt ≤ 30%)\n• Større enn (>) — for numeriske verdiar\n• Mindre enn (<) — for numeriske verdiar",
-          "visibility_state": "Verdien som skal samanliknast. For 'Lik' eller 'Ikkje lik': kva som helst tekstverde (t.d. 'on', 'off', 'home', 'away'). For numeriske operatorar (≥, ≤, >, <): skriv inn eit tal (t.d. 25, 50,5, 100). Døme: Eining 'sensor.temperature', Operator '≥', Verdi '20' viser oppgåva når temperaturen er 20°C eller høgare."
+          "visibility_state": "Verdien som skal samanliknast. For 'Lik' eller 'Ikkje lik': kva som helst tekstverde (t.d. 'on', 'off', 'home', 'away'). For numeriske operatorar (≥, ≤, >, <): skriv inn eit tal (t.d. 25, 50,5, 100). Døme: Eining 'sensor.temperature', Operator '≥', Verdi '20' viser oppgåva når temperaturen er 20°C eller høgare.",
+          "assignment_mode": "Alle = kvart tilknytt barn ser oppgåva. Vekslande = eitt barn om gongen, roterer dagleg. Tilfeldig = eitt barn plukka tilfeldig kvar dag (stabilt gjennom dagen).",
+          "assignment_rotation_anchor": "Dag 0 i den vekslande rotasjonen. Lat stå tom for å starte i dag. Vert brukt berre når tildelingsmodus er 'Vekslande'.",
+          "publish_calendar_entities": "Vel ein eller fleire Home Assistant-kalenderentitetar. Kvar gong oppgåva vert oppretta, oppdatert eller skiftar ved midnatt vert dagens tildelte barn lagt til som ei kalenderoppføring i kvar valde kalender. Fungerer med eit kva som helst tal kalendrar."
         }
       },
       "add_chores_bulk": {
@@ -137,7 +143,10 @@
           "completion_sound": "Lyd når oppgåva vert fullført",
           "visibility_entity": "Home Assistant-eining for synlegheit",
           "visibility_operator": "Synlegheitsoperator",
-          "visibility_state": "Synlegheitstilstand"
+          "visibility_state": "Synlegheitstilstand",
+          "assignment_mode": "Tildelingsmodus",
+          "assignment_rotation_anchor": "Startdato for rotasjon (berre vekslande)",
+          "publish_calendar_entities": "Publiser til kalendrar (valfritt)"
         },
         "data_description": {
           "claim_allowance_minutes": "Extra minutes after this time-of-day window ends during which the chore can still be claimed. 0 disables the grace period. Night chores are always capped at midnight.",
@@ -146,7 +155,10 @@
           "completion_sound": "Lyd som skal spelast når denne oppgåva vert fullført",
           "visibility_entity": "Home Assistant-eining-ID som styr når denne oppgåva vert viste. Lat stå tom for alltid å vise oppgåva. Døme: binary_sensor.dishwasher, sensor.soil_moisture, input_boolean.guest_mode, switch.laundry_room. Oppgåva vert berre viste på bornekortet når synlegheitsbetingelsen er oppfylt.",
           "visibility_operator": "Korleis samanliknast eininga si noverande tilstand med målverdien:\n• Ingen filter — vis alltid oppgåva (ignorerer eininga si tilstand)\n• Lik — tilstanden stemmer nøyaktig (t.d. 'on', 'home', 'running')\n• Ikkje lik — tilstanden stemmer ikkje\n• Større enn eller lik (≥) — for numeriske verdiar (t.d. 80 for batteri ≥ 80%)\n• Mindre enn eller lik (≤) — for numeriske verdiar (t.d. 30 for fukt ≤ 30%)\n• Større enn (>) — for numeriske verdiar\n• Mindre enn (<) — for numeriske verdiar",
-          "visibility_state": "Verdien som skal samanliknast. For 'Lik' eller 'Ikkje lik': kva som helst tekstverde (t.d. 'on', 'off', 'home', 'away'). For numeriske operatorar (≥, ≤, >, <): skriv inn eit tal (t.d. 25, 50,5, 100). Døme: Eining 'sensor.temperature', Operator '≥', Verdi '20' viser oppgåva når temperaturen er 20°C eller høgare."
+          "visibility_state": "Verdien som skal samanliknast. For 'Lik' eller 'Ikkje lik': kva som helst tekstverde (t.d. 'on', 'off', 'home', 'away'). For numeriske operatorar (≥, ≤, >, <): skriv inn eit tal (t.d. 25, 50,5, 100). Døme: Eining 'sensor.temperature', Operator '≥', Verdi '20' viser oppgåva når temperaturen er 20°C eller høgare.",
+          "assignment_mode": "Alle = kvart tilknytt barn ser oppgåva. Vekslande = eitt barn om gongen, roterer dagleg. Tilfeldig = eitt barn plukka tilfeldig kvar dag (stabilt gjennom dagen).",
+          "assignment_rotation_anchor": "Dag 0 i den vekslande rotasjonen. Lat stå tom for å starte i dag. Vert brukt berre når tildelingsmodus er 'Vekslande'.",
+          "publish_calendar_entities": "Vel ein eller fleire Home Assistant-kalenderentitetar. Kvar gong oppgåva vert oppretta, oppdatert eller skiftar ved midnatt vert dagens tildelte barn lagt til som ei kalenderoppføring i kvar valde kalender. Fungerer med eit kva som helst tal kalendrar."
         }
       },
       "manage_rewards": {
@@ -364,6 +376,13 @@
         "lte": "Mindre enn eller lik (≤) — Vis når numerisk verdi er ≤ målverdien",
         "gt": "Større enn (>) — Vis når numerisk verdi er > målverdien",
         "lt": "Mindre enn (<) — Vis når numerisk verdi er < målverdien"
+      }
+    },
+    "assignment_mode": {
+      "options": {
+        "everyone": "Alle — kvart tildelt barn ser oppgåva",
+        "alternating": "Vekslande — roter mellom dei tildelte barna, eitt per dag",
+        "random": "Tilfeldig — plukk eitt tildelt barn tilfeldig kvar dag"
       }
     }
   },

--- a/custom_components/taskmate/translations/pt-BR.json
+++ b/custom_components/taskmate/translations/pt-BR.json
@@ -79,7 +79,10 @@
           "completion_sound": "Som de conclusão",
           "visibility_entity": "Mostrar quando a entidade for (opcional)",
           "visibility_operator": "Como comparar",
-          "visibility_state": "Valor a comparar"
+          "visibility_state": "Valor a comparar",
+          "assignment_mode": "Modo de atribuição",
+          "assignment_rotation_anchor": "Data de início da rotação (apenas alternância)",
+          "publish_calendar_entities": "Publicar nos calendários (opcional)"
         },
         "data_description": {
           "claim_allowance_minutes": "Minutos extras após o fim desta janela horária durante os quais a tarefa ainda pode ser reivindicada. 0 desativa o período de tolerância. As tarefas noturnas são sempre limitadas à meia-noite.",
@@ -88,7 +91,10 @@
           "completion_sound": "Som a tocar quando esta tarefa é concluída",
           "visibility_entity": "ID da entidade Home Assistant que controla quando esta tarefa aparece. Deixe em branco para sempre mostrar a tarefa. Exemplos: binary_sensor.lava_louça, sensor.humidade_solo, input_boolean.modo_visitantes, switch.sala_lavagem. A tarefa só aparece no cartão da criança quando a condição de visibilidade é atendida.",
           "visibility_operator": "Como comparar o estado atual da entidade com seu valor-alvo:\n• Sem filtro — sempre mostrar a tarefa (ignora o estado da entidade)\n• Igual — o estado corresponde exatamente (ex.: 'on', 'home', 'running')\n• Não igual — o estado não corresponde\n• Maior ou igual (≥) — para valores numéricos (ex.: 80 para bateria ≥ 80%)\n• Menor ou igual (≤) — para valores numéricos (ex.: 30 para umidade ≤ 30%)\n• Maior que (>) — para valores numéricos\n• Menor que (<) — para valores numéricos",
-          "visibility_state": "O valor a comparar. Para 'Igual' ou 'Não igual': qualquer valor de texto (ex.: 'on', 'off', 'home', 'away'). Para operadores numéricos (≥, ≤, >, <): digite um número (ex.: 25, 50.5, 100). Exemplo: Entidade 'sensor.temperature', Operador '>=', Valor '20' mostra a tarefa quando a temperatura é 20°C ou mais alta."
+          "visibility_state": "O valor a comparar. Para 'Igual' ou 'Não igual': qualquer valor de texto (ex.: 'on', 'off', 'home', 'away'). Para operadores numéricos (≥, ≤, >, <): digite um número (ex.: 25, 50.5, 100). Exemplo: Entidade 'sensor.temperature', Operador '>=', Valor '20' mostra a tarefa quando a temperatura é 20°C ou mais alta.",
+          "assignment_mode": "Todos = todas as crianças atribuídas veem esta tarefa. Alternado = uma criança de cada vez, alternando por dia. Aleatório = uma criança escolhida aleatoriamente por dia (estável durante o dia).",
+          "assignment_rotation_anchor": "Dia 0 da rotação alternada. Deixe em branco para começar hoje. Usado apenas quando o modo de atribuição é 'Alternado'.",
+          "publish_calendar_entities": "Escolha uma ou mais entidades de calendário do Home Assistant. Sempre que esta tarefa for criada, atualizada ou passar da meia-noite, a criança atribuída do dia é adicionada como evento em cada calendário selecionado. Funciona com qualquer número de calendários."
         }
       },
       "add_chores_bulk": {
@@ -137,7 +143,10 @@
           "completion_sound": "Som de conclusão",
           "visibility_entity": "Mostrar quando a entidade for (opcional)",
           "visibility_operator": "Como comparar",
-          "visibility_state": "Valor a comparar"
+          "visibility_state": "Valor a comparar",
+          "assignment_mode": "Modo de atribuição",
+          "assignment_rotation_anchor": "Data de início da rotação (apenas alternância)",
+          "publish_calendar_entities": "Publicar nos calendários (opcional)"
         },
         "data_description": {
           "claim_allowance_minutes": "Minutos extras após o fim desta janela horária durante os quais a tarefa ainda pode ser reivindicada. 0 desativa o período de tolerância. As tarefas noturnas são sempre limitadas à meia-noite.",
@@ -146,7 +155,10 @@
           "completion_sound": "Som a tocar quando esta tarefa é concluída",
           "visibility_entity": "ID da entidade Home Assistant que controla quando esta tarefa aparece. Deixe em branco para sempre mostrar a tarefa. Exemplos: binary_sensor.lava_louça, sensor.humidade_solo, input_boolean.modo_visitantes, switch.sala_lavagem. A tarefa só aparece no cartão da criança quando a condição de visibilidade é atendida.",
           "visibility_operator": "Como comparar o estado atual da entidade com seu valor-alvo:\n• Sem filtro — sempre mostrar a tarefa (ignora o estado da entidade)\n• Igual — o estado corresponde exatamente (ex.: 'on', 'home', 'running')\n• Não igual — o estado não corresponde\n• Maior ou igual (≥) — para valores numéricos (ex.: 80 para bateria ≥ 80%)\n• Menor ou igual (≤) — para valores numéricos (ex.: 30 para umidade ≤ 30%)\n• Maior que (>) — para valores numéricos\n• Menor que (<) — para valores numéricos",
-          "visibility_state": "O valor a comparar. Para 'Igual' ou 'Não igual': qualquer valor de texto (ex.: 'on', 'off', 'home', 'away'). Para operadores numéricos (≥, ≤, >, <): digite um número (ex.: 25, 50.5, 100). Exemplo: Entidade 'sensor.temperature', Operador '>=', Valor '20' mostra a tarefa quando a temperatura é 20°C ou mais alta."
+          "visibility_state": "O valor a comparar. Para 'Igual' ou 'Não igual': qualquer valor de texto (ex.: 'on', 'off', 'home', 'away'). Para operadores numéricos (≥, ≤, >, <): digite um número (ex.: 25, 50.5, 100). Exemplo: Entidade 'sensor.temperature', Operador '>=', Valor '20' mostra a tarefa quando a temperatura é 20°C ou mais alta.",
+          "assignment_mode": "Todos = todas as crianças atribuídas veem esta tarefa. Alternado = uma criança de cada vez, alternando por dia. Aleatório = uma criança escolhida aleatoriamente por dia (estável durante o dia).",
+          "assignment_rotation_anchor": "Dia 0 da rotação alternada. Deixe em branco para começar hoje. Usado apenas quando o modo de atribuição é 'Alternado'.",
+          "publish_calendar_entities": "Escolha uma ou mais entidades de calendário do Home Assistant. Sempre que esta tarefa for criada, atualizada ou passar da meia-noite, a criança atribuída do dia é adicionada como evento em cada calendário selecionado. Funciona com qualquer número de calendários."
         }
       },
       "manage_rewards": {
@@ -364,6 +376,13 @@
         "lte": "Menor ou igual (≤) — Mostrar quando valor numérico é ≤ alvo",
         "gt": "Maior que (>) — Mostrar quando valor numérico é > alvo",
         "lt": "Menor que (<) — Mostrar quando valor numérico é < alvo"
+      }
+    },
+    "assignment_mode": {
+      "options": {
+        "everyone": "Todos — todas as crianças atribuídas veem a tarefa",
+        "alternating": "Alternado — alterna entre as crianças atribuídas, uma por dia",
+        "random": "Aleatório — escolhe aleatoriamente uma criança atribuída por dia"
       }
     }
   },

--- a/custom_components/taskmate/translations/pt.json
+++ b/custom_components/taskmate/translations/pt.json
@@ -79,7 +79,10 @@
           "completion_sound": "Som quando a tarefa é concluída",
           "visibility_entity": "Entidade Home Assistant para visibilidade",
           "visibility_operator": "Operador de visibilidade",
-          "visibility_state": "Estado de visibilidade"
+          "visibility_state": "Estado de visibilidade",
+          "assignment_mode": "Modo de atribuição",
+          "assignment_rotation_anchor": "Data de início da rotação (apenas alternância)",
+          "publish_calendar_entities": "Publicar nos calendários (opcional)"
         },
         "data_description": {
           "claim_allowance_minutes": "Minutos extra após o fim desta janela horária durante os quais a tarefa ainda pode ser reivindicada. 0 desativa o período de tolerância. As tarefas noturnas são sempre limitadas à meia-noite.",
@@ -88,7 +91,10 @@
           "completion_sound": "Som a reproduzir quando esta tarefa é concluída",
           "visibility_entity": "ID da entidade Home Assistant que controla quando esta tarefa é apresentada. Deixe vazio para mostrar sempre a tarefa. Exemplos: binary_sensor.dishwasher, sensor.soil_moisture, input_boolean.guest_mode, switch.laundry_room. A tarefa só aparece no cartão da criança quando a condição de visibilidade é atendida.",
           "visibility_operator": "Como comparar o estado atual da entidade com seu valor alvo:\n• Sem filtro — mostrar sempre a tarefa (ignora o estado da entidade)\n• Igual — estado corresponde exatamente (p. ex., 'on', 'home', 'running')\n• Não igual — estado não corresponde\n• Maior ou igual (≥) — para valores numéricos (p. ex., 80 para bateria ≥ 80%)\n• Menor ou igual (≤) — para valores numéricos (p. ex., 30 para umidade ≤ 30%)\n• Maior que (>) — para valores numéricos\n• Menor que (<) — para valores numéricos",
-          "visibility_state": "O valor a comparar. Para 'Igual' ou 'Não igual': qualquer valor de texto (p. ex., 'on', 'off', 'home', 'away'). Para operadores numéricos (≥, ≤, >, <): introduza um número (p. ex., 25, 50.5, 100). Exemplo: Entidade 'sensor.temperature', Operador '≥', Valor '20' mostra a tarefa quando a temperatura é 20°C ou superior."
+          "visibility_state": "O valor a comparar. Para 'Igual' ou 'Não igual': qualquer valor de texto (p. ex., 'on', 'off', 'home', 'away'). Para operadores numéricos (≥, ≤, >, <): introduza um número (p. ex., 25, 50.5, 100). Exemplo: Entidade 'sensor.temperature', Operador '≥', Valor '20' mostra a tarefa quando a temperatura é 20°C ou superior.",
+          "assignment_mode": "Todos = todas as crianças atribuídas veem esta tarefa. Alternado = uma criança de cada vez, alternando por dia. Aleatório = uma criança escolhida aleatoriamente por dia (estável durante o dia).",
+          "assignment_rotation_anchor": "Dia 0 da rotação alternada. Deixe em branco para começar hoje. Usado apenas quando o modo de atribuição é 'Alternado'.",
+          "publish_calendar_entities": "Escolha uma ou mais entidades de calendário do Home Assistant. Sempre que esta tarefa for criada, atualizada ou passar da meia-noite, a criança atribuída do dia é adicionada como evento em cada calendário selecionado. Funciona com qualquer número de calendários."
         }
       },
       "add_chores_bulk": {
@@ -137,7 +143,10 @@
           "completion_sound": "Som quando a tarefa é concluída",
           "visibility_entity": "Entidade Home Assistant para visibilidade",
           "visibility_operator": "Operador de visibilidade",
-          "visibility_state": "Estado de visibilidade"
+          "visibility_state": "Estado de visibilidade",
+          "assignment_mode": "Modo de atribuição",
+          "assignment_rotation_anchor": "Data de início da rotação (apenas alternância)",
+          "publish_calendar_entities": "Publicar nos calendários (opcional)"
         },
         "data_description": {
           "claim_allowance_minutes": "Minutos extra após o fim desta janela horária durante os quais a tarefa ainda pode ser reivindicada. 0 desativa o período de tolerância. As tarefas noturnas são sempre limitadas à meia-noite.",
@@ -146,7 +155,10 @@
           "completion_sound": "Som a reproduzir quando esta tarefa é concluída",
           "visibility_entity": "ID da entidade Home Assistant que controla quando esta tarefa é apresentada. Deixe vazio para mostrar sempre a tarefa. Exemplos: binary_sensor.dishwasher, sensor.soil_moisture, input_boolean.guest_mode, switch.laundry_room. A tarefa só aparece no cartão da criança quando a condição de visibilidade é atendida.",
           "visibility_operator": "Como comparar o estado atual da entidade com seu valor alvo:\n• Sem filtro — mostrar sempre a tarefa (ignora o estado da entidade)\n• Igual — estado corresponde exatamente (p. ex., 'on', 'home', 'running')\n• Não igual — estado não corresponde\n• Maior ou igual (≥) — para valores numéricos (p. ex., 80 para bateria ≥ 80%)\n• Menor ou igual (≤) — para valores numéricos (p. ex., 30 para umidade ≤ 30%)\n• Maior que (>) — para valores numéricos\n• Menor que (<) — para valores numéricos",
-          "visibility_state": "O valor a comparar. Para 'Igual' ou 'Não igual': qualquer valor de texto (p. ex., 'on', 'off', 'home', 'away'). Para operadores numéricos (≥, ≤, >, <): introduza um número (p. ex., 25, 50.5, 100). Exemplo: Entidade 'sensor.temperature', Operador '≥', Valor '20' mostra a tarefa quando a temperatura é 20°C ou superior."
+          "visibility_state": "O valor a comparar. Para 'Igual' ou 'Não igual': qualquer valor de texto (p. ex., 'on', 'off', 'home', 'away'). Para operadores numéricos (≥, ≤, >, <): introduza um número (p. ex., 25, 50.5, 100). Exemplo: Entidade 'sensor.temperature', Operador '≥', Valor '20' mostra a tarefa quando a temperatura é 20°C ou superior.",
+          "assignment_mode": "Todos = todas as crianças atribuídas veem esta tarefa. Alternado = uma criança de cada vez, alternando por dia. Aleatório = uma criança escolhida aleatoriamente por dia (estável durante o dia).",
+          "assignment_rotation_anchor": "Dia 0 da rotação alternada. Deixe em branco para começar hoje. Usado apenas quando o modo de atribuição é 'Alternado'.",
+          "publish_calendar_entities": "Escolha uma ou mais entidades de calendário do Home Assistant. Sempre que esta tarefa for criada, atualizada ou passar da meia-noite, a criança atribuída do dia é adicionada como evento em cada calendário selecionado. Funciona com qualquer número de calendários."
         }
       },
       "manage_rewards": {
@@ -364,6 +376,13 @@
         "lte": "Menor ou igual (≤) — Mostrar quando valor numérico é ≤ alvo",
         "gt": "Maior que (>) — Mostrar quando valor numérico é > alvo",
         "lt": "Menor que (<) — Mostrar quando valor numérico é < alvo"
+      }
+    },
+    "assignment_mode": {
+      "options": {
+        "everyone": "Todos — todas as crianças atribuídas veem a tarefa",
+        "alternating": "Alternado — alterna entre as crianças atribuídas, uma por dia",
+        "random": "Aleatório — escolhe aleatoriamente uma criança atribuída por dia"
       }
     }
   },

--- a/custom_components/taskmate/www/taskmate-child-card.js
+++ b/custom_components/taskmate/www/taskmate-child-card.js
@@ -1359,7 +1359,15 @@ class TaskMateChildCard extends LitElement {
       if (!Array.isArray(assignedTo)) assignedTo = [];
       const assignedToStrings = assignedTo.map(id => String(id));
       const isAssignedToAll = assignedToStrings.length === 0;
-      const isAssignedToChild = isAssignedToAll || assignedToStrings.includes(childId);
+      let isAssignedToChild = isAssignedToAll || assignedToStrings.includes(childId);
+
+      // Dynamic assignment (alternating / random): only the currently-active child
+      // sees the chore. The backend caches today's pick in assignment_current_child_id.
+      const assignmentMode = chore.assignment_mode || 'everyone';
+      if (assignmentMode !== 'everyone' && isAssignedToChild) {
+        const activeId = chore.assignment_current_child_id ? String(chore.assignment_current_child_id) : '';
+        isAssignedToChild = activeId !== '' && activeId === String(childId);
+      }
 
       // Check visibility_entity — if set, chore is only visible if entity matches visibility_state
       // Supports exact match, numeric comparisons, and attributes

--- a/tests/test_assignment_modes.py
+++ b/tests/test_assignment_modes.py
@@ -1,0 +1,250 @@
+"""Tests for dynamic chore assignment (alternating/random) and calendar publishing.
+
+Covers:
+- `_compute_active_children` for each mode (everyone/alternating/random).
+- `is_chore_available_for_child` respects the dynamic active child.
+- `_publish_chore_to_calendars` fans out calendar.create_event per entity.
+- Immediate publish on chore create/update.
+- Scale smoke test: 50 chores x 5 children x 3 calendars run concurrently.
+- Storage round-trip keeps legacy chores backwards-compatible.
+"""
+from __future__ import annotations
+
+import asyncio
+import datetime as dt
+import time
+from datetime import date, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.taskmate.coordinator import TaskMateCoordinator
+from custom_components.taskmate.models import Child, Chore
+
+from .conftest import dt_util_mock, run_async
+
+UTC = timezone.utc
+
+
+def _coord(children: list[Child]) -> TaskMateCoordinator:
+    coord = object.__new__(TaskMateCoordinator)
+    coord.hass = MagicMock()
+    coord.hass.services = MagicMock()
+    coord.hass.services.async_call = AsyncMock()
+    coord.data = {}
+    coord._unsub_midnight = None
+    coord._unsub_prune = None
+
+    by_id = {c.id: c for c in children}
+    stored_chores: list[Chore] = []
+
+    storage = MagicMock()
+    storage.get_children = MagicMock(return_value=list(children))
+    storage.get_child = MagicMock(side_effect=lambda cid: by_id.get(cid))
+    storage.get_chores = MagicMock(side_effect=lambda: list(stored_chores))
+
+    def _get_chore(cid):
+        found = next((c for c in stored_chores if c.id == cid), None)
+        # Return a snapshot so callers comparing against the stored state see
+        # the pre-update values (mirrors real serialize/deserialize behaviour).
+        return Chore.from_dict(found.to_dict()) if found is not None else None
+
+    storage.get_chore = MagicMock(side_effect=_get_chore)
+    storage.add_chore = MagicMock(side_effect=stored_chores.append)
+    storage.update_chore = MagicMock(side_effect=lambda chore: stored_chores.__setitem__(
+        next(i for i, c in enumerate(stored_chores) if c.id == chore.id), chore
+    ))
+    storage.async_save = AsyncMock()
+
+    coord.storage = storage
+    coord.async_refresh = AsyncMock()
+    return coord
+
+
+def test_compute_active_everyone_returns_assigned_list():
+    a, b = Child(name="A"), Child(name="B")
+    coord = _coord([a, b])
+    chore = Chore(name="X", assigned_to=[a.id, b.id])
+    assert coord._compute_active_children(chore, date(2026, 4, 20)) == [a.id, b.id]
+
+
+def test_compute_active_alternating_rotates_day_by_day():
+    a, b = Child(name="A"), Child(name="B")
+    coord = _coord([a, b])
+    anchor = date(2026, 4, 20)  # Monday
+    chore = Chore(
+        name="Litter box",
+        assigned_to=[a.id, b.id],
+        assignment_mode="alternating",
+        assignment_rotation_anchor=anchor.isoformat(),
+    )
+    assert coord._compute_active_children(chore, anchor) == [a.id]
+    assert coord._compute_active_children(chore, anchor + dt.timedelta(days=1)) == [b.id]
+    assert coord._compute_active_children(chore, anchor + dt.timedelta(days=2)) == [a.id]
+    # Three-child rotation wraps correctly
+    c = Child(name="C")
+    coord2 = _coord([a, b, c])
+    chore2 = Chore(name="Table", assigned_to=[a.id, b.id, c.id], assignment_mode="alternating",
+                   assignment_rotation_anchor=anchor.isoformat())
+    picks = [coord2._compute_active_children(chore2, anchor + dt.timedelta(days=i))[0] for i in range(4)]
+    assert picks == [a.id, b.id, c.id, a.id]
+
+
+def test_compute_active_alternating_defaults_to_all_children_when_unassigned():
+    a, b = Child(name="A"), Child(name="B")
+    coord = _coord([a, b])
+    chore = Chore(name="Any", assignment_mode="alternating")
+    today = date(2026, 4, 20)
+    # Should pick one of the two children deterministically
+    pick = coord._compute_active_children(chore, today)
+    assert pick and pick[0] in (a.id, b.id)
+
+
+def test_compute_active_random_is_stable_per_day():
+    kids = [Child(name=f"K{i}") for i in range(5)]
+    coord = _coord(kids)
+    chore = Chore(name="Lottery", assigned_to=[c.id for c in kids], assignment_mode="random")
+    today = date(2026, 4, 20)
+    a1 = coord._compute_active_children(chore, today)
+    a2 = coord._compute_active_children(chore, today)
+    assert a1 == a2
+    assert len(a1) == 1 and a1[0] in {c.id for c in kids}
+
+
+def test_compute_active_random_varies_by_date():
+    # Over a week's worth of dates at least two picks must differ for a 5-child pool.
+    kids = [Child(name=f"K{i}") for i in range(5)]
+    coord = _coord(kids)
+    chore = Chore(name="Roulette", assigned_to=[c.id for c in kids], assignment_mode="random")
+    picks = {coord._compute_active_children(chore, date(2026, 4, 20) + dt.timedelta(days=i))[0]
+             for i in range(14)}
+    assert len(picks) >= 2
+
+
+def test_is_chore_available_respects_dynamic_assignment():
+    a, b = Child(name="A"), Child(name="B")
+    coord = _coord([a, b])
+    # needs storage.get_last_completed for is_chore_available_for_child
+    coord.storage.get_last_completed = MagicMock(return_value={})
+    anchor = date(2026, 4, 20)
+    dt_util_mock._now = dt.datetime.combine(anchor, dt.time(12, 0), tzinfo=UTC)
+    chore = Chore(
+        name="Dishes",
+        assigned_to=[a.id, b.id],
+        assignment_mode="alternating",
+        assignment_rotation_anchor=anchor.isoformat(),
+    )
+    assert coord.is_chore_available_for_child(chore, a.id) is True
+    assert coord.is_chore_available_for_child(chore, b.id) is False
+    # Everyone mode is unchanged
+    chore.assignment_mode = "everyone"
+    assert coord.is_chore_available_for_child(chore, a.id) is True
+    assert coord.is_chore_available_for_child(chore, b.id) is True
+
+
+def test_publish_fans_out_one_call_per_calendar():
+    a, b = Child(name="A"), Child(name="B")
+    coord = _coord([a, b])
+    today = date(2026, 4, 20)
+    chore = Chore(
+        name="Litter box",
+        assigned_to=[a.id, b.id],
+        assignment_mode="alternating",
+        assignment_rotation_anchor=today.isoformat(),
+        publish_calendar_entities=["calendar.kids", "calendar.family", "calendar.shared"],
+    )
+    run_async(coord._publish_chore_to_calendars(chore, today))
+    assert coord.hass.services.async_call.await_count == 3
+    # Dedup: second call on the same day is a no-op.
+    run_async(coord._publish_chore_to_calendars(chore, today))
+    assert coord.hass.services.async_call.await_count == 3
+    # Next day re-enables publishing.
+    run_async(coord._publish_chore_to_calendars(chore, today + dt.timedelta(days=1)))
+    assert coord.hass.services.async_call.await_count == 6
+    # Summary references today's active child (A on day-0)
+    first_call = coord.hass.services.async_call.await_args_list[0]
+    payload = first_call.args[2]
+    assert payload["summary"] == "Litter box — A"
+    assert payload["start_date"] == today.isoformat()
+
+
+def test_publish_is_noop_when_no_entities_configured():
+    a = Child(name="A")
+    coord = _coord([a])
+    chore = Chore(name="Solo", assigned_to=[a.id])
+    run_async(coord._publish_chore_to_calendars(chore, date(2026, 4, 20)))
+    assert coord.hass.services.async_call.await_count == 0
+
+
+def test_async_add_chore_publishes_immediately():
+    a, b = Child(name="A"), Child(name="B")
+    coord = _coord([a, b])
+    dt_util_mock._now = dt.datetime(2026, 4, 20, 10, 0, tzinfo=UTC)
+    chore = run_async(coord.async_add_chore(
+        name="Trash day",
+        assigned_to=[a.id, b.id],
+        assignment_mode="alternating",
+        assignment_rotation_anchor="2026-04-20",
+        publish_calendar_entities=["calendar.kids", "calendar.family"],
+    ))
+    assert coord.hass.services.async_call.await_count == 2
+    assert chore.publish_calendar_last_date == "2026-04-20"
+    assert chore.assignment_current_child_id == a.id
+
+
+def test_async_update_chore_republishes_on_name_change():
+    a = Child(name="A")
+    coord = _coord([a])
+    dt_util_mock._now = dt.datetime(2026, 4, 20, 10, 0, tzinfo=UTC)
+    chore = run_async(coord.async_add_chore(
+        name="Old",
+        assigned_to=[a.id],
+        publish_calendar_entities=["calendar.x"],
+    ))
+    # One publish for the initial create
+    assert coord.hass.services.async_call.await_count == 1
+    # Simulate an edit flow: fetch a fresh copy, mutate, save.
+    edited = coord.storage.get_chore(chore.id)
+    edited.name = "New"
+    run_async(coord.async_update_chore(edited))
+    # Guard cleared due to name change, so we publish again
+    assert coord.hass.services.async_call.await_count == 2
+
+
+def test_scale_50_chores_5_children_3_calendars():
+    kids = [Child(name=f"K{i}") for i in range(5)]
+    coord = _coord(kids)
+    today = date(2026, 4, 20)
+    dt_util_mock._now = dt.datetime.combine(today, dt.time(0, 0, 5), tzinfo=UTC)
+    cals = ["calendar.a", "calendar.b", "calendar.c"]
+    for i in range(50):
+        chore = Chore(
+            name=f"Chore {i}",
+            assigned_to=[c.id for c in kids],
+            assignment_mode="alternating" if i % 2 == 0 else "random",
+            assignment_rotation_anchor=today.isoformat(),
+            publish_calendar_entities=list(cals),
+        )
+        coord.storage.add_chore(chore)
+
+    started = time.monotonic()
+    run_async(coord._async_refresh_assignments_and_publish())
+    duration = time.monotonic() - started
+
+    assert coord.hass.services.async_call.await_count == 50 * 3
+    # Concurrency guarantees the midnight tick stays sub-second even with 150 calls.
+    assert duration < 5.0
+
+
+def test_chore_from_dict_defaults_are_legacy_safe():
+    legacy = {"name": "Legacy"}
+    chore = Chore.from_dict(legacy)
+    assert chore.assignment_mode == "everyone"
+    assert chore.assignment_rotation_anchor == ""
+    assert chore.assignment_current_child_id == ""
+    assert chore.publish_calendar_entities == []
+    assert chore.publish_calendar_last_date == ""
+    # Round-trip preserves the new fields
+    restored = Chore.from_dict(chore.to_dict())
+    assert restored.assignment_mode == "everyone"
+    assert restored.publish_calendar_entities == []

--- a/tests/test_assignment_modes.py
+++ b/tests/test_assignment_modes.py
@@ -10,13 +10,10 @@ Covers:
 """
 from __future__ import annotations
 
-import asyncio
 import datetime as dt
 import time
 from datetime import date, timezone
 from unittest.mock import AsyncMock, MagicMock
-
-import pytest
 
 from custom_components.taskmate.coordinator import TaskMateCoordinator
 from custom_components.taskmate.models import Child, Chore


### PR DESCRIPTION
## Summary

- Adds an **Assignment Mode** to every chore: `everyone` (default, unchanged), `alternating` (one child per day, rotating from an anchor date), and `random` (deterministic per-day pick). Fixes the "kids fight over the litter-box chore" problem raised in the feature request.
- Adds an orthogonal **Publish to calendars** list on every chore. Pick any number of HA `calendar.*` entities and today's assignment is mirrored onto each one. Publishing happens at the midnight tick **and** immediately on chore create/update, so a chore added at 2pm shows up on the calendar in seconds rather than after the next midnight rollover.
- Fan-out uses `asyncio.gather` throughout (midnight loop across chores, plus per-chore calendar fan-out) so runtime scales with the slowest single call regardless of how many chores, children, or calendars are configured — no hard limits.
- Legacy stored chores deserialize as `assignment_mode="everyone"` with an empty calendar list, so no storage migration is needed (`STORAGE_VERSION` unchanged).
- Bumps `manifest.json` to `3.2.0`.

## Implementation notes

- New fields on `Chore`: `assignment_mode`, `assignment_rotation_anchor`, `assignment_current_child_id`, `publish_calendar_entities`, `publish_calendar_last_date`. All default to legacy-safe values.
- `TaskMateCoordinator._compute_active_children`, `_publish_chore_to_calendars`, and `_async_refresh_assignments_and_publish` added. `is_chore_available_for_child` now hides alternating/random chores from non-active children.
- Config flow exposes the new fields on both add-chore and edit-chore steps; translation keys added to `strings.json` and mirrored to every locale.
- Frontend child card respects `assignment_current_child_id` when `assignment_mode !== "everyone"`.

## Test plan

- [x] `pytest` — 183 passed, including new `tests/test_assignment_modes.py`:
  - rotation across 3 consecutive days for 2- and 3-child pools,
  - per-day stability + cross-day variation of the random mode,
  - `is_chore_available_for_child` hides alternating chores from the inactive child,
  - `_publish_chore_to_calendars` issues one `calendar.create_event` per entity and dedupes same-day repeats,
  - `async_add_chore` publishes immediately; `async_update_chore` republishes after a name change,
  - 50 chores × 5 children × 3 calendars scale smoke test (150 service calls, well under the timeout),
  - `Chore.from_dict({"name": "Legacy"})` round-trips with mode=`everyone` and empty calendars.
- [ ] Manual: create an alternating chore between two children with two `calendar.*` entities selected — confirm both calendars receive an event immediately and the child card swaps ownership on day +1.