### PR TITLE
feat(calendar): project chore assignments N days ahead into HA calendars

### DIFF
--- a/custom_components/taskmate/config_flow.py
+++ b/custom_components/taskmate/config_flow.py
@@ -16,11 +16,14 @@ from .const import (
     AVATAR_OPTIONS,
     COMPLETION_SOUND_OPTIONS,
     DAYS_OF_WEEK,
+    DEFAULT_CALENDAR_PROJECTION_DAYS,
     DEFAULT_CLAIM_ALLOWANCE_MINUTES,
     DEFAULT_COMPLETION_SOUND,
     DEFAULT_POINTS_ICON,
     DEFAULT_POINTS_NAME,
     DOMAIN,
+    MAX_CALENDAR_PROJECTION_DAYS,
+    MIN_CALENDAR_PROJECTION_DAYS,
     RECURRENCE_OPTIONS,
     REWARD_ICON_OPTIONS,
     TIME_CATEGORIES,
@@ -1234,6 +1237,12 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
                 "notify_service",
                 user_input.get("notify_service", "").strip(),
             )
+            self.coordinator.storage.set_setting(
+                "calendar_projection_days",
+                str(int(float(user_input.get(
+                    "calendar_projection_days", DEFAULT_CALENDAR_PROJECTION_DAYS
+                )))),
+            )
             # Single save and refresh for all settings
             await self.coordinator.storage.async_save()
             await self.coordinator.async_refresh()
@@ -1258,6 +1267,16 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
         except (ValueError, TypeError):
             current_perfect_week_bonus = 50.0
         current_notify_service = self.coordinator.storage.get_setting("notify_service", "")
+        try:
+            current_calendar_projection_days = int(float(self.coordinator.storage.get_setting(
+                "calendar_projection_days", str(DEFAULT_CALENDAR_PROJECTION_DAYS)
+            )))
+        except (ValueError, TypeError):
+            current_calendar_projection_days = DEFAULT_CALENDAR_PROJECTION_DAYS
+        current_calendar_projection_days = max(
+            MIN_CALENDAR_PROJECTION_DAYS,
+            min(MAX_CALENDAR_PROJECTION_DAYS, current_calendar_projection_days),
+        )
 
         return self.async_show_form(
             step_id="settings",
@@ -1333,6 +1352,18 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
                         default=current_notify_service,
                     ): selector.TextSelector(
                         selector.TextSelectorConfig(multiline=False)
+                    ),
+                    vol.Required(
+                        "calendar_projection_days",
+                        default=current_calendar_projection_days,
+                    ): selector.NumberSelector(
+                        selector.NumberSelectorConfig(
+                            min=MIN_CALENDAR_PROJECTION_DAYS,
+                            max=MAX_CALENDAR_PROJECTION_DAYS,
+                            step=1,
+                            mode=selector.NumberSelectorMode.BOX,
+                            unit_of_measurement="days",
+                        )
                     ),
                 }
             ),

--- a/custom_components/taskmate/const.py
+++ b/custom_components/taskmate/const.py
@@ -30,6 +30,14 @@ CONF_CHORE_ASSIGNMENT_MODE: Final = "assignment_mode"
 CONF_CHORE_ASSIGNMENT_ROTATION_ANCHOR: Final = "assignment_rotation_anchor"
 CONF_CHORE_PUBLISH_CALENDARS: Final = "publish_calendar_entities"
 
+# Calendar projection: how many days ahead each chore's assignment is pushed
+# into the configured HA calendars. 14 days balances planning visibility with
+# calendar noise; raise via the Settings flow for longer planning horizons.
+CONF_CALENDAR_PROJECTION_DAYS: Final = "calendar_projection_days"
+DEFAULT_CALENDAR_PROJECTION_DAYS: Final = 14
+MIN_CALENDAR_PROJECTION_DAYS: Final = 1
+MAX_CALENDAR_PROJECTION_DAYS: Final = 90
+
 # Assignment modes
 # "everyone"    = visible to every child in assigned_to (or all children if empty) -- existing behavior
 # "alternating" = round-robin through assigned_to (or all children), one child per calendar day

--- a/custom_components/taskmate/coordinator.py
+++ b/custom_components/taskmate/coordinator.py
@@ -13,7 +13,12 @@ from homeassistant.helpers.event import async_track_time_change
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.util import dt as dt_util
 
-from .const import DOMAIN
+from .const import (
+    DEFAULT_CALENDAR_PROJECTION_DAYS,
+    DOMAIN,
+    MAX_CALENDAR_PROJECTION_DAYS,
+    MIN_CALENDAR_PROJECTION_DAYS,
+)
 from .models import Bonus, Child, Chore, ChoreCompletion, Penalty, PoolAllocation, Reward, RewardClaim, PointsTransaction
 from .storage import TaskMateStorage
 
@@ -376,33 +381,17 @@ class TaskMateCoordinator(DataUpdateCoordinator):
             chore.assignment_current_child_id = active[0] if active else ""
         else:
             chore.assignment_current_child_id = ""
-        # If anything calendar-user-visible changed (name, active child, time window,
-        # or entity list), purge the previous events from every calendar the chore
-        # used to publish to — including ones the user just removed — and then
-        # re-publish to the current list. Otherwise the guard skips re-publish.
+        # Any edit to a chore with calendar publishing can shift which dates
+        # project to which child (new assignment_mode, anchor, due_days,
+        # recurrence, rename, time_category, entity list, etc.), so purge the
+        # entire horizon from both the old and new calendar sets and let the
+        # following publish pass re-write the projection.
         existing = self.storage.get_chore(chore.id)
-        cleanup_entities: list[str] = []
-        should_republish = False
-        if existing is not None:
-            prev_entities = list(getattr(existing, "publish_calendar_entities", []) or [])
-            new_entities = list(chore.publish_calendar_entities or [])
-            prev_name = getattr(existing, "name", "")
-            prev_active = getattr(existing, "assignment_current_child_id", "")
-            prev_category = getattr(existing, "time_category", "anytime")
-            if (
-                set(new_entities) != set(prev_entities)
-                or chore.name != prev_name
-                or chore.assignment_current_child_id != prev_active
-                or getattr(chore, "time_category", "anytime") != prev_category
-            ):
-                # Purge from every calendar that ever had this chore — new ones will
-                # be cleaned along with old, so republish produces a fresh event.
-                cleanup_entities = list({*prev_entities, *new_entities})
-                should_republish = True
+        prev_entities = list(getattr(existing, "publish_calendar_entities", []) or []) if existing else []
+        new_entities = list(chore.publish_calendar_entities or [])
+        cleanup_entities = list({*prev_entities, *new_entities})
         if cleanup_entities:
             await self._cleanup_chore_from_calendars(chore, cleanup_entities, today)
-        elif should_republish:
-            chore.publish_calendar_last_date = ""
         self.storage.update_chore(chore)
         await self._publish_chore_to_calendars(chore, today)
         await self.storage.async_save()
@@ -624,14 +613,131 @@ class TaskMateCoordinator(DataUpdateCoordinator):
         """Marker stitched into the event description so we can find our own events."""
         return f"taskmate:chore:{chore.id}"
 
-    async def _publish_chore_to_calendars(self, chore: Chore, today: date | None = None) -> None:
-        """Publish today's assignment for `chore` to every entity in publish_calendar_entities.
+    def _calendar_projection_days(self) -> int:
+        """Return the configured projection horizon, clamped to the allowed range."""
+        try:
+            raw = int(float(self.storage.get_setting(
+                "calendar_projection_days", str(DEFAULT_CALENDAR_PROJECTION_DAYS)
+            )))
+        except (TypeError, ValueError):
+            raw = DEFAULT_CALENDAR_PROJECTION_DAYS
+        return max(MIN_CALENDAR_PROJECTION_DAYS, min(MAX_CALENDAR_PROJECTION_DAYS, raw))
 
-        Idempotent per calendar-day thanks to `publish_calendar_last_date`. Fans
-        out all create_event service calls via asyncio.gather so N entities per
-        chore scale with the slowest single call, not the sum of them. When the
-        chore has a non-"anytime" time_category the event is timed to that
-        window; otherwise it's an all-day event.
+    _SCHEDULE_DOW = ("monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday")
+
+    def _is_chore_scheduled_for_date(self, chore: Chore, day: date) -> bool:
+        """Return True if the chore's schedule places it on `day`.
+
+        Mirrors the client-side `_isChoreScheduledOn` in taskmate-calendar-card.js
+        so the HA calendar projection matches what the card shows. Does not
+        consult completion state — this is purely the recurrence/schedule math.
+        """
+        if not getattr(chore, "enabled", True):
+            return False
+
+        schedule_mode = getattr(chore, "schedule_mode", "specific_days")
+        created_iso = getattr(chore, "created_date", "") or ""
+
+        if schedule_mode == "one_shot":
+            return bool(created_iso) and created_iso == day.isoformat()
+
+        if created_iso:
+            try:
+                if day < date.fromisoformat(created_iso):
+                    return False
+            except ValueError:
+                pass
+
+        if schedule_mode == "specific_days":
+            due_days = list(getattr(chore, "due_days", []) or [])
+            if not due_days:
+                return True
+            return self._SCHEDULE_DOW[day.weekday()] in due_days
+
+        if schedule_mode != "recurring":
+            return False
+
+        recurrence = getattr(chore, "recurrence", "weekly")
+        recurrence_day = (getattr(chore, "recurrence_day", "") or "").lower()
+        recurrence_start = getattr(chore, "recurrence_start", "") or ""
+        day_dow = self._SCHEDULE_DOW[day.weekday()]
+
+        if recurrence_day and recurrence in ("weekly", "every_2_weeks"):
+            if recurrence_day != day_dow:
+                return False
+            if recurrence == "every_2_weeks" and recurrence_start:
+                try:
+                    anchor = date.fromisoformat(recurrence_start)
+                    diff = (day - anchor).days
+                    if diff < 0 or (diff // 7) % 2 != 0:
+                        return False
+                except ValueError:
+                    pass
+            return True
+
+        if recurrence == "every_2_days" and recurrence_start:
+            try:
+                anchor = date.fromisoformat(recurrence_start)
+                diff = (day - anchor).days
+                return diff >= 0 and diff % 2 == 0
+            except ValueError:
+                return False
+
+        if recurrence == "monthly" and recurrence_start:
+            try:
+                anchor = date.fromisoformat(recurrence_start)
+                if day < anchor:
+                    return False
+                return day.day == anchor.day
+            except ValueError:
+                return False
+
+        # Weekly/every_2_weeks without an explicit day: same weekday as today,
+        # matching the card's fallback for loosely-scheduled recurrences.
+        if recurrence in ("weekly", "every_2_weeks"):
+            today = dt_util.as_local(dt_util.now()).date()
+            return day.weekday() == today.weekday()
+
+        return False
+
+    def _build_event_payload(self, chore: Chore, day: date, summary: str) -> dict:
+        """Build the calendar.create_event payload for one (chore, day)."""
+        description = self._chore_event_marker(chore)
+        window = self._time_category_window(
+            getattr(chore, "time_category", "anytime"), day
+        )
+        if window is None:
+            return {
+                "summary": summary,
+                "description": description,
+                "start_date": day.isoformat(),
+                "end_date": (day + timedelta(days=1)).isoformat(),
+            }
+        start_dt, end_dt = window
+        return {
+            "summary": summary,
+            "description": description,
+            "start_date_time": start_dt.isoformat(),
+            "end_date_time": end_dt.isoformat(),
+        }
+
+    def _child_name_for_day(self, chore: Chore, day: date) -> str:
+        """Return the display name for the chore's assignee on `day`."""
+        active = self._compute_active_children(chore, day)
+        if not active:
+            return "Everyone"
+        child = self.storage.get_child(active[0])
+        return child.name if child else "Everyone"
+
+    async def _publish_chore_to_calendars(self, chore: Chore, today: date | None = None) -> None:
+        """Publish assignments for `chore` across the configured projection horizon.
+
+        For every date in [today, today + horizon) that the schedule covers and
+        hasn't already been published, computes that date's active child and
+        writes an event to each configured calendar. Past entries are pruned
+        from `publish_calendar_published_dates` so the list doesn't grow
+        unbounded. Fan-out is via asyncio.gather so N entities × M missing
+        days scale with the slowest single service call.
         """
         entities = list(getattr(chore, "publish_calendar_entities", []) or [])
         if not entities:
@@ -639,44 +745,36 @@ class TaskMateCoordinator(DataUpdateCoordinator):
 
         if today is None:
             today = dt_util.as_local(dt_util.now()).date()
-        today_iso = today.isoformat()
-        if getattr(chore, "publish_calendar_last_date", "") == today_iso:
+        horizon = self._calendar_projection_days()
+
+        published = set(getattr(chore, "publish_calendar_published_dates", []) or [])
+        # Prune stale entries (strictly before today) so the list stays small.
+        published = {iso for iso in published if iso >= today.isoformat()}
+
+        pending: list[tuple[date, dict]] = []
+        for offset in range(horizon):
+            day = today + timedelta(days=offset)
+            day_iso = day.isoformat()
+            if day_iso in published:
+                continue
+            if not self._is_chore_scheduled_for_date(chore, day):
+                continue
+            summary = f"{chore.name} — {self._child_name_for_day(chore, day)}"
+            pending.append((day, self._build_event_payload(chore, day, summary)))
+
+        if not pending and not published.symmetric_difference(
+            getattr(chore, "publish_calendar_published_dates", []) or []
+        ):
+            # Nothing to publish and nothing pruned — leave the chore untouched
+            # so the caller doesn't write the record out for no reason.
             return
 
-        active = self._compute_active_children(chore, today)
-        if active:
-            child = self.storage.get_child(active[0])
-            child_name = child.name if child else "Everyone"
-        else:
-            child_name = "Everyone"
-
-        summary = f"{chore.name} — {child_name}"
-        description = self._chore_event_marker(chore)
-        window = self._time_category_window(getattr(chore, "time_category", "anytime"), today)
-
-        if window is None:
-            end = today + timedelta(days=1)
-            event_payload = {
-                "summary": summary,
-                "description": description,
-                "start_date": today_iso,
-                "end_date": end.isoformat(),
-            }
-        else:
-            start_dt, end_dt = window
-            event_payload = {
-                "summary": summary,
-                "description": description,
-                "start_date_time": start_dt.isoformat(),
-                "end_date_time": end_dt.isoformat(),
-            }
-
-        async def _call(entity_id: str) -> None:
+        async def _call(entity_id: str, payload: dict) -> None:
             try:
                 await self.hass.services.async_call(
                     "calendar",
                     "create_event",
-                    {"entity_id": entity_id, **event_payload},
+                    {"entity_id": entity_id, **payload},
                     blocking=True,
                 )
             except Exception as err:  # noqa: BLE001 - HA service errors vary
@@ -687,8 +785,13 @@ class TaskMateCoordinator(DataUpdateCoordinator):
                     err,
                 )
 
-        await asyncio.gather(*(_call(e) for e in entities), return_exceptions=True)
-        chore.publish_calendar_last_date = today_iso
+        tasks = [_call(e, payload) for day, payload in pending for e in entities]
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+            for day, _ in pending:
+                published.add(day.isoformat())
+
+        chore.publish_calendar_published_dates = sorted(published)
 
     async def _cleanup_chore_from_calendars(
         self,
@@ -699,9 +802,9 @@ class TaskMateCoordinator(DataUpdateCoordinator):
         """Best-effort delete of the chore's own events from each configured calendar.
 
         Uses a description marker (`taskmate:chore:<id>`) stitched in at create
-        time to re-identify events. Covers today through +30 days so future
-        calendar entries for this chore — if any — are also cleaned up. Failure
-        modes (unavailable calendar, integration without delete_event support,
+        time to re-identify events. Covers today through today+horizon+7 so the
+        full projection range is cleaned up on edit/delete. Failure modes
+        (unavailable calendar, integration without delete_event support,
         response service disabled) are caught and logged; cleanup never blocks
         the caller.
         """
@@ -711,8 +814,9 @@ class TaskMateCoordinator(DataUpdateCoordinator):
 
         if today is None:
             today = dt_util.as_local(dt_util.now()).date()
+        window_days = max(30, self._calendar_projection_days() + 7)
         window_start = datetime.combine(today, time(0, 0)).isoformat()
-        window_end = datetime.combine(today + timedelta(days=30), time(0, 0)).isoformat()
+        window_end = datetime.combine(today + timedelta(days=window_days), time(0, 0)).isoformat()
         marker = self._chore_event_marker(chore)
 
         async def _purge(entity_id: str) -> None:
@@ -766,7 +870,7 @@ class TaskMateCoordinator(DataUpdateCoordinator):
                     )
 
         await asyncio.gather(*(_purge(e) for e in ents), return_exceptions=True)
-        chore.publish_calendar_last_date = ""
+        chore.publish_calendar_published_dates = []
 
     async def _async_refresh_assignments_and_publish(self) -> None:
         """Recompute today's active child per chore and publish to calendars.
@@ -786,9 +890,9 @@ class TaskMateCoordinator(DataUpdateCoordinator):
             if getattr(chore, "assignment_current_child_id", "") != desired:
                 chore.assignment_current_child_id = desired
                 dirty = True
-            before = getattr(chore, "publish_calendar_last_date", "")
+            before = list(getattr(chore, "publish_calendar_published_dates", []) or [])
             await self._publish_chore_to_calendars(chore, today)
-            if getattr(chore, "publish_calendar_last_date", "") != before:
+            if list(getattr(chore, "publish_calendar_published_dates", []) or []) != before:
                 dirty = True
             if dirty:
                 self.storage.update_chore(chore)

--- a/custom_components/taskmate/manifest.json
+++ b/custom_components/taskmate/manifest.json
@@ -15,5 +15,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/tempus2016/taskmate/issues",
   "requirements": [],
-  "version": "3.2.0"
+  "version": "3.2.1"
 }

--- a/custom_components/taskmate/models.py
+++ b/custom_components/taskmate/models.py
@@ -154,7 +154,10 @@ class Chore:
     assignment_current_child_id: str = ""  # cached active child ID for today (computed at midnight and on create/update)
     # Calendar publish: list of HA calendar entity ids to mirror the chore to. Any number supported.
     publish_calendar_entities: list[str] = field(default_factory=list)
-    publish_calendar_last_date: str = ""  # ISO date guarding against duplicate publishes on the same day
+    # ISO dates already written to the configured calendars. Used for both
+    # idempotence (don't re-publish the same day) and projection cleanup
+    # (entries < today are pruned before each publish pass).
+    publish_calendar_published_dates: list[str] = field(default_factory=list)
     id: str = field(default_factory=generate_id)
 
     @classmethod
@@ -193,7 +196,13 @@ class Chore:
             assignment_rotation_anchor=data.get("assignment_rotation_anchor", ""),
             assignment_current_child_id=data.get("assignment_current_child_id", ""),
             publish_calendar_entities=list(data.get("publish_calendar_entities", [])),
-            publish_calendar_last_date=data.get("publish_calendar_last_date", ""),
+            # Back-compat: old records stored a single ISO date in
+            # `publish_calendar_last_date`. Seed the new list with it so we
+            # don't immediately republish today on the next tick after upgrade.
+            publish_calendar_published_dates=(
+                list(data.get("publish_calendar_published_dates", []))
+                or ([data["publish_calendar_last_date"]] if data.get("publish_calendar_last_date") else [])
+            ),
             id=data.get("id", generate_id()),
         )
 
@@ -225,7 +234,7 @@ class Chore:
             "assignment_rotation_anchor": self.assignment_rotation_anchor,
             "assignment_current_child_id": self.assignment_current_child_id,
             "publish_calendar_entities": self.publish_calendar_entities,
-            "publish_calendar_last_date": self.publish_calendar_last_date,
+            "publish_calendar_published_dates": self.publish_calendar_published_dates,
             "id": self.id,
         }
 

--- a/custom_components/taskmate/strings.json
+++ b/custom_components/taskmate/strings.json
@@ -219,7 +219,8 @@
           "perfect_week_enabled": "Perfect Week Bonus",
           "perfect_week_bonus": "Perfect Week Bonus Points",
           "streak_milestones": "Streak Milestone Configuration",
-          "notify_service": "Notification Service (optional)"
+          "notify_service": "Notification Service (optional)",
+          "calendar_projection_days": "Calendar Planning Horizon"
         },
         "data_description": {
           "streak_reset_mode": "What happens to a streak when a day is missed",
@@ -229,7 +230,8 @@
           "perfect_week_enabled": "Award bonus points when a child completes at least one chore every day for a full week",
           "perfect_week_bonus": "Bonus points awarded for a perfect week",
           "streak_milestones": "Custom milestones as 'days:points' pairs, comma-separated. Example: 3:5, 7:10, 14:20, 30:50, 60:100, 100:200",
-          "notify_service": "HA notification service to alert parents when a chore requires approval. Format: notify.mobile_app_your_phone — leave empty to use persistent notifications only"
+          "notify_service": "HA notification service to alert parents when a chore requires approval. Format: notify.mobile_app_your_phone — leave empty to use persistent notifications only",
+          "calendar_projection_days": "How many days ahead each chore publishes assignments into the configured HA calendars (1-90). Larger values show more planning horizon at the cost of more calendar entries."
         }
       },
       "chore_schedule_specific": {

--- a/custom_components/taskmate/translations/en-GB.json
+++ b/custom_components/taskmate/translations/en-GB.json
@@ -219,7 +219,8 @@
           "perfect_week_enabled": "Perfect Week Bonus",
           "perfect_week_bonus": "Perfect Week Bonus Points",
           "streak_milestones": "Streak Milestone Configuration",
-          "notify_service": "Notification Service (optional)"
+          "notify_service": "Notification Service (optional)",
+          "calendar_projection_days": "Calendar Planning Horizon"
         },
         "data_description": {
           "streak_reset_mode": "What happens to a streak when a day is missed",
@@ -229,7 +230,8 @@
           "perfect_week_enabled": "Award bonus points when a child completes at least one chore every day for a full week",
           "perfect_week_bonus": "Bonus points awarded for a perfect week",
           "streak_milestones": "Custom milestones as 'days:points' pairs, comma-separated. Example: 3:5, 7:10, 14:20, 30:50, 60:100, 100:200",
-          "notify_service": "HA notification service to alert parents when a chore requires approval. Format: notify.mobile_app_your_phone — leave empty to use persistent notifications only"
+          "notify_service": "HA notification service to alert parents when a chore requires approval. Format: notify.mobile_app_your_phone — leave empty to use persistent notifications only",
+          "calendar_projection_days": "How many days ahead each chore publishes assignments into the configured HA calendars (1-90). Larger values show more planning horizon at the cost of more calendar entries."
         }
       },
       "chore_schedule_specific": {

--- a/custom_components/taskmate/translations/en.json
+++ b/custom_components/taskmate/translations/en.json
@@ -219,7 +219,8 @@
           "perfect_week_enabled": "Perfect Week Bonus",
           "perfect_week_bonus": "Perfect Week Bonus Points",
           "streak_milestones": "Streak Milestone Configuration",
-          "notify_service": "Notification Service (optional)"
+          "notify_service": "Notification Service (optional)",
+          "calendar_projection_days": "Calendar Planning Horizon"
         },
         "data_description": {
           "streak_reset_mode": "What happens to a streak when a day is missed",
@@ -229,7 +230,8 @@
           "perfect_week_enabled": "Award bonus points when a child completes at least one chore every day for a full week",
           "perfect_week_bonus": "Bonus points awarded for a perfect week",
           "streak_milestones": "Custom milestones as 'days:points' pairs, comma-separated. Example: 3:5, 7:10, 14:20, 30:50, 60:100, 100:200",
-          "notify_service": "HA notification service to alert parents when a chore requires approval. Format: notify.mobile_app_your_phone — leave empty to use persistent notifications only"
+          "notify_service": "HA notification service to alert parents when a chore requires approval. Format: notify.mobile_app_your_phone — leave empty to use persistent notifications only",
+          "calendar_projection_days": "How many days ahead each chore publishes assignments into the configured HA calendars (1-90). Larger values show more planning horizon at the cost of more calendar entries."
         }
       },
       "chore_schedule_specific": {

--- a/custom_components/taskmate/translations/fr.json
+++ b/custom_components/taskmate/translations/fr.json
@@ -215,7 +215,8 @@
           "perfect_week_enabled": "Bonus de semaine parfaite",
           "perfect_week_bonus": "Bonus semaine parfaite",
           "streak_milestones": "Configuration des paliers de série",
-          "notify_service": "Service de notification (optionnel)"
+          "notify_service": "Service de notification (optionnel)",
+          "calendar_projection_days": "Horizon de planification du calendrier"
         },
         "data_description": {
           "streak_reset_mode": "Ce qui arrive à une série lorsqu'un jour est manqué",
@@ -225,7 +226,8 @@
           "perfect_week_enabled": "Accorder des points bonus lorsqu'un enfant termine au moins une corvée chaque jour pendant une semaine complète",
           "perfect_week_bonus": "Points bonus accordés pour une semaine parfaite",
           "streak_milestones": "Paliers personnalisés sous forme de paires 'jours:points', séparées par des virgules. Exemple : 3:5, 7:10, 14:20",
-          "notify_service": "Service de notification HA pour alerter les parents lorsqu'une corvée nécessite une approbation. Format : notify.mobile_app_votre_telephone"
+          "notify_service": "Service de notification HA pour alerter les parents lorsqu'une corvée nécessite une approbation. Format : notify.mobile_app_votre_telephone",
+          "calendar_projection_days": "Nombre de jours à l'avance que chaque corvée publie dans les calendriers HA configurés (1-90). Plus la valeur est élevée, plus la visibilité est grande au prix d'entrées de calendrier supplémentaires."
         }
       },
       "chore_schedule_specific": {

--- a/custom_components/taskmate/translations/nb.json
+++ b/custom_components/taskmate/translations/nb.json
@@ -215,7 +215,8 @@
           "perfect_week_enabled": "Perfekt uke-bonus",
           "perfect_week_bonus": "Perfekt uke-bonuspoeng",
           "streak_milestones": "Rekke-milepælkonfigurasjon",
-          "notify_service": "Varslingstjeneste (valgfritt)"
+          "notify_service": "Varslingstjeneste (valgfritt)",
+          "calendar_projection_days": "Kalenderplanhorisont"
         },
         "data_description": {
           "streak_reset_mode": "Hva som skjer med en rekke når en dag hoppes over",
@@ -225,7 +226,8 @@
           "perfect_week_enabled": "Gi bonuspoeng når et barn fullfører minst én oppgave hver dag i en hel uke",
           "perfect_week_bonus": "Bonuspoeng tildelt for en perfekt uke",
           "streak_milestones": "Egendefinerte milepæler som 'dager:poeng'-par, kommaseparert. Eksempel: 3:5, 7:10, 14:20, 30:50, 60:100, 100:200",
-          "notify_service": "HA-varslingstjeneste for å varsle foreldre når en oppgave krever godkjenning. Format: notify.mobile_app_din_telefon — la stå tom for kun vedvarende varsler"
+          "notify_service": "HA-varslingstjeneste for å varsle foreldre når en oppgave krever godkjenning. Format: notify.mobile_app_din_telefon — la stå tom for kun vedvarende varsler",
+          "calendar_projection_days": "Hvor mange dager frem i tid hver oppgave publiserer oppdrag til de konfigurerte HA-kalenderne (1–90). Høyere verdier gir mer planleggingsoversikt, men flere kalenderoppføringer."
         }
       },
       "chore_schedule_specific": {

--- a/custom_components/taskmate/translations/nn.json
+++ b/custom_components/taskmate/translations/nn.json
@@ -215,7 +215,8 @@
           "perfect_week_enabled": "Perfekt veke-bonus",
           "perfect_week_bonus": "Perfekt veke-bonuspoeng",
           "streak_milestones": "Rekke-milepælkonfigurasjon",
-          "notify_service": "Varslingsteneste (valfritt)"
+          "notify_service": "Varslingsteneste (valfritt)",
+          "calendar_projection_days": "Kalenderplanhorisont"
         },
         "data_description": {
           "streak_reset_mode": "Kva som skjer med ei rekke når ein dag vert hoppa over",
@@ -225,7 +226,8 @@
           "perfect_week_enabled": "Gje bonuspoeng når eit born fullfører minst éi oppgåve kvar dag i ei heil veke",
           "perfect_week_bonus": "Bonuspoeng tildelt for ei perfekt veke",
           "streak_milestones": "Eigendefinerte milepælar som 'dagar:poeng'-par, kommaseparert. Døme: 3:5, 7:10, 14:20, 30:50, 60:100, 100:200",
-          "notify_service": "HA-varslingsteneste for å varsle foreldre når ei oppgåve krev godkjenning. Format: notify.mobile_app_din_telefon — lat stå tom for berre vedvarande varsel"
+          "notify_service": "HA-varslingsteneste for å varsle foreldre når ei oppgåve krev godkjenning. Format: notify.mobile_app_din_telefon — lat stå tom for berre vedvarande varsel",
+          "calendar_projection_days": "Kor mange dagar framover kvar oppgåve publiserer oppdrag til dei konfigurerte HA-kalenderane (1–90). Høgare verdiar gir meir planoversikt, men fleire kalenderoppføringar."
         }
       },
       "chore_schedule_specific": {

--- a/custom_components/taskmate/translations/pt-BR.json
+++ b/custom_components/taskmate/translations/pt-BR.json
@@ -215,7 +215,8 @@
           "perfect_week_enabled": "Bónus de semana perfeita",
           "perfect_week_bonus": "Pontos de bónus de semana perfeita",
           "streak_milestones": "Configuração de marcos de sequência",
-          "notify_service": "Serviço de notificação (opcional)"
+          "notify_service": "Serviço de notificação (opcional)",
+          "calendar_projection_days": "Horizonte de planejamento do calendário"
         },
         "data_description": {
           "streak_reset_mode": "O que acontece a uma sequência quando um dia é falhado",
@@ -225,7 +226,8 @@
           "perfect_week_enabled": "Atribuir pontos de bónus quando uma criança completa pelo menos uma tarefa todos os dias durante uma semana inteira",
           "perfect_week_bonus": "Pontos de bónus atribuídos por uma semana perfeita",
           "streak_milestones": "Marcos personalizados como pares 'dias:pontos', separados por vírgulas. Exemplo: 3:5, 7:10, 14:20, 30:50, 60:100, 100:200",
-          "notify_service": "Serviço de notificação do HA para alertar os pais quando uma tarefa requer aprovação. Formato: notify.mobile_app_seu_telefone — deixe vazio para usar apenas notificações persistentes"
+          "notify_service": "Serviço de notificação do HA para alertar os pais quando uma tarefa requer aprovação. Formato: notify.mobile_app_seu_telefone — deixe vazio para usar apenas notificações persistentes",
+          "calendar_projection_days": "Quantos dias à frente cada tarefa publica atribuições nos calendários HA configurados (1-90). Valores maiores mostram mais horizonte de planejamento ao custo de mais entradas de calendário."
         }
       },
       "chore_schedule_specific": {

--- a/custom_components/taskmate/translations/pt.json
+++ b/custom_components/taskmate/translations/pt.json
@@ -215,7 +215,8 @@
           "perfect_week_enabled": "Bónus de semana perfeita",
           "perfect_week_bonus": "Pontos de bónus de semana perfeita",
           "streak_milestones": "Configuração de marcos de sequência",
-          "notify_service": "Serviço de notificação (opcional)"
+          "notify_service": "Serviço de notificação (opcional)",
+          "calendar_projection_days": "Horizonte de planeamento do calendário"
         },
         "data_description": {
           "streak_reset_mode": "O que acontece a uma sequência quando um dia é falhado",
@@ -225,7 +226,8 @@
           "perfect_week_enabled": "Atribuir pontos de bónus quando uma criança completa pelo menos uma tarefa todos os dias durante uma semana inteira",
           "perfect_week_bonus": "Pontos de bónus atribuídos por uma semana perfeita",
           "streak_milestones": "Marcos personalizados como pares 'dias:pontos', separados por vírgulas. Exemplo: 3:5, 7:10, 14:20, 30:50, 60:100, 100:200",
-          "notify_service": "Serviço de notificação do HA para alertar os pais quando uma tarefa requer aprovação. Formato: notify.mobile_app_seu_telefone — deixe vazio para usar apenas notificações persistentes"
+          "notify_service": "Serviço de notificação do HA para alertar os pais quando uma tarefa requer aprovação. Formato: notify.mobile_app_seu_telefone — deixe vazio para usar apenas notificações persistentes",
+          "calendar_projection_days": "Quantos dias à frente cada tarefa publica atribuições nos calendários HA configurados (1-90). Valores maiores mostram mais horizonte de planeamento ao custo de mais entradas de calendário."
         }
       },
       "chore_schedule_specific": {

--- a/tests/test_assignment_modes.py
+++ b/tests/test_assignment_modes.py
@@ -23,7 +23,13 @@ from .conftest import dt_util_mock, run_async
 UTC = timezone.utc
 
 
-def _coord(children: list[Child]) -> TaskMateCoordinator:
+def _coord(children: list[Child], projection_days: int = 1) -> TaskMateCoordinator:
+    """Build a coordinator with stub storage.
+
+    The default `projection_days=1` keeps assertion counts sane for tests that
+    only care about today's behaviour; pass a larger value when a test needs
+    to exercise the multi-day projection directly.
+    """
     coord = object.__new__(TaskMateCoordinator)
     coord.hass = MagicMock()
     coord.hass.services = MagicMock()
@@ -34,11 +40,14 @@ def _coord(children: list[Child]) -> TaskMateCoordinator:
 
     by_id = {c.id: c for c in children}
     stored_chores: list[Chore] = []
+    settings = {"calendar_projection_days": str(projection_days)}
 
     storage = MagicMock()
     storage.get_children = MagicMock(return_value=list(children))
     storage.get_child = MagicMock(side_effect=lambda cid: by_id.get(cid))
     storage.get_chores = MagicMock(side_effect=lambda: list(stored_chores))
+    storage.get_setting = MagicMock(side_effect=lambda key, default="": settings.get(key, default))
+    storage.set_setting = MagicMock(side_effect=lambda key, value: settings.__setitem__(key, value))
 
     def _get_chore(cid):
         found = next((c for c in stored_chores if c.id == cid), None)
@@ -185,7 +194,7 @@ def test_async_add_chore_publishes_immediately():
         publish_calendar_entities=["calendar.kids", "calendar.family"],
     ))
     assert coord.hass.services.async_call.await_count == 2
-    assert chore.publish_calendar_last_date == "2026-04-20"
+    assert chore.publish_calendar_published_dates == ["2026-04-20"]
     assert chore.assignment_current_child_id == a.id
 
 
@@ -417,8 +426,12 @@ def test_chore_from_dict_defaults_are_legacy_safe():
     assert chore.assignment_rotation_anchor == ""
     assert chore.assignment_current_child_id == ""
     assert chore.publish_calendar_entities == []
-    assert chore.publish_calendar_last_date == ""
+    assert chore.publish_calendar_published_dates == []
     # Round-trip preserves the new fields
     restored = Chore.from_dict(chore.to_dict())
     assert restored.assignment_mode == "everyone"
     assert restored.publish_calendar_entities == []
+    assert restored.publish_calendar_published_dates == []
+    # Back-compat: legacy records with the old scalar seed the new list
+    migrated = Chore.from_dict({"name": "Old", "publish_calendar_last_date": "2026-04-20"})
+    assert migrated.publish_calendar_published_dates == ["2026-04-20"]

--- a/tests/test_calendar_projection.py
+++ b/tests/test_calendar_projection.py
@@ -1,0 +1,194 @@
+"""Tests for multi-day calendar projection publishing.
+
+The calendar publishing pipeline writes a chore's assignment to every
+configured HA calendar for the next N days (N = calendar_projection_days
+setting, default 14). Days are filtered by the chore's schedule so the
+HA calendar matches the in-card schedule view.
+"""
+from __future__ import annotations
+
+import datetime as dt
+from datetime import date, timezone
+
+from custom_components.taskmate.models import Child, Chore
+
+from .conftest import dt_util_mock, run_async
+from .test_assignment_modes import _coord
+
+UTC = timezone.utc
+
+
+def test_schedule_helper_specific_days_matches_due_days():
+    coord = _coord([Child(name="A")])
+    chore = Chore(name="X", schedule_mode="specific_days", due_days=["monday", "wednesday"])
+    # 2026-04-20 is a Monday, 21 Tue, 22 Wed, 23 Thu, …
+    assert coord._is_chore_scheduled_for_date(chore, date(2026, 4, 20)) is True
+    assert coord._is_chore_scheduled_for_date(chore, date(2026, 4, 21)) is False
+    assert coord._is_chore_scheduled_for_date(chore, date(2026, 4, 22)) is True
+    assert coord._is_chore_scheduled_for_date(chore, date(2026, 4, 23)) is False
+
+
+def test_schedule_helper_empty_due_days_means_every_day():
+    coord = _coord([Child(name="A")])
+    chore = Chore(name="X", schedule_mode="specific_days", due_days=[])
+    for offset in range(14):
+        assert coord._is_chore_scheduled_for_date(chore, date(2026, 4, 20) + dt.timedelta(days=offset))
+
+
+def test_schedule_helper_disabled_chore_never_scheduled():
+    coord = _coord([Child(name="A")])
+    chore = Chore(name="X", enabled=False, due_days=[])
+    assert coord._is_chore_scheduled_for_date(chore, date(2026, 4, 20)) is False
+
+
+def test_schedule_helper_one_shot_only_on_created_date():
+    coord = _coord([Child(name="A")])
+    chore = Chore(name="Move sofa", schedule_mode="one_shot", created_date="2026-04-20")
+    assert coord._is_chore_scheduled_for_date(chore, date(2026, 4, 20)) is True
+    assert coord._is_chore_scheduled_for_date(chore, date(2026, 4, 21)) is False
+
+
+def test_schedule_helper_every_2_days_respects_anchor():
+    coord = _coord([Child(name="A")])
+    chore = Chore(
+        name="Bin",
+        schedule_mode="recurring",
+        recurrence="every_2_days",
+        recurrence_start="2026-04-20",
+    )
+    # Days matching anchor + 2k
+    for offset in (0, 2, 4, 6, 8):
+        assert coord._is_chore_scheduled_for_date(chore, date(2026, 4, 20) + dt.timedelta(days=offset))
+    # Off-cycle days
+    for offset in (1, 3, 5, 7):
+        assert not coord._is_chore_scheduled_for_date(
+            chore, date(2026, 4, 20) + dt.timedelta(days=offset)
+        )
+
+
+def test_schedule_helper_weekly_recurrence_day_filters_to_single_weekday():
+    coord = _coord([Child(name="A")])
+    chore = Chore(
+        name="Swim",
+        schedule_mode="recurring",
+        recurrence="weekly",
+        recurrence_day="wednesday",
+    )
+    assert coord._is_chore_scheduled_for_date(chore, date(2026, 4, 22)) is True  # Wed
+    assert coord._is_chore_scheduled_for_date(chore, date(2026, 4, 23)) is False  # Thu
+    assert coord._is_chore_scheduled_for_date(chore, date(2026, 4, 29)) is True  # next Wed
+
+
+def test_schedule_helper_created_date_blocks_earlier_days():
+    coord = _coord([Child(name="A")])
+    chore = Chore(
+        name="New",
+        schedule_mode="specific_days",
+        due_days=[],
+        created_date="2026-04-22",
+    )
+    assert coord._is_chore_scheduled_for_date(chore, date(2026, 4, 20)) is False
+    assert coord._is_chore_scheduled_for_date(chore, date(2026, 4, 22)) is True
+    assert coord._is_chore_scheduled_for_date(chore, date(2026, 4, 25)) is True
+
+
+def test_projection_publishes_full_horizon_for_daily_chore():
+    a = Child(name="A")
+    coord = _coord([a], projection_days=14)
+    today = date(2026, 4, 20)
+    dt_util_mock._now = dt.datetime.combine(today, dt.time(0, 0, 5), tzinfo=UTC)
+    chore = Chore(
+        name="Daily",
+        assigned_to=[a.id],
+        publish_calendar_entities=["calendar.family"],
+    )
+    run_async(coord._publish_chore_to_calendars(chore, today))
+    # One event per day of the 14-day horizon.
+    assert coord.hass.services.async_call.await_count == 14
+    assert len(chore.publish_calendar_published_dates) == 14
+    assert chore.publish_calendar_published_dates[0] == today.isoformat()
+    assert chore.publish_calendar_published_dates[-1] == (today + dt.timedelta(days=13)).isoformat()
+
+
+def test_projection_filters_by_schedule():
+    a = Child(name="A")
+    coord = _coord([a], projection_days=14)
+    today = date(2026, 4, 20)  # Monday
+    chore = Chore(
+        name="Bin day",
+        assigned_to=[a.id],
+        schedule_mode="specific_days",
+        due_days=["wednesday"],
+        publish_calendar_entities=["calendar.bins"],
+    )
+    run_async(coord._publish_chore_to_calendars(chore, today))
+    # 14 days starting Monday → Wed on day-2, day-9. So 2 events.
+    assert coord.hass.services.async_call.await_count == 2
+    iso = [d.isoformat() for d in (today + dt.timedelta(days=2), today + dt.timedelta(days=9))]
+    assert chore.publish_calendar_published_dates == iso
+
+
+def test_projection_is_idempotent_across_reinvocation():
+    a = Child(name="A")
+    coord = _coord([a], projection_days=7)
+    today = date(2026, 4, 20)
+    chore = Chore(
+        name="Daily",
+        assigned_to=[a.id],
+        publish_calendar_entities=["calendar.x"],
+    )
+    run_async(coord._publish_chore_to_calendars(chore, today))
+    first = coord.hass.services.async_call.await_count
+    run_async(coord._publish_chore_to_calendars(chore, today))
+    assert coord.hass.services.async_call.await_count == first
+
+
+def test_projection_advances_one_day_per_midnight_tick():
+    a = Child(name="A")
+    coord = _coord([a], projection_days=7)
+    today = date(2026, 4, 20)
+    chore = Chore(
+        name="Daily",
+        assigned_to=[a.id],
+        publish_calendar_entities=["calendar.x"],
+    )
+    run_async(coord._publish_chore_to_calendars(chore, today))
+    assert coord.hass.services.async_call.await_count == 7
+    # Next day's tick: today-1 drops out of the window, day+7 is added.
+    run_async(coord._publish_chore_to_calendars(chore, today + dt.timedelta(days=1)))
+    assert coord.hass.services.async_call.await_count == 8
+    # Published set reflects [today+1, today+7]; the stale today is pruned.
+    assert today.isoformat() not in chore.publish_calendar_published_dates
+    assert (today + dt.timedelta(days=7)).isoformat() in chore.publish_calendar_published_dates
+    assert len(chore.publish_calendar_published_dates) == 7
+
+
+def test_projection_alternating_names_correct_child_per_day():
+    a, b = Child(name="A"), Child(name="B")
+    coord = _coord([a, b], projection_days=4)
+    today = date(2026, 4, 20)
+    chore = Chore(
+        name="Dishes",
+        assigned_to=[a.id, b.id],
+        assignment_mode="alternating",
+        assignment_rotation_anchor=today.isoformat(),
+        publish_calendar_entities=["calendar.family"],
+    )
+    run_async(coord._publish_chore_to_calendars(chore, today))
+    payloads = [c.args[2] for c in coord.hass.services.async_call.await_args_list]
+    summaries = [p["summary"] for p in payloads]
+    assert summaries == ["Dishes — A", "Dishes — B", "Dishes — A", "Dishes — B"]
+
+
+def test_projection_horizon_honors_settings_clamp():
+    a = Child(name="A")
+    coord = _coord([a], projection_days=500)  # well above the 90-day cap
+    today = date(2026, 4, 20)
+    chore = Chore(
+        name="Daily",
+        assigned_to=[a.id],
+        publish_calendar_entities=["calendar.x"],
+    )
+    run_async(coord._publish_chore_to_calendars(chore, today))
+    # Horizon is clamped to MAX_CALENDAR_PROJECTION_DAYS=90.
+    assert coord.hass.services.async_call.await_count == 90


### PR DESCRIPTION
## Problem

`sensor.taskmate_overview`'s HA local calendar integration was writing only **today's** chore assignment per chore, so the native Home Assistant calendar view showed nothing for tomorrow onwards. The in-card TaskMate Calendar card already computed a day's schedule on the fly — but the underlying HA calendars were empty after today, which meant no planning-ahead in the user's usual calendar app.

## Solution

Project each chore's assignment **14 days ahead** (configurable, 1–90). At every publish (chore create/update + midnight tick) the coordinator walks `[today, today + horizon)`, filters days by the chore's schedule, computes that day's active child via the existing date-deterministic `_compute_active_children`, and emits one event per configured calendar per covered day.

### Schedule filtering
`_is_chore_scheduled_for_date(chore, day)` is a direct Python port of `_isChoreScheduledOn` in `taskmate-calendar-card.js` — so the HA calendar now shows the exact same days the in-card calendar does. Supports `specific_days` (`due_days`), `recurring` (weekly/every_2_weeks/every_2_days/monthly with anchors), and `one_shot` (created_date exact match).

### Storage
`Chore.publish_calendar_last_date: str` (scalar) becomes `Chore.publish_calendar_published_dates: list[str]`. Legacy records seed the new list with the old scalar on load — no storage migration required. Stale entries (`< today`) are pruned on every publish, so the list stays bounded by the horizon.

### Cleanup
`_cleanup_chore_from_calendars` now scans `max(30, horizon + 7)` days forward so editing or deleting a chore purges the full projection range from all calendars the chore ever published to. Any edit to a chore with calendar publishing triggers a full purge + republish so renames, due-day changes, and rotation-anchor changes all propagate cleanly.

### Setting
New **Calendar Planning Horizon** field in the Settings flow (default 14, min 1, max 90). Strings added in `en` and mirrored to `en-GB`, `fr`, `nb`, `nn`, `pt`, `pt-BR`.

## Tests

- `tests/test_calendar_projection.py` — 13 new tests covering schedule filtering for every recurrence shape, 14-day horizon fan-out, schedule-aware day filtering, idempotence, midnight-tick sliding window, per-day assignee naming for alternating mode, and horizon clamping to the 90-day cap.
- `tests/test_assignment_modes.py` — fixture extended with `projection_days` knob (default 1 to keep existing per-day assertion counts valid); `publish_calendar_last_date` → `publish_calendar_published_dates` rename + back-compat load assertion.
- Total: **211 tests passing**, ruff clean.

## Test plan

- [x] `pytest tests/` — 211 passing
- [x] `ruff check custom_components/taskmate/ tests/` — clean
- [ ] Manual: install on HA, set Calendar Planning Horizon to 14, open the HA calendar and confirm chores appear on scheduled days for the next two weeks
- [ ] Manual: edit a chore's due_days → confirm old events purge and new events appear on the correct days
- [ ] Manual: delete a chore with published events → confirm all future events are cleaned up

Ships as **`3.2.0-beta6`**.