### PR TITLE
feat(calendar): timed events from time_category + cleanup on update/remove

### DIFF
--- a/custom_components/taskmate/coordinator.py
+++ b/custom_components/taskmate/coordinator.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Callable
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, time, timedelta
 import hashlib
 import logging
 from typing import Any
@@ -376,21 +376,33 @@ class TaskMateCoordinator(DataUpdateCoordinator):
             chore.assignment_current_child_id = active[0] if active else ""
         else:
             chore.assignment_current_child_id = ""
-        # Re-publish on update so a changed name/assignment/calendar list shows up ASAP.
-        # Force a re-publish by clearing the guard if the publish list changed meaningfully;
-        # otherwise the guard keeps us from spamming duplicate events.
+        # If anything calendar-user-visible changed (name, active child, time window,
+        # or entity list), purge the previous events from every calendar the chore
+        # used to publish to — including ones the user just removed — and then
+        # re-publish to the current list. Otherwise the guard skips re-publish.
         existing = self.storage.get_chore(chore.id)
+        cleanup_entities: list[str] = []
+        should_republish = False
         if existing is not None:
-            prev_entities = set(getattr(existing, "publish_calendar_entities", []) or [])
-            new_entities = set(chore.publish_calendar_entities or [])
+            prev_entities = list(getattr(existing, "publish_calendar_entities", []) or [])
+            new_entities = list(chore.publish_calendar_entities or [])
             prev_name = getattr(existing, "name", "")
             prev_active = getattr(existing, "assignment_current_child_id", "")
+            prev_category = getattr(existing, "time_category", "anytime")
             if (
-                new_entities != prev_entities
+                set(new_entities) != set(prev_entities)
                 or chore.name != prev_name
                 or chore.assignment_current_child_id != prev_active
+                or getattr(chore, "time_category", "anytime") != prev_category
             ):
-                chore.publish_calendar_last_date = ""
+                # Purge from every calendar that ever had this chore — new ones will
+                # be cleaned along with old, so republish produces a fresh event.
+                cleanup_entities = list({*prev_entities, *new_entities})
+                should_republish = True
+        if cleanup_entities:
+            await self._cleanup_chore_from_calendars(chore, cleanup_entities, today)
+        elif should_republish:
+            chore.publish_calendar_last_date = ""
         self.storage.update_chore(chore)
         await self._publish_chore_to_calendars(chore, today)
         await self.storage.async_save()
@@ -398,6 +410,9 @@ class TaskMateCoordinator(DataUpdateCoordinator):
 
     async def async_remove_chore(self, chore_id: str) -> None:
         """Remove a chore and all associated data."""
+        existing = self.storage.get_chore(chore_id)
+        if existing is not None and getattr(existing, "publish_calendar_entities", []):
+            await self._cleanup_chore_from_calendars(existing)
         self.storage.remove_chore(chore_id)
         self.storage.remove_completions_for_chore(chore_id)
         self.storage.remove_last_completed_for_chore(chore_id)
@@ -588,12 +603,35 @@ class TaskMateCoordinator(DataUpdateCoordinator):
         start = int.from_bytes(start_digest[:4], "big") % len(pool)
         return [pool[(start + position) % len(pool)]]
 
+    # time_category -> (start_time, end_time). None means "anytime" -> all-day event.
+    _TIME_CATEGORY_WINDOWS: dict[str, tuple[time, time] | None] = {
+        "morning":   (time(6, 0),  time(12, 0)),
+        "afternoon": (time(12, 0), time(17, 0)),
+        "evening":   (time(17, 0), time(21, 0)),
+        "night":     (time(21, 0), time(23, 59)),
+        "anytime":   None,
+    }
+
+    def _time_category_window(self, category: str, today: date) -> tuple[datetime, datetime] | None:
+        """Return (start, end) datetimes for a time_category, or None for all-day."""
+        window = self._TIME_CATEGORY_WINDOWS.get(category or "anytime")
+        if window is None:
+            return None
+        start_t, end_t = window
+        return datetime.combine(today, start_t), datetime.combine(today, end_t)
+
+    def _chore_event_marker(self, chore: Chore) -> str:
+        """Marker stitched into the event description so we can find our own events."""
+        return f"taskmate:chore:{chore.id}"
+
     async def _publish_chore_to_calendars(self, chore: Chore, today: date | None = None) -> None:
         """Publish today's assignment for `chore` to every entity in publish_calendar_entities.
 
         Idempotent per calendar-day thanks to `publish_calendar_last_date`. Fans
         out all create_event service calls via asyncio.gather so N entities per
-        chore scale with the slowest single call, not the sum of them.
+        chore scale with the slowest single call, not the sum of them. When the
+        chore has a non-"anytime" time_category the event is timed to that
+        window; otherwise it's an all-day event.
         """
         entities = list(getattr(chore, "publish_calendar_entities", []) or [])
         if not entities:
@@ -613,19 +651,32 @@ class TaskMateCoordinator(DataUpdateCoordinator):
             child_name = "Everyone"
 
         summary = f"{chore.name} — {child_name}"
-        end = today + timedelta(days=1)
+        description = self._chore_event_marker(chore)
+        window = self._time_category_window(getattr(chore, "time_category", "anytime"), today)
+
+        if window is None:
+            end = today + timedelta(days=1)
+            event_payload = {
+                "summary": summary,
+                "description": description,
+                "start_date": today_iso,
+                "end_date": end.isoformat(),
+            }
+        else:
+            start_dt, end_dt = window
+            event_payload = {
+                "summary": summary,
+                "description": description,
+                "start_date_time": start_dt.isoformat(),
+                "end_date_time": end_dt.isoformat(),
+            }
 
         async def _call(entity_id: str) -> None:
             try:
                 await self.hass.services.async_call(
                     "calendar",
                     "create_event",
-                    {
-                        "entity_id": entity_id,
-                        "summary": summary,
-                        "start_date": today_iso,
-                        "end_date": end.isoformat(),
-                    },
+                    {"entity_id": entity_id, **event_payload},
                     blocking=True,
                 )
             except Exception as err:  # noqa: BLE001 - HA service errors vary
@@ -638,6 +689,84 @@ class TaskMateCoordinator(DataUpdateCoordinator):
 
         await asyncio.gather(*(_call(e) for e in entities), return_exceptions=True)
         chore.publish_calendar_last_date = today_iso
+
+    async def _cleanup_chore_from_calendars(
+        self,
+        chore: Chore,
+        entities: list[str] | None = None,
+        today: date | None = None,
+    ) -> None:
+        """Best-effort delete of the chore's own events from each configured calendar.
+
+        Uses a description marker (`taskmate:chore:<id>`) stitched in at create
+        time to re-identify events. Covers today through +30 days so future
+        calendar entries for this chore — if any — are also cleaned up. Failure
+        modes (unavailable calendar, integration without delete_event support,
+        response service disabled) are caught and logged; cleanup never blocks
+        the caller.
+        """
+        ents = list(entities if entities is not None else getattr(chore, "publish_calendar_entities", []) or [])
+        if not ents:
+            return
+
+        if today is None:
+            today = dt_util.as_local(dt_util.now()).date()
+        window_start = datetime.combine(today, time(0, 0)).isoformat()
+        window_end = datetime.combine(today + timedelta(days=30), time(0, 0)).isoformat()
+        marker = self._chore_event_marker(chore)
+
+        async def _purge(entity_id: str) -> None:
+            try:
+                response = await self.hass.services.async_call(
+                    "calendar",
+                    "get_events",
+                    {
+                        "entity_id": entity_id,
+                        "start_date_time": window_start,
+                        "end_date_time": window_end,
+                    },
+                    blocking=True,
+                    return_response=True,
+                )
+            except Exception as err:  # noqa: BLE001
+                _LOGGER.debug(
+                    "TaskMate: could not list events on %s for cleanup: %s",
+                    entity_id,
+                    err,
+                )
+                return
+
+            events = []
+            if isinstance(response, dict):
+                bucket = response.get(entity_id, response)
+                if isinstance(bucket, dict):
+                    events = bucket.get("events", []) or []
+                elif isinstance(bucket, list):
+                    events = bucket
+
+            for event in events:
+                if marker not in (event.get("description") or ""):
+                    continue
+                uid = event.get("uid") or event.get("recurrence_id") or event.get("id")
+                if not uid:
+                    continue
+                try:
+                    await self.hass.services.async_call(
+                        "calendar",
+                        "delete_event",
+                        {"entity_id": entity_id, "uid": uid},
+                        blocking=True,
+                    )
+                except Exception as err:  # noqa: BLE001
+                    _LOGGER.warning(
+                        "TaskMate: failed to delete event %s from %s: %s",
+                        uid,
+                        entity_id,
+                        err,
+                    )
+
+        await asyncio.gather(*(_purge(e) for e in ents), return_exceptions=True)
+        chore.publish_calendar_last_date = ""
 
     async def _async_refresh_assignments_and_publish(self) -> None:
         """Recompute today's active child per chore and publish to calendars.

--- a/tests/test_assignment_modes.py
+++ b/tests/test_assignment_modes.py
@@ -198,14 +198,16 @@ def test_async_update_chore_republishes_on_name_change():
         assigned_to=[a.id],
         publish_calendar_entities=["calendar.x"],
     ))
-    # One publish for the initial create
-    assert coord.hass.services.async_call.await_count == 1
+    # One create_event from the initial add
+    services = [c.args[1] for c in coord.hass.services.async_call.await_args_list]
+    assert services == ["create_event"]
     # Simulate an edit flow: fetch a fresh copy, mutate, save.
     edited = coord.storage.get_chore(chore.id)
     edited.name = "New"
     run_async(coord.async_update_chore(edited))
-    # Guard cleared due to name change, so we publish again
-    assert coord.hass.services.async_call.await_count == 2
+    services = [c.args[1] for c in coord.hass.services.async_call.await_args_list]
+    # Update pattern: get_events (cleanup probe) → (no delete because nothing matched) → create_event
+    assert services == ["create_event", "get_events", "create_event"]
 
 
 def test_scale_50_chores_5_children_3_calendars():
@@ -302,6 +304,110 @@ def test_balanced_pools_are_independent():
     assert set(ab_picks) == {a.id, b.id}
     assert sorted(ab_picks).count(a.id) == 2
     assert set(bc_picks) == {b.id, c.id}
+
+
+def test_timed_event_uses_time_category_window():
+    a = Child(name="A")
+    coord = _coord([a])
+    today = date(2026, 4, 20)
+    chore = Chore(
+        name="Dishes",
+        assigned_to=[a.id],
+        time_category="evening",
+        publish_calendar_entities=["calendar.x"],
+    )
+    run_async(coord._publish_chore_to_calendars(chore, today))
+    args = coord.hass.services.async_call.await_args_list[0].args
+    payload = args[2]
+    assert payload["start_date_time"] == "2026-04-20T17:00:00"
+    assert payload["end_date_time"] == "2026-04-20T21:00:00"
+    assert "start_date" not in payload
+    assert payload["description"] == f"taskmate:chore:{chore.id}"
+
+
+def test_anytime_chore_still_emits_all_day_event():
+    a = Child(name="A")
+    coord = _coord([a])
+    chore = Chore(
+        name="Open",
+        assigned_to=[a.id],
+        time_category="anytime",
+        publish_calendar_entities=["calendar.x"],
+    )
+    run_async(coord._publish_chore_to_calendars(chore, date(2026, 4, 20)))
+    payload = coord.hass.services.async_call.await_args_list[0].args[2]
+    assert payload["start_date"] == "2026-04-20"
+    assert payload["end_date"] == "2026-04-21"
+    assert "start_date_time" not in payload
+
+
+def test_update_chore_cleans_up_old_events_before_republishing():
+    a = Child(name="A")
+    coord = _coord([a])
+    dt_util_mock._now = dt.datetime(2026, 4, 20, 10, 0, tzinfo=UTC)
+
+    chore = run_async(coord.async_add_chore(
+        name="Old Name",
+        assigned_to=[a.id],
+        publish_calendar_entities=["calendar.x"],
+    ))
+    marker = coord._chore_event_marker(chore)
+    # 1 publish from create.
+    assert coord.hass.services.async_call.await_count == 1
+
+    # Mock calendar.get_events to return one event that carries our marker.
+    async def _service_side_effect(domain, service, data, *args, **kwargs):
+        if service == "get_events":
+            return {data["entity_id"]: {"events": [
+                {"uid": "evt-abc", "summary": "Old Name — A", "description": marker},
+                {"uid": "evt-foreign", "summary": "Unrelated", "description": ""},
+            ]}}
+        return None
+    coord.hass.services.async_call.side_effect = _service_side_effect
+
+    edited = coord.storage.get_chore(chore.id)
+    edited.name = "New Name"
+    run_async(coord.async_update_chore(edited))
+
+    services_seen = [call.args[1] for call in coord.hass.services.async_call.await_args_list]
+    assert "get_events" in services_seen
+    assert "delete_event" in services_seen
+    assert services_seen.count("delete_event") == 1  # foreign event left alone
+    # and the new event got created after the purge
+    assert services_seen[-1] == "create_event"
+    new_payload = coord.hass.services.async_call.await_args_list[-1].args[2]
+    assert new_payload["summary"] == "New Name — A"
+
+
+def test_remove_chore_cleans_up_events():
+    a = Child(name="A")
+    coord = _coord([a])
+    dt_util_mock._now = dt.datetime(2026, 4, 20, 10, 0, tzinfo=UTC)
+    chore = run_async(coord.async_add_chore(
+        name="Trash",
+        assigned_to=[a.id],
+        publish_calendar_entities=["calendar.family"],
+    ))
+    marker = coord._chore_event_marker(chore)
+
+    # Fake a stored event we previously published.
+    async def _service_side_effect(domain, service, data, *args, **kwargs):
+        if service == "get_events":
+            return {data["entity_id"]: {"events": [
+                {"uid": "evt-purge-me", "summary": "Trash — A", "description": marker},
+            ]}}
+        return None
+    coord.hass.services.async_call.side_effect = _service_side_effect
+    # Storage needs these mocks for async_remove_chore's cleanup pass
+    coord.storage.remove_chore = MagicMock()
+    coord.storage.remove_completions_for_chore = MagicMock()
+    coord.storage.remove_last_completed_for_chore = MagicMock()
+
+    run_async(coord.async_remove_chore(chore.id))
+    services_seen = [call.args[1] for call in coord.hass.services.async_call.await_args_list]
+    assert services_seen.count("get_events") == 1
+    assert services_seen.count("delete_event") == 1
+    coord.storage.remove_chore.assert_called_once_with(chore.id)
 
 
 def test_chore_from_dict_defaults_are_legacy_safe():


### PR DESCRIPTION
## Summary

**Timed calendar events.** Published events now honour the chore's `time_category`:

| Category   | Start | End   |
|------------|-------|-------|
| morning    | 06:00 | 12:00 |
| afternoon  | 12:00 | 17:00 |
| evening    | 17:00 | 21:00 |
| night      | 21:00 | 23:59 |
| anytime    | all-day (unchanged) |

**Cleanup on chore mutation.** Previously, editing or deleting a chore left stale events on the target calendars forever. Now:

- Renaming a chore, changing the active child, changing the calendar list, or changing the time category **purges every old event** (including from calendars the user just unselected) and publishes a fresh one.
- Deleting a chore purges its events first, then tears down the chore.

Cleanup uses a `taskmate:chore:<id>` marker stitched into the event description. We call `calendar.get_events` to re-identify our own events, then `calendar.delete_event` to remove them. Best-effort: integrations without `delete_event` support log a warning and carry on.

## Test plan

- [x] `pytest` — 190 passed, new cases cover:
  - timed events use `start_date_time`/`end_date_time` for non-anytime chores,
  - anytime chores keep emitting all-day `start_date`/`end_date` events,
  - rename-flow calls `get_events` → `delete_event` → `create_event` in that order,
  - remove-flow cleans up calendars before removing storage,
  - existing tests unchanged otherwise.
- [x] `ruff check` clean.
- [ ] Manual: create a "morning" chore on a Local Calendar, rename it → old event disappears and the new one appears in the 06:00–12:00 slot. Delete the chore → event disappears.