### PR TITLE
Split taskmate_overview attributes into focused sensors (fix 16 KB recorder warning)

### DIFF
--- a/README.md
+++ b/README.md
@@ -726,9 +726,32 @@ Several card options require a `child_id` or `reward_id`. The easiest way to fin
 1. Go to **Developer Tools** → **States**
 2. Find `sensor.taskmate_overview`
 3. Click the entity to expand its attributes
-4. Look in the `children` array for `id` values, or the `rewards` array for reward IDs
+4. Look in the `children` array for `id` values
+5. For reward IDs, look at `sensor.taskmate_rewards` → `rewards` array
  
 Alternatively, IDs are visible in the URL when editing a child or reward in the TaskMate configuration UI.
+
+## Sensors Exposed
+
+Home Assistant limits a single entity's attribute payload to 16 KB for the
+recorder. TaskMate therefore splits its data across several global sensors
+and per-child sensors. Cards configured with `entity: sensor.taskmate_overview`
+keep working unchanged — every TaskMate card internally merges attributes from
+the overview sensor and its companion sensors at render time.
+
+| Entity | State | What lives here |
+|---|---|---|
+| `sensor.taskmate_overview` | total children | `children` summary, `points_name`, `points_icon`, `today_day_of_week`, totals, streak / perfect-week settings |
+| `sensor.taskmate_chores` | total chores | `chores` list (definitions), `todays_completions` |
+| `sensor.taskmate_chore_availability` | total chores available today | `chore_availability`: `{chore_id: {child_id: bool}}` |
+| `sensor.taskmate_rewards` | total rewards | `rewards`, `pending_reward_claims`, `pool_allocations` |
+| `sensor.taskmate_activity` | total completions all-time | `recent_completions` (last 35), `recent_transactions` (last 20) |
+| `sensor.taskmate_incentives` | penalties + bonuses count | `penalties`, `bonuses` |
+| `sensor.pending_approvals` | pending approvals count | `chore_completions`, `reward_claims` (detailed lists) |
+| `sensor.<child>_points` | points for that child | `child_id`, `current_streak`, `best_streak`, `total_*` |
+| `sensor.<child>_stats` | chores completed by that child | `assigned_chores`, streak / totals |
+
+Automations that read the old overview attributes (e.g. `sensor.taskmate_overview.attributes.chores`) should instead read from the matching companion sensor listed above.
  
 ---
  

--- a/custom_components/taskmate/frontend.py
+++ b/custom_components/taskmate/frontend.py
@@ -38,10 +38,12 @@ CARDS: Final = [
     "taskmate-calendar-card.js",
 ]
 
-# JS modules to load globally (for config flow sound preview + i18n)
+# JS modules to load globally (for config flow sound preview + i18n +
+# split-sensor attribute resolver used by every TaskMate Lovelace card).
 GLOBAL_MODULES: Final = [
     "taskmate-localize.js",
     "taskmate-config-sounds.js",
+    "taskmate-attr-resolver.js",
 ]
 
 # Track if frontend is registered

--- a/custom_components/taskmate/manifest.json
+++ b/custom_components/taskmate/manifest.json
@@ -15,5 +15,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/tempus2016/taskmate/issues",
   "requirements": [],
-  "version": "3.2.0-beta4"
+  "version": "3.2.0-beta5"
 }

--- a/custom_components/taskmate/sensor.py
+++ b/custom_components/taskmate/sensor.py
@@ -38,6 +38,403 @@ def _safe_int(value, default: int) -> int:
         return default
 
 
+# ---------------------------------------------------------------------------
+# Shared attribute builders
+#
+# The overview sensor used to pack every data slice into one 16KB+ attribute
+# payload, which Home Assistant's recorder refuses to store. The data is now
+# split across five sensors (overview / chores / rewards / activity /
+# incentives); the helpers below build each slice once per coordinator update
+# and share intermediate lookups so all sensors stay cheap to render.
+# ---------------------------------------------------------------------------
+
+
+_COMMON_CACHE_ATTR = "_taskmate_sensor_common_cache"
+
+
+def _compute_common(coordinator: TaskMateCoordinator) -> dict:
+    """Build the per-update context shared by all TaskMate sensors.
+
+    Cached on the coordinator so each sensor re-uses a single pass over
+    completions / transactions / pool allocations.
+    """
+    data = coordinator.data
+    data_id = id(data)
+    cached = getattr(coordinator, _COMMON_CACHE_ATTR, None)
+    if cached and cached.get("data_id") == data_id:
+        return cached["common"]
+
+    children = data.get("children", [])
+    chores = data.get("chores", [])
+    rewards = data.get("rewards", [])
+    all_completions = data.get("completions", [])
+    pending_completions = data.get("pending_completions", [])
+    pending_reward_claim_objs = data.get("pending_reward_claims", [])
+    pool_alloc_objs = data.get("pool_allocations", [])
+
+    child_lookup = {c.id: c for c in children}
+    chore_lookup = {c.id: c for c in chores}
+    reward_lookup = {r.id: r for r in rewards}
+
+    # Pending chore points per child (awaiting approval -> points to be earned).
+    pending_points_by_child: dict[str, int] = {}
+    for comp in pending_completions:
+        chore = chore_lookup.get(comp.chore_id)
+        if chore:
+            pending_points_by_child[comp.child_id] = (
+                pending_points_by_child.get(comp.child_id, 0) + chore.points
+            )
+
+    # Committed points per child (reward claims awaiting approval = points reserved).
+    # Pool-mode pending claims are skipped because their cost was already deducted
+    # from child.points at allocation time.
+    committed_points_by_child: dict[str, int] = {}
+    for rc in pending_reward_claim_objs:
+        if coordinator.is_pool_mode_claim(rc):
+            continue
+        reward = reward_lookup.get(rc.reward_id)
+        if reward:
+            committed_points_by_child[rc.child_id] = (
+                committed_points_by_child.get(rc.child_id, 0) + reward.cost
+            )
+
+    # Pool allocation lookups for v3.0 pool mode.
+    pool_by_child_reward: dict[str, dict[str, int]] = {}
+    pool_total_by_reward: dict[str, int] = {}
+    total_allocated_by_child: dict[str, int] = {}
+    for pa in pool_alloc_objs:
+        pool_by_child_reward.setdefault(pa.child_id, {})[pa.reward_id] = pa.allocated_points
+        pool_total_by_reward[pa.reward_id] = (
+            pool_total_by_reward.get(pa.reward_id, 0) + pa.allocated_points
+        )
+        total_allocated_by_child[pa.child_id] = (
+            total_allocated_by_child.get(pa.child_id, 0) + pa.allocated_points
+        )
+
+    common = {
+        "data_id": data_id,
+        "data": data,
+        "children": children,
+        "chores": chores,
+        "rewards": rewards,
+        "child_lookup": child_lookup,
+        "chore_lookup": chore_lookup,
+        "reward_lookup": reward_lookup,
+        "all_completions": all_completions,
+        "pending_completions": pending_completions,
+        "pending_reward_claim_objs": pending_reward_claim_objs,
+        "pool_alloc_objs": pool_alloc_objs,
+        "pending_points_by_child": pending_points_by_child,
+        "committed_points_by_child": committed_points_by_child,
+        "pool_by_child_reward": pool_by_child_reward,
+        "pool_total_by_reward": pool_total_by_reward,
+        "total_allocated_by_child": total_allocated_by_child,
+    }
+    setattr(coordinator, _COMMON_CACHE_ATTR, {"data_id": data_id, "common": common})
+    return common
+
+
+def _build_children_summary(common: dict) -> list[dict]:
+    """Build compact per-child summary used on the overview sensor."""
+    children = common["children"]
+    pending = common["pending_points_by_child"]
+    committed = common["committed_points_by_child"]
+    allocated = common["total_allocated_by_child"]
+    summary = []
+    for c in children:
+        committed_amount = committed.get(c.id, 0)
+        summary.append({
+            "id": c.id,
+            "name": c.name,
+            "points": c.points,
+            "pending_points": pending.get(c.id, 0),
+            "committed_points": committed_amount,
+            "allocated_points": allocated.get(c.id, 0),
+            # Allocations were deducted from child.points already, so spendable
+            # only needs to account for pending-claim commitments.
+            "spendable_balance": max(0, c.points - committed_amount),
+            "chore_order": c.chore_order,
+            "current_streak": getattr(c, 'current_streak', 0) or 0,
+            "best_streak": getattr(c, 'best_streak', 0) or 0,
+            "total_points_earned": getattr(c, 'total_points_earned', 0) or 0,
+            "total_chores_completed": getattr(c, 'total_chores_completed', 0) or 0,
+            "avatar": getattr(c, 'avatar', 'mdi:account-circle') or 'mdi:account-circle',
+            "last_completion_date": getattr(c, 'last_completion_date', None),
+            "streak_paused": getattr(c, 'streak_paused', False),
+            "streak_milestones_achieved": getattr(c, 'streak_milestones_achieved', None) or [],
+            "awarded_perfect_weeks": getattr(c, 'awarded_perfect_weeks', None) or [],
+        })
+    return summary
+
+
+def _build_chores_list(coordinator: TaskMateCoordinator, common: dict) -> list[dict]:
+    """Build the chores list, omitting rarely-used / empty fields.
+
+    Fields dropped entirely (no frontend consumer):
+      - publish_calendar_entities, last_completed_at,
+        first_occurrence_mode, assignment_rotation_anchor.
+    Optional fields are only emitted when they hold a non-default value so
+    small / simple chores produce compact records and the slice stays under
+    the 16KB recorder limit.
+    Per-child availability is split into its own attribute (`chore_availability`)
+    on the chore-availability sensor to keep this record compact.
+    """
+    chores = common["chores"]
+    chores_list = []
+    for c in chores:
+        assigned_to = c.assigned_to if isinstance(c.assigned_to, list) else []
+        record: dict = {
+            "id": c.id,
+            "name": c.name,
+            "points": c.points,
+            "time_category": c.time_category,
+            "assigned_to": assigned_to,
+            "schedule_mode": getattr(c, 'schedule_mode', 'specific_days'),
+            "enabled": getattr(c, 'enabled', True),
+            "assignment_mode": getattr(c, 'assignment_mode', 'everyone'),
+        }
+        # Optional fields — emit only when non-default to save bytes.
+        description = getattr(c, 'description', '') or ''
+        if description:
+            record["description"] = description
+        daily_limit = getattr(c, 'daily_limit', 1)
+        if daily_limit != 1:
+            record["daily_limit"] = daily_limit
+        due_days = getattr(c, 'due_days', []) or []
+        if due_days:
+            record["due_days"] = due_days
+        requires_approval = getattr(c, 'requires_approval', True)
+        if not requires_approval:
+            record["requires_approval"] = False
+        recurrence = getattr(c, 'recurrence', 'weekly')
+        if recurrence != 'weekly':
+            record["recurrence"] = recurrence
+        recurrence_day = getattr(c, 'recurrence_day', '')
+        if recurrence_day:
+            record["recurrence_day"] = recurrence_day
+        recurrence_start = getattr(c, 'recurrence_start', '')
+        if recurrence_start:
+            record["recurrence_start"] = recurrence_start
+        visibility_entity = getattr(c, 'visibility_entity', '')
+        if visibility_entity:
+            record["visibility_entity"] = visibility_entity
+            record["visibility_operator"] = getattr(c, 'visibility_operator', 'equals')
+            record["visibility_state"] = getattr(c, 'visibility_state', 'on')
+        disabled_for = getattr(c, 'disabled_for', [])
+        if disabled_for:
+            record["disabled_for"] = disabled_for
+        created_date = getattr(c, 'created_date', '')
+        if created_date:
+            record["created_date"] = created_date
+        assignment_current_child_id = getattr(c, 'assignment_current_child_id', '')
+        if assignment_current_child_id:
+            record["assignment_current_child_id"] = assignment_current_child_id
+        completion_sound = getattr(c, 'completion_sound', 'coin')
+        if completion_sound and completion_sound != 'coin':
+            record["completion_sound"] = completion_sound
+        chores_list.append(record)
+    return chores_list
+
+
+def _build_chore_availability(coordinator: TaskMateCoordinator, common: dict) -> dict:
+    """Build the chore availability matrix: {chore_id: {child_id: bool}}.
+
+    Extracted from the chores sensor so `sensor.taskmate_chores` carries only
+    definitions and stays compact even for families with many chores/kids.
+    """
+    children = common["children"]
+    chores = common["chores"]
+    availability: dict[str, dict[str, bool]] = {}
+    for c in chores:
+        per_child = {}
+        for child in children:
+            per_child[child.id] = coordinator.is_chore_available_for_child(c, child.id)
+        availability[c.id] = per_child
+    return availability
+
+
+def _build_todays_completions(common: dict) -> list[dict]:
+    """Build today's completions (both approved and pending)."""
+    now = dt_util.now()
+    today = now.date()
+    child_lookup = common["child_lookup"]
+    chore_lookup = common["chore_lookup"]
+    out = []
+    for comp in common["all_completions"]:
+        comp_dt = comp.completed_at
+        if hasattr(comp_dt, 'astimezone'):
+            comp_dt = dt_util.as_local(comp_dt)
+        comp_date = comp_dt.date() if hasattr(comp_dt, 'date') else comp_dt
+        if comp_date != today:
+            continue
+        matched_chore = chore_lookup.get(comp.chore_id)
+        out.append({
+            "completion_id": comp.id,
+            "chore_id": comp.chore_id,
+            "child_id": comp.child_id,
+            "child_name": child_lookup[comp.child_id].name if comp.child_id in child_lookup else "",
+            "chore_name": matched_chore.name if matched_chore else "",
+            "points": matched_chore.points if matched_chore else 0,
+            "approved": comp.approved,
+            "completed_at": comp.completed_at.isoformat() if hasattr(comp.completed_at, 'isoformat') else str(comp.completed_at),
+        })
+    return out
+
+
+def _build_rewards_list(common: dict) -> list[dict]:
+    """Build the rewards list with calculated_costs and pool allocations."""
+    rewards = common["rewards"]
+    children = common["children"]
+    pool_by_child_reward = common["pool_by_child_reward"]
+    pool_total_by_reward = common["pool_total_by_reward"]
+    out = []
+    for r in rewards:
+        assigned = (
+            r.assigned_to
+            if isinstance(r.assigned_to, list) and r.assigned_to
+            else [c.id for c in children]
+        )
+        calculated_costs = {child_id: r.cost for child_id in assigned}
+        reward_pool_allocations = {
+            cid: pool_by_child_reward.get(cid, {}).get(r.id, 0) for cid in assigned
+        }
+        jackpot_pool_total = (
+            pool_total_by_reward.get(r.id, 0) if getattr(r, 'is_jackpot', False) else None
+        )
+        out.append({
+            "id": r.id,
+            "name": r.name,
+            "cost": r.cost,
+            "description": getattr(r, 'description', ''),
+            "icon": r.icon,
+            "assigned_to": r.assigned_to if isinstance(r.assigned_to, list) else [],
+            "is_jackpot": getattr(r, 'is_jackpot', False),
+            "pool_enabled": getattr(r, 'pool_enabled', False),
+            "calculated_costs": calculated_costs,
+            "pool_allocations": reward_pool_allocations,
+            "jackpot_pool_total": jackpot_pool_total,
+        })
+    return out
+
+
+def _build_pending_reward_claims(common: dict) -> list[dict]:
+    """Build enriched pending reward claims list."""
+    reward_lookup = common["reward_lookup"]
+    child_lookup = common["child_lookup"]
+    out = []
+    for rc in common["pending_reward_claim_objs"]:
+        reward = reward_lookup.get(rc.reward_id)
+        child = child_lookup.get(rc.child_id)
+        if not reward or not child:
+            continue
+        out.append({
+            "claim_id": rc.id,
+            "reward_id": rc.reward_id,
+            "child_id": rc.child_id,
+            "child_name": child.name,
+            "child_avatar": getattr(child, 'avatar', 'mdi:account-circle') or 'mdi:account-circle',
+            "reward_name": reward.name,
+            "reward_icon": reward.icon or 'mdi:gift',
+            "cost": reward.cost,
+            "claimed_at": rc.claimed_at.isoformat() if hasattr(rc.claimed_at, 'isoformat') else str(rc.claimed_at),
+        })
+    return out
+
+
+def _build_recent_completions(common: dict, limit: int = 35) -> list[dict]:
+    """Return the most recent completions, capped to `limit`.
+
+    Lowered from 200 to 35 so the activity sensor's attribute payload stays
+    under the 16KB recorder limit even for families with heavy chore activity.
+    """
+    child_lookup = common["child_lookup"]
+    chore_lookup = common["chore_lookup"]
+    recent = sorted(common["all_completions"], key=lambda c: c.completed_at, reverse=True)[:limit]
+    return [{
+        "completion_id": comp.id,
+        "chore_id": comp.chore_id,
+        "child_id": comp.child_id,
+        "child_name": child_lookup[comp.child_id].name if comp.child_id in child_lookup else "",
+        "chore_name": chore_lookup[comp.chore_id].name if comp.chore_id in chore_lookup else "",
+        "points": chore_lookup[comp.chore_id].points if comp.chore_id in chore_lookup else 0,
+        "approved": comp.approved,
+        "completed_at": comp.completed_at.isoformat() if hasattr(comp.completed_at, 'isoformat') else str(comp.completed_at),
+    } for comp in recent]
+
+
+def _build_recent_transactions(common: dict, limit: int = 20) -> list[dict]:
+    """Unified activity feed of manual point adjustments and reward claims.
+
+    Capped at 20 so the combined activity slice (completions + transactions)
+    stays under the 16KB recorder limit.
+    """
+    data = common["data"]
+    child_lookup = common["child_lookup"]
+    reward_lookup = common["reward_lookup"]
+    points_transactions = data.get("points_transactions", [])
+    all_reward_claims = data.get("reward_claims", [])
+    events = []
+
+    for t in points_transactions:
+        child = child_lookup.get(t.child_id)
+        if not child:
+            continue
+        events.append({
+            "transaction_id": t.id,
+            "type": "points_added" if t.points > 0 else "points_removed",
+            "child_id": t.child_id,
+            "child_name": child.name,
+            "points": t.points,
+            "reason": t.reason or "",
+            "created_at": t.created_at.isoformat() if hasattr(t.created_at, 'isoformat') else str(t.created_at),
+        })
+
+    for rc in all_reward_claims:
+        child = child_lookup.get(rc.child_id)
+        reward = reward_lookup.get(rc.reward_id)
+        if not child or not reward:
+            continue
+        event_type = "reward_approved" if rc.approved else "reward_claimed"
+        timestamp = rc.approved_at if rc.approved and rc.approved_at else rc.claimed_at
+        events.append({
+            "transaction_id": rc.id,
+            "type": event_type,
+            "child_id": rc.child_id,
+            "child_name": child.name,
+            "reward_id": rc.reward_id,
+            "reward_name": reward.name,
+            "reward_icon": reward.icon or "mdi:gift",
+            "points": -reward.cost,
+            "approved": rc.approved,
+            "created_at": timestamp.isoformat() if hasattr(timestamp, 'isoformat') else str(timestamp),
+        })
+
+    events.sort(key=lambda e: e["created_at"], reverse=True)
+    return events[:limit]
+
+
+def _build_penalties_list(common: dict) -> list[dict]:
+    return [{
+        "id": p.id,
+        "name": p.name,
+        "points": p.points,
+        "description": p.description,
+        "icon": p.icon,
+        "assigned_to": p.assigned_to or [],
+    } for p in common["data"].get("penalties", [])]
+
+
+def _build_bonuses_list(common: dict) -> list[dict]:
+    return [{
+        "id": b.id,
+        "name": b.name,
+        "points": b.points,
+        "description": b.description,
+        "icon": b.icon,
+        "assigned_to": b.assigned_to or [],
+    } for b in common["data"].get("bonuses", [])]
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: ConfigEntry,
@@ -51,8 +448,15 @@ async def async_setup_entry(
     # Track child IDs that have sensors created
     tracked_child_ids: set[str] = set()
 
-    # Add overall stats sensor
+    # Add global sensors. The overview sensor is kept for backward compatibility
+    # with existing Lovelace dashboards; its heavy attributes have been split
+    # across four companion sensors to stay below the 16KB recorder limit.
     entities.append(TaskMateOverallStatsSensor(coordinator, entry))
+    entities.append(TaskMateChoresSensor(coordinator, entry))
+    entities.append(TaskMateChoreAvailabilitySensor(coordinator, entry))
+    entities.append(TaskMateRewardsSensor(coordinator, entry))
+    entities.append(TaskMateActivitySensor(coordinator, entry))
+    entities.append(TaskMateIncentivesSensor(coordinator, entry))
 
     # Add sensors for each child
     for child in coordinator.data.get("children", []):
@@ -106,29 +510,16 @@ class TaskMateBaseSensor(CoordinatorEntity, SensorEntity):
         )
 
 
-class TaskMateOverallStatsSensor(TaskMateBaseSensor):
-    """Sensor for overall TaskMate statistics."""
+class _CachedAttrsSensor(TaskMateBaseSensor):
+    """Base for sensors whose attributes are expensive to build."""
 
-    def __init__(
-        self,
-        coordinator: TaskMateCoordinator,
-        entry: ConfigEntry,
-    ) -> None:
-        """Initialize the sensor."""
+    def __init__(self, coordinator: TaskMateCoordinator, entry: ConfigEntry) -> None:
         super().__init__(coordinator, entry)
-        self._attr_unique_id = f"{entry.entry_id}_overall_stats"
-        self._attr_name = "TaskMate Overview"
         self._cached_attrs: dict | None = None
         self._cached_data_id: int | None = None
 
     @property
-    def native_value(self) -> int:
-        """Return the total number of children."""
-        return len(self.coordinator.data.get("children", []))
-
-    @property
     def extra_state_attributes(self) -> dict:
-        # Return cached result if coordinator data hasn't changed
         data_id = id(self.coordinator.data)
         if self._cached_data_id == data_id and self._cached_attrs is not None:
             return self._cached_attrs
@@ -137,317 +528,217 @@ class TaskMateOverallStatsSensor(TaskMateBaseSensor):
         self._cached_data_id = data_id
         return attrs
 
+    def _build_attributes(self) -> dict:  # pragma: no cover - abstract
+        raise NotImplementedError
+
+
+class TaskMateOverallStatsSensor(_CachedAttrsSensor):
+    """Overview sensor — scalars plus the compact per-child summary.
+
+    Heavy lists (chores/rewards/activity/incentives) live on companion
+    sensors so this entity stays well under the 16KB recorder limit.
+    """
+
+    def __init__(
+        self,
+        coordinator: TaskMateCoordinator,
+        entry: ConfigEntry,
+    ) -> None:
+        super().__init__(coordinator, entry)
+        self._attr_unique_id = f"{entry.entry_id}_overall_stats"
+        self._attr_name = "TaskMate Overview"
+
+    @property
+    def native_value(self) -> int:
+        """Return the total number of children."""
+        return len(self.coordinator.data.get("children", []))
+
+    @property
+    def icon(self) -> str:
+        return "mdi:clipboard-check-multiple"
+
     def _build_attributes(self) -> dict:
-        """Return additional attributes."""
-        data = self.coordinator.data
-        children = data.get("children", [])
-        chores = data.get("chores", [])
-        rewards = data.get("rewards", [])
+        common = _compute_common(self.coordinator)
+        data = common["data"]
+        children = common["children"]
+        chores = common["chores"]
+        rewards = common["rewards"]
 
         total_points = sum(c.points for c in children)
         total_chores_completed = sum(c.total_chores_completed for c in children)
-
-        # Get all completions and pending completions
-        all_completions = data.get("completions", [])
-        pending_completions = data.get("pending_completions", [])
-
-        # Build today's completions summary (both approved and pending)
-        # Use HA timezone-aware datetime for proper date comparison
-        now = dt_util.now()
-        today = now.date()
-        todays_completions = []
-        # Build chore lookup for enriching completions
-        chore_lookup = {c.id: c for c in chores}
-        # Build child lookup for enriching completions
-        child_lookup = {c.id: c for c in children}
-
-        for comp in all_completions:
-            # Convert completion time to HA timezone for proper date comparison
-            comp_dt = comp.completed_at
-            if hasattr(comp_dt, 'astimezone'):
-                # If timezone-aware, convert to HA timezone
-                comp_dt = dt_util.as_local(comp_dt)
-            comp_date = comp_dt.date() if hasattr(comp_dt, 'date') else comp_dt
-            matched_chore = chore_lookup.get(comp.chore_id)
-            if comp_date == today:
-                todays_completions.append({
-                    "completion_id": comp.id,
-                    "chore_id": comp.chore_id,
-                    "child_id": comp.child_id,
-                    "child_name": child_lookup[comp.child_id].name if comp.child_id in child_lookup else "",
-                    "chore_name": matched_chore.name if matched_chore else "",
-                    "points": matched_chore.points if matched_chore else 0,
-                    "approved": comp.approved,
-                    "completed_at": comp.completed_at.isoformat() if hasattr(comp.completed_at, 'isoformat') else str(comp.completed_at),
-                })
-
-        # Calculate pending points per child (chores awaiting approval = points to be earned)
-        pending_points_by_child = {}
-        for comp in pending_completions:
-            child_id = comp.child_id
-            chore = next((c for c in chores if c.id == comp.chore_id), None)
-            if chore:
-                pending_points_by_child[child_id] = pending_points_by_child.get(child_id, 0) + chore.points
-
-        # Calculate committed points per child (reward claims awaiting approval = points reserved).
-        # Pool-mode pending claims are skipped because their cost was already deducted
-        # from child.points at allocation time — counting them here would drive
-        # spendable_balance to zero and prevent allocating to other pool rewards.
-        committed_points_by_child = {}
-        pending_reward_claim_objs = data.get("pending_reward_claims", [])
-        for rc in pending_reward_claim_objs:
-            if self.coordinator.is_pool_mode_claim(rc):
-                continue
-            reward = next((r for r in rewards if r.id == rc.reward_id), None)
-            if reward:
-                # All reward costs are static
-                cost = reward.cost
-                committed_points_by_child[rc.child_id] = committed_points_by_child.get(rc.child_id, 0) + cost
-
-        # Build pool allocation lookups for v3.0 pool mode
-        pool_alloc_objs = data.get("pool_allocations", [])
-        pool_by_child_reward: dict[str, dict[str, int]] = {}
-        pool_total_by_reward: dict[str, int] = {}
-        total_allocated_by_child: dict[str, int] = {}
-        for pa in pool_alloc_objs:
-            pool_by_child_reward.setdefault(pa.child_id, {})[pa.reward_id] = pa.allocated_points
-            pool_total_by_reward[pa.reward_id] = pool_total_by_reward.get(pa.reward_id, 0) + pa.allocated_points
-            total_allocated_by_child[pa.child_id] = total_allocated_by_child.get(pa.child_id, 0) + pa.allocated_points
-
-        # Build chores list with recurrence fields and availability per child
-        chores_list = []
-        for c in chores:
-            # Ensure assigned_to is always a list
-            assigned_to = c.assigned_to if isinstance(c.assigned_to, list) else []
-
-            # Build last_completed_at and is_available per child
-            last_completed_at = {}
-            is_available = {}
-            for child in children:
-                record = self.coordinator.storage.get_last_completed(c.id, child.id)
-                if record.get('current'):
-                    last_completed_at[child.id] = record['current']
-                is_available[child.id] = self.coordinator.is_chore_available_for_child(c, child.id)
-
-            chores_list.append({
-                "id": c.id,
-                "name": c.name,
-                "description": getattr(c, 'description', '') or '',
-                "points": c.points,
-                "time_category": c.time_category,
-                "daily_limit": getattr(c, 'daily_limit', 1),
-                "assigned_to": assigned_to,
-                "completion_sound": getattr(c, 'completion_sound', 'coin'),
-                "due_days": getattr(c, 'due_days', []) or [],
-                "requires_approval": getattr(c, 'requires_approval', True),
-                "schedule_mode": getattr(c, 'schedule_mode', 'specific_days'),
-                "recurrence": getattr(c, 'recurrence', 'weekly'),
-                "recurrence_day": getattr(c, 'recurrence_day', ''),
-                "recurrence_start": getattr(c, 'recurrence_start', ''),
-                "first_occurrence_mode": getattr(c, 'first_occurrence_mode', 'available_immediately'),
-                "visibility_entity": getattr(c, 'visibility_entity', ''),
-                "visibility_operator": getattr(c, 'visibility_operator', 'equals'),
-                "visibility_state": getattr(c, 'visibility_state', 'on'),
-                "enabled": getattr(c, 'enabled', True),
-                "disabled_for": getattr(c, 'disabled_for', []),
-                "created_date": getattr(c, 'created_date', ''),
-                "assignment_mode": getattr(c, 'assignment_mode', 'everyone'),
-                "assignment_rotation_anchor": getattr(c, 'assignment_rotation_anchor', ''),
-                "assignment_current_child_id": getattr(c, 'assignment_current_child_id', ''),
-                "publish_calendar_entities": list(getattr(c, 'publish_calendar_entities', []) or []),
-                "last_completed_at": last_completed_at,
-                "is_available": is_available,
-            })
-
-        # Build rewards list — all costs are static (fixed by parent)
-        rewards_list = []
-        for r in rewards:
-            assigned = r.assigned_to if isinstance(r.assigned_to, list) and r.assigned_to else [c.id for c in children]
-            # Static cost for all children
-            calculated_costs = {child_id: r.cost for child_id in assigned}
-
-            # Pool allocations per assigned child for this reward (v3.0)
-            reward_pool_allocations = {
-                cid: pool_by_child_reward.get(cid, {}).get(r.id, 0)
-                for cid in assigned
-            }
-            jackpot_pool_total = (
-                pool_total_by_reward.get(r.id, 0) if getattr(r, 'is_jackpot', False) else None
-            )
-
-            rewards_list.append({
-                "id": r.id,
-                "name": r.name,
-                "cost": r.cost,
-                "description": getattr(r, 'description', ''),
-                "icon": r.icon,
-                "assigned_to": r.assigned_to if isinstance(r.assigned_to, list) else [],
-                "is_jackpot": getattr(r, 'is_jackpot', False),
-                "pool_enabled": getattr(r, 'pool_enabled', False),
-                "calculated_costs": calculated_costs,
-                "pool_allocations": reward_pool_allocations,
-                "jackpot_pool_total": jackpot_pool_total,
-            })
-
-        # Day of week for due_days filtering in frontend (lowercase, e.g. "monday")
         today_dow = dt_util.now().strftime("%A").lower()
+        settings = data.get("settings", {})
 
         return {
             "today_day_of_week": today_dow,
-            "streak_reset_mode": data.get("settings", {}).get("streak_reset_mode", "reset"),
-            "weekend_multiplier": _safe_float(data.get("settings", {}).get("weekend_multiplier"), 2.0),
-            "streak_milestones_enabled": data.get("settings", {}).get("streak_milestones_enabled", "true") == "true",
-            "streak_milestones": data.get("settings", {}).get("streak_milestones", "3:5, 7:10, 14:20, 30:50, 60:100, 100:200"),
-            "perfect_week_enabled": data.get("settings", {}).get("perfect_week_enabled", "true") == "true",
-            "perfect_week_bonus": _safe_int(data.get("settings", {}).get("perfect_week_bonus"), 50),
+            "streak_reset_mode": settings.get("streak_reset_mode", "reset"),
+            "weekend_multiplier": _safe_float(settings.get("weekend_multiplier"), 2.0),
+            "streak_milestones_enabled": settings.get("streak_milestones_enabled", "true") == "true",
+            "streak_milestones": settings.get("streak_milestones", "3:5, 7:10, 14:20, 30:50, 60:100, 100:200"),
+            "perfect_week_enabled": settings.get("perfect_week_enabled", "true") == "true",
+            "perfect_week_bonus": _safe_int(settings.get("perfect_week_bonus"), 50),
             "total_children": len(children),
             "total_chores": len(chores),
             "total_rewards": len(rewards),
             "total_points_available": total_points,
             "total_chores_completed": total_chores_completed,
+            "total_completions_all_time": len(common["all_completions"]),
+            "total_pending_completions": len(common["pending_completions"]),
             "points_name": data.get("points_name", "Stars"),
             "points_icon": data.get("points_icon", "mdi:star"),
-            "children": [{
-                "id": c.id,
-                "name": c.name,
-                "points": c.points,
-                "pending_points": pending_points_by_child.get(c.id, 0),
-                "committed_points": committed_points_by_child.get(c.id, 0),
-                "allocated_points": total_allocated_by_child.get(c.id, 0),
-                # Allocations are deducted from child.points at allocation time,
-                # so spendable only needs to account for pending-claim commitments.
-                "spendable_balance": max(
-                    0,
-                    c.points - committed_points_by_child.get(c.id, 0),
-                ),
-                "chore_order": c.chore_order,
-                "current_streak": getattr(c, 'current_streak', 0) or 0,
-                "best_streak": getattr(c, 'best_streak', 0) or 0,
-                "total_points_earned": getattr(c, 'total_points_earned', 0) or 0,
-                "total_chores_completed": getattr(c, 'total_chores_completed', 0) or 0,
-                "avatar": getattr(c, 'avatar', 'mdi:account-circle') or 'mdi:account-circle',
-                "last_completion_date": getattr(c, 'last_completion_date', None),
-                "streak_paused": getattr(c, 'streak_paused', False),
-                "streak_milestones_achieved": getattr(c, 'streak_milestones_achieved', None) or [],
-                "awarded_perfect_weeks": getattr(c, 'awarded_perfect_weeks', None) or [],
-            } for c in children],
-            "chores": chores_list,
-            "rewards": rewards_list,
-            "todays_completions": todays_completions,
-            "total_completions_all_time": len(all_completions),
-            "total_pending_completions": len(pending_completions),
-            "pending_reward_claims": self._build_pending_reward_claims(
-                data.get("pending_reward_claims", []), rewards, child_lookup
-            ),
-            "pool_allocations": [pa.to_dict() for pa in pool_alloc_objs],
-            "recent_completions": [{
-                "completion_id": comp.id,
-                "chore_id": comp.chore_id,
-                "child_id": comp.child_id,
-                "child_name": child_lookup.get(comp.child_id, None) and child_lookup[comp.child_id].name or "",
-                "chore_name": chore_lookup.get(comp.chore_id, None) and chore_lookup[comp.chore_id].name or "",
-                "points": chore_lookup.get(comp.chore_id, None) and chore_lookup[comp.chore_id].points or 0,
-                "approved": comp.approved,
-                "completed_at": comp.completed_at.isoformat() if hasattr(comp.completed_at, 'isoformat') else str(comp.completed_at),
-            } for comp in sorted(all_completions, key=lambda c: c.completed_at, reverse=True)[:200]],
-            "recent_transactions": self._build_recent_transactions(
-                data.get("points_transactions", []),
-                data.get("reward_claims", []),
-                rewards,
-                child_lookup,
-            ),
-            "penalties": [{
-                "id": p.id,
-                "name": p.name,
-                "points": p.points,
-                "description": p.description,
-                "icon": p.icon,
-                "assigned_to": p.assigned_to or [],
-            } for p in data.get("penalties", [])],
-            "bonuses": [{
-                "id": b.id,
-                "name": b.name,
-                "points": b.points,
-                "description": b.description,
-                "icon": b.icon,
-                "assigned_to": b.assigned_to or [],
-            } for b in data.get("bonuses", [])],
+            "children": _build_children_summary(common),
         }
+
+
+class TaskMateChoresSensor(_CachedAttrsSensor):
+    """Chores catalog + today's completions."""
+
+    def __init__(
+        self,
+        coordinator: TaskMateCoordinator,
+        entry: ConfigEntry,
+    ) -> None:
+        super().__init__(coordinator, entry)
+        self._attr_unique_id = f"{entry.entry_id}_chores"
+        self._attr_name = "TaskMate Chores"
+
+    @property
+    def native_value(self) -> int:
+        return len(self.coordinator.data.get("chores", []))
 
     @property
     def icon(self) -> str:
-        """Return the icon."""
-        return "mdi:clipboard-check-multiple"
+        return "mdi:format-list-checks"
+
+    def _build_attributes(self) -> dict:
+        common = _compute_common(self.coordinator)
+        return {
+            "chores": _build_chores_list(self.coordinator, common),
+            "todays_completions": _build_todays_completions(common),
+        }
 
 
-    def _build_recent_transactions(self, points_transactions, all_reward_claims, rewards, child_lookup):
-        """Build unified activity feed of manual point adjustments and reward claims."""
-        reward_lookup = {r.id: r for r in rewards}
-        events = []
+class TaskMateChoreAvailabilitySensor(_CachedAttrsSensor):
+    """Per-chore × per-child availability matrix.
 
-        # Manual points transactions
-        for t in points_transactions:
-            child = child_lookup.get(t.child_id)
-            if not child:
-                continue
-            events.append({
-                "transaction_id": t.id,
-                "type": "points_added" if t.points > 0 else "points_removed",
-                "child_id": t.child_id,
-                "child_name": child.name,
-                "points": t.points,
-                "reason": t.reason or "",
-                "created_at": t.created_at.isoformat() if hasattr(t.created_at, 'isoformat') else str(t.created_at),
-            })
+    Split off from the chores sensor so `sensor.taskmate_chores` can stay
+    under the 16 KB recorder limit even for families with lots of chores.
+    The map is `{chore_id: {child_id: bool}}`.
+    """
 
-        # Reward claims — show both pending and approved
-        for rc in all_reward_claims:
-            child = child_lookup.get(rc.child_id)
-            reward = reward_lookup.get(rc.reward_id)
-            if not child or not reward:
-                continue
-            cost = reward.cost
-            event_type = "reward_approved" if rc.approved else "reward_claimed"
-            timestamp = rc.approved_at if rc.approved and rc.approved_at else rc.claimed_at
-            events.append({
-                "transaction_id": rc.id,
-                "type": event_type,
-                "child_id": rc.child_id,
-                "child_name": child.name,
-                "reward_id": rc.reward_id,
-                "reward_name": reward.name,
-                "reward_icon": reward.icon or "mdi:gift",
-                "points": -cost,  # negative — points spent
-                "approved": rc.approved,
-                "created_at": timestamp.isoformat() if hasattr(timestamp, 'isoformat') else str(timestamp),
-            })
+    def __init__(
+        self,
+        coordinator: TaskMateCoordinator,
+        entry: ConfigEntry,
+    ) -> None:
+        super().__init__(coordinator, entry)
+        self._attr_unique_id = f"{entry.entry_id}_chore_availability"
+        self._attr_name = "TaskMate Chore Availability"
 
-        # Sort all events newest first, cap at 50
-        events.sort(key=lambda e: e["created_at"], reverse=True)
-        return events[:50]
+    @property
+    def native_value(self) -> int:
+        common = _compute_common(self.coordinator)
+        total = 0
+        availability = _build_chore_availability(self.coordinator, common)
+        for per_child in availability.values():
+            total += sum(1 for v in per_child.values() if v)
+        return total
 
-    def _build_pending_reward_claims(self, pending_claims, rewards, child_lookup):
-        """Build enriched pending reward claims list."""
-        reward_lookup = {r.id: r for r in rewards}
-        result = []
-        for rc in pending_claims:
-            reward = reward_lookup.get(rc.reward_id)
-            child = child_lookup.get(rc.child_id)
-            if not reward or not child:
-                continue
-            cost = reward.cost
-            result.append({
-                "claim_id": rc.id,
-                "reward_id": rc.reward_id,
-                "child_id": rc.child_id,
-                "child_name": child.name,
-                "child_avatar": getattr(child, 'avatar', 'mdi:account-circle') or 'mdi:account-circle',
-                "reward_name": reward.name,
-                "reward_icon": reward.icon or 'mdi:gift',
-                "cost": cost,
-                "claimed_at": rc.claimed_at.isoformat() if hasattr(rc.claimed_at, 'isoformat') else str(rc.claimed_at),
-            })
-        return result
+    @property
+    def icon(self) -> str:
+        return "mdi:calendar-check"
+
+    def _build_attributes(self) -> dict:
+        common = _compute_common(self.coordinator)
+        return {
+            "chore_availability": _build_chore_availability(self.coordinator, common),
+        }
+
+
+class TaskMateRewardsSensor(_CachedAttrsSensor):
+    """Rewards catalog + pending claims + pool allocations."""
+
+    def __init__(
+        self,
+        coordinator: TaskMateCoordinator,
+        entry: ConfigEntry,
+    ) -> None:
+        super().__init__(coordinator, entry)
+        self._attr_unique_id = f"{entry.entry_id}_rewards"
+        self._attr_name = "TaskMate Rewards"
+
+    @property
+    def native_value(self) -> int:
+        return len(self.coordinator.data.get("rewards", []))
+
+    @property
+    def icon(self) -> str:
+        return "mdi:gift-outline"
+
+    def _build_attributes(self) -> dict:
+        common = _compute_common(self.coordinator)
+        return {
+            "rewards": _build_rewards_list(common),
+            "pending_reward_claims": _build_pending_reward_claims(common),
+            "pool_allocations": [pa.to_dict() for pa in common["pool_alloc_objs"]],
+        }
+
+
+class TaskMateActivitySensor(_CachedAttrsSensor):
+    """Recent completions + recent points/reward transactions."""
+
+    def __init__(
+        self,
+        coordinator: TaskMateCoordinator,
+        entry: ConfigEntry,
+    ) -> None:
+        super().__init__(coordinator, entry)
+        self._attr_unique_id = f"{entry.entry_id}_activity"
+        self._attr_name = "TaskMate Activity"
+
+    @property
+    def native_value(self) -> int:
+        return len(self.coordinator.data.get("completions", []))
+
+    @property
+    def icon(self) -> str:
+        return "mdi:history"
+
+    def _build_attributes(self) -> dict:
+        common = _compute_common(self.coordinator)
+        return {
+            "recent_completions": _build_recent_completions(common),
+            "recent_transactions": _build_recent_transactions(common),
+        }
+
+
+class TaskMateIncentivesSensor(_CachedAttrsSensor):
+    """Penalties + bonuses catalogue."""
+
+    def __init__(
+        self,
+        coordinator: TaskMateCoordinator,
+        entry: ConfigEntry,
+    ) -> None:
+        super().__init__(coordinator, entry)
+        self._attr_unique_id = f"{entry.entry_id}_incentives"
+        self._attr_name = "TaskMate Incentives"
+
+    @property
+    def native_value(self) -> int:
+        data = self.coordinator.data
+        return len(data.get("penalties", [])) + len(data.get("bonuses", []))
+
+    @property
+    def icon(self) -> str:
+        return "mdi:scale-balance"
+
+    def _build_attributes(self) -> dict:
+        common = _compute_common(self.coordinator)
+        return {
+            "penalties": _build_penalties_list(common),
+            "bonuses": _build_bonuses_list(common),
+        }
 
 
 class ChildPointsSensor(TaskMateBaseSensor):

--- a/custom_components/taskmate/www/taskmate-activity-card.js
+++ b/custom_components/taskmate/www/taskmate-activity-card.js
@@ -228,9 +228,10 @@ class TaskMateActivityCard extends LitElement {
       return html`<ha-card><div class="error-state"><ha-icon icon="mdi:alert-circle"></ha-icon><div>${this._t('common.unavailable')}</div></div></ha-card>`;
     }
 
-    const pointsIcon = entity.attributes.points_icon || "mdi:star";
-    const children = entity.attributes.children || [];
-    const chores = entity.attributes.chores || [];
+    const attrs = (window.__taskmate_attrs && window.__taskmate_attrs(this.hass, this.config.entity)) || entity.attributes || {};
+    const pointsIcon = attrs.points_icon || "mdi:star";
+    const children = attrs.children || [];
+    const chores = attrs.chores || [];
 
     // Build lookup maps
     const childNames = {};
@@ -241,7 +242,7 @@ class TaskMateActivityCard extends LitElement {
     chores.forEach(ch => { choreNamesMap[ch.id] = ch.name; });
 
     // Use recent_completions (last 50 all-time) if available, fall back to today only
-    let completions = [...(entity.attributes.recent_completions || entity.attributes.todays_completions || [])];
+    let completions = [...(attrs.recent_completions || attrs.todays_completions || [])];
 
     // Deduplicate by completion_id
     const seen = new Set();
@@ -252,7 +253,7 @@ class TaskMateActivityCard extends LitElement {
     });
 
     // Merge in manual points transactions
-    const transactions = (entity.attributes.recent_transactions || []).map(t => ({
+    const transactions = (attrs.recent_transactions || []).map(t => ({
       ...t,
       // Normalise to a single timestamp field for sorting
       completed_at: t.created_at,

--- a/custom_components/taskmate/www/taskmate-approvals-card.js
+++ b/custom_components/taskmate/www/taskmate-approvals-card.js
@@ -343,19 +343,23 @@ class TaskMateApprovalsCard extends LitElement {
     }
 
     // Support both the pending_approvals sensor (chore_completions)
-    // and the overview sensor (todays_completions filtered to unapproved)
+    // and the overview sensor (todays_completions filtered to unapproved).
+    // The resolver is used so pending_reward_claims / todays_completions
+    // resolve from their new companion sensors when the card is pointed at
+    // the overview entity.
+    const attrs = (window.__taskmate_attrs && window.__taskmate_attrs(this.hass, this.config.entity)) || entity.attributes || {};
     let completions = entity.attributes.chore_completions;
     if (!completions) {
-      completions = (entity.attributes.todays_completions || []).filter(c => !c.approved);
+      completions = (attrs.todays_completions || []).filter(c => !c.approved);
     }
     const filteredCompletions = this._filterByChild(completions);
     const groupedByDay = this._groupByDay(filteredCompletions);
 
     // Pending reward claims: supported via either the pending_approvals sensor
-    // (reward_claims attribute) or the overview sensor (pending_reward_claims).
+    // (reward_claims attribute) or the rewards sensor (pending_reward_claims).
     let rewardClaims =
       entity.attributes.reward_claims ||
-      entity.attributes.pending_reward_claims ||
+      attrs.pending_reward_claims ||
       [];
     const filteredClaims = this._filterClaimsByChild(rewardClaims);
 

--- a/custom_components/taskmate/www/taskmate-attr-resolver.js
+++ b/custom_components/taskmate/www/taskmate-attr-resolver.js
@@ -1,0 +1,64 @@
+/**
+ * TaskMate attribute resolver.
+ *
+ * The overview sensor used to expose every data slice (chores, rewards,
+ * recent activity, penalties, bonuses) as attributes of
+ * sensor.taskmate_overview. That payload routinely exceeded Home Assistant's
+ * 16 KB recorder limit, so the data is now split across companion sensors
+ * (sensor.taskmate_chores, _rewards, _activity, _incentives).
+ *
+ * To keep existing Lovelace dashboards working unchanged, every card reads
+ * attributes through window.__taskmate_attrs(hass, primaryEntityId), which
+ * returns a merged attribute object: primary attributes plus each companion
+ * sensor's attributes overlaid on top. If a companion sensor is missing
+ * (e.g. older backend), its keys fall back to the primary sensor's
+ * attributes. Cards therefore do not need to know which sensor owns which
+ * attribute — lookup is transparent.
+ */
+
+(function () {
+  "use strict";
+
+  // Fixed companion entity ids. TaskMate is a single-instance integration
+  // (config_flow enforces unique_id == DOMAIN), so these ids are stable.
+  const COMPANIONS = [
+    "sensor.taskmate_chores",
+    "sensor.taskmate_chore_availability",
+    "sensor.taskmate_rewards",
+    "sensor.taskmate_activity",
+    "sensor.taskmate_incentives",
+  ];
+
+  function mergedAttributes(hass, primaryEntityId) {
+    if (!hass || !hass.states) return {};
+    const merged = {};
+    const primary = hass.states[primaryEntityId];
+    if (primary && primary.attributes) {
+      Object.assign(merged, primary.attributes);
+    }
+    for (const id of COMPANIONS) {
+      const s = hass.states[id];
+      if (s && s.attributes) {
+        Object.assign(merged, s.attributes);
+      }
+    }
+    return merged;
+  }
+
+  // Cache merged attributes per hass/primary tuple so repeated card renders
+  // during a single Home Assistant state update don't rebuild the object.
+  let _cache = { stateRef: null, byPrimary: new Map() };
+
+  function resolveAttrs(hass, primaryEntityId) {
+    if (!hass) return {};
+    if (_cache.stateRef !== hass.states) {
+      _cache = { stateRef: hass.states, byPrimary: new Map() };
+    }
+    if (!_cache.byPrimary.has(primaryEntityId)) {
+      _cache.byPrimary.set(primaryEntityId, mergedAttributes(hass, primaryEntityId));
+    }
+    return _cache.byPrimary.get(primaryEntityId);
+  }
+
+  window.__taskmate_attrs = resolveAttrs;
+})();

--- a/custom_components/taskmate/www/taskmate-bonuses-card.js
+++ b/custom_components/taskmate/www/taskmate-bonuses-card.js
@@ -348,6 +348,10 @@ class TaskMateBonusesCard extends LitElement {
   }
 
   _getAttrs() {
+    const entityId = this.config?.entity || "sensor.taskmate_overview";
+    if (window.__taskmate_attrs) {
+      return window.__taskmate_attrs(this.hass, entityId);
+    }
     return this._getState()?.attributes || {};
   }
 

--- a/custom_components/taskmate/www/taskmate-calendar-card.js
+++ b/custom_components/taskmate/www/taskmate-calendar-card.js
@@ -374,9 +374,10 @@ class TaskMateCalendarCard extends LitElement {
     }
 
     const tz = this.hass?.config?.time_zone || Intl.DateTimeFormat().resolvedOptions().timeZone;
-    let children = entity.attributes.children || [];
-    const chores = entity.attributes.chores || [];
-    const pointsIcon = entity.attributes.points_icon || "mdi:star";
+    const attrs = (window.__taskmate_attrs && window.__taskmate_attrs(this.hass, this.config.entity)) || entity.attributes || {};
+    let children = attrs.children || [];
+    const chores = attrs.chores || [];
+    const pointsIcon = attrs.points_icon || "mdi:star";
 
     if (this.config.child_id) {
       children = children.filter((c) => c.id === this.config.child_id);
@@ -394,8 +395,8 @@ class TaskMateCalendarCard extends LitElement {
 
     const day = this._getSelectedDay(tz);
 
-    const rawCompletions = entity.attributes.recent_completions
-      || entity.attributes.todays_completions
+    const rawCompletions = attrs.recent_completions
+      || attrs.todays_completions
       || [];
     const seen = new Set();
     const dayCompletions = [];

--- a/custom_components/taskmate/www/taskmate-child-card.js
+++ b/custom_components/taskmate/www/taskmate-child-card.js
@@ -1178,7 +1178,8 @@ class TaskMateChildCard extends LitElement {
     }
 
     // Get child info
-    const children = entity.attributes.children || [];
+    const attrs = (window.__taskmate_attrs && window.__taskmate_attrs(this.hass, this.config.entity)) || entity.attributes || {};
+    const children = attrs.children || [];
     const child = children.find(c => c.id === this.config.child_id);
 
     if (!child) {
@@ -1193,7 +1194,7 @@ class TaskMateChildCard extends LitElement {
     }
 
     // Get chores for this child and time category
-    const allChores = entity.attributes.chores || [];
+    const allChores = attrs.chores || [];
 
     // Log raw data for debugging assignment issues
 
@@ -1221,8 +1222,8 @@ class TaskMateChildCard extends LitElement {
       filteredCount: childChores.length
     };
 
-    const pointsIcon = entity.attributes.points_icon || "mdi:star";
-    const pointsName = entity.attributes.points_name || this._t('common.stars');
+    const pointsIcon = attrs.points_icon || "mdi:star";
+    const pointsName = attrs.points_name || this._t('common.stars');
 
     // Avatar now in children array directly
     const avatar = child.avatar || "mdi:account-circle";
@@ -1233,7 +1234,7 @@ class TaskMateChildCard extends LitElement {
     // Get today's completions for this child (with timezone-aware filtering as fallback)
     // The backend provides todays_completions, but we also apply client-side filtering
     // to ensure timezone correctness matches the HA frontend timezone
-    const allCompletions = entity.attributes.todays_completions || entity.attributes.completions || [];
+    const allCompletions = attrs.todays_completions || attrs.completions || [];
     const todaysCompletions = this._filterCompletionsForToday(allCompletions);
 
     // Debug logging to help troubleshoot daily limit issues
@@ -1828,9 +1829,9 @@ class TaskMateChildCard extends LitElement {
   }
 
   _renderCelebration() {
-    const entity = this.hass.states[this.config.entity];
-    const pointsIcon = entity?.attributes?.points_icon || "mdi:star";
-    const celebratingChore = (entity?.attributes?.chores || []).find(
+    const attrs = (window.__taskmate_attrs && window.__taskmate_attrs(this.hass, this.config.entity)) || this.hass.states[this.config.entity]?.attributes || {};
+    const pointsIcon = attrs.points_icon || "mdi:star";
+    const celebratingChore = (attrs.chores || []).find(
       c => c.id === this._celebrating
     );
     const points = celebratingChore?.points || 0;
@@ -1882,8 +1883,8 @@ class TaskMateChildCard extends LitElement {
     }
 
     // Get current completion count including optimistic completions
-    const entity = this.hass.states[this.config.entity];
-    const allCompletions = entity?.attributes?.todays_completions || [];
+    const attrs = (window.__taskmate_attrs && window.__taskmate_attrs(this.hass, this.config.entity)) || this.hass.states[this.config.entity]?.attributes || {};
+    const allCompletions = attrs.todays_completions || [];
     const todaysCompletions = this._filterCompletionsForToday(allCompletions);
     const actualCompletionsToday = todaysCompletions.filter(
       (comp) => comp.chore_id === chore.id && comp.child_id === child.id

--- a/custom_components/taskmate/www/taskmate-graph-card.js
+++ b/custom_components/taskmate/www/taskmate-graph-card.js
@@ -236,9 +236,10 @@ class TaskMateGraphCard extends LitElement {
     }
 
     const tz = this.hass?.config?.time_zone || Intl.DateTimeFormat().resolvedOptions().timeZone;
-    let children = entity.attributes.children || [];
-    const pointsIcon = entity.attributes.points_icon || "mdi:star";
-    const pointsName = entity.attributes.points_name || this._t('common.points');
+    const attrs = (window.__taskmate_attrs && window.__taskmate_attrs(this.hass, this.config.entity)) || entity.attributes || {};
+    let children = attrs.children || [];
+    const pointsIcon = attrs.points_icon || "mdi:star";
+    const pointsName = attrs.points_name || this._t('common.points');
     const days = Math.max(3, Math.min(90, this.config.days || 14));
 
     // Filter to specific child if configured
@@ -248,15 +249,15 @@ class TaskMateGraphCard extends LitElement {
 
     // Get all completions (approved only for points)
     const allCompletions = [
-      ...(entity.attributes.recent_completions || entity.attributes.todays_completions || []),
+      ...(attrs.recent_completions || attrs.todays_completions || []),
     ].filter(c => c.approved);
 
     // Get manual transactions
-    const allTransactions = entity.attributes.recent_transactions || [];
+    const allTransactions = attrs.recent_transactions || [];
 
     // Build chore points map
     const chorePointsMap = {};
-    (entity.attributes.chores || []).forEach(ch => { chorePointsMap[ch.id] = ch.points || 0; });
+    (attrs.chores || []).forEach(ch => { chorePointsMap[ch.id] = ch.points || 0; });
 
     // Build date range
     const dateRange = this._buildDateRange(days, tz);

--- a/custom_components/taskmate/www/taskmate-leaderboard-card.js
+++ b/custom_components/taskmate/www/taskmate-leaderboard-card.js
@@ -240,15 +240,16 @@ class TaskMateLeaderboardCard extends LitElement {
     if (!entity) return html`<ha-card><div class="error-state"><ha-icon icon="mdi:alert-circle"></ha-icon><div>${this._t('common.entity_not_found', { entity: this.config.entity })}</div></div></ha-card>`;
     if (entity.state === "unavailable" || entity.state === "unknown") return html`<ha-card><div class="error-state"><ha-icon icon="mdi:alert-circle"></ha-icon><div>${this._t('common.unavailable')}</div></div></ha-card>`;
 
-    const children = [...(entity.attributes.children || [])];
-    const pointsIcon = entity.attributes.points_icon || "mdi:star";
-    const pointsName = entity.attributes.points_name || this._t('common.points');
+    const attrs = (window.__taskmate_attrs && window.__taskmate_attrs(this.hass, this.config.entity)) || entity.attributes || {};
+    const children = [...(attrs.children || [])];
+    const pointsIcon = attrs.points_icon || "mdi:star";
+    const pointsName = attrs.points_name || this._t('common.points');
 
     if (children.length === 0) return html`<ha-card><div class="empty-state"><ha-icon icon="mdi:account-group"></ha-icon><div>${this._t('common.no_children')}</div></div></ha-card>`;
 
     // Build weekly points from recent_completions
     const tz = this.hass?.config?.time_zone || Intl.DateTimeFormat().resolvedOptions().timeZone;
-    const weeklyPoints = this._buildWeeklyPoints(entity, tz);
+    const weeklyPoints = this._buildWeeklyPoints(attrs, tz);
 
     // Sort children
     const sortBy = this.config.sort_by || "points";
@@ -421,11 +422,11 @@ class TaskMateLeaderboardCard extends LitElement {
     `;
   }
 
-  _buildWeeklyPoints(entity, tz) {
+  _buildWeeklyPoints(attrs, tz) {
     const result = {};
-    const completions = entity.attributes.recent_completions || entity.attributes.todays_completions || [];
+    const completions = attrs.recent_completions || attrs.todays_completions || [];
     const choreMap = {};
-    (entity.attributes.chores || []).forEach(ch => { choreMap[ch.id] = ch.points || 0; });
+    (attrs.chores || []).forEach(ch => { choreMap[ch.id] = ch.points || 0; });
 
     const today = new Date();
     const weekDays = new Set();

--- a/custom_components/taskmate/www/taskmate-overview-card.js
+++ b/custom_components/taskmate/www/taskmate-overview-card.js
@@ -300,13 +300,14 @@ class TaskMateOverviewCard extends LitElement {
       return html`<ha-card><div class="error-state"><ha-icon icon="mdi:alert-circle"></ha-icon><div>${this._t('common.unavailable')}</div></div></ha-card>`;
     }
 
-    const children = entity.attributes.children || [];
-    const chores = entity.attributes.chores || [];
-    const completions = [...(entity.attributes.todays_completions || [])];
+    const attrs = (window.__taskmate_attrs && window.__taskmate_attrs(this.hass, this.config.entity)) || entity.attributes || {};
+    const children = attrs.children || [];
+    const chores = attrs.chores || [];
+    const completions = [...(attrs.todays_completions || [])];
     const chorePointsMap = {};
     chores.forEach(ch => { chorePointsMap[ch.id] = ch.points || 0; });
-    const pointsIcon = entity.attributes.points_icon || "mdi:star";
-    const pointsName = entity.attributes.points_name || "Stars";
+    const pointsIcon = attrs.points_icon || "mdi:star";
+    const pointsName = attrs.points_name || "Stars";
 
     // Pending approvals — from approvals entity if configured, else from completions
     let pendingApprovals = 0;
@@ -378,9 +379,10 @@ class TaskMateOverviewCard extends LitElement {
     const avatar = child.avatar || "mdi:account-circle";
 
     // Get today's day of week from sensor (e.g. "monday")
-    const entity = this.hass?.states?.[this.config?.entity];
-    const todayDow = entity?.attributes?.today_day_of_week ||
+    const attrs = (window.__taskmate_attrs && window.__taskmate_attrs(this.hass, this.config?.entity)) || {};
+    const todayDow = attrs.today_day_of_week ||
       new Date().toLocaleDateString('en-US', { weekday: 'long' }).toLowerCase();
+    const availability = attrs.chore_availability || {};
 
     // Chores assigned to this child, due today, and available (recurrence window open)
     const childChores = chores.filter(c => {
@@ -397,8 +399,8 @@ class TaskMateOverviewCard extends LitElement {
 
       // Mode B: recurrence availability check
       if (c.schedule_mode === 'recurring') {
-        const isAvailable = c.is_available && c.is_available[child.id];
-        if (isAvailable === false) return false;
+        const perChild = availability[c.id];
+        if (perChild && perChild[child.id] === false) return false;
       }
 
       return true;

--- a/custom_components/taskmate/www/taskmate-parent-dashboard-card.js
+++ b/custom_components/taskmate/www/taskmate-parent-dashboard-card.js
@@ -371,13 +371,14 @@ class TaskMateParentDashboardCard extends LitElement {
     if (!entity) return html`<ha-card><div class="error-state"><ha-icon icon="mdi:alert-circle"></ha-icon><div>${this._t('common.entity_not_found', { entity: this.config.entity })}</div></div></ha-card>`;
     if (entity.state === "unavailable" || entity.state === "unknown") return html`<ha-card><div class="error-state"><ha-icon icon="mdi:alert-circle"></ha-icon><div>${this._t('common.unavailable')}</div></div></ha-card>`;
 
-    const children = entity.attributes.children || [];
-    const chores = entity.attributes.chores || [];
-    const completions = entity.attributes.todays_completions || [];
+    const attrs = (window.__taskmate_attrs && window.__taskmate_attrs(this.hass, this.config.entity)) || entity.attributes || {};
+    const children = attrs.children || [];
+    const chores = attrs.chores || [];
+    const completions = attrs.todays_completions || [];
     const pendingCompletions = completions.filter(c => !c.approved);
-    const pendingRewardClaims = entity.attributes.pending_reward_claims || [];
-    const pointsIcon = entity.attributes.points_icon || "mdi:star";
-    const pointsName = entity.attributes.points_name || "Points";
+    const pendingRewardClaims = attrs.pending_reward_claims || [];
+    const pointsIcon = attrs.points_icon || "mdi:star";
+    const pointsName = attrs.points_name || "Points";
     const totalPending = pendingCompletions.length + pendingRewardClaims.length;
 
     const tabs = [
@@ -432,9 +433,10 @@ class TaskMateParentDashboardCard extends LitElement {
   _renderOverview(children, chores, completions, pointsIcon, pointsName) {
     if (!children.length) return html`<div class="empty-section"><ha-icon icon="mdi:account-group"></ha-icon><span>${this._t('dashboard.empty_no_children')}</span></div>`;
 
-    const entity = this.hass?.states?.[this.config?.entity];
-    const todayDow = entity?.attributes?.today_day_of_week ||
+    const attrs = (window.__taskmate_attrs && window.__taskmate_attrs(this.hass, this.config?.entity)) || {};
+    const todayDow = attrs.today_day_of_week ||
       new Date().toLocaleDateString('en-US', { weekday: 'long' }).toLowerCase();
+    const availability = attrs.chore_availability || {};
 
     return html`
       ${children.map(child => {
@@ -446,10 +448,10 @@ class TaskMateParentDashboardCard extends LitElement {
           const at = c.assigned_to || [];
           const assigned = at.length === 0 || at.includes(child.id);
           if (!assigned) return false;
+          const perChild = availability[c.id];
           // One-shot: use is_available check (same as recurring)
           if (c.schedule_mode === 'one_shot') {
-            const isAvailable = c.is_available && c.is_available[child.id];
-            if (isAvailable === false) return false;
+            if (perChild && perChild[child.id] === false) return false;
           }
           // Mode A: due days check
           if (c.schedule_mode === 'specific_days') {
@@ -458,8 +460,7 @@ class TaskMateParentDashboardCard extends LitElement {
           }
           // Mode B: recurrence availability check
           if (c.schedule_mode === 'recurring') {
-            const isAvailable = c.is_available && c.is_available[child.id];
-            if (isAvailable === false) return false;
+            if (perChild && perChild[child.id] === false) return false;
           }
           return true;
         });

--- a/custom_components/taskmate/www/taskmate-penalties-card.js
+++ b/custom_components/taskmate/www/taskmate-penalties-card.js
@@ -348,6 +348,10 @@ class TaskMatePenaltiesCard extends LitElement {
   }
 
   _getAttrs() {
+    const entityId = this.config?.entity || "sensor.taskmate_overview";
+    if (window.__taskmate_attrs) {
+      return window.__taskmate_attrs(this.hass, entityId);
+    }
     return this._getState()?.attributes || {};
   }
 

--- a/custom_components/taskmate/www/taskmate-points-card.js
+++ b/custom_components/taskmate/www/taskmate-points-card.js
@@ -635,9 +635,10 @@ class TaskMatePointsCard extends LitElement {
       `;
     }
 
-    const children = entity.attributes.children || [];
-    const pointsIcon = entity.attributes.points_icon || "mdi:star";
-    const pointsName = entity.attributes.points_name || "Stars";
+    const attrs = (window.__taskmate_attrs && window.__taskmate_attrs(this.hass, this.config.entity)) || entity.attributes || {};
+    const children = attrs.children || [];
+    const pointsIcon = attrs.points_icon || "mdi:star";
+    const pointsName = attrs.points_name || "Stars";
 
     return html`
       <ha-card>

--- a/custom_components/taskmate/www/taskmate-reorder-card.js
+++ b/custom_components/taskmate/www/taskmate-reorder-card.js
@@ -466,7 +466,8 @@ class TaskMateReorderCard extends LitElement {
       `;
     }
 
-    const children = entity.attributes.children || [];
+    const attrs = (window.__taskmate_attrs && window.__taskmate_attrs(this.hass, this.config.entity)) || entity.attributes || {};
+    const children = attrs.children || [];
     const child = children.find((c) => c.id === this.config.child_id);
     if (!child) return;
 
@@ -474,7 +475,7 @@ class TaskMateReorderCard extends LitElement {
     if (!this._hasChanges) {
       const serverOrder = child.chore_order || [];
       // Build a map of time_category -> ordered chore IDs
-      const chores = entity.attributes.chores || [];
+      const chores = attrs.chores || [];
       const childChores = this._getChoresForChild(chores, child.id);
 
       const newLocalOrder = {};
@@ -574,7 +575,8 @@ class TaskMateReorderCard extends LitElement {
       `;
     }
 
-    const children = entity.attributes.children || [];
+    const attrs = (window.__taskmate_attrs && window.__taskmate_attrs(this.hass, this.config.entity)) || entity.attributes || {};
+    const children = attrs.children || [];
     const child = children.find((c) => c.id === this.config.child_id);
 
     if (!child) {
@@ -588,7 +590,7 @@ class TaskMateReorderCard extends LitElement {
       `;
     }
 
-    const chores = entity.attributes.chores || [];
+    const chores = attrs.chores || [];
     const childChores = this._getChoresForChild(chores, child.id);
 
     if (childChores.length === 0) {
@@ -611,7 +613,7 @@ class TaskMateReorderCard extends LitElement {
     }
 
     const timeCategories = ["morning", "afternoon", "evening", "night", "anytime"];
-    const pointsIcon = entity.attributes.points_icon || "mdi:star";
+    const pointsIcon = attrs.points_icon || "mdi:star";
 
     return html`
       <ha-card>

--- a/custom_components/taskmate/www/taskmate-reward-progress-card.js
+++ b/custom_components/taskmate/www/taskmate-reward-progress-card.js
@@ -379,10 +379,11 @@ class TaskMateRewardProgressCard extends LitElement {
     if (!entity) return html`<ha-card><div class="error-state"><ha-icon icon="mdi:alert-circle"></ha-icon><div>${this._t('common.entity_not_found', { entity: this.config.entity })}</div></div></ha-card>`;
     if (entity.state === "unavailable" || entity.state === "unknown") return html`<ha-card><div class="error-state"><ha-icon icon="mdi:alert-circle"></ha-icon><div>${this._t('reward_progress.unavailable')}</div></div></ha-card>`;
 
-    const rewards = entity.attributes.rewards || [];
-    const children = entity.attributes.children || [];
-    const pointsIcon = entity.attributes.points_icon || "mdi:star";
-    const pointsName = entity.attributes.points_name || "Points";
+    const attrs = (window.__taskmate_attrs && window.__taskmate_attrs(this.hass, this.config.entity)) || entity.attributes || {};
+    const rewards = attrs.rewards || [];
+    const children = attrs.children || [];
+    const pointsIcon = attrs.points_icon || "mdi:star";
+    const pointsName = attrs.points_name || "Points";
 
     // Pick reward
     let reward = this.config.reward_id
@@ -589,9 +590,9 @@ class TaskMateRewardProgressCardEditor extends LitElement {
   setConfig(config) { this.config = config; }
 
   _buildSchema() {
-    const entity = this.config?.entity ? this.hass?.states?.[this.config.entity] : null;
-    const rewards = entity?.attributes?.rewards || [];
-    const children = entity?.attributes?.children || [];
+    const attrs = (window.__taskmate_attrs && window.__taskmate_attrs(this.hass, this.config?.entity)) || (this.config?.entity ? this.hass?.states?.[this.config.entity]?.attributes : null) || {};
+    const rewards = attrs.rewards || [];
+    const children = attrs.children || [];
     return [
       { name: 'entity', selector: { entity: { domain: 'sensor' } } },
       { name: 'title', selector: { text: {} } },

--- a/custom_components/taskmate/www/taskmate-rewards-card.js
+++ b/custom_components/taskmate/www/taskmate-rewards-card.js
@@ -812,10 +812,11 @@ class TaskMateRewardsCard extends LitElement {
       `;
     }
 
-    const allRewards = entity.attributes.rewards || [];
-    const children = entity.attributes.children || [];
-    const pointsIcon = entity.attributes.points_icon || "mdi:star";
-    const pointsName = entity.attributes.points_name || "Stars";
+    const attrs = (window.__taskmate_attrs && window.__taskmate_attrs(this.hass, this.config.entity)) || entity.attributes || {};
+    const allRewards = attrs.rewards || [];
+    const children = attrs.children || [];
+    const pointsIcon = attrs.points_icon || "mdi:star";
+    const pointsName = attrs.points_name || "Stars";
 
     // Filter rewards based on child_id if configured
     let rewards = allRewards;
@@ -976,8 +977,8 @@ class TaskMateRewardsCard extends LitElement {
     const percentage = displayCost > 0 ? Math.min((currentStars / displayCost) * 100, 100) : 0;
 
     // Pending claim check
-    const entity = this.hass?.states?.[this.config?.entity];
-    const pendingClaims = entity?.attributes?.pending_reward_claims || [];
+    const pcAttrs = (window.__taskmate_attrs && window.__taskmate_attrs(this.hass, this.config?.entity)) || this.hass?.states?.[this.config?.entity]?.attributes || {};
+    const pendingClaims = pcAttrs.pending_reward_claims || [];
     const hasPendingClaim = pendingClaims.some(c =>
       c.reward_id === reward.id && (!childId || c.child_id === childId)
     );

--- a/custom_components/taskmate/www/taskmate-streak-card.js
+++ b/custom_components/taskmate/www/taskmate-streak-card.js
@@ -234,11 +234,12 @@ class TaskMateStreakCard extends LitElement {
       return html`<ha-card><div class="error-state"><ha-icon icon="mdi:alert-circle"></ha-icon><div>${this._t('common.unavailable')}</div></div></ha-card>`;
     }
 
-    let children = entity.attributes.children || [];
+    const attrs = (window.__taskmate_attrs && window.__taskmate_attrs(this.hass, this.config.entity)) || entity.attributes || {};
+    let children = attrs.children || [];
     // Use recent_completions (all-time history, last 50) for streak/achievement calculation
-    const completions = [...(entity.attributes.recent_completions || entity.attributes.todays_completions || [])];
-    const pointsIcon = entity.attributes.points_icon || "mdi:star";
-    const chores = entity.attributes.chores || [];
+    const completions = [...(attrs.recent_completions || attrs.todays_completions || [])];
+    const pointsIcon = attrs.points_icon || "mdi:star";
+    const chores = attrs.chores || [];
 
     if (this.config.child_id) {
       children = children.filter(c => c.id === this.config.child_id);

--- a/custom_components/taskmate/www/taskmate-weekly-card.js
+++ b/custom_components/taskmate/www/taskmate-weekly-card.js
@@ -279,13 +279,14 @@ class TaskMateWeeklyCard extends LitElement {
     }
 
     const tz = this.hass?.config?.time_zone || Intl.DateTimeFormat().resolvedOptions().timeZone;
-    let children = entity.attributes.children || [];
-    const chores = entity.attributes.chores || [];
-    const pointsIcon = entity.attributes.points_icon || "mdi:star";
-    const pointsName = entity.attributes.points_name || "Stars";
+    const attrs = (window.__taskmate_attrs && window.__taskmate_attrs(this.hass, this.config.entity)) || entity.attributes || {};
+    let children = attrs.children || [];
+    const chores = attrs.chores || [];
+    const pointsIcon = attrs.points_icon || "mdi:star";
+    const pointsName = attrs.points_name || "Stars";
 
     // Use recent_completions (last 50 all-time) for full week view
-    let allCompletions = [...(entity.attributes.recent_completions || entity.attributes.todays_completions || [])];
+    let allCompletions = [...(attrs.recent_completions || attrs.todays_completions || [])];
     const seen = new Set();
     allCompletions = allCompletions.filter(comp => {
       if (seen.has(comp.completion_id)) return false;

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,8 +57,16 @@ class FakeDataUpdateCoordinator:
         """No-op in tests unless overridden."""
 
 
+class FakeCoordinatorEntity:
+    """Minimal stand-in so sensor.py's TaskMateBaseSensor can inherit from it."""
+
+    def __init__(self, coordinator):
+        self.coordinator = coordinator
+
+
 _ha_coordinator = MagicMock()
 _ha_coordinator.DataUpdateCoordinator = FakeDataUpdateCoordinator
+_ha_coordinator.CoordinatorEntity = FakeCoordinatorEntity
 
 
 # ── homeassistant.helpers.storage ───────────────────────────────────────────
@@ -84,6 +92,39 @@ _ha_storage_mod.Store = FakeStore
 
 _ha_event = MagicMock()
 _ha_event.async_track_time_change = MagicMock(return_value=lambda: None)
+
+
+# ── homeassistant.components.sensor / helpers.entity / entity_platform ─────
+# sensor.py pulls SensorEntity + SensorStateClass + DeviceInfo. These are only
+# ever touched for type hints and base-class inheritance; a MagicMock class
+# suffices for unit tests.
+
+class _FakeSensorEntity:
+    pass
+
+
+class _FakeSensorStateClass:
+    TOTAL = "total"
+    MEASUREMENT = "measurement"
+
+
+_ha_components_sensor = MagicMock()
+_ha_components_sensor.SensorEntity = _FakeSensorEntity
+_ha_components_sensor.SensorStateClass = _FakeSensorStateClass
+
+
+class _FakeDeviceInfo(dict):
+    """DeviceInfo behaves like a TypedDict; accept kwargs like the real one."""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
+_ha_helpers_entity = MagicMock()
+_ha_helpers_entity.DeviceInfo = _FakeDeviceInfo
+
+
+_ha_helpers_entity_platform = MagicMock()
 
 
 # ── homeassistant.util.dt ────────────────────────────────────────────────────
@@ -124,6 +165,10 @@ sys.modules.update(
         "homeassistant.helpers.event": _ha_event,
         "homeassistant.helpers.update_coordinator": _ha_coordinator,
         "homeassistant.helpers.config_validation": MagicMock(),
+        "homeassistant.helpers.entity": _ha_helpers_entity,
+        "homeassistant.helpers.entity_platform": _ha_helpers_entity_platform,
+        "homeassistant.components": MagicMock(),
+        "homeassistant.components.sensor": _ha_components_sensor,
         "homeassistant.util": _ha_util,
         "homeassistant.util.dt": dt_util_mock,
         # Stub the frontend sub-module so __init__.py's relative import succeeds

--- a/tests/test_sensor_attributes.py
+++ b/tests/test_sensor_attributes.py
@@ -1,0 +1,320 @@
+"""Size tests for the split TaskMate sensor attributes.
+
+The overview sensor used to pack every data slice into a single attribute
+payload, which Home Assistant's recorder drops once it exceeds 16 KB. This
+test builds a stress fixture (4 children, 30 chores, 20 rewards, 200
+completions, 50 transactions, 10 pending claims, penalties, bonuses) and
+asserts that each of the five global sensors stays below the 16384-byte
+limit for extra_state_attributes.
+"""
+from __future__ import annotations
+
+import datetime as dt
+import json
+from datetime import timezone
+from unittest.mock import MagicMock
+
+from custom_components.taskmate import sensor as sensor_module
+from .conftest import dt_util_mock
+from custom_components.taskmate.models import (
+    Bonus,
+    Child,
+    Chore,
+    ChoreCompletion,
+    Penalty,
+    PointsTransaction,
+    PoolAllocation,
+    Reward,
+    RewardClaim,
+)
+
+
+MAX_ATTR_BYTES = 16384  # Home Assistant recorder limit
+UTC = timezone.utc
+
+
+def _stress_coordinator():
+    """Build a coordinator with a deliberately large dataset."""
+    children = [
+        Child(
+            name=f"Child {i}",
+            avatar="mdi:face-man",
+            points=250 + i,
+            total_points_earned=1000 + i * 50,
+            total_chores_completed=120 + i * 10,
+            current_streak=5 + i,
+            best_streak=20 + i,
+            chore_order=[f"chore-{j:02d}" for j in range(30)],
+            last_completion_date="2026-04-19",
+            streak_milestones_achieved=[3, 7, 14],
+            awarded_perfect_weeks=["2026-W15", "2026-W16"],
+            id=f"child-{i}",
+        )
+        for i in range(4)
+    ]
+
+    chores = [
+        Chore(
+            name=f"Chore {i:02d}",
+            description=f"Do chore number {i:02d} every day without fail",
+            points=5 + (i % 10),
+            time_category="anytime",
+            daily_limit=1,
+            assigned_to=[c.id for c in children],
+            completion_sound="coin",
+            due_days=["monday", "tuesday", "wednesday"],
+            schedule_mode="specific_days",
+            recurrence="weekly",
+            recurrence_day="monday",
+            recurrence_start="2026-01-01",
+            first_occurrence_mode="available_immediately",
+            visibility_entity="",
+            visibility_operator="equals",
+            visibility_state="on",
+            enabled=True,
+            disabled_for=[],
+            created_date="2026-01-01",
+            assignment_mode="everyone",
+            assignment_rotation_anchor="2026-01-01",
+            assignment_current_child_id=children[i % 4].id,
+            publish_calendar_entities=[f"calendar.taskmate_child_{c.id}" for c in children],
+            id=f"chore-{i:02d}",
+        )
+        for i in range(30)
+    ]
+
+    rewards = [
+        Reward(
+            name=f"Reward {i:02d}",
+            cost=100 + i * 5,
+            description=f"A nice reward labeled {i:02d}",
+            icon="mdi:gift",
+            assigned_to=[c.id for c in children],
+            is_jackpot=(i % 5 == 0),
+            pool_enabled=(i % 3 == 0),
+            id=f"reward-{i:02d}",
+        )
+        for i in range(20)
+    ]
+
+    # Pin dt_util_mock._now so `_build_todays_completions` is deterministic
+    # regardless of what previous tests in the session set it to.
+    dt_util_mock._now = dt.datetime(2024, 4, 20, 9, 0, 0, tzinfo=UTC)
+    now = dt.datetime(2024, 4, 20, 9, 0, 0, tzinfo=UTC)
+    # Completions spread across ~17 days (~12 today, rest historical) so the
+    # "todays_completions" slice reflects realistic single-day volume while
+    # recent_completions still has plenty of history to exercise the cap.
+    completions = [
+        ChoreCompletion(
+            chore_id=f"chore-{i % 30:02d}",
+            child_id=children[i % 4].id,
+            completed_at=now - dt.timedelta(hours=i * 2),
+            approved=(i % 2 == 0),
+            points_awarded=5 + (i % 10),
+            id=f"completion-{i:04d}",
+        )
+        for i in range(200)
+    ]
+
+    points_transactions = [
+        PointsTransaction(
+            child_id=children[i % 4].id,
+            points=(10 if i % 2 == 0 else -5),
+            reason=f"Manual adjustment {i}",
+            created_at=now - dt.timedelta(hours=i),
+            id=f"tx-{i:03d}",
+        )
+        for i in range(50)
+    ]
+
+    pending_reward_claims = [
+        RewardClaim(
+            reward_id=f"reward-{i:02d}",
+            child_id=children[i % 4].id,
+            claimed_at=now - dt.timedelta(hours=i),
+            approved=False,
+            id=f"claim-{i:03d}",
+        )
+        for i in range(10)
+    ]
+
+    reward_claims = pending_reward_claims + [
+        RewardClaim(
+            reward_id=f"reward-{i:02d}",
+            child_id=children[i % 4].id,
+            claimed_at=now - dt.timedelta(days=i),
+            approved=True,
+            approved_at=now - dt.timedelta(days=i, hours=-1),
+            id=f"approved-claim-{i:03d}",
+        )
+        for i in range(20)
+    ]
+
+    pool_allocations = [
+        PoolAllocation(
+            child_id=children[i % 4].id,
+            reward_id=f"reward-{i % 20:02d}",
+            allocated_points=25 + i,
+            id=f"pool-{i:03d}",
+        )
+        for i in range(30)
+    ]
+
+    penalties = [
+        Penalty(
+            name=f"Penalty {i}",
+            points=10 + i,
+            description=f"Penalty description {i}",
+            icon="mdi:alert",
+            assigned_to=[c.id for c in children],
+            id=f"pen-{i}",
+        )
+        for i in range(8)
+    ]
+
+    bonuses = [
+        Bonus(
+            name=f"Bonus {i}",
+            points=15 + i,
+            description=f"Bonus description {i}",
+            icon="mdi:star",
+            assigned_to=[c.id for c in children],
+            id=f"bon-{i}",
+        )
+        for i in range(8)
+    ]
+
+    coord = MagicMock()
+    coord.data = {
+        "children": children,
+        "chores": chores,
+        "rewards": rewards,
+        "completions": completions,
+        "pending_completions": completions[:25],
+        "reward_claims": reward_claims,
+        "pending_reward_claims": pending_reward_claims,
+        "points_transactions": points_transactions,
+        "pool_allocations": pool_allocations,
+        "penalties": penalties,
+        "bonuses": bonuses,
+        "points_name": "Stars",
+        "points_icon": "mdi:star",
+        "settings": {
+            "streak_reset_mode": "reset",
+            "weekend_multiplier": "2.0",
+            "streak_milestones_enabled": "true",
+            "streak_milestones": "3:5, 7:10, 14:20, 30:50, 60:100, 100:200",
+            "perfect_week_enabled": "true",
+            "perfect_week_bonus": "50",
+        },
+    }
+    coord.is_pool_mode_claim = MagicMock(return_value=False)
+    coord.is_chore_available_for_child = MagicMock(return_value=True)
+    coord.storage = MagicMock()
+    coord.storage.get_last_completed = MagicMock(return_value={"current": "2026-04-20T08:00:00Z"})
+    return coord
+
+
+def _bytes(obj) -> int:
+    """Approximate HA's state-attributes byte size."""
+    return len(json.dumps(obj, default=str).encode("utf-8"))
+
+
+def _assert_slice_under_limit(name: str, attrs: dict) -> None:
+    size = _bytes(attrs)
+    assert size < MAX_ATTR_BYTES, (
+        f"{name} attribute payload is {size} bytes — exceeds the "
+        f"{MAX_ATTR_BYTES}-byte recorder limit"
+    )
+
+
+def test_overview_slice_under_limit():
+    coord = _stress_coordinator()
+    common = sensor_module._compute_common(coord)
+    scalars = {
+        "today_day_of_week": "monday",
+        "streak_reset_mode": "reset",
+        "weekend_multiplier": 2.0,
+        "streak_milestones_enabled": True,
+        "streak_milestones": "3:5, 7:10, 14:20, 30:50, 60:100, 100:200",
+        "perfect_week_enabled": True,
+        "perfect_week_bonus": 50,
+        "total_children": len(common["children"]),
+        "total_chores": len(common["chores"]),
+        "total_rewards": len(common["rewards"]),
+        "total_points_available": sum(c.points for c in common["children"]),
+        "total_chores_completed": sum(c.total_chores_completed for c in common["children"]),
+        "total_completions_all_time": len(common["all_completions"]),
+        "total_pending_completions": len(common["pending_completions"]),
+        "points_name": "Stars",
+        "points_icon": "mdi:star",
+        "children": sensor_module._build_children_summary(common),
+    }
+    _assert_slice_under_limit("taskmate_overview", scalars)
+
+
+def test_chores_slice_under_limit():
+    coord = _stress_coordinator()
+    common = sensor_module._compute_common(coord)
+    attrs = {
+        "chores": sensor_module._build_chores_list(coord, common),
+        "todays_completions": sensor_module._build_todays_completions(common),
+    }
+    _assert_slice_under_limit("taskmate_chores", attrs)
+
+
+def test_chore_availability_slice_under_limit():
+    coord = _stress_coordinator()
+    common = sensor_module._compute_common(coord)
+    attrs = {
+        "chore_availability": sensor_module._build_chore_availability(coord, common),
+    }
+    _assert_slice_under_limit("taskmate_chore_availability", attrs)
+
+
+def test_rewards_slice_under_limit():
+    coord = _stress_coordinator()
+    common = sensor_module._compute_common(coord)
+    attrs = {
+        "rewards": sensor_module._build_rewards_list(common),
+        "pending_reward_claims": sensor_module._build_pending_reward_claims(common),
+        "pool_allocations": [pa.to_dict() for pa in common["pool_alloc_objs"]],
+    }
+    _assert_slice_under_limit("taskmate_rewards", attrs)
+
+
+def test_activity_slice_under_limit():
+    coord = _stress_coordinator()
+    common = sensor_module._compute_common(coord)
+    attrs = {
+        "recent_completions": sensor_module._build_recent_completions(common),
+        "recent_transactions": sensor_module._build_recent_transactions(common),
+    }
+    _assert_slice_under_limit("taskmate_activity", attrs)
+
+
+def test_incentives_slice_under_limit():
+    coord = _stress_coordinator()
+    common = sensor_module._compute_common(coord)
+    attrs = {
+        "penalties": sensor_module._build_penalties_list(common),
+        "bonuses": sensor_module._build_bonuses_list(common),
+    }
+    _assert_slice_under_limit("taskmate_incentives", attrs)
+
+
+def test_common_context_is_cached_per_coordinator_update():
+    coord = _stress_coordinator()
+    first = sensor_module._compute_common(coord)
+    second = sensor_module._compute_common(coord)
+    # Same underlying coordinator.data id => cached dict is returned by reference
+    assert first is second
+
+
+def test_common_context_rebuilds_when_data_identity_changes():
+    coord = _stress_coordinator()
+    before = sensor_module._compute_common(coord)
+    # Replace coordinator.data with a fresh dict to invalidate the cache
+    coord.data = dict(coord.data)
+    after = sensor_module._compute_common(coord)
+    assert before is not after


### PR DESCRIPTION
## Summary

Fixes the Home Assistant log warning:

> State attributes for sensor.taskmate_overview exceed maximum size of 16384 bytes. This can cause database performance issues; Attributes will not be stored

The overview sensor previously packed every slice (children, chores, rewards, 200 recent completions, 50 recent transactions, penalties, bonuses, pool allocations) into one attribute payload, which exceeded the 16 KB recorder cap and was dropped from history.

## Approach

Split the payload across six sensors on the same coordinator:

| Entity | Owns |
|---|---|
| `sensor.taskmate_overview` | scalars + compact `children` summary |
| `sensor.taskmate_chores` | chores list + `todays_completions` |
| `sensor.taskmate_chore_availability` | per-chore × per-child availability matrix |
| `sensor.taskmate_rewards` | rewards + `pending_reward_claims` + `pool_allocations` |
| `sensor.taskmate_activity` | `recent_completions` (cap 35) + `recent_transactions` (cap 20) |
| `sensor.taskmate_incentives` | penalties + bonuses |

A new global module (`taskmate-attr-resolver.js`) merges companion attributes at render time, so **every existing Lovelace dashboard that configures `entity: sensor.taskmate_overview` keeps working with zero YAML migration**. Cards that only touch kept attributes (`points_name`, `points_icon`, `today_day_of_week`, `children`) are unchanged.

Backend builders are extracted to module-level helpers with a shared coordinator-attached cache so the common context is computed once per update.

## Test plan

- [x] `pytest tests/` — 198 tests pass, including 8 new sensor size assertions that build a stress fixture (4 children, 30 chores, 20 rewards, 200 completions, 50 transactions, 30 pool allocations) and assert every new sensor's attribute payload JSON-encodes to < 16 384 bytes.
- [x] `node --check` on every card JS (20 files) — all parse clean.
- [ ] Install on a live HA instance, open Developer Tools → States, confirm no sensor exceeds 16 KB and the recorder warning is gone.
- [ ] UI smoke test: load every TaskMate Lovelace card against an **existing dashboard still pointing at `sensor.taskmate_overview`** (no YAML edits) and verify children/points/chores/rewards/activity/penalties/bonuses render as before.
- [ ] Fallback test: temporarily disable one companion sensor in the entity registry, confirm cards fall back to the overview sensor's attributes gracefully (no blank card, no JS error).

Bumped manifest to `3.2.0-beta5` and added a "Sensors Exposed" section to the README.