### PR TITLE
fix(a11y): keyboard support for chore cards and points dialog

### DIFF
--- a/custom_components/taskmate/www/taskmate-child-card.js
+++ b/custom_components/taskmate/www/taskmate-child-card.js
@@ -610,6 +610,13 @@ class TaskMateChildCard extends LitElement {
         transform: scale(0.98);
         box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
       }
+      .chore-card:focus {
+        outline: none;
+      }
+      .chore-card:focus-visible {
+        outline: 2px solid var(--primary-color, #2196f3);
+        outline-offset: 2px;
+      }
 
       @media (hover: hover) {
         .chore-card:hover {
@@ -1778,6 +1785,13 @@ class TaskMateChildCard extends LitElement {
         this._handleComplete(chore, child);
       }
     };
+    const isInteractive = !(isLoading || notDueToday || notAvailableRecurrence || isLockedPreview || timeElapsed);
+    const handleRowKeyDown = (e) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        handleRowClick();
+      }
+    };
 
     const titleText = isLockedPreview
       ? (lockedUntilLabel || this._t('child.chore_locked_until_generic'))
@@ -1792,7 +1806,12 @@ class TaskMateChildCard extends LitElement {
     return html`
       <div
         class="chore-card ${isLoading ? "loading" : ""} ${isCelebrating ? "celebrating" : ""} ${isCompletedForToday ? "completed" : ""} ${notDueToday ? "not-due-today" : ""} ${notAvailableRecurrence ? "recurrence-unavailable" : ""} ${timeElapsed ? "time-elapsed" : ""} ${isLockedPreview ? "chore-locked" : ""}"
+        role="button"
+        tabindex="${isInteractive ? '0' : '-1'}"
+        aria-disabled="${isInteractive ? 'false' : 'true'}"
+        aria-label="${chore.name}"
         @click="${handleRowClick}"
+        @keydown="${handleRowKeyDown}"
         title="${titleText}"
       >
         <div class="chore-info">

--- a/custom_components/taskmate/www/taskmate-points-card.js
+++ b/custom_components/taskmate/www/taskmate-points-card.js
@@ -848,6 +848,10 @@ class TaskMatePointsCard extends LitElement {
 
   _openDialog(child, action, pointsIcon, pointsName) {
     this._dialog = { child, action, pointsIcon, pointsName };
+    this._dialogKeyHandler = (e) => {
+      if (e.key === "Escape") this._closeDialog();
+    };
+    document.addEventListener("keydown", this._dialogKeyHandler);
     this.requestUpdate();
 
     // Focus the points input after dialog renders
@@ -862,7 +866,19 @@ class TaskMatePointsCard extends LitElement {
 
   _closeDialog() {
     this._dialog = null;
+    if (this._dialogKeyHandler) {
+      document.removeEventListener("keydown", this._dialogKeyHandler);
+      this._dialogKeyHandler = null;
+    }
     this.requestUpdate();
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    if (this._dialogKeyHandler) {
+      document.removeEventListener("keydown", this._dialogKeyHandler);
+      this._dialogKeyHandler = null;
+    }
   }
 
   _handleKeyDown(e, child, action) {


### PR DESCRIPTION
## Summary
- Chore cards in `taskmate-child-card.js` were divs with a `@click` handler but no keyboard affordance. Adds `role="button"`, `tabindex` (`0` when interactive, `-1` when dimmed/locked), `aria-disabled`, `aria-label`, a `@keydown` handler for Enter/Space, and a `:focus-visible` outline so keyboard-only users can complete and undo chores.
- The points-card dialog closed on `Escape` only while an input was focused. Adds a document-level `keydown` listener in `_openDialog` that closes the dialog on `Escape` regardless of focus. The listener is cleaned up in both `_closeDialog` and `disconnectedCallback` to avoid leaks.

## Test plan
- [x] `node --check` on both modified JS files.
- [ ] Tab to a chore card and press Enter / Space — chore completes / undoes.
- [ ] Tab to a chore card that is dimmed / locked — receives no focus (tabindex=-1).
- [ ] Open the add/remove-points dialog and press Escape with no input focused — dialog closes.
- [ ] Unmount the card while the dialog is open — no lingering listener.