### PR TITLE
feat(rewards): limited quantity and expiration date with auto-refund

### DIFF
--- a/custom_components/taskmate/config_flow.py
+++ b/custom_components/taskmate/config_flow.py
@@ -1,6 +1,7 @@
 """Config flow for TaskMate integration."""
 from __future__ import annotations
 
+from datetime import date, datetime
 import logging
 from typing import Any
 
@@ -30,6 +31,30 @@ from .const import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _normalise_quantity(value: Any) -> int | None:
+    """Coerce a form value to an int stock count, or None if blank/invalid."""
+    if value is None or value == "":
+        return None
+    try:
+        return max(0, int(value))
+    except (TypeError, ValueError):
+        return None
+
+
+def _normalise_expires_at(value: Any) -> str | None:
+    """Coerce a DateSelector value to an ISO 'YYYY-MM-DD' string or None."""
+    if not value:
+        return None
+    if isinstance(value, date) and not isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, datetime):
+        return value.date().isoformat()
+    try:
+        return date.fromisoformat(str(value)).isoformat()
+    except (TypeError, ValueError):
+        return None
 
 
 class TaskMateConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -1058,6 +1083,8 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
                     assigned_to=user_input.get("assigned_to", []),
                     is_jackpot=user_input.get("is_jackpot", False),
                     pool_enabled=user_input.get("pool_enabled", False),
+                    quantity=_normalise_quantity(user_input.get("quantity")),
+                    expires_at=_normalise_expires_at(user_input.get("expires_at")),
                 )
                 return await self.async_step_manage_rewards()
 
@@ -1083,6 +1110,10 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
             vol.Required("cost", default=50): selector.NumberSelector(
                 selector.NumberSelectorConfig(min=1, max=10000, mode=selector.NumberSelectorMode.BOX)
             ),
+            vol.Optional("quantity"): selector.NumberSelector(
+                selector.NumberSelectorConfig(min=0, max=10000, mode=selector.NumberSelectorMode.BOX)
+            ),
+            vol.Optional("expires_at"): selector.DateSelector(),
         }
 
         if child_options:
@@ -1126,6 +1157,8 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
                 reward.pool_enabled = user_input.get(
                     "pool_enabled", getattr(reward, "pool_enabled", False)
                 )
+                reward.quantity = _normalise_quantity(user_input.get("quantity"))
+                reward.expires_at = _normalise_expires_at(user_input.get("expires_at"))
                 await self.coordinator.async_update_reward(reward)
                 return await self.async_step_manage_rewards()
 
@@ -1168,6 +1201,22 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
                     multiple=True,
                 )
             )
+
+        quantity_key = (
+            vol.Optional("quantity", default=reward.quantity)
+            if reward.quantity is not None
+            else vol.Optional("quantity")
+        )
+        schema_dict[quantity_key] = selector.NumberSelector(
+            selector.NumberSelectorConfig(min=0, max=10000, mode=selector.NumberSelectorMode.BOX)
+        )
+
+        expires_key = (
+            vol.Optional("expires_at", default=reward.expires_at)
+            if reward.expires_at
+            else vol.Optional("expires_at")
+        )
+        schema_dict[expires_key] = selector.DateSelector()
 
         return self.async_show_form(
             step_id="edit_reward",

--- a/custom_components/taskmate/const.py
+++ b/custom_components/taskmate/const.py
@@ -52,6 +52,8 @@ CONF_REWARD_DESCRIPTION: Final = "description"
 CONF_REWARD_COST: Final = "cost"
 CONF_REWARD_ICON: Final = "icon"
 CONF_REWARD_ID: Final = "id"
+CONF_REWARD_QUANTITY: Final = "quantity"
+CONF_REWARD_EXPIRES_AT: Final = "expires_at"
 
 # Default values
 DEFAULT_POINTS_NAME: Final = "Stars"

--- a/custom_components/taskmate/coordinator.py
+++ b/custom_components/taskmate/coordinator.py
@@ -68,6 +68,7 @@ class TaskMateCoordinator(DataUpdateCoordinator):
         """Scheduled callback at midnight to check and reset streaks if needed."""
         self.hass.async_create_task(self._async_check_streaks())
         self.hass.async_create_task(self._async_expire_one_shot_chores())
+        self.hass.async_create_task(self._async_expire_rewards())
         # Rotate assignment_current_child_id and publish today's events to every configured calendar
         self.hass.async_create_task(self._async_refresh_assignments_and_publish())
         # Check for perfect week bonus every Monday at midnight
@@ -1222,6 +1223,33 @@ class TaskMateCoordinator(DataUpdateCoordinator):
             await self.storage.async_save()
             await self.async_refresh()
 
+    async def _async_expire_rewards(self) -> None:
+        """Refund pool allocations on any reward whose expires_at is past.
+
+        The reward row itself is kept in storage so the sensor can surface the
+        "Expired" state and existing claim history stays intact.
+        """
+        changed = False
+        for reward in self.storage.get_rewards():
+            if not self._reward_is_expired(reward):
+                continue
+            allocations_before = [
+                a for a in self.storage.get_pool_allocations()
+                if a.reward_id == reward.id and a.allocated_points > 0
+            ]
+            if not allocations_before:
+                continue
+            self._refund_all_pool_allocations(reward, "Pool refund (reward expired)")
+            changed = True
+            _LOGGER.info(
+                "Reward '%s' expired on %s — refunded %d pool allocation(s)",
+                reward.name, reward.expires_at, len(allocations_before),
+            )
+
+        if changed:
+            await self.storage.async_save()
+            await self.async_refresh()
+
     # ── Reward operations ─────────────────────────────────────────────────────
 
     async def async_add_reward(
@@ -1233,6 +1261,8 @@ class TaskMateCoordinator(DataUpdateCoordinator):
         assigned_to: list[str] | None = None,
         is_jackpot: bool = False,
         pool_enabled: bool = False,
+        quantity: int | None = None,
+        expires_at: str | None = None,
     ) -> Reward:
         """Add a new reward."""
         reward = Reward(
@@ -1243,6 +1273,8 @@ class TaskMateCoordinator(DataUpdateCoordinator):
             assigned_to=assigned_to or [],
             is_jackpot=is_jackpot,
             pool_enabled=pool_enabled,
+            quantity=quantity,
+            expires_at=expires_at,
         )
         self.storage.add_reward(reward)
         await self.storage.async_save()
@@ -1254,14 +1286,64 @@ class TaskMateCoordinator(DataUpdateCoordinator):
 
         If the cost is reduced below any existing pool allocation, the excess is
         refunded to the contributing children's wallets so over-allocated pools
-        can't appear as e.g. 11/10.
+        can't appear as e.g. 11/10. If the edit makes the reward unavailable
+        (quantity set to 0, or expires_at moved into the past) any pool
+        allocations on that reward are refunded in full.
         """
         old = self.get_reward(reward.id)
         self.storage.update_reward(reward)
         if old and reward.cost < old.cost:
             self._refund_pool_excess(reward, "Pool refund (reward cost reduced)")
+        became_unavailable = (
+            self._reward_is_unavailable(reward)
+            and old is not None
+            and not self._reward_is_unavailable(old)
+        )
+        if became_unavailable:
+            reason = (
+                "Pool refund (reward expired)"
+                if self._reward_is_expired(reward)
+                else "Pool refund (reward sold out)"
+            )
+            self._refund_all_pool_allocations(reward, reason)
         await self.storage.async_save()
         await self.async_refresh()
+
+    @staticmethod
+    def _reward_is_sold_out(reward: Reward) -> bool:
+        """True if the reward has a stock count and it's been exhausted."""
+        return reward.quantity is not None and reward.quantity <= 0
+
+    @staticmethod
+    def _reward_is_expired(reward: Reward) -> bool:
+        """True if the reward has an expiry date and it's on/before today."""
+        if not reward.expires_at:
+            return False
+        try:
+            deadline = date.fromisoformat(reward.expires_at)
+        except (TypeError, ValueError):
+            return False
+        return deadline <= dt_util.now().date()
+
+    @classmethod
+    def _reward_is_unavailable(cls, reward: Reward) -> bool:
+        """True if the reward cannot currently be claimed or allocated to."""
+        return cls._reward_is_sold_out(reward) or cls._reward_is_expired(reward)
+
+    def _refund_all_pool_allocations(self, reward: Reward, reason: str) -> None:
+        """Refund every pool allocation on `reward` back to its contributor.
+
+        Used when a reward becomes unavailable (sold out or expired) while
+        children still have points earmarked for it. Reuses the existing
+        per-allocation refund helper so the PointsTransaction audit trail
+        stays consistent with cost-reduction refunds.
+        """
+        allocations = [
+            a for a in self.storage.get_pool_allocations()
+            if a.reward_id == reward.id and a.allocated_points > 0
+        ]
+        for alloc in allocations:
+            self._apply_pool_refund(alloc, alloc.allocated_points, reward, reason)
 
     def _refund_pool_excess(self, reward: Reward, reason: str) -> None:
         """Trim any pool allocations on `reward` that exceed its cost.
@@ -1423,6 +1505,11 @@ class TaskMateCoordinator(DataUpdateCoordinator):
         if not child:
             raise ValueError(f"Child {child_id} not found")
 
+        if self._reward_is_sold_out(reward):
+            raise ValueError(f"Reward '{reward.name}' is sold out")
+        if self._reward_is_expired(reward):
+            raise ValueError(f"Reward '{reward.name}' has expired")
+
         # Cost is always static
         effective_cost = reward.cost
 
@@ -1526,6 +1613,16 @@ class TaskMateCoordinator(DataUpdateCoordinator):
                     child.points -= effective_cost
                     self.storage.update_child(child)
 
+                if reward.quantity is not None:
+                    reward.quantity = max(0, reward.quantity - 1)
+                    self.storage.update_reward(reward)
+                    if reward.quantity == 0:
+                        # Last unit claimed — refund any points other children
+                        # still have earmarked for this reward's pool.
+                        self._refund_all_pool_allocations(
+                            reward, "Pool refund (reward sold out)"
+                        )
+
                 claim.approved = True
                 claim.approved_at = dt_util.now()
                 self.storage.update_reward_claim(claim)
@@ -1558,6 +1655,11 @@ class TaskMateCoordinator(DataUpdateCoordinator):
         reward = self.get_reward(reward_id)
         if not reward:
             raise ValueError(f"Reward {reward_id} not found")
+
+        if self._reward_is_sold_out(reward):
+            raise ValueError(f"Reward '{reward.name}' is sold out")
+        if self._reward_is_expired(reward):
+            raise ValueError(f"Reward '{reward.name}' has expired")
 
         if points < 1:
             raise ValueError("Points to allocate must be at least 1")

--- a/custom_components/taskmate/models.py
+++ b/custom_components/taskmate/models.py
@@ -250,11 +250,17 @@ class Reward:
     assigned_to: list[str] = field(default_factory=list)  # List of child IDs, empty means all children
     is_jackpot: bool = False  # If True, pool stars from all assigned children together
     pool_enabled: bool = False  # If True, this reward uses pool-mode (savings jar) semantics
+    quantity: int | None = None  # Remaining stock; None means unlimited
+    expires_at: str | None = None  # ISO "YYYY-MM-DD"; None means no deadline
     id: str = field(default_factory=generate_id)
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> Reward:
         """Create a Reward from a dictionary."""
+        raw_quantity = data.get("quantity")
+        quantity = int(raw_quantity) if raw_quantity is not None else None
+        raw_expires = data.get("expires_at")
+        expires_at = str(raw_expires) if raw_expires else None
         return cls(
             name=data.get("name", ""),
             cost=data.get("cost", 50),
@@ -263,6 +269,8 @@ class Reward:
             assigned_to=list(data.get("assigned_to", [])),
             is_jackpot=data.get("is_jackpot", False),
             pool_enabled=data.get("pool_enabled", False),
+            quantity=quantity,
+            expires_at=expires_at,
             id=data.get("id", generate_id()),
         )
 
@@ -276,6 +284,8 @@ class Reward:
             "assigned_to": self.assigned_to,
             "is_jackpot": self.is_jackpot,
             "pool_enabled": self.pool_enabled,
+            "quantity": self.quantity,
+            "expires_at": self.expires_at,
             "id": self.id,
         }
 

--- a/custom_components/taskmate/sensor.py
+++ b/custom_components/taskmate/sensor.py
@@ -1,6 +1,8 @@
 """Sensor platform for TaskMate integration."""
 from __future__ import annotations
 
+from datetime import date
+
 from homeassistant.components.sensor import (
     SensorEntity,
     SensorStateClass,
@@ -287,6 +289,7 @@ def _build_rewards_list(common: dict) -> list[dict]:
     children = common["children"]
     pool_by_child_reward = common["pool_by_child_reward"]
     pool_total_by_reward = common["pool_total_by_reward"]
+    today = dt_util.now().date()
     out = []
     for r in rewards:
         assigned = (
@@ -301,6 +304,18 @@ def _build_rewards_list(common: dict) -> list[dict]:
         jackpot_pool_total = (
             pool_total_by_reward.get(r.id, 0) if getattr(r, 'is_jackpot', False) else None
         )
+        quantity = getattr(r, 'quantity', None)
+        expires_at = getattr(r, 'expires_at', None)
+        is_sold_out = quantity is not None and quantity <= 0
+        is_expired = False
+        days_until_expiry: int | None = None
+        if expires_at:
+            try:
+                deadline = date.fromisoformat(expires_at)
+                is_expired = deadline <= today
+                days_until_expiry = (deadline - today).days
+            except (TypeError, ValueError):
+                pass
         out.append({
             "id": r.id,
             "name": r.name,
@@ -313,6 +328,12 @@ def _build_rewards_list(common: dict) -> list[dict]:
             "calculated_costs": calculated_costs,
             "pool_allocations": reward_pool_allocations,
             "jackpot_pool_total": jackpot_pool_total,
+            "quantity": quantity,
+            "expires_at": expires_at,
+            "is_sold_out": is_sold_out,
+            "is_expired": is_expired,
+            "is_available": not (is_sold_out or is_expired),
+            "days_until_expiry": days_until_expiry,
         })
     return out
 

--- a/custom_components/taskmate/strings.json
+++ b/custom_components/taskmate/strings.json
@@ -179,12 +179,16 @@
           "icon": "Icon",
           "assigned_to": "Assigned To (leave empty for all children)",
           "is_jackpot": "Is Jackpot",
-          "pool_enabled": "Pool Reward (Savings Jar)"
+          "pool_enabled": "Pool Reward (Savings Jar)",
+          "quantity": "Limited Quantity (leave blank for unlimited)",
+          "expires_at": "Expiration Date (optional)"
         },
         "data_description": {
           "is_jackpot": "Pool points from all assigned children toward one shared reward",
           "pool_enabled": "Children deposit points into this reward's dedicated pool rather than spending from their global balance. Good for long-term savings goals.",
-          "cost": "Number of points required to claim this reward"
+          "cost": "Number of points required to claim this reward",
+          "quantity": "How many of this reward exist. Each approved claim reduces it by 1. When it reaches 0, the reward is marked Sold Out and any points other children had pooled for it are refunded to their balance.",
+          "expires_at": "The reward disappears on this date. Any points children have pooled for it are refunded to their balance at midnight."
         }
       },
       "edit_reward": {
@@ -198,12 +202,16 @@
           "assigned_to": "Assigned To",
           "is_jackpot": "Is Jackpot",
           "pool_enabled": "Pool Reward (Savings Jar)",
+          "quantity": "Limited Quantity (leave blank for unlimited)",
+          "expires_at": "Expiration Date (optional)",
           "action": "Action"
         },
         "data_description": {
           "is_jackpot": "Pool points from all assigned children toward one shared reward",
           "pool_enabled": "Children deposit points into this reward's dedicated pool rather than spending from their global balance. Good for long-term savings goals.",
-          "cost": "Number of points required to claim this reward"
+          "cost": "Number of points required to claim this reward",
+          "quantity": "Remaining stock. Each approved claim reduces it by 1. Set to 0 now to immediately mark as Sold Out and refund any pooled points.",
+          "expires_at": "The reward disappears on this date and any pooled points are refunded."
         }
       },
       "settings": {

--- a/custom_components/taskmate/translations/en-GB.json
+++ b/custom_components/taskmate/translations/en-GB.json
@@ -179,12 +179,16 @@
           "icon": "Icon",
           "assigned_to": "Assigned To (leave empty for all children)",
           "is_jackpot": "Is Jackpot",
-          "pool_enabled": "Pool Reward (Savings Jar)"
+          "pool_enabled": "Pool Reward (Savings Jar)",
+          "quantity": "Limited Quantity (leave blank for unlimited)",
+          "expires_at": "Expiration Date (optional)"
         },
         "data_description": {
           "is_jackpot": "Pool points from all assigned children toward one shared reward",
           "pool_enabled": "Children deposit points into this reward's dedicated pool rather than spending from their global balance. Good for long-term savings goals.",
-          "cost": "Number of points required to claim this reward"
+          "cost": "Number of points required to claim this reward",
+          "quantity": "How many of this reward exist. Each approved claim reduces it by 1. When it reaches 0, the reward is marked Sold Out and any points other children had pooled for it are refunded to their balance.",
+          "expires_at": "The reward disappears on this date. Any points children have pooled for it are refunded to their balance at midnight."
         }
       },
       "edit_reward": {
@@ -198,12 +202,16 @@
           "assigned_to": "Assigned To",
           "is_jackpot": "Is Jackpot",
           "pool_enabled": "Pool Reward (Savings Jar)",
+          "quantity": "Limited Quantity (leave blank for unlimited)",
+          "expires_at": "Expiration Date (optional)",
           "action": "Action"
         },
         "data_description": {
           "is_jackpot": "Pool points from all assigned children toward one shared reward",
           "pool_enabled": "Children deposit points into this reward's dedicated pool rather than spending from their global balance. Good for long-term savings goals.",
-          "cost": "Number of points required to claim this reward"
+          "cost": "Number of points required to claim this reward",
+          "quantity": "Remaining stock. Each approved claim reduces it by 1. Set to 0 now to immediately mark as Sold Out and refund any pooled points.",
+          "expires_at": "The reward disappears on this date and any pooled points are refunded."
         }
       },
       "settings": {

--- a/custom_components/taskmate/translations/en.json
+++ b/custom_components/taskmate/translations/en.json
@@ -179,12 +179,16 @@
           "icon": "Icon",
           "assigned_to": "Assigned To (leave empty for all children)",
           "is_jackpot": "Is Jackpot",
-          "pool_enabled": "Pool Reward (Savings Jar)"
+          "pool_enabled": "Pool Reward (Savings Jar)",
+          "quantity": "Limited Quantity (leave blank for unlimited)",
+          "expires_at": "Expiration Date (optional)"
         },
         "data_description": {
           "is_jackpot": "Pool points from all assigned children toward one shared reward",
           "pool_enabled": "Children deposit points into this reward's dedicated pool rather than spending from their global balance. Good for long-term savings goals.",
-          "cost": "Number of points required to claim this reward"
+          "cost": "Number of points required to claim this reward",
+          "quantity": "How many of this reward exist. Each approved claim reduces it by 1. When it reaches 0, the reward is marked Sold Out and any points other children had pooled for it are refunded to their balance.",
+          "expires_at": "The reward disappears on this date. Any points children have pooled for it are refunded to their balance at midnight."
         }
       },
       "edit_reward": {
@@ -198,12 +202,16 @@
           "assigned_to": "Assigned To",
           "is_jackpot": "Is Jackpot",
           "pool_enabled": "Pool Reward (Savings Jar)",
+          "quantity": "Limited Quantity (leave blank for unlimited)",
+          "expires_at": "Expiration Date (optional)",
           "action": "Action"
         },
         "data_description": {
           "is_jackpot": "Pool points from all assigned children toward one shared reward",
           "pool_enabled": "Children deposit points into this reward's dedicated pool rather than spending from their global balance. Good for long-term savings goals.",
-          "cost": "Number of points required to claim this reward"
+          "cost": "Number of points required to claim this reward",
+          "quantity": "Remaining stock. Each approved claim reduces it by 1. Set to 0 now to immediately mark as Sold Out and refund any pooled points.",
+          "expires_at": "The reward disappears on this date and any pooled points are refunded."
         }
       },
       "settings": {

--- a/custom_components/taskmate/www/locales/en-GB.json
+++ b/custom_components/taskmate/www/locales/en-GB.json
@@ -376,6 +376,13 @@
   "rewards.deposit_disabled_no_child": "Select a child to deposit",
   "rewards.deposit_disabled_insufficient": "Not enough spendable ({spendable} available)",
   "rewards.deposit_disabled_loading": "Depositing…",
+  "rewards.sold_out": "Sold Out",
+  "rewards.expired": "Expired",
+  "rewards.only_n_left": "Only {count} left!",
+  "rewards.expires_today": "Expires today",
+  "rewards.expires_in_days": "Expires in {count} day",
+  "rewards.expires_in_days_plural": "Expires in {count} days",
+  "rewards.unavailable_hint": "This reward can no longer be claimed",
 
   "streak.card_name": "TaskMate Streaks & Achievements",
   "streak.card_description": "Consecutive day streaks and milestone badges for each child",

--- a/custom_components/taskmate/www/locales/en.json
+++ b/custom_components/taskmate/www/locales/en.json
@@ -376,6 +376,13 @@
   "rewards.deposit_disabled_no_child": "Select a child to deposit",
   "rewards.deposit_disabled_insufficient": "Not enough spendable ({spendable} available)",
   "rewards.deposit_disabled_loading": "Depositing…",
+  "rewards.sold_out": "Sold Out",
+  "rewards.expired": "Expired",
+  "rewards.only_n_left": "Only {count} left!",
+  "rewards.expires_today": "Expires today",
+  "rewards.expires_in_days": "Expires in {count} day",
+  "rewards.expires_in_days_plural": "Expires in {count} days",
+  "rewards.unavailable_hint": "This reward can no longer be claimed",
 
   "streak.card_name": "TaskMate Streaks & Achievements",
   "streak.card_description": "Consecutive day streaks and milestone badges for each child",

--- a/custom_components/taskmate/www/taskmate-reward-progress-card.js
+++ b/custom_components/taskmate/www/taskmate-reward-progress-card.js
@@ -289,6 +289,35 @@ class TaskMateRewardProgressCard extends LitElement {
 
       .jackpot-badge ha-icon { --mdc-icon-size: 14px; }
 
+      /* Availability badges (low stock / sold out / expiring / expired) */
+      .availability-badge {
+        display: inline-flex;
+        align-items: center;
+        border-radius: 20px;
+        padding: 3px 10px;
+        font-size: 0.75rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        align-self: flex-start;
+      }
+      .availability-badge.badge-sold-out {
+        background: rgba(189,195,199,0.3);
+        color: #7f8c8d;
+      }
+      .availability-badge.badge-expired {
+        background: rgba(52,73,94,0.2);
+        color: #34495e;
+      }
+      .availability-badge.badge-low-stock {
+        background: rgba(231,76,60,0.18);
+        color: #c0392b;
+      }
+      .availability-badge.badge-expiring-soon {
+        background: rgba(243,156,18,0.2);
+        color: #d35400;
+      }
+
       .jackpot-pool {
         display: flex;
         flex-direction: column;
@@ -399,6 +428,30 @@ class TaskMateRewardProgressCard extends LitElement {
     if (!showChildren.length) showChildren = children;
 
     const isJackpot = reward.is_jackpot;
+    const isSoldOut = reward.is_sold_out === true;
+    const isExpired = reward.is_expired === true;
+    const daysUntilExpiry = (typeof reward.days_until_expiry === 'number')
+      ? reward.days_until_expiry
+      : null;
+    let availabilityLabel = '';
+    let availabilityClass = '';
+    if (isExpired) {
+      availabilityLabel = this._t('rewards.expired');
+      availabilityClass = 'badge-expired';
+    } else if (isSoldOut) {
+      availabilityLabel = this._t('rewards.sold_out');
+      availabilityClass = 'badge-sold-out';
+    } else if (typeof reward.quantity === 'number' && reward.quantity > 0 && reward.quantity <= 3) {
+      availabilityLabel = this._t('rewards.only_n_left', { count: reward.quantity });
+      availabilityClass = 'badge-low-stock';
+    } else if (typeof daysUntilExpiry === 'number' && daysUntilExpiry >= 0 && daysUntilExpiry <= 7) {
+      availabilityLabel = daysUntilExpiry === 0
+        ? this._t('rewards.expires_today')
+        : (daysUntilExpiry === 1
+            ? this._t('rewards.expires_in_days', { count: daysUntilExpiry })
+            : this._t('rewards.expires_in_days_plural', { count: daysUntilExpiry }));
+      availabilityClass = 'badge-expiring-soon';
+    }
 
     return html`
       <ha-card>
@@ -416,6 +469,9 @@ class TaskMateRewardProgressCard extends LitElement {
             </div>
             <div class="reward-name">${reward.name}</div>
             ${reward.description ? html`<div class="reward-description">${reward.description}</div>` : ''}
+            ${availabilityLabel ? html`
+              <div class="availability-badge ${availabilityClass}">${availabilityLabel}</div>
+            ` : ''}
             ${isJackpot ? html`
               <div class="jackpot-badge">
                 <ha-icon icon="mdi:star-shooting"></ha-icon>

--- a/custom_components/taskmate/www/taskmate-rewards-card.js
+++ b/custom_components/taskmate/www/taskmate-rewards-card.js
@@ -530,6 +530,35 @@ class TaskMateRewardsCard extends LitElement {
 
       .pending-label ha-icon { --mdc-icon-size: 12px; }
 
+      /* Availability badges (low stock / sold out / expiring / expired) */
+      .availability-badges { display: inline-flex; flex-wrap: wrap; gap: 4px; margin-top: 4px; }
+      .availability-badge {
+        display: inline-flex;
+        align-items: center;
+        border-radius: 8px;
+        padding: 3px 8px;
+        font-size: 0.72rem;
+        font-weight: 700;
+        letter-spacing: 0.02em;
+      }
+      .availability-badge.badge-sold-out {
+        background: rgba(189,195,199,0.25);
+        color: #7f8c8d;
+      }
+      .availability-badge.badge-expired {
+        background: rgba(52,73,94,0.18);
+        color: #34495e;
+      }
+      .availability-badge.badge-low-stock {
+        background: rgba(231,76,60,0.15);
+        color: #c0392b;
+      }
+      .availability-badge.badge-expiring-soon {
+        background: rgba(243,156,18,0.18);
+        color: #d35400;
+      }
+      .reward-row.unavailable { opacity: 0.55; }
+
       /* Claim button */
       .claim-btn {
         width: 42px; height: 42px;
@@ -1000,12 +1029,21 @@ class TaskMateRewardsCard extends LitElement {
     const isLoading = this._loading[reward.id];
     const isAllocLoading = this._loading[`${reward.id}_alloc`];
 
+    // Availability (quantity / expiration)
+    const isSoldOut = reward.is_sold_out === true;
+    const isExpired = reward.is_expired === true;
+    const isUnavailable = isSoldOut || isExpired;
+    const daysUntilExpiry = (typeof reward.days_until_expiry === 'number')
+      ? reward.days_until_expiry
+      : null;
+    const availabilityBadge = this._renderAvailabilityBadge(reward, isSoldOut, isExpired, daysUntilExpiry);
+
     // Pool-mode controls render below the progress bar (full width) rather than
     // in the right column, so the progress bar keeps its full width.
-    const showPoolControls = enablePoolMode && childId && !hasPendingClaim;
+    const showPoolControls = enablePoolMode && childId && !hasPendingClaim && !isUnavailable;
 
     return html`
-      <div class="reward-row ${isJackpot ? 'jackpot' : ''} ${hasPendingClaim ? 'pending-approval' : ''} ${enablePoolMode ? 'pool-mode' : ''}">
+      <div class="reward-row ${isJackpot ? 'jackpot' : ''} ${hasPendingClaim ? 'pending-approval' : ''} ${enablePoolMode ? 'pool-mode' : ''} ${isUnavailable ? 'unavailable' : ''}">
         <div class="cost-badge">
           <ha-icon icon="${pointsIcon}"></ha-icon>
           <span class="cost-value">${displayCost}</span>
@@ -1014,6 +1052,7 @@ class TaskMateRewardsCard extends LitElement {
         <div class="reward-details">
           ${isJackpot ? html`<div class="jackpot-label"><span>&#127920;</span> ${this._t('rewards.jackpot')}</div>` : ''}
           <div class="reward-name">${reward.name}</div>
+          ${availabilityBadge}
           ${hasDescription
             ? html`<div class="reward-description">${reward.description}</div>`
             : ""}
@@ -1047,7 +1086,7 @@ class TaskMateRewardsCard extends LitElement {
             : ""}
         </div>
         <div class="reward-right-col">
-          ${!enablePoolMode && !hasPendingClaim && childId ? html`
+          ${!enablePoolMode && !hasPendingClaim && childId && !isUnavailable ? html`
             <button
               class="claim-btn ${!canAfford ? 'cant-afford' : ''}"
               ?disabled="${!canAfford || isLoading}"
@@ -1057,13 +1096,36 @@ class TaskMateRewardsCard extends LitElement {
               <ha-icon icon="${isLoading ? 'mdi:loading' : rewardIcon}"></ha-icon>
             </button>
           ` : html`
-            <div class="reward-icon-container">
+            <div class="reward-icon-container" title="${isUnavailable ? this._t('rewards.unavailable_hint') : ''}">
               <ha-icon icon="${rewardIcon}"></ha-icon>
             </div>
           `}
         </div>
       </div>
     `;
+  }
+
+  _renderAvailabilityBadge(reward, isSoldOut, isExpired, daysUntilExpiry) {
+    if (isExpired) {
+      return html`<div class="availability-badge badge-expired">${this._t('rewards.expired')}</div>`;
+    }
+    if (isSoldOut) {
+      return html`<div class="availability-badge badge-sold-out">${this._t('rewards.sold_out')}</div>`;
+    }
+    const badges = [];
+    if (typeof reward.quantity === 'number' && reward.quantity > 0 && reward.quantity <= 3) {
+      badges.push(html`<div class="availability-badge badge-low-stock">${this._t('rewards.only_n_left', { count: reward.quantity })}</div>`);
+    }
+    if (typeof daysUntilExpiry === 'number' && daysUntilExpiry >= 0 && daysUntilExpiry <= 7) {
+      const label = daysUntilExpiry === 0
+        ? this._t('rewards.expires_today')
+        : (daysUntilExpiry === 1
+            ? this._t('rewards.expires_in_days', { count: daysUntilExpiry })
+            : this._t('rewards.expires_in_days_plural', { count: daysUntilExpiry }));
+      badges.push(html`<div class="availability-badge badge-expiring-soon">${label}</div>`);
+    }
+    if (badges.length === 0) return '';
+    return html`<div class="availability-badges">${badges}</div>`;
   }
 
   _renderPoolControls(reward, child, spendable, poolFull, isAllocLoading, isRedeemLoading) {

--- a/tests/test_coordinator_rewards.py
+++ b/tests/test_coordinator_rewards.py
@@ -474,3 +474,167 @@ class TestPoolOverallocationRefund:
         # 1 point refunded back to the wallet on redeem
         assert child.points == 90
         coord.storage.remove_pool_allocation.assert_called()
+
+
+class TestRewardStockAndExpiration:
+    """Quantity-based sold-out behaviour and expires_at expiration, plus the
+    automatic refund that fires when either condition makes a reward
+    unavailable while children still have points earmarked for it."""
+
+    def test_approve_decrements_quantity(self):
+        import datetime as dt
+        child = _child(points=100)
+        reward = Reward(name="Unique toy", cost=50, quantity=2, id="reward1")
+        claim = RewardClaim(
+            reward_id="reward1", child_id="kid1",
+            claimed_at=dt.datetime.now(dt.timezone.utc), id="claim1",
+        )
+        coord = _make_coord(children=[child], rewards=[reward], claims=[claim])
+        run(coord.async_approve_reward("claim1"))
+        assert reward.quantity == 1
+        coord.storage.update_reward.assert_called()
+
+    def test_unlimited_quantity_not_decremented(self):
+        import datetime as dt
+        child = _child(points=100)
+        reward = Reward(name="Ice cream", cost=50, quantity=None, id="reward1")
+        claim = RewardClaim(
+            reward_id="reward1", child_id="kid1",
+            claimed_at=dt.datetime.now(dt.timezone.utc), id="claim1",
+        )
+        coord = _make_coord(children=[child], rewards=[reward], claims=[claim])
+        run(coord.async_approve_reward("claim1"))
+        assert reward.quantity is None
+
+    def test_approve_sold_out_refunds_other_pool_allocations(self):
+        """Non-jackpot reward with quantity 1: child A redeems, child B had
+        pre-allocated points on the same reward. On approval the reward hits 0
+        and child B's allocation must be refunded to their wallet."""
+        import datetime as dt
+        child_a = Child(name="A", points=100, id="kidA")
+        child_b = Child(name="B", points=50, id="kidB")
+        reward = Reward(name="Unique toy", cost=50, quantity=1, id="reward1")
+        alloc_b = PoolAllocation(
+            child_id="kidB", reward_id="reward1", allocated_points=20, id="alloc_b",
+        )
+        claim = RewardClaim(
+            reward_id="reward1", child_id="kidA",
+            claimed_at=dt.datetime.now(dt.timezone.utc), id="claim1",
+        )
+        coord = _make_coord(
+            children=[child_a, child_b], rewards=[reward], claims=[claim],
+        )
+        # Child A is redeeming from their wallet; allocations belong to B.
+        coord.storage.get_pool_allocation = MagicMock(return_value=None)
+        coord.storage.get_pool_allocations = MagicMock(return_value=[alloc_b])
+
+        run(coord.async_approve_reward("claim1"))
+
+        assert reward.quantity == 0
+        assert child_a.points == 50  # 100 − 50 cost
+        assert child_b.points == 70  # 50 + 20 refunded
+        coord.storage.remove_pool_allocation.assert_any_call("kidB", "reward1")
+
+    def test_jackpot_sold_out_refunds_remaining_contributors(self):
+        """Jackpot redeem of a quantity=1 reward: allocations are cleared by
+        the pool-mode redeem path, so when quantity hits 0 there's nothing
+        left to refund. Points stay spent on the reward."""
+        import datetime as dt
+        child_a = Child(name="A", points=0, id="kidA")
+        child_b = Child(name="B", points=0, id="kidB")
+        reward = Reward(name="Shared prize", cost=80, quantity=1, is_jackpot=True, id="rewardJ")
+        alloc_a = PoolAllocation(child_id="kidA", reward_id="rewardJ", allocated_points=50, id="a1")
+        alloc_b = PoolAllocation(child_id="kidB", reward_id="rewardJ", allocated_points=30, id="a2")
+        claim = RewardClaim(
+            reward_id="rewardJ", child_id="kidA",
+            claimed_at=dt.datetime.now(dt.timezone.utc), id="claim1",
+        )
+        coord = _make_coord(
+            children=[child_a, child_b], rewards=[reward], claims=[claim],
+        )
+        coord.storage.get_total_allocated_for_reward = MagicMock(return_value=80)
+
+        # Stateful mock: allocations shrink as storage.remove_pool_allocation
+        # is called, mirroring the real storage behaviour.
+        allocs = {("kidA", "rewardJ"): alloc_a, ("kidB", "rewardJ"): alloc_b}
+        coord.storage.get_pool_allocations = MagicMock(
+            side_effect=lambda: list(allocs.values())
+        )
+        def _remove(child_id, reward_id):
+            allocs.pop((child_id, reward_id), None)
+        coord.storage.remove_pool_allocation = MagicMock(side_effect=_remove)
+
+        run(coord.async_approve_reward("claim1"))
+
+        assert reward.quantity == 0
+        # Points stay spent — they were deducted at allocation time and the
+        # redeem consumed them. No refund fires because allocations are gone
+        # by the time the sold-out check runs.
+        assert child_a.points == 0
+        assert child_b.points == 0
+        assert allocs == {}
+
+    def test_claim_blocked_when_sold_out(self):
+        child = _child(points=100)
+        reward = Reward(name="Gone", cost=50, quantity=0, id="reward1")
+        coord = _make_coord(children=[child], rewards=[reward])
+        with pytest.raises(ValueError, match="sold out"):
+            run(coord.async_claim_reward("reward1", "kid1"))
+
+    def test_pool_allocation_blocked_when_sold_out(self):
+        child = _child(points=100)
+        reward = Reward(name="Gone", cost=50, quantity=0, id="reward1")
+        coord = _make_coord(children=[child], rewards=[reward])
+        with pytest.raises(ValueError, match="sold out"):
+            run(coord.async_allocate_points_to_pool("kid1", "reward1", 10))
+
+    def test_claim_blocked_when_expired(self):
+        child = _child(points=100)
+        # dt_util_mock returns 2024-03-20; use 2024-03-19 to be expired.
+        reward = Reward(name="Old", cost=50, expires_at="2024-03-19", id="reward1")
+        coord = _make_coord(children=[child], rewards=[reward])
+        with pytest.raises(ValueError, match="expired"):
+            run(coord.async_claim_reward("reward1", "kid1"))
+
+    def test_pool_allocation_blocked_when_expired(self):
+        child = _child(points=100)
+        reward = Reward(name="Old", cost=50, expires_at="2024-03-19", id="reward1")
+        coord = _make_coord(children=[child], rewards=[reward])
+        with pytest.raises(ValueError, match="expired"):
+            run(coord.async_allocate_points_to_pool("kid1", "reward1", 10))
+
+    def test_expires_at_in_future_does_not_expire_yet(self):
+        child = _child(points=100)
+        reward = Reward(name="Future", cost=50, expires_at="2099-01-01", id="reward1")
+        coord = _make_coord(children=[child], rewards=[reward])
+        claim = run(coord.async_claim_reward("reward1", "kid1"))
+        assert claim.reward_id == "reward1"
+
+    def test_expiration_midnight_refunds_all_allocations(self):
+        child_a = Child(name="A", points=10, id="kidA")
+        child_b = Child(name="B", points=20, id="kidB")
+        reward = Reward(name="Old", cost=100, expires_at="2024-03-19", id="reward1")
+        alloc_a = PoolAllocation(child_id="kidA", reward_id="reward1", allocated_points=15, id="a1")
+        alloc_b = PoolAllocation(child_id="kidB", reward_id="reward1", allocated_points=25, id="a2")
+        coord = _make_coord(children=[child_a, child_b], rewards=[reward])
+        coord.storage.get_rewards = MagicMock(return_value=[reward])
+        coord.storage.get_pool_allocations = MagicMock(return_value=[alloc_a, alloc_b])
+
+        run(coord._async_expire_rewards())
+
+        assert child_a.points == 25  # 10 + 15 refund
+        assert child_b.points == 45  # 20 + 25 refund
+
+    def test_update_reward_to_quantity_zero_refunds_allocations(self):
+        child = _child(points=50)
+        reward = Reward(name="Limited", cost=100, quantity=2, id="reward1")
+        alloc = PoolAllocation(child_id="kid1", reward_id="reward1", allocated_points=30, id="a1")
+        coord = _make_coord(children=[child], rewards=[reward])
+        coord.storage.get_pool_allocation = MagicMock(return_value=alloc)
+        coord.storage.get_pool_allocations = MagicMock(return_value=[alloc])
+
+        updated = Reward(name="Limited", cost=100, quantity=0, id="reward1")
+        run(coord.async_update_reward(updated))
+
+        assert child.points == 80  # 50 + 30 refund
+        coord.storage.remove_pool_allocation.assert_called_with("kid1", "reward1")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -234,6 +234,29 @@ class TestReward:
         reward = Reward.from_dict(legacy)
         assert reward.pool_enabled is False
 
+    def test_quantity_and_expires_at_defaults(self):
+        reward = Reward(name="Ice cream")
+        assert reward.quantity is None
+        assert reward.expires_at is None
+
+    def test_quantity_and_expires_at_roundtrip(self):
+        reward = Reward(
+            name="Movie tickets",
+            cost=200,
+            quantity=3,
+            expires_at="2024-12-31",
+            id="r_movie",
+        )
+        restored = Reward.from_dict(reward.to_dict())
+        assert restored.quantity == 3
+        assert restored.expires_at == "2024-12-31"
+
+    def test_legacy_missing_quantity_and_expires_at_backcompat(self):
+        legacy = {"name": "Old reward", "cost": 20, "id": "r1"}
+        reward = Reward.from_dict(legacy)
+        assert reward.quantity is None
+        assert reward.expires_at is None
+
 
 # ---------------------------------------------------------------------------
 # ChoreCompletion


### PR DESCRIPTION
## Summary

Adds two optional fields to `Reward` so parents can configure one-off and time-limited rewards without manually deleting them:

- **Limited Quantity** — integer stock count. Each approved claim decrements it, and the reward is marked "Sold Out" once it hits 0.
- **Expiration Date** — optional ISO date after which the reward is "Expired".

Both unavailable states trigger an automatic **pool refund**: any points children had dropped into that reward's savings-jar pool are returned to their wallet. Expiration is checked once a day from the existing midnight hook, and `claim_reward` / `allocate_points_to_pool` now reject unavailable rewards up front.

### UX

- Sensor attributes: `quantity`, `expires_at`, `is_sold_out`, `is_expired`, `is_available`, `days_until_expiry`.
- Rewards card and reward-progress card render badges: "Only N left!", "Expires in N days", "Expires today", "Sold Out", "Expired".
- Claim / allocate buttons are hidden or disabled when the reward is unavailable.
- New labels added to `strings.json`, `translations/en*.json`, and `www/locales/en*.json`.

### Data model

`Reward.from_dict` defaults both fields to `None` so existing saved storage round-trips unchanged.

## Test plan

- [x] `pytest tests/` — 230 passing (including 11 new tests covering stock decrement, sold-out refund for non-jackpot and jackpot pools, claim/allocate blocks, midnight expiration refund, and edit-to-zero-quantity refund).
- [x] Round-trip test for the new Reward fields and back-compat for legacy storage.
- [ ] Smoke-test in a live HA instance: `quantity=1` + two children pool-allocated; approve child A → child B refunded, card shows "Sold Out".
- [ ] Smoke-test: `expires_at` set to yesterday → midnight task refunds allocations and card shows "Expired".
- [ ] Lovelace cards render badges for `quantity <= 3` and `days_until_expiry <= 7`.
