### PR TITLE
chore(release): bump version to 3.2.0-beta1

### DIFF
--- a/custom_components/taskmate/manifest.json
+++ b/custom_components/taskmate/manifest.json
@@ -15,5 +15,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/tempus2016/taskmate/issues",
   "requirements": [],
-  "version": "3.2.0"
+  "version": "3.2.0-beta1"
 }


### PR DESCRIPTION
## Summary

- Bumps `custom_components/taskmate/manifest.json` to `3.2.0-beta1` so the dynamic-assignment + calendar-publishing feature (merged in #132) ships as a beta first.

## Test plan

- [x] `manifest.json` is valid JSON.
- [ ] Confirm HACS / Validate integration CI passes on the new version string.