### PR TITLE
feat(chores): add Balanced assignment mode

### DIFF
--- a/custom_components/taskmate/const.py
+++ b/custom_components/taskmate/const.py
@@ -33,8 +33,9 @@ CONF_CHORE_PUBLISH_CALENDARS: Final = "publish_calendar_entities"
 # Assignment modes
 # "everyone"    = visible to every child in assigned_to (or all children if empty) -- existing behavior
 # "alternating" = round-robin through assigned_to (or all children), one child per calendar day
-# "random"      = deterministic per-day random pick from the same pool
-ASSIGNMENT_MODES: Final = ["everyone", "alternating", "random"]
+# "random"      = deterministic per-day random pick from the same pool (each chore picks independently)
+# "balanced"    = split today's balanced-mode chores evenly across the pool so no one child gets swamped
+ASSIGNMENT_MODES: Final = ["everyone", "alternating", "random", "balanced"]
 DEFAULT_ASSIGNMENT_MODE: Final = "everyone"
 
 # Reward keys

--- a/custom_components/taskmate/coordinator.py
+++ b/custom_components/taskmate/coordinator.py
@@ -538,9 +538,12 @@ class TaskMateCoordinator(DataUpdateCoordinator):
         - everyone: whatever `assigned_to` already said (empty = all children).
         - alternating: one child picked by `(today - anchor).days % len(pool)`.
         - random: one child picked by a deterministic per-day+chore-id hash.
+        - balanced: today's balanced-mode chores sharing this pool are evenly
+          split across the pool via a round-robin anchored by the date — so 10
+          chores across 2 children always land 5/5 (11 lands 6/5, etc.).
         """
         mode = getattr(chore, "assignment_mode", "everyone")
-        if mode not in ("alternating", "random"):
+        if mode not in ("alternating", "random", "balanced"):
             return list(chore.assigned_to or [])
 
         pool = self._chore_assignment_pool(chore)
@@ -560,10 +563,30 @@ class TaskMateCoordinator(DataUpdateCoordinator):
             idx = offset % len(pool)
             return [pool[idx]]
 
-        # random: stable per (chore.id, date) so the frontend and backend agree
-        digest = hashlib.sha256(f"{chore.id}:{today.toordinal()}".encode()).digest()
-        idx = int.from_bytes(digest[:8], "big") % len(pool)
-        return [pool[idx]]
+        if mode == "random":
+            # random: stable per (chore.id, date) so the frontend and backend agree
+            digest = hashlib.sha256(f"{chore.id}:{today.toordinal()}".encode()).digest()
+            idx = int.from_bytes(digest[:8], "big") % len(pool)
+            return [pool[idx]]
+
+        # balanced: group today's balanced-mode chores that share this exact pool,
+        # sort them by id for determinism, then round-robin across the pool. A
+        # per-day start offset rotates who gets the "first" chore so no child is
+        # always the one doing chore #1.
+        pool_key = tuple(sorted(pool))
+        group_ids = sorted(
+            c.id
+            for c in self.storage.get_chores()
+            if getattr(c, "assignment_mode", "everyone") == "balanced"
+            and tuple(sorted(self._chore_assignment_pool(c))) == pool_key
+        )
+        try:
+            position = group_ids.index(chore.id)
+        except ValueError:
+            position = 0
+        start_digest = hashlib.sha256(f"balanced:{pool_key}:{today.toordinal()}".encode()).digest()
+        start = int.from_bytes(start_digest[:4], "big") % len(pool)
+        return [pool[(start + position) % len(pool)]]
 
     async def _publish_chore_to_calendars(self, chore: Chore, today: date | None = None) -> None:
         """Publish today's assignment for `chore` to every entity in publish_calendar_entities.

--- a/custom_components/taskmate/strings.json
+++ b/custom_components/taskmate/strings.json
@@ -92,7 +92,7 @@
           "visibility_entity": "Home Assistant entity ID that controls when this chore appears. Leave blank to always show the chore. Examples: binary_sensor.dishwasher, sensor.soil_moisture, input_boolean.guest_mode, switch.laundry_room. The chore only appears on the child card when the visibility condition is met.",
           "visibility_operator": "How to compare the entity's current state with your target value:\n• No filter — always show the chore (ignores entity state)\n• Equals — state exactly matches (e.g., 'on', 'home', 'running')\n• Not Equal — state does not match\n• Greater than or equal (≥) — for numeric values (e.g., 80 for battery ≥ 80%)\n• Less than or equal (≤) — for numeric values (e.g., 30 for moisture ≤ 30%)\n• Greater than (>) — for numeric values\n• Less than (<) — for numeric values",
           "visibility_state": "The value to compare against. For 'Equals' or 'Not Equal': any text value (e.g., 'on', 'off', 'home', 'away'). For numeric operators (≥, ≤, >, <): enter a number (e.g., 25, 50.5, 100). Example: Entity 'sensor.temperature', Operator '>=', Value '20' shows chore when temperature is 20°C or higher.",
-          "assignment_mode": "Everyone = every assigned child sees this chore. Alternating = one child at a time, rotating by day. Random = one randomly picked child per day (stable within the day).",
+          "assignment_mode": "Everyone = every assigned child sees this chore. Alternating = one child at a time, rotating by day. Random = one randomly picked child per day (stable within the day). Balanced = today's balanced chores are split evenly across the assigned children — no one child ends up with everything.",
           "assignment_rotation_anchor": "Day-0 of the alternating rotation. Leave blank to start today. Only used when Assignment Mode is 'Alternating'.",
           "publish_calendar_entities": "Pick one or more Home Assistant calendar entities. Whenever this chore is created, updated, or rolls over at midnight, today's assigned child is added as a calendar event on each selected calendar. Works with any number of calendars."
         }
@@ -156,7 +156,7 @@
           "visibility_entity": "Home Assistant entity ID that controls when this chore appears. Leave blank to always show the chore. Examples: binary_sensor.dishwasher, sensor.soil_moisture, input_boolean.guest_mode, switch.laundry_room. The chore only appears on the child card when the visibility condition is met.",
           "visibility_operator": "How to compare the entity's current state with your target value:\n• No filter — always show the chore (ignores entity state)\n• Equals — state exactly matches (e.g., 'on', 'home', 'running')\n• Not Equal — state does not match\n• Greater than or equal (≥) — for numeric values (e.g., 80 for battery ≥ 80%)\n• Less than or equal (≤) — for numeric values (e.g., 30 for moisture ≤ 30%)\n• Greater than (>) — for numeric values\n• Less than (<) — for numeric values",
           "visibility_state": "The value to compare against. For 'Equals' or 'Not Equal': any text value (e.g., 'on', 'off', 'home', 'away'). For numeric operators (≥, ≤, >, <): enter a number (e.g., 25, 50.5, 100). Example: Entity 'sensor.temperature', Operator '>=', Value '20' shows chore when temperature is 20°C or higher.",
-          "assignment_mode": "Everyone = every assigned child sees this chore. Alternating = one child at a time, rotating by day. Random = one randomly picked child per day (stable within the day).",
+          "assignment_mode": "Everyone = every assigned child sees this chore. Alternating = one child at a time, rotating by day. Random = one randomly picked child per day (stable within the day). Balanced = today's balanced chores are split evenly across the assigned children — no one child ends up with everything.",
           "assignment_rotation_anchor": "Day-0 of the alternating rotation. Leave blank to start today. Only used when Assignment Mode is 'Alternating'.",
           "publish_calendar_entities": "Pick one or more Home Assistant calendar entities. Whenever this chore is created, updated, or rolls over at midnight, today's assigned child is added as a calendar event on each selected calendar. Works with any number of calendars."
         }
@@ -389,7 +389,8 @@
       "options": {
         "everyone": "Everyone — every assigned child sees the chore",
         "alternating": "Alternating — rotate through the assigned children, one per day",
-        "random": "Random — pick one assigned child at random each day"
+        "random": "Random — pick one assigned child at random each day",
+        "balanced": "Balanced — split today's balanced chores evenly across the assigned children"
       }
     }
   },

--- a/custom_components/taskmate/translations/en-GB.json
+++ b/custom_components/taskmate/translations/en-GB.json
@@ -92,7 +92,7 @@
           "visibility_entity": "Home Assistant entity ID that controls when this chore appears. Leave blank to always show the chore. Examples: binary_sensor.dishwasher, sensor.soil_moisture, input_boolean.guest_mode, switch.laundry_room. The chore only appears on the child card when the visibility condition is met.",
           "visibility_operator": "How to compare the entity's current state with your target value:\n• No filter — always show the chore (ignores entity state)\n• Equals — state exactly matches (e.g., 'on', 'home', 'running')\n• Not Equal — state does not match\n• Greater than or equal (≥) — for numeric values (e.g., 80 for battery ≥ 80%)\n• Less than or equal (≤) — for numeric values (e.g., 30 for moisture ≤ 30%)\n• Greater than (>) — for numeric values\n• Less than (<) — for numeric values",
           "visibility_state": "The value to compare against. For 'Equals' or 'Not Equal': any text value (e.g., 'on', 'off', 'home', 'away'). For numeric operators (≥, ≤, >, <): enter a number (e.g., 25, 50.5, 100). Example: Entity 'sensor.temperature', Operator '≥', Value '20' shows chore when temperature is 20°C or higher.",
-          "assignment_mode": "Everyone = every assigned child sees this chore. Alternating = one child at a time, rotating by day. Random = one randomly picked child per day (stable within the day).",
+          "assignment_mode": "Everyone = every assigned child sees this chore. Alternating = one child at a time, rotating by day. Random = one randomly picked child per day (stable within the day). Balanced = today's balanced chores are split evenly across the assigned children — no one child ends up with everything.",
           "assignment_rotation_anchor": "Day-0 of the alternating rotation. Leave blank to start today. Only used when Assignment Mode is 'Alternating'.",
           "publish_calendar_entities": "Pick one or more Home Assistant calendar entities. Whenever this chore is created, updated, or rolls over at midnight, today's assigned child is added as a calendar event on each selected calendar. Works with any number of calendars."
         }
@@ -156,7 +156,7 @@
           "visibility_entity": "Home Assistant entity ID that controls when this chore appears. Leave blank to always show the chore. Examples: binary_sensor.dishwasher, sensor.soil_moisture, input_boolean.guest_mode, switch.laundry_room. The chore only appears on the child card when the visibility condition is met.",
           "visibility_operator": "How to compare the entity's current state with your target value:\n• No filter — always show the chore (ignores entity state)\n• Equals — state exactly matches (e.g., 'on', 'home', 'running')\n• Not Equal — state does not match\n• Greater than or equal (≥) — for numeric values (e.g., 80 for battery ≥ 80%)\n• Less than or equal (≤) — for numeric values (e.g., 30 for moisture ≤ 30%)\n• Greater than (>) — for numeric values\n• Less than (<) — for numeric values",
           "visibility_state": "The value to compare against. For 'Equals' or 'Not Equal': any text value (e.g., 'on', 'off', 'home', 'away'). For numeric operators (≥, ≤, >, <): enter a number (e.g., 25, 50.5, 100). Example: Entity 'sensor.temperature', Operator '≥', Value '20' shows chore when temperature is 20°C or higher.",
-          "assignment_mode": "Everyone = every assigned child sees this chore. Alternating = one child at a time, rotating by day. Random = one randomly picked child per day (stable within the day).",
+          "assignment_mode": "Everyone = every assigned child sees this chore. Alternating = one child at a time, rotating by day. Random = one randomly picked child per day (stable within the day). Balanced = today's balanced chores are split evenly across the assigned children — no one child ends up with everything.",
           "assignment_rotation_anchor": "Day-0 of the alternating rotation. Leave blank to start today. Only used when Assignment Mode is 'Alternating'.",
           "publish_calendar_entities": "Pick one or more Home Assistant calendar entities. Whenever this chore is created, updated, or rolls over at midnight, today's assigned child is added as a calendar event on each selected calendar. Works with any number of calendars."
         }
@@ -386,7 +386,8 @@
       "options": {
         "everyone": "Everyone — every assigned child sees the chore",
         "alternating": "Alternating — rotate through the assigned children, one per day",
-        "random": "Random — pick one assigned child at random each day"
+        "random": "Random — pick one assigned child at random each day",
+        "balanced": "Balanced — split today's balanced chores evenly across the assigned children"
       }
     }
   },

--- a/custom_components/taskmate/translations/en.json
+++ b/custom_components/taskmate/translations/en.json
@@ -92,7 +92,7 @@
           "visibility_entity": "Home Assistant entity ID that controls when this chore appears. Leave blank to always show the chore. Examples: binary_sensor.dishwasher, sensor.soil_moisture, input_boolean.guest_mode, switch.laundry_room. The chore only appears on the child card when the visibility condition is met.",
           "visibility_operator": "How to compare the entity's current state with your target value:\n• No filter — always show the chore (ignores entity state)\n• Equals — state exactly matches (e.g., 'on', 'home', 'running')\n• Not Equal — state does not match\n• Greater than or equal (≥) — for numeric values (e.g., 80 for battery ≥ 80%)\n• Less than or equal (≤) — for numeric values (e.g., 30 for moisture ≤ 30%)\n• Greater than (>) — for numeric values\n• Less than (<) — for numeric values",
           "visibility_state": "The value to compare against. For 'Equals' or 'Not Equal': any text value (e.g., 'on', 'off', 'home', 'away'). For numeric operators (≥, ≤, >, <): enter a number (e.g., 25, 50.5, 100). Example: Entity 'sensor.temperature', Operator '>=', Value '20' shows chore when temperature is 20°C or higher.",
-          "assignment_mode": "Everyone = every assigned child sees this chore. Alternating = one child at a time, rotating by day. Random = one randomly picked child per day (stable within the day).",
+          "assignment_mode": "Everyone = every assigned child sees this chore. Alternating = one child at a time, rotating by day. Random = one randomly picked child per day (stable within the day). Balanced = today's balanced chores are split evenly across the assigned children — no one child ends up with everything.",
           "assignment_rotation_anchor": "Day-0 of the alternating rotation. Leave blank to start today. Only used when Assignment Mode is 'Alternating'.",
           "publish_calendar_entities": "Pick one or more Home Assistant calendar entities. Whenever this chore is created, updated, or rolls over at midnight, today's assigned child is added as a calendar event on each selected calendar. Works with any number of calendars."
         }
@@ -156,7 +156,7 @@
           "visibility_entity": "Home Assistant entity ID that controls when this chore appears. Leave blank to always show the chore. Examples: binary_sensor.dishwasher, sensor.soil_moisture, input_boolean.guest_mode, switch.laundry_room. The chore only appears on the child card when the visibility condition is met.",
           "visibility_operator": "How to compare the entity's current state with your target value:\n• No filter — always show the chore (ignores entity state)\n• Equals — state exactly matches (e.g., 'on', 'home', 'running')\n• Not Equal — state does not match\n• Greater than or equal (≥) — for numeric values (e.g., 80 for battery ≥ 80%)\n• Less than or equal (≤) — for numeric values (e.g., 30 for moisture ≤ 30%)\n• Greater than (>) — for numeric values\n• Less than (<) — for numeric values",
           "visibility_state": "The value to compare against. For 'Equals' or 'Not Equal': any text value (e.g., 'on', 'off', 'home', 'away'). For numeric operators (≥, ≤, >, <): enter a number (e.g., 25, 50.5, 100). Example: Entity 'sensor.temperature', Operator '>=', Value '20' shows chore when temperature is 20°C or higher.",
-          "assignment_mode": "Everyone = every assigned child sees this chore. Alternating = one child at a time, rotating by day. Random = one randomly picked child per day (stable within the day).",
+          "assignment_mode": "Everyone = every assigned child sees this chore. Alternating = one child at a time, rotating by day. Random = one randomly picked child per day (stable within the day). Balanced = today's balanced chores are split evenly across the assigned children — no one child ends up with everything.",
           "assignment_rotation_anchor": "Day-0 of the alternating rotation. Leave blank to start today. Only used when Assignment Mode is 'Alternating'.",
           "publish_calendar_entities": "Pick one or more Home Assistant calendar entities. Whenever this chore is created, updated, or rolls over at midnight, today's assigned child is added as a calendar event on each selected calendar. Works with any number of calendars."
         }
@@ -386,7 +386,8 @@
       "options": {
         "everyone": "Everyone — every assigned child sees the chore",
         "alternating": "Alternating — rotate through the assigned children, one per day",
-        "random": "Random — pick one assigned child at random each day"
+        "random": "Random — pick one assigned child at random each day",
+        "balanced": "Balanced — split today's balanced chores evenly across the assigned children"
       }
     }
   },

--- a/custom_components/taskmate/translations/fr.json
+++ b/custom_components/taskmate/translations/fr.json
@@ -92,7 +92,7 @@
           "visibility_entity": "ID d'entité Home Assistant qui contrôle quand cette corvée apparaît. Laissez vide pour toujours afficher la corvée. Exemples : binary_sensor.lave_vaisselle, sensor.humidite_sol, input_boolean.mode_invite, switch.salle_blanchisserie. La corvée n'apparaît sur la carte enfant que quand la condition de visibilité est satisfaite.",
           "visibility_operator": "Comment comparer l'état actuel de l'entité avec votre valeur cible :\n• Aucun filtre — toujours afficher la corvée (ignore l'état de l'entité)\n• Égale — l'état correspond exactement (ex. : 'on', 'home', 'running')\n• Non égale — l'état ne correspond pas\n• Supérieur ou égal (≥) — pour valeurs numériques (ex. : 80 pour batterie ≥ 80%)\n• Inférieur ou égal (≤) — pour valeurs numériques (ex. : 30 pour humidité ≤ 30%)\n• Supérieur (>) — pour valeurs numériques\n• Inférieur (<) — pour valeurs numériques",
           "visibility_state": "La valeur à comparer. Pour 'Égale' ou 'Non égale' : tout texte (ex. : 'on', 'off', 'home', 'away'). Pour opérateurs numériques (≥, ≤, >, <) : entrez un nombre (ex. : 25, 50.5, 100). Exemple : Entité 'sensor.temperature', Opérateur '>=', Valeur '20' affiche la corvée quand la température est 20°C ou plus.",
-          "assignment_mode": "Tout le monde = chaque enfant assigné voit cette tâche. Alternance = un enfant à la fois, rotation par jour. Aléatoire = un enfant choisi au hasard chaque jour (stable dans la journée).",
+          "assignment_mode": "Tout le monde = chaque enfant assigné voit cette tâche. Alternance = un enfant à la fois, rotation par jour. Aléatoire = un enfant choisi au hasard chaque jour (stable dans la journée). Équilibré = les tâches en mode équilibré du jour sont réparties équitablement entre les enfants assignés — aucun enfant ne se retrouve avec tout.",
           "assignment_rotation_anchor": "Jour 0 du roulement alterné. Laissez vide pour commencer aujourd'hui. Utilisé uniquement avec le mode 'Alternance'.",
           "publish_calendar_entities": "Choisissez un ou plusieurs calendriers Home Assistant. À chaque création, mise à jour ou passage à minuit, l'enfant attribué du jour est ajouté comme événement sur chaque calendrier sélectionné. Fonctionne avec un nombre illimité de calendriers."
         }
@@ -156,7 +156,7 @@
           "visibility_entity": "ID d'entité Home Assistant qui contrôle quand cette corvée apparaît. Laissez vide pour toujours afficher la corvée. Exemples : binary_sensor.lave_vaisselle, sensor.humidite_sol, input_boolean.mode_invite, switch.salle_blanchisserie. La corvée n'apparaît sur la carte enfant que quand la condition de visibilité est satisfaite.",
           "visibility_operator": "Comment comparer l'état actuel de l'entité avec votre valeur cible :\n• Aucun filtre — toujours afficher la corvée (ignore l'état de l'entité)\n• Égale — l'état correspond exactement (ex. : 'on', 'home', 'running')\n• Non égale — l'état ne correspond pas\n• Supérieur ou égal (≥) — pour valeurs numériques (ex. : 80 pour batterie ≥ 80%)\n• Inférieur ou égal (≤) — pour valeurs numériques (ex. : 30 pour humidité ≤ 30%)\n• Supérieur (>) — pour valeurs numériques\n• Inférieur (<) — pour valeurs numériques",
           "visibility_state": "La valeur à comparer. Pour 'Égale' ou 'Non égale' : tout texte (ex. : 'on', 'off', 'home', 'away'). Pour opérateurs numériques (≥, ≤, >, <) : entrez un nombre (ex. : 25, 50.5, 100). Exemple : Entité 'sensor.temperature', Opérateur '>=', Valeur '20' affiche la corvée quand la température est 20°C ou plus.",
-          "assignment_mode": "Tout le monde = chaque enfant assigné voit cette tâche. Alternance = un enfant à la fois, rotation par jour. Aléatoire = un enfant choisi au hasard chaque jour (stable dans la journée).",
+          "assignment_mode": "Tout le monde = chaque enfant assigné voit cette tâche. Alternance = un enfant à la fois, rotation par jour. Aléatoire = un enfant choisi au hasard chaque jour (stable dans la journée). Équilibré = les tâches en mode équilibré du jour sont réparties équitablement entre les enfants assignés — aucun enfant ne se retrouve avec tout.",
           "assignment_rotation_anchor": "Jour 0 du roulement alterné. Laissez vide pour commencer aujourd'hui. Utilisé uniquement avec le mode 'Alternance'.",
           "publish_calendar_entities": "Choisissez un ou plusieurs calendriers Home Assistant. À chaque création, mise à jour ou passage à minuit, l'enfant attribué du jour est ajouté comme événement sur chaque calendrier sélectionné. Fonctionne avec un nombre illimité de calendriers."
         }
@@ -382,7 +382,8 @@
       "options": {
         "everyone": "Tout le monde — chaque enfant assigné voit la tâche",
         "alternating": "Alternance — rotation entre les enfants assignés, un par jour",
-        "random": "Aléatoire — un enfant assigné choisi au hasard chaque jour"
+        "random": "Aléatoire — un enfant assigné choisi au hasard chaque jour",
+        "balanced": "Équilibré — répartit les tâches équilibrées du jour équitablement entre les enfants assignés"
       }
     }
   },

--- a/custom_components/taskmate/translations/nb.json
+++ b/custom_components/taskmate/translations/nb.json
@@ -92,7 +92,7 @@
           "visibility_entity": "Home Assistant-enhets-ID som styrer når denne oppgaven vises. La stå tom for alltid å vise oppgaven. Eksempler: binary_sensor.dishwasher, sensor.soil_moisture, input_boolean.guest_mode, switch.laundry_room. Oppgaven vises kun på barnets kort når synlighetsbetingelsen er oppfylt.",
           "visibility_operator": "Hvordan sammenlignes enhetens nåværende tilstand med målverdien:\n• Ingen filter — vis alltid oppgaven (ignorerer enhetens tilstand)\n• Lik — tilstanden stemmer nøyaktig (f.eks. 'on', 'home', 'running')\n• Ikke lik — tilstanden stemmer ikke\n• Større enn eller lik (≥) — for numeriske verdier (f.eks. 80 for batteri ≥ 80%)\n• Mindre enn eller lik (≤) — for numeriske verdier (f.eks. 30 for fuktighet ≤ 30%)\n• Større enn (>) — for numeriske verdier\n• Mindre enn (<) — for numeriske verdier",
           "visibility_state": "Verdien som skal sammenlignes. For 'Lik' eller 'Ikke lik': hvilken som helst tekstverdi (f.eks. 'on', 'off', 'home', 'away'). For numeriske operatorer (≥, ≤, >, <): skriv inn et tall (f.eks. 25, 50,5, 100). Eksempel: Enhet 'sensor.temperature', Operatør '≥', Verdi '20' viser oppgaven når temperaturen er 20°C eller høyere.",
-          "assignment_mode": "Alle = hvert tilknyttet barn ser oppgaven. Vekslende = ett barn om gangen, roterer daglig. Tilfeldig = ett barn plukket tilfeldig hver dag (stabilt gjennom dagen).",
+          "assignment_mode": "Alle = hvert tilknyttet barn ser oppgaven. Vekslende = ett barn om gangen, roterer daglig. Tilfeldig = ett barn plukket tilfeldig hver dag (stabilt gjennom dagen). Balansert = dagens balanserte oppgaver fordeles jevnt mellom de tildelte barna — ingen ender opp med alt.",
           "assignment_rotation_anchor": "Dag 0 i den vekslende rotasjonen. La stå tom for å starte i dag. Brukes kun når tildelingsmodus er 'Vekslende'.",
           "publish_calendar_entities": "Velg én eller flere Home Assistant-kalenderentiteter. Hver gang oppgaven opprettes, oppdateres eller bytter ved midnatt legges dagens tildelte barn til som en kalenderoppføring i hver valgte kalender. Fungerer med et hvilket som helst antall kalendere."
         }
@@ -156,7 +156,7 @@
           "visibility_entity": "Home Assistant-enhets-ID som styrer når denne oppgaven vises. La stå tom for alltid å vise oppgaven. Eksempler: binary_sensor.dishwasher, sensor.soil_moisture, input_boolean.guest_mode, switch.laundry_room. Oppgaven vises kun på barnets kort når synlighetsbetingelsen er oppfylt.",
           "visibility_operator": "Hvordan sammenlignes enhetens nåværende tilstand med målverdien:\n• Ingen filter — vis alltid oppgaven (ignorerer enhetens tilstand)\n• Lik — tilstanden stemmer nøyaktig (f.eks. 'on', 'home', 'running')\n• Ikke lik — tilstanden stemmer ikke\n• Større enn eller lik (≥) — for numeriske verdier (f.eks. 80 for batteri ≥ 80%)\n• Mindre enn eller lik (≤) — for numeriske verdier (f.eks. 30 for fuktighet ≤ 30%)\n• Større enn (>) — for numeriske verdier\n• Mindre enn (<) — for numeriske verdier",
           "visibility_state": "Verdien som skal sammenlignes. For 'Lik' eller 'Ikke lik': hvilken som helst tekstverdi (f.eks. 'on', 'off', 'home', 'away'). For numeriske operatorer (≥, ≤, >, <): skriv inn et tall (f.eks. 25, 50,5, 100). Eksempel: Enhet 'sensor.temperature', Operatør '≥', Verdi '20' viser oppgaven når temperaturen er 20°C eller høyere.",
-          "assignment_mode": "Alle = hvert tilknyttet barn ser oppgaven. Vekslende = ett barn om gangen, roterer daglig. Tilfeldig = ett barn plukket tilfeldig hver dag (stabilt gjennom dagen).",
+          "assignment_mode": "Alle = hvert tilknyttet barn ser oppgaven. Vekslende = ett barn om gangen, roterer daglig. Tilfeldig = ett barn plukket tilfeldig hver dag (stabilt gjennom dagen). Balansert = dagens balanserte oppgaver fordeles jevnt mellom de tildelte barna — ingen ender opp med alt.",
           "assignment_rotation_anchor": "Dag 0 i den vekslende rotasjonen. La stå tom for å starte i dag. Brukes kun når tildelingsmodus er 'Vekslende'.",
           "publish_calendar_entities": "Velg én eller flere Home Assistant-kalenderentiteter. Hver gang oppgaven opprettes, oppdateres eller bytter ved midnatt legges dagens tildelte barn til som en kalenderoppføring i hver valgte kalender. Fungerer med et hvilket som helst antall kalendere."
         }
@@ -382,7 +382,8 @@
       "options": {
         "everyone": "Alle — hvert tildelt barn ser oppgaven",
         "alternating": "Vekslende — roter mellom de tildelte barna, ett per dag",
-        "random": "Tilfeldig — plukk ett tildelt barn tilfeldig hver dag"
+        "random": "Tilfeldig — plukk ett tildelt barn tilfeldig hver dag",
+        "balanced": "Balansert — fordel dagens balanserte oppgaver jevnt mellom de tildelte barna"
       }
     }
   },

--- a/custom_components/taskmate/translations/nn.json
+++ b/custom_components/taskmate/translations/nn.json
@@ -92,7 +92,7 @@
           "visibility_entity": "Home Assistant-eining-ID som styr når denne oppgåva vert viste. Lat stå tom for alltid å vise oppgåva. Døme: binary_sensor.dishwasher, sensor.soil_moisture, input_boolean.guest_mode, switch.laundry_room. Oppgåva vert berre viste på bornekortet når synlegheitsbetingelsen er oppfylt.",
           "visibility_operator": "Korleis samanliknast eininga si noverande tilstand med målverdien:\n• Ingen filter — vis alltid oppgåva (ignorerer eininga si tilstand)\n• Lik — tilstanden stemmer nøyaktig (t.d. 'on', 'home', 'running')\n• Ikkje lik — tilstanden stemmer ikkje\n• Større enn eller lik (≥) — for numeriske verdiar (t.d. 80 for batteri ≥ 80%)\n• Mindre enn eller lik (≤) — for numeriske verdiar (t.d. 30 for fukt ≤ 30%)\n• Større enn (>) — for numeriske verdiar\n• Mindre enn (<) — for numeriske verdiar",
           "visibility_state": "Verdien som skal samanliknast. For 'Lik' eller 'Ikkje lik': kva som helst tekstverde (t.d. 'on', 'off', 'home', 'away'). For numeriske operatorar (≥, ≤, >, <): skriv inn eit tal (t.d. 25, 50,5, 100). Døme: Eining 'sensor.temperature', Operator '≥', Verdi '20' viser oppgåva når temperaturen er 20°C eller høgare.",
-          "assignment_mode": "Alle = kvart tilknytt barn ser oppgåva. Vekslande = eitt barn om gongen, roterer dagleg. Tilfeldig = eitt barn plukka tilfeldig kvar dag (stabilt gjennom dagen).",
+          "assignment_mode": "Alle = kvart tilknytt barn ser oppgåva. Vekslande = eitt barn om gongen, roterer dagleg. Tilfeldig = eitt barn plukka tilfeldig kvar dag (stabilt gjennom dagen). Balansert = dagens balanserte oppgåver vert fordelte jamt mellom dei tildelte barna — ingen endar opp med alt.",
           "assignment_rotation_anchor": "Dag 0 i den vekslande rotasjonen. Lat stå tom for å starte i dag. Vert brukt berre når tildelingsmodus er 'Vekslande'.",
           "publish_calendar_entities": "Vel ein eller fleire Home Assistant-kalenderentitetar. Kvar gong oppgåva vert oppretta, oppdatert eller skiftar ved midnatt vert dagens tildelte barn lagt til som ei kalenderoppføring i kvar valde kalender. Fungerer med eit kva som helst tal kalendrar."
         }
@@ -156,7 +156,7 @@
           "visibility_entity": "Home Assistant-eining-ID som styr når denne oppgåva vert viste. Lat stå tom for alltid å vise oppgåva. Døme: binary_sensor.dishwasher, sensor.soil_moisture, input_boolean.guest_mode, switch.laundry_room. Oppgåva vert berre viste på bornekortet når synlegheitsbetingelsen er oppfylt.",
           "visibility_operator": "Korleis samanliknast eininga si noverande tilstand med målverdien:\n• Ingen filter — vis alltid oppgåva (ignorerer eininga si tilstand)\n• Lik — tilstanden stemmer nøyaktig (t.d. 'on', 'home', 'running')\n• Ikkje lik — tilstanden stemmer ikkje\n• Større enn eller lik (≥) — for numeriske verdiar (t.d. 80 for batteri ≥ 80%)\n• Mindre enn eller lik (≤) — for numeriske verdiar (t.d. 30 for fukt ≤ 30%)\n• Større enn (>) — for numeriske verdiar\n• Mindre enn (<) — for numeriske verdiar",
           "visibility_state": "Verdien som skal samanliknast. For 'Lik' eller 'Ikkje lik': kva som helst tekstverde (t.d. 'on', 'off', 'home', 'away'). For numeriske operatorar (≥, ≤, >, <): skriv inn eit tal (t.d. 25, 50,5, 100). Døme: Eining 'sensor.temperature', Operator '≥', Verdi '20' viser oppgåva når temperaturen er 20°C eller høgare.",
-          "assignment_mode": "Alle = kvart tilknytt barn ser oppgåva. Vekslande = eitt barn om gongen, roterer dagleg. Tilfeldig = eitt barn plukka tilfeldig kvar dag (stabilt gjennom dagen).",
+          "assignment_mode": "Alle = kvart tilknytt barn ser oppgåva. Vekslande = eitt barn om gongen, roterer dagleg. Tilfeldig = eitt barn plukka tilfeldig kvar dag (stabilt gjennom dagen). Balansert = dagens balanserte oppgåver vert fordelte jamt mellom dei tildelte barna — ingen endar opp med alt.",
           "assignment_rotation_anchor": "Dag 0 i den vekslande rotasjonen. Lat stå tom for å starte i dag. Vert brukt berre når tildelingsmodus er 'Vekslande'.",
           "publish_calendar_entities": "Vel ein eller fleire Home Assistant-kalenderentitetar. Kvar gong oppgåva vert oppretta, oppdatert eller skiftar ved midnatt vert dagens tildelte barn lagt til som ei kalenderoppføring i kvar valde kalender. Fungerer med eit kva som helst tal kalendrar."
         }
@@ -382,7 +382,8 @@
       "options": {
         "everyone": "Alle — kvart tildelt barn ser oppgåva",
         "alternating": "Vekslande — roter mellom dei tildelte barna, eitt per dag",
-        "random": "Tilfeldig — plukk eitt tildelt barn tilfeldig kvar dag"
+        "random": "Tilfeldig — plukk eitt tildelt barn tilfeldig kvar dag",
+        "balanced": "Balansert — fordel dagens balanserte oppgåver jamt mellom dei tildelte barna"
       }
     }
   },

--- a/custom_components/taskmate/translations/pt-BR.json
+++ b/custom_components/taskmate/translations/pt-BR.json
@@ -92,7 +92,7 @@
           "visibility_entity": "ID da entidade Home Assistant que controla quando esta tarefa aparece. Deixe em branco para sempre mostrar a tarefa. Exemplos: binary_sensor.lava_louça, sensor.humidade_solo, input_boolean.modo_visitantes, switch.sala_lavagem. A tarefa só aparece no cartão da criança quando a condição de visibilidade é atendida.",
           "visibility_operator": "Como comparar o estado atual da entidade com seu valor-alvo:\n• Sem filtro — sempre mostrar a tarefa (ignora o estado da entidade)\n• Igual — o estado corresponde exatamente (ex.: 'on', 'home', 'running')\n• Não igual — o estado não corresponde\n• Maior ou igual (≥) — para valores numéricos (ex.: 80 para bateria ≥ 80%)\n• Menor ou igual (≤) — para valores numéricos (ex.: 30 para umidade ≤ 30%)\n• Maior que (>) — para valores numéricos\n• Menor que (<) — para valores numéricos",
           "visibility_state": "O valor a comparar. Para 'Igual' ou 'Não igual': qualquer valor de texto (ex.: 'on', 'off', 'home', 'away'). Para operadores numéricos (≥, ≤, >, <): digite um número (ex.: 25, 50.5, 100). Exemplo: Entidade 'sensor.temperature', Operador '>=', Valor '20' mostra a tarefa quando a temperatura é 20°C ou mais alta.",
-          "assignment_mode": "Todos = todas as crianças atribuídas veem esta tarefa. Alternado = uma criança de cada vez, alternando por dia. Aleatório = uma criança escolhida aleatoriamente por dia (estável durante o dia).",
+          "assignment_mode": "Todos = todas as crianças atribuídas veem esta tarefa. Alternado = uma criança de cada vez, alternando por dia. Aleatório = uma criança escolhida aleatoriamente por dia (estável durante o dia). Equilibrado = as tarefas no modo equilibrado do dia são divididas igualmente entre as crianças atribuídas — nenhuma fica com tudo.",
           "assignment_rotation_anchor": "Dia 0 da rotação alternada. Deixe em branco para começar hoje. Usado apenas quando o modo de atribuição é 'Alternado'.",
           "publish_calendar_entities": "Escolha uma ou mais entidades de calendário do Home Assistant. Sempre que esta tarefa for criada, atualizada ou passar da meia-noite, a criança atribuída do dia é adicionada como evento em cada calendário selecionado. Funciona com qualquer número de calendários."
         }
@@ -156,7 +156,7 @@
           "visibility_entity": "ID da entidade Home Assistant que controla quando esta tarefa aparece. Deixe em branco para sempre mostrar a tarefa. Exemplos: binary_sensor.lava_louça, sensor.humidade_solo, input_boolean.modo_visitantes, switch.sala_lavagem. A tarefa só aparece no cartão da criança quando a condição de visibilidade é atendida.",
           "visibility_operator": "Como comparar o estado atual da entidade com seu valor-alvo:\n• Sem filtro — sempre mostrar a tarefa (ignora o estado da entidade)\n• Igual — o estado corresponde exatamente (ex.: 'on', 'home', 'running')\n• Não igual — o estado não corresponde\n• Maior ou igual (≥) — para valores numéricos (ex.: 80 para bateria ≥ 80%)\n• Menor ou igual (≤) — para valores numéricos (ex.: 30 para umidade ≤ 30%)\n• Maior que (>) — para valores numéricos\n• Menor que (<) — para valores numéricos",
           "visibility_state": "O valor a comparar. Para 'Igual' ou 'Não igual': qualquer valor de texto (ex.: 'on', 'off', 'home', 'away'). Para operadores numéricos (≥, ≤, >, <): digite um número (ex.: 25, 50.5, 100). Exemplo: Entidade 'sensor.temperature', Operador '>=', Valor '20' mostra a tarefa quando a temperatura é 20°C ou mais alta.",
-          "assignment_mode": "Todos = todas as crianças atribuídas veem esta tarefa. Alternado = uma criança de cada vez, alternando por dia. Aleatório = uma criança escolhida aleatoriamente por dia (estável durante o dia).",
+          "assignment_mode": "Todos = todas as crianças atribuídas veem esta tarefa. Alternado = uma criança de cada vez, alternando por dia. Aleatório = uma criança escolhida aleatoriamente por dia (estável durante o dia). Equilibrado = as tarefas no modo equilibrado do dia são divididas igualmente entre as crianças atribuídas — nenhuma fica com tudo.",
           "assignment_rotation_anchor": "Dia 0 da rotação alternada. Deixe em branco para começar hoje. Usado apenas quando o modo de atribuição é 'Alternado'.",
           "publish_calendar_entities": "Escolha uma ou mais entidades de calendário do Home Assistant. Sempre que esta tarefa for criada, atualizada ou passar da meia-noite, a criança atribuída do dia é adicionada como evento em cada calendário selecionado. Funciona com qualquer número de calendários."
         }
@@ -382,7 +382,8 @@
       "options": {
         "everyone": "Todos — todas as crianças atribuídas veem a tarefa",
         "alternating": "Alternado — alterna entre as crianças atribuídas, uma por dia",
-        "random": "Aleatório — escolhe aleatoriamente uma criança atribuída por dia"
+        "random": "Aleatório — escolhe aleatoriamente uma criança atribuída por dia",
+        "balanced": "Equilibrado — divide as tarefas equilibradas do dia igualmente entre as crianças atribuídas"
       }
     }
   },

--- a/custom_components/taskmate/translations/pt.json
+++ b/custom_components/taskmate/translations/pt.json
@@ -92,7 +92,7 @@
           "visibility_entity": "ID da entidade Home Assistant que controla quando esta tarefa é apresentada. Deixe vazio para mostrar sempre a tarefa. Exemplos: binary_sensor.dishwasher, sensor.soil_moisture, input_boolean.guest_mode, switch.laundry_room. A tarefa só aparece no cartão da criança quando a condição de visibilidade é atendida.",
           "visibility_operator": "Como comparar o estado atual da entidade com seu valor alvo:\n• Sem filtro — mostrar sempre a tarefa (ignora o estado da entidade)\n• Igual — estado corresponde exatamente (p. ex., 'on', 'home', 'running')\n• Não igual — estado não corresponde\n• Maior ou igual (≥) — para valores numéricos (p. ex., 80 para bateria ≥ 80%)\n• Menor ou igual (≤) — para valores numéricos (p. ex., 30 para umidade ≤ 30%)\n• Maior que (>) — para valores numéricos\n• Menor que (<) — para valores numéricos",
           "visibility_state": "O valor a comparar. Para 'Igual' ou 'Não igual': qualquer valor de texto (p. ex., 'on', 'off', 'home', 'away'). Para operadores numéricos (≥, ≤, >, <): introduza um número (p. ex., 25, 50.5, 100). Exemplo: Entidade 'sensor.temperature', Operador '≥', Valor '20' mostra a tarefa quando a temperatura é 20°C ou superior.",
-          "assignment_mode": "Todos = todas as crianças atribuídas veem esta tarefa. Alternado = uma criança de cada vez, alternando por dia. Aleatório = uma criança escolhida aleatoriamente por dia (estável durante o dia).",
+          "assignment_mode": "Todos = todas as crianças atribuídas veem esta tarefa. Alternado = uma criança de cada vez, alternando por dia. Aleatório = uma criança escolhida aleatoriamente por dia (estável durante o dia). Equilibrado = as tarefas no modo equilibrado do dia são divididas igualmente entre as crianças atribuídas — nenhuma fica com tudo.",
           "assignment_rotation_anchor": "Dia 0 da rotação alternada. Deixe em branco para começar hoje. Usado apenas quando o modo de atribuição é 'Alternado'.",
           "publish_calendar_entities": "Escolha uma ou mais entidades de calendário do Home Assistant. Sempre que esta tarefa for criada, atualizada ou passar da meia-noite, a criança atribuída do dia é adicionada como evento em cada calendário selecionado. Funciona com qualquer número de calendários."
         }
@@ -156,7 +156,7 @@
           "visibility_entity": "ID da entidade Home Assistant que controla quando esta tarefa é apresentada. Deixe vazio para mostrar sempre a tarefa. Exemplos: binary_sensor.dishwasher, sensor.soil_moisture, input_boolean.guest_mode, switch.laundry_room. A tarefa só aparece no cartão da criança quando a condição de visibilidade é atendida.",
           "visibility_operator": "Como comparar o estado atual da entidade com seu valor alvo:\n• Sem filtro — mostrar sempre a tarefa (ignora o estado da entidade)\n• Igual — estado corresponde exatamente (p. ex., 'on', 'home', 'running')\n• Não igual — estado não corresponde\n• Maior ou igual (≥) — para valores numéricos (p. ex., 80 para bateria ≥ 80%)\n• Menor ou igual (≤) — para valores numéricos (p. ex., 30 para umidade ≤ 30%)\n• Maior que (>) — para valores numéricos\n• Menor que (<) — para valores numéricos",
           "visibility_state": "O valor a comparar. Para 'Igual' ou 'Não igual': qualquer valor de texto (p. ex., 'on', 'off', 'home', 'away'). Para operadores numéricos (≥, ≤, >, <): introduza um número (p. ex., 25, 50.5, 100). Exemplo: Entidade 'sensor.temperature', Operador '≥', Valor '20' mostra a tarefa quando a temperatura é 20°C ou superior.",
-          "assignment_mode": "Todos = todas as crianças atribuídas veem esta tarefa. Alternado = uma criança de cada vez, alternando por dia. Aleatório = uma criança escolhida aleatoriamente por dia (estável durante o dia).",
+          "assignment_mode": "Todos = todas as crianças atribuídas veem esta tarefa. Alternado = uma criança de cada vez, alternando por dia. Aleatório = uma criança escolhida aleatoriamente por dia (estável durante o dia). Equilibrado = as tarefas no modo equilibrado do dia são divididas igualmente entre as crianças atribuídas — nenhuma fica com tudo.",
           "assignment_rotation_anchor": "Dia 0 da rotação alternada. Deixe em branco para começar hoje. Usado apenas quando o modo de atribuição é 'Alternado'.",
           "publish_calendar_entities": "Escolha uma ou mais entidades de calendário do Home Assistant. Sempre que esta tarefa for criada, atualizada ou passar da meia-noite, a criança atribuída do dia é adicionada como evento em cada calendário selecionado. Funciona com qualquer número de calendários."
         }
@@ -382,7 +382,8 @@
       "options": {
         "everyone": "Todos — todas as crianças atribuídas veem a tarefa",
         "alternating": "Alternado — alterna entre as crianças atribuídas, uma por dia",
-        "random": "Aleatório — escolhe aleatoriamente uma criança atribuída por dia"
+        "random": "Aleatório — escolhe aleatoriamente uma criança atribuída por dia",
+        "balanced": "Equilibrado — divide as tarefas equilibradas do dia igualmente entre as crianças atribuídas"
       }
     }
   },

--- a/tests/test_assignment_modes.py
+++ b/tests/test_assignment_modes.py
@@ -233,6 +233,77 @@ def test_scale_50_chores_5_children_3_calendars():
     assert duration < 5.0
 
 
+def test_balanced_splits_evenly_across_pool():
+    a, b = Child(name="A"), Child(name="B")
+    coord = _coord([a, b])
+    today = date(2026, 4, 20)
+    pool = [a.id, b.id]
+    chores = []
+    for i in range(10):
+        chore = Chore(name=f"C{i}", assigned_to=pool, assignment_mode="balanced")
+        coord.storage.add_chore(chore)
+        chores.append(chore)
+
+    picks = [coord._compute_active_children(c, today)[0] for c in chores]
+    counts = {cid: picks.count(cid) for cid in pool}
+    # 10 chores, 2 children → exactly 5/5 with zero overlap.
+    assert counts == {a.id: 5, b.id: 5}
+
+    # 11th chore — ceiling split means 6/5.
+    extra = Chore(name="C10", assigned_to=pool, assignment_mode="balanced")
+    coord.storage.add_chore(extra)
+    chores.append(extra)
+    picks = [coord._compute_active_children(c, today)[0] for c in chores]
+    counts = {cid: picks.count(cid) for cid in pool}
+    assert sorted(counts.values()) == [5, 6]
+
+
+def test_balanced_rotates_starting_child_across_days():
+    a, b = Child(name="A"), Child(name="B")
+    coord = _coord([a, b])
+    chores = []
+    for i in range(4):
+        c = Chore(name=f"C{i}", assigned_to=[a.id, b.id], assignment_mode="balanced")
+        coord.storage.add_chore(c)
+        chores.append(c)
+
+    def day_picks(d):
+        return [coord._compute_active_children(c, d)[0] for c in chores]
+
+    # Over a span of days the starting child should flip at least once.
+    first_children = {day_picks(date(2026, 4, 20) + dt.timedelta(days=i))[0] for i in range(14)}
+    assert len(first_children) == 2
+
+
+def test_balanced_pools_are_independent():
+    a, b = Child(name="A"), Child(name="B")
+    c = Child(name="C")
+    coord = _coord([a, b, c])
+    today = date(2026, 4, 20)
+
+    # Pool AB: 4 chores → 2/2 across {a, b}
+    pool_ab = [a.id, b.id]
+    ab_chores = []
+    for i in range(4):
+        ch = Chore(name=f"AB{i}", assigned_to=pool_ab, assignment_mode="balanced")
+        coord.storage.add_chore(ch)
+        ab_chores.append(ch)
+
+    # Pool BC: 2 chores → 1/1 across {b, c}; must not be affected by pool AB.
+    pool_bc = [b.id, c.id]
+    bc_chores = []
+    for i in range(2):
+        ch = Chore(name=f"BC{i}", assigned_to=pool_bc, assignment_mode="balanced")
+        coord.storage.add_chore(ch)
+        bc_chores.append(ch)
+
+    ab_picks = [coord._compute_active_children(ch, today)[0] for ch in ab_chores]
+    bc_picks = [coord._compute_active_children(ch, today)[0] for ch in bc_chores]
+    assert set(ab_picks) == {a.id, b.id}
+    assert sorted(ab_picks).count(a.id) == 2
+    assert set(bc_picks) == {b.id, c.id}
+
+
 def test_chore_from_dict_defaults_are_legacy_safe():
     legacy = {"name": "Legacy"}
     chore = Chore.from_dict(legacy)


### PR DESCRIPTION
## Summary

- Adds a fourth assignment mode — **Balanced** — that groups every balanced-mode chore sharing the same child pool and rotates them round-robin across the pool. 10 chores across 2 children land exactly 5/5; 11 land 6/5. No one child ever gets all of today's chores.
- A per-day hash rotates the *starting* child so the same child isn't always assigned chore #1.
- Pool-scoped: chores assigned to `{A,B}` and chores assigned to `{B,C}` balance independently — overlapping pools don't tip each other's split.

Random mode is still available for households that want pure per-chore randomness; Balanced is for those who want a guaranteed even split.

## Test plan

- [x] `pytest` — 186 passed, new cases:
  - 10 chores / 2 children → exactly 5/5; 11 chores → 6/5,
  - starting child flips at least once over a 14-day window,
  - two overlapping pools each balance independently.
- [x] `ruff check` clean.
- [ ] Manual: create 10 balanced chores between two children, confirm each child sees exactly 5 in the card.