### PR TITLE
fix(a11y): aria-labels, color-mix fallback, and README alt text

### DIFF
--- a/README.md
+++ b/README.md
@@ -629,7 +629,7 @@ header_color: "#b7950b"
 Parent-facing card for applying point-deduction penalties. Select the child using tabs, then tap **Apply** next to the relevant penalty. Tap the pencil icon to add, edit, or delete penalty definitions.
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/tempus2016/taskmate/main/images/penalties.png" alt="Settings Menu" width="500">
+  <img src="https://raw.githubusercontent.com/tempus2016/taskmate/main/images/penalties.png" alt="Penalties Card" width="500">
 </p>
 
 ```yaml

--- a/custom_components/taskmate/www/taskmate-bonuses-card.js
+++ b/custom_components/taskmate/www/taskmate-bonuses-card.js
@@ -517,10 +517,10 @@ class TaskMateBonusesCard extends LitElement {
 
         ${this._editMode ? html`
           <div class="edit-actions">
-            <button class="edit-btn" title="${this._t('bonuses.btn_edit_title')}" @click=${() => this._startEdit(b)}>
+            <button class="edit-btn" title="${this._t('bonuses.btn_edit_title')}" aria-label="${this._t('bonuses.btn_edit_title')}" @click=${() => this._startEdit(b)}>
               <ha-icon icon="mdi:pencil"></ha-icon>
             </button>
-            <button class="edit-btn delete" title="${this._t('bonuses.btn_delete_title')}" @click=${() => this._deleteBonus(b.id)}>
+            <button class="edit-btn delete" title="${this._t('bonuses.btn_delete_title')}" aria-label="${this._t('bonuses.btn_delete_title')}" @click=${() => this._deleteBonus(b.id)}>
               <ha-icon icon="mdi:trash-can-outline"></ha-icon>
             </button>
           </div>

--- a/custom_components/taskmate/www/taskmate-child-card.js
+++ b/custom_components/taskmate/www/taskmate-child-card.js
@@ -587,21 +587,25 @@ class TaskMateChildCard extends LitElement {
 
       .chore-card:nth-child(odd) {
         border-color: var(--fun-blue);
+        background: var(--card-background-color, #fff);
         background: color-mix(in srgb, var(--fun-blue) 10%, var(--card-background-color, #fff));
       }
 
       .chore-card:nth-child(even) {
         border-color: var(--fun-pink);
+        background: var(--card-background-color, #fff);
         background: color-mix(in srgb, var(--fun-pink) 10%, var(--card-background-color, #fff));
       }
 
       .chore-card:nth-child(3n) {
         border-color: var(--fun-green);
+        background: var(--card-background-color, #fff);
         background: color-mix(in srgb, var(--fun-green) 10%, var(--card-background-color, #fff));
       }
 
       .chore-card:nth-child(4n) {
         border-color: var(--fun-orange);
+        background: var(--card-background-color, #fff);
         background: color-mix(in srgb, var(--fun-orange) 10%, var(--card-background-color, #fff));
       }
 

--- a/custom_components/taskmate/www/taskmate-parent-dashboard-card.js
+++ b/custom_components/taskmate/www/taskmate-parent-dashboard-card.js
@@ -535,10 +535,10 @@ class TaskMateParentDashboardCard extends LitElement {
               </div>
             </div>
             <div class="approval-actions">
-              <button class="btn-approve" @click="${() => this._handleApprove(comp.completion_id)}" title="${this._t('common.approve')}">
+              <button class="btn-approve" @click="${() => this._handleApprove(comp.completion_id)}" title="${this._t('common.approve')}" aria-label="${this._t('common.approve')}">
                 <ha-icon icon="mdi:check-bold"></ha-icon>
               </button>
-              <button class="btn-reject" @click="${() => this._handleReject(comp.completion_id)}" title="${this._t('common.reject')}">
+              <button class="btn-reject" @click="${() => this._handleReject(comp.completion_id)}" title="${this._t('common.reject')}" aria-label="${this._t('common.reject')}">
                 <ha-icon icon="mdi:close-thick"></ha-icon>
               </button>
             </div>
@@ -576,10 +576,10 @@ class TaskMateParentDashboardCard extends LitElement {
               </div>
             </div>
             <div class="approval-actions">
-              <button class="btn-approve" @click="${() => this._handleApproveReward(claim.claim_id)}" title="${this._t('common.approve')}">
+              <button class="btn-approve" @click="${() => this._handleApproveReward(claim.claim_id)}" title="${this._t('common.approve')}" aria-label="${this._t('common.approve')}">
                 <ha-icon icon="mdi:check-bold"></ha-icon>
               </button>
-              <button class="btn-reject" @click="${() => this._handleRejectReward(claim.claim_id)}" title="${this._t('common.reject')}">
+              <button class="btn-reject" @click="${() => this._handleRejectReward(claim.claim_id)}" title="${this._t('common.reject')}" aria-label="${this._t('common.reject')}">
                 <ha-icon icon="mdi:close-thick"></ha-icon>
               </button>
             </div>
@@ -604,10 +604,10 @@ class TaskMateParentDashboardCard extends LitElement {
             ${child.points}
           </span>
           <div class="qp-actions">
-            <button class="btn-remove" @click="${() => this._handlePoints(child.id, -amount)}" title="${this._t('dashboard.btn_remove_points_title', { amount, pointsName })}">
+            <button class="btn-remove" @click="${() => this._handlePoints(child.id, -amount)}" title="${this._t('dashboard.btn_remove_points_title', { amount, pointsName })}" aria-label="${this._t('dashboard.btn_remove_points_title', { amount, pointsName })}">
               <ha-icon icon="mdi:minus"></ha-icon>
             </button>
-            <button class="btn-add" @click="${() => this._handlePoints(child.id, amount)}" title="${this._t('dashboard.btn_add_points_title', { amount, pointsName })}">
+            <button class="btn-add" @click="${() => this._handlePoints(child.id, amount)}" title="${this._t('dashboard.btn_add_points_title', { amount, pointsName })}" aria-label="${this._t('dashboard.btn_add_points_title', { amount, pointsName })}">
               <ha-icon icon="mdi:plus"></ha-icon>
             </button>
           </div>

--- a/custom_components/taskmate/www/taskmate-penalties-card.js
+++ b/custom_components/taskmate/www/taskmate-penalties-card.js
@@ -515,10 +515,10 @@ class TaskMatePenaltiesCard extends LitElement {
 
         ${this._editMode ? html`
           <div class="edit-actions">
-            <button class="edit-btn" title="${this._t('penalties.btn_edit_title')}" @click=${() => this._startEdit(p)}>
+            <button class="edit-btn" title="${this._t('penalties.btn_edit_title')}" aria-label="${this._t('penalties.btn_edit_title')}" @click=${() => this._startEdit(p)}>
               <ha-icon icon="mdi:pencil"></ha-icon>
             </button>
-            <button class="edit-btn delete" title="${this._t('penalties.btn_delete_title')}" @click=${() => this._deletePenalty(p.id)}>
+            <button class="edit-btn delete" title="${this._t('penalties.btn_delete_title')}" aria-label="${this._t('penalties.btn_delete_title')}" @click=${() => this._deletePenalty(p.id)}>
               <ha-icon icon="mdi:trash-can-outline"></ha-icon>
             </button>
           </div>


### PR DESCRIPTION
## Summary
- Adds `aria-label` to the ten icon-only buttons in `bonuses-card`, `penalties-card`, and `parent-dashboard-card` (edit / delete / approve / reject / add-points / remove-points). `title` is unreliable for screen readers, so pair it with a localized `aria-label` reusing the same string.
- Adds a plain `background: var(--card-background-color)` declaration before every `color-mix(in srgb, ...)` rule in `taskmate-child-card.js`. Browsers that don't understand `color-mix` (Chrome <111, Firefox <113, Safari <16.4) now fall back to the base card colour instead of dropping the background entirely; the border continues to signal the variant.
- Fixes `README.md:632` alt text for `penalties.png` — was accidentally `"Settings Menu"` (copied from `settingsPage.png`), now `"Penalties Card"`.

## Test plan
- [x] `node --check` on all four modified JS files.
- [ ] Inspect each icon-only button with a screen reader — each announces its purpose.
- [ ] Load the child card in a browser with `color-mix` support and one without — confirm both render with a usable background.