### PR TITLE
chore(python+ci): narrow excepts, add binary_sensor tests, add concurrency

### DIFF
--- a/.github/workflows/hassfest.yaml
+++ b/.github/workflows/hassfest.yaml
@@ -5,7 +5,11 @@ on:
   pull_request:
   schedule:
     - cron: "0 0 * * *"
-  
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   validate:
     runs-on: "ubuntu-latest"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ruff:
     name: Ruff

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   validate:
     name: Validate integration

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -6,6 +6,10 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   hacs:
     runs-on: ubuntu-latest

--- a/custom_components/taskmate/config_flow.py
+++ b/custom_components/taskmate/config_flow.py
@@ -121,7 +121,7 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
                     user_data = await frontend_data.async_get_user_data(user_id)
                     if user_data and user_data.get("language"):
                         return user_data["language"]
-        except Exception as err:
+        except (AttributeError, KeyError, TypeError) as err:
             _LOGGER.debug("TaskMate i18n: could not resolve user language: %s", err)
         # Fall back to system language
         return getattr(self.hass.config, 'language', None) or "en"
@@ -145,7 +145,7 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
             if self._translations:
                 _LOGGER.debug("TaskMate i18n: loaded %d keys via HA for lang=%s", len(self._translations), lang)
                 return
-        except Exception as e:
+        except (ImportError, AttributeError, RuntimeError) as e:
             _LOGGER.debug("TaskMate i18n: HA translation system unavailable: %s", e)
 
         # Fallback: load translation file directly

--- a/custom_components/taskmate/coordinator.py
+++ b/custom_components/taskmate/coordinator.py
@@ -123,7 +123,7 @@ class TaskMateCoordinator(DataUpdateCoordinator):
                     comp_date_str = comp_local.date().isoformat()
                     if comp_date_str in last_week_dates:
                         completed_days.add(comp_date_str)
-                except Exception:
+                except (ValueError, TypeError, AttributeError):
                     continue
 
             if completed_days == last_week_dates:

--- a/custom_components/taskmate/frontend.py
+++ b/custom_components/taskmate/frontend.py
@@ -58,7 +58,7 @@ async def _async_get_version(hass: HomeAssistant) -> str:
             manifest_path.read_text, "utf-8"
         )
         return json.loads(content).get("version", "1.0.0")
-    except Exception:  # noqa: BLE001
+    except (OSError, json.JSONDecodeError, AttributeError):
         return "1.0.0"
 
 
@@ -181,5 +181,5 @@ async def async_register_cards(hass: HomeAssistant) -> None:
                 else:
                     _LOGGER.debug("TaskMate: resource up to date: %s", versioned_url)
 
-    except Exception as err:  # noqa: BLE001
+    except (AttributeError, KeyError, TypeError, OSError) as err:
         _LOGGER.error("TaskMate: error managing Lovelace resources: %s", err)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -113,6 +113,14 @@ _ha_components_sensor.SensorEntity = _FakeSensorEntity
 _ha_components_sensor.SensorStateClass = _FakeSensorStateClass
 
 
+class _FakeBinarySensorEntity:
+    pass
+
+
+_ha_components_binary_sensor = MagicMock()
+_ha_components_binary_sensor.BinarySensorEntity = _FakeBinarySensorEntity
+
+
 class _FakeDeviceInfo(dict):
     """DeviceInfo behaves like a TypedDict; accept kwargs like the real one."""
 
@@ -169,6 +177,7 @@ sys.modules.update(
         "homeassistant.helpers.entity_platform": _ha_helpers_entity_platform,
         "homeassistant.components": MagicMock(),
         "homeassistant.components.sensor": _ha_components_sensor,
+        "homeassistant.components.binary_sensor": _ha_components_binary_sensor,
         "homeassistant.util": _ha_util,
         "homeassistant.util.dt": dt_util_mock,
         # Stub the frontend sub-module so __init__.py's relative import succeeds

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -1,0 +1,51 @@
+"""Tests for the pending-approvals binary sensor."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from custom_components.taskmate.binary_sensor import HasPendingApprovalsBinarySensor
+
+
+def _make_sensor(pending_completions=None, pending_reward_claims=None):
+    """Build a HasPendingApprovalsBinarySensor with a stubbed coordinator/entry."""
+    coordinator = MagicMock()
+    coordinator.data = {
+        "pending_completions": pending_completions or [],
+        "pending_reward_claims": pending_reward_claims or [],
+    }
+    entry = MagicMock()
+    entry.entry_id = "test-entry"
+    return HasPendingApprovalsBinarySensor(coordinator, entry)
+
+
+def test_is_off_when_no_pending_items():
+    sensor = _make_sensor()
+    assert sensor.is_on is False
+    assert sensor.icon == "mdi:bell-check"
+
+
+def test_is_on_when_pending_chore_completion():
+    sensor = _make_sensor(pending_completions=[{"id": "c1"}])
+    assert sensor.is_on is True
+    assert sensor.icon == "mdi:bell-alert"
+
+
+def test_is_on_when_pending_reward_claim():
+    sensor = _make_sensor(pending_reward_claims=[{"id": "r1"}])
+    assert sensor.is_on is True
+
+
+def test_extra_state_attributes_reports_counts():
+    sensor = _make_sensor(
+        pending_completions=[{"id": "c1"}, {"id": "c2"}],
+        pending_reward_claims=[{"id": "r1"}],
+    )
+    attrs = sensor.extra_state_attributes
+    assert attrs["pending_chore_completions"] == 2
+    assert attrs["pending_reward_claims"] == 1
+    assert attrs["total_pending"] == 3
+
+
+def test_unique_id_includes_entry_id():
+    sensor = _make_sensor()
+    assert sensor._attr_unique_id == "test-entry_has_pending_approvals"


### PR DESCRIPTION
## Summary
- **Narrow `except Exception`** in five sites so real bugs no longer hide:
  - `config_flow.py:124` → `(AttributeError, KeyError, TypeError)`
  - `config_flow.py:148` → `(ImportError, AttributeError, RuntimeError)`
  - `coordinator.py:126` → `(ValueError, TypeError, AttributeError)` (perfect-week date parsing)
  - `frontend.py:61` → `(OSError, json.JSONDecodeError, AttributeError)` (manifest read)
  - `frontend.py:184` → `(AttributeError, KeyError, TypeError, OSError)` (Lovelace resource management)
- **Add `tests/test_binary_sensor.py`** covering `HasPendingApprovalsBinarySensor`: `is_on` transitions, icon, `extra_state_attributes`, and unique_id. Extends `conftest.py` with a `homeassistant.components.binary_sensor` stub so the module imports without a real HA install.
- **Add `concurrency:` groups** to `lint.yml`, `tests.yml`, `validate.yml`, `hassfest.yaml` keyed on `${{ github.workflow }}-${{ github.ref }}` with `cancel-in-progress: true`. Rapid consecutive pushes on the same branch now cancel superseded runs instead of queueing. `release-announcement.yml` and `issue-comment-labels.yml` intentionally left alone — they are event-scoped, not ref-scoped.

## Deferred
Button and config-flow tests were scoped out of this PR: `button.py` is mostly service-registration boilerplate (integration-test territory), and `config_flow.py`'s multi-step routing needs a broader stub layer that would dwarf the narrow-exception fix here. These belong in a follow-up.

## Test plan
- [x] `python -m py_compile` on every edited Python file and `yaml.safe_load` on every edited workflow.
- [ ] CI (Ruff, Run tests, Validate integration, hacs, validate) is green.
- [ ] Manual: push two commits in quick succession to a feature branch — confirm the older workflow run is cancelled.