### PR TITLE
fix(cards): fire button entity on dashboard chore complete / reward claim

### DIFF
--- a/custom_components/taskmate/www/taskmate-attr-resolver.js
+++ b/custom_components/taskmate/www/taskmate-attr-resolver.js
@@ -61,4 +61,38 @@
   }
 
   window.__taskmate_attrs = resolveAttrs;
+
+  /**
+   * Find the entity id of a TaskMate button by (child_id, action, target_id).
+   *
+   * TaskMate creates per-child/per-chore and per-child/per-reward button
+   * entities. Lovelace cards used to call the backend services directly
+   * (e.g. taskmate.complete_chore), which bypassed the button entity and
+   * left its last_pressed state unchanged — so HA state-trigger automations
+   * on button.taskmate_<child>_complete_<chore> never fired. Cards now
+   * resolve the matching button entity and call button.press, making the
+   * card and the HA entity the same code path.
+   *
+   * action: "complete" (chore) | "claim" (reward)
+   * target_id: chore_id or reward_id
+   */
+  function findButtonEntity(hass, childId, action, targetId) {
+    if (!hass || !hass.states || !childId || !targetId) return null;
+    const targetKey = action === "claim" ? "reward_id" : "chore_id";
+    for (const [entityId, state] of Object.entries(hass.states)) {
+      if (!entityId.startsWith("button.taskmate_")) continue;
+      const attrs = state && state.attributes;
+      if (!attrs) continue;
+      if (attrs.child_id !== childId) continue;
+      if (attrs[targetKey] !== targetId) continue;
+      // Disambiguate chore complete vs reward claim — both carry child_id,
+      // but only one of chore_id / reward_id.
+      if (action === "claim" && !("reward_id" in attrs)) continue;
+      if (action === "complete" && !("chore_id" in attrs)) continue;
+      return entityId;
+    }
+    return null;
+  }
+
+  window.__taskmate_find_button = findButtonEntity;
 })();

--- a/custom_components/taskmate/www/taskmate-child-card.js
+++ b/custom_components/taskmate/www/taskmate-child-card.js
@@ -1947,10 +1947,20 @@ class TaskMateChildCard extends LitElement {
 
     let cleanupTimeout;
     try {
-      await this.hass.callService("taskmate", "complete_chore", {
-        chore_id: chore.id,
-        child_id: child.id,
-      });
+      // Prefer pressing the per-child/per-chore button entity so HA
+      // state-trigger automations on button.taskmate_<child>_complete_<chore>
+      // fire. Falls back to the service call if the entity isn't registered
+      // yet (e.g. right after HA restart).
+      const buttonEntityId = window.__taskmate_find_button
+        && window.__taskmate_find_button(this.hass, child.id, "complete", chore.id);
+      if (buttonEntityId) {
+        await this.hass.callService("button", "press", { entity_id: buttonEntityId });
+      } else {
+        await this.hass.callService("taskmate", "complete_chore", {
+          chore_id: chore.id,
+          child_id: child.id,
+        });
+      }
 
       // Trigger celebration!
       this._celebrating = chore.id;

--- a/custom_components/taskmate/www/taskmate-rewards-card.js
+++ b/custom_components/taskmate/www/taskmate-rewards-card.js
@@ -1178,10 +1178,19 @@ class TaskMateRewardsCard extends LitElement {
     this._loading = { ...this._loading, [reward.id]: true };
     this.requestUpdate();
     try {
-      await this.hass.callService("taskmate", "claim_reward", {
-        reward_id: reward.id,
-        child_id: child.id,
-      });
+      // Prefer pressing the per-child/per-reward button entity so HA
+      // state-trigger automations on button.taskmate_<child>_claim_<reward>
+      // fire. Falls back to the service call if the entity isn't registered.
+      const buttonEntityId = window.__taskmate_find_button
+        && window.__taskmate_find_button(this.hass, child.id, "claim", reward.id);
+      if (buttonEntityId) {
+        await this.hass.callService("button", "press", { entity_id: buttonEntityId });
+      } else {
+        await this.hass.callService("taskmate", "claim_reward", {
+          reward_id: reward.id,
+          child_id: child.id,
+        });
+      }
     } catch (e) {
       console.error("Failed to claim reward:", e);
       if (this.hass && this.hass.callService) {


### PR DESCRIPTION
## Summary

Fixes a bug where HA state-trigger automations on the per-child/per-chore `button.taskmate_<child>_complete_<chore>` entities (and the equivalent reward-claim button entities) never fired when the child completed a chore from the TaskMate Child Dashboard card or claimed a reward from the TaskMate Rewards card.

### Root cause

- `taskmate-child-card.js` called `taskmate.complete_chore` directly.
- `taskmate-rewards-card.js` called `taskmate.claim_reward` directly.

Both routed straight into the coordinator — so points/logs updated correctly — but the matching `ButtonEntity` (`CompleteChoreButton` / `ClaimRewardButton`) was never pressed. Its `last_pressed` state never changed, so state-trigger automations keyed off the button entity didn't fire.

### Fix

- New helper `window.__taskmate_find_button(hass, child_id, action, target_id)` in the existing globally-loaded `taskmate-attr-resolver.js`. It locates the TaskMate button entity by matching its exposed `child_id` + (`chore_id` | `reward_id`) attributes — no reliance on fragile entity-id slugification.
- The child card and rewards card now resolve the matching button entity and call `button.press`, so the dashboard and the HA button entity are a single code path.
- If no button entity is found (e.g. right after HA restart before entities register), the cards fall back to the original service call so behaviour doesn't regress.

Reported in v3.2 + HA 2026.4.3.

## Test plan

- [x] `pytest tests/` — 230 passing (no Python changed, just confirming no regressions).
- [x] `node --check` on all three modified JS files.
- [ ] Manual: create a `state` trigger automation on `button.taskmate_<child>_complete_<chore>`. Complete the chore via the TaskMate Child Dashboard card — automation should fire.
- [ ] Manual: same for `button.taskmate_<child>_claim_<reward>` via the Rewards card.
- [ ] Manual: confirm pressing the button from the HA Settings UI still works.
