### PR TITLE
fix(js): debug gating, robust audio logging, hass optional chaining

### DIFF
--- a/custom_components/taskmate/www/taskmate-child-card.js
+++ b/custom_components/taskmate/www/taskmate-child-card.js
@@ -394,8 +394,10 @@ class TaskMateChildCard extends LitElement {
       const audio = new Audio(`/local/taskmate/${filename}`);
       audio.volume = 1.0;
       audio.play().catch(e => {
+        console.warn(`[TaskMate] Failed to play ${filename}:`, e);
       });
     } catch (e) {
+      console.warn(`[TaskMate] Error preparing audio ${filename}:`, e);
     }
   }
 
@@ -1852,7 +1854,7 @@ class TaskMateChildCard extends LitElement {
   }
 
   _renderCelebration() {
-    const attrs = (window.__taskmate_attrs && window.__taskmate_attrs(this.hass, this.config.entity)) || this.hass.states[this.config.entity]?.attributes || {};
+    const attrs = (window.__taskmate_attrs && window.__taskmate_attrs(this.hass, this.config.entity)) || this.hass?.states?.[this.config.entity]?.attributes || {};
     const pointsIcon = attrs.points_icon || "mdi:star";
     const celebratingChore = (attrs.chores || []).find(
       c => c.id === this._celebrating
@@ -1906,7 +1908,7 @@ class TaskMateChildCard extends LitElement {
     }
 
     // Get current completion count including optimistic completions
-    const attrs = (window.__taskmate_attrs && window.__taskmate_attrs(this.hass, this.config.entity)) || this.hass.states[this.config.entity]?.attributes || {};
+    const attrs = (window.__taskmate_attrs && window.__taskmate_attrs(this.hass, this.config.entity)) || this.hass?.states?.[this.config.entity]?.attributes || {};
     const allCompletions = attrs.todays_completions || [];
     const todaysCompletions = this._filterCompletionsForToday(allCompletions);
     const actualCompletionsToday = todaysCompletions.filter(

--- a/custom_components/taskmate/www/taskmate-config-sounds.js
+++ b/custom_components/taskmate/www/taskmate-config-sounds.js
@@ -7,6 +7,15 @@
 (function() {
   'use strict';
 
+  // Debug logging gate. Set window.__taskmate_config_sounds_debug = true in the
+  // browser console to enable the chatty console.debug/warn output.
+  const debugLog = (...args) => {
+    if (window.__taskmate_config_sounds_debug) console.debug(...args);
+  };
+  const debugWarn = (...args) => {
+    if (window.__taskmate_config_sounds_debug) console.warn(...args);
+  };
+
   // Audio context for sound preview (lazy initialized)
   let audioContext = null;
 
@@ -410,7 +419,7 @@
    */
   function playSound(soundName) {
     if (!soundName || soundName === 'none') {
-      console.debug('[TaskMate Config] No sound to play');
+      debugLog('[TaskMate Config] No sound to play');
       return;
     }
 
@@ -428,11 +437,11 @@
         case 'fart': playFartSound(ctx, now); break;
         case 'fart_long': playFartLongSound(ctx, now); break;
         default:
-          console.warn(`[TaskMate Config] Unknown sound: ${soundName}`);
+          debugWarn(`[TaskMate Config] Unknown sound: ${soundName}`);
           playCoinSound(ctx, now);
       }
     } catch (e) {
-      console.warn('[TaskMate Config] Error playing sound:', e);
+      debugWarn('[TaskMate Config] Error playing sound:', e);
     }
   }
 
@@ -474,7 +483,7 @@
       const value = e.target?.value || e.detail?.value;
       const soundValue = textToSoundValue(value) || value;
 
-      console.debug('[TaskMate Config] Sound changed to:', soundValue);
+      debugLog('[TaskMate Config] Sound changed to:', soundValue);
 
       if (soundValue && soundValue !== 'none' && VALID_SOUNDS.includes(soundValue)) {
         playSound(soundValue);
@@ -496,7 +505,7 @@
       }
     });
 
-    console.debug('[TaskMate Config] Attached sound change listener to element');
+    debugLog('[TaskMate Config] Attached sound change listener to element');
   }
 
   /**
@@ -580,7 +589,7 @@
       subtree: true,
     });
 
-    console.debug('[TaskMate Config] Sound change observer started');
+    debugLog('[TaskMate Config] Sound change observer started');
   }
 
   // Initialize
@@ -593,7 +602,7 @@
     // Periodic scan to catch dynamically loaded content
     window._taskmateConfigSoundsPoll = setInterval(findAndEnhanceSoundSelectors, 2000);
 
-    window.addEventListener('beforeunload', () => {
+    const cleanup = () => {
       if (window._taskmateConfigSoundsPoll) {
         clearInterval(window._taskmateConfigSoundsPoll);
         window._taskmateConfigSoundsPoll = null;
@@ -602,7 +611,10 @@
         clearTimeout(window._taskmateScanTimeout);
         window._taskmateScanTimeout = null;
       }
-    }, { once: true });
+    };
+    // pagehide covers SPA navigation in HA; beforeunload covers full reloads.
+    window.addEventListener('pagehide', cleanup, { once: true });
+    window.addEventListener('beforeunload', cleanup, { once: true });
   }
 
   if (document.readyState === 'loading') {


### PR DESCRIPTION
## Summary
- `taskmate-config-sounds.js` was chatty on every dropdown scan. Gate every `console.debug/warn` behind a new `window.__taskmate_config_sounds_debug` flag (off by default) so the console stays clean. Also switch the interval/timeout cleanup to listen on both `pagehide` and `beforeunload` — HA dashboards are SPAs and `beforeunload` often doesn't fire on navigation.
- `taskmate-child-card.js` `_playAudioFile` silently swallowed `audio.play()` rejections and `new Audio()` errors with empty catch blocks. Log the error via `console.warn` in both paths so failures are diagnosable.
- Guard the two `window.__taskmate_attrs` fallback sites in `taskmate-child-card.js` with `?.states?.[entity]` instead of `.states[entity]` so the fallback can't throw when `hass` is briefly undefined during reconnects.

## Deferred (noted in the broader audit)
The shared audio module, `_t()` mixin, and Lit `repeat()` swap were scoped out: every card boot-straps `LitElement` via `customElements.get()` rather than an ES module import, so there is no clean way to load `repeat` or a shared module in the current architecture. These belong in a follow-up that first introduces ES-module loading for the card resources.

## Test plan
- [x] `node --check` on both modified files.
- [ ] Load a dashboard with a chore card; play a fart sound; confirm console is quiet.
- [ ] Trigger an audio failure (e.g., block autoplay); confirm a warning is now logged.
- [ ] Set `window.__taskmate_config_sounds_debug = true` and confirm debug logs reappear.