### PR TITLE
feat(assignment): availability-aware child rotation

### DIFF
--- a/custom_components/taskmate/config_flow.py
+++ b/custom_components/taskmate/config_flow.py
@@ -256,6 +256,7 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
                 await self.coordinator.async_add_child(
                     name=name,
                     avatar=user_input.get("avatar", "mdi:account-circle"),
+                    availability_entity=user_input.get("availability_entity", "") or "",
                 )
                 return await self.async_step_manage_children()
 
@@ -272,6 +273,9 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
                             ],
                             mode=selector.SelectSelectorMode.DROPDOWN,
                         )
+                    ),
+                    vol.Optional("availability_entity", default=""): selector.EntitySelector(
+                        selector.EntitySelectorConfig()
                     ),
                 }
             ),
@@ -296,8 +300,18 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
             elif action == "save":
                 child.name = user_input.get("name", child.name)
                 child.avatar = user_input.get("avatar", child.avatar)
+                child.availability_entity = (
+                    user_input.get("availability_entity", "") or ""
+                )
                 await self.coordinator.async_update_child(child)
                 return await self.async_step_manage_children()
+
+        availability_default = getattr(child, "availability_entity", "") or ""
+        availability_key = (
+            vol.Optional("availability_entity", default=availability_default)
+            if availability_default
+            else vol.Optional("availability_entity")
+        )
 
         return self.async_show_form(
             step_id="edit_child",
@@ -312,6 +326,9 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
                             ],
                             mode=selector.SelectSelectorMode.DROPDOWN,
                         )
+                    ),
+                    availability_key: selector.EntitySelector(
+                        selector.EntitySelectorConfig()
                     ),
                     vol.Required("action", default="save"): selector.SelectSelector(
                         selector.SelectSelectorConfig(
@@ -427,6 +444,7 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
             vol.Optional("assignment_rotation_anchor", default=""): selector.TextSelector(
                 selector.TextSelectorConfig(type=selector.TextSelectorType.DATE)
             ),
+            vol.Optional("require_availability", default=False): selector.BooleanSelector(),
             vol.Optional("publish_calendar_entities", default=[]): selector.EntitySelector(
                 selector.EntitySelectorConfig(domain="calendar", multiple=True)
             ),
@@ -469,6 +487,7 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
                 assignment_mode=s1.get("assignment_mode", "everyone"),
                 assignment_rotation_anchor=s1.get("assignment_rotation_anchor", "") or "",
                 publish_calendar_entities=list(s1.get("publish_calendar_entities") or []),
+                require_availability=bool(s1.get("require_availability", False)),
             )
             self._chore_step1_data = None
             return await self.async_step_manage_chores()
@@ -507,6 +526,7 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
             assignment_mode=s1.get("assignment_mode", "everyone"),
             assignment_rotation_anchor=s1.get("assignment_rotation_anchor", "") or "",
             publish_calendar_entities=list(s1.get("publish_calendar_entities") or []),
+            require_availability=bool(s1.get("require_availability", False)),
         )
         self._chore_step1_data = None
         return await self.async_step_manage_chores()
@@ -550,6 +570,7 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
                 assignment_mode=s1.get("assignment_mode", "everyone"),
                 assignment_rotation_anchor=s1.get("assignment_rotation_anchor", "") or "",
                 publish_calendar_entities=list(s1.get("publish_calendar_entities") or []),
+                require_availability=bool(s1.get("require_availability", False)),
             )
             self._chore_step1_data = None
             return await self.async_step_manage_chores()
@@ -776,6 +797,7 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
                 mode_in = user_input.get("assignment_mode", getattr(chore, "assignment_mode", "everyone"))
                 chore.assignment_mode = mode_in if mode_in in ASSIGNMENT_MODES else "everyone"
                 chore.assignment_rotation_anchor = user_input.get("assignment_rotation_anchor", getattr(chore, "assignment_rotation_anchor", "")) or ""
+                chore.require_availability = bool(user_input.get("require_availability", getattr(chore, "require_availability", False)))
                 chore.publish_calendar_entities = list(user_input.get("publish_calendar_entities", getattr(chore, "publish_calendar_entities", []) or []))
                 self._edited_chore = chore
                 _LOGGER.debug(
@@ -873,6 +895,7 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
         schema_dict[vol.Optional("assignment_rotation_anchor", default=getattr(chore, "assignment_rotation_anchor", "") or "")] = selector.TextSelector(
             selector.TextSelectorConfig(type=selector.TextSelectorType.DATE)
         )
+        schema_dict[vol.Optional("require_availability", default=bool(getattr(chore, "require_availability", False)))] = selector.BooleanSelector()
         existing_calendars = list(getattr(chore, "publish_calendar_entities", []) or [])
         if existing_calendars:
             schema_dict[vol.Optional("publish_calendar_entities", default=existing_calendars)] = selector.EntitySelector(

--- a/custom_components/taskmate/const.py
+++ b/custom_components/taskmate/const.py
@@ -15,6 +15,7 @@ CONF_CHILD_NAME: Final = "name"
 CONF_CHILD_AVATAR: Final = "avatar"
 CONF_CHILD_POINTS: Final = "points"
 CONF_CHILD_ID: Final = "id"
+CONF_CHILD_AVAILABILITY_ENTITY: Final = "availability_entity"
 
 # Chore keys
 CONF_CHORE_NAME: Final = "name"
@@ -29,6 +30,7 @@ DEFAULT_CLAIM_ALLOWANCE_MINUTES: Final = 0
 CONF_CHORE_ASSIGNMENT_MODE: Final = "assignment_mode"
 CONF_CHORE_ASSIGNMENT_ROTATION_ANCHOR: Final = "assignment_rotation_anchor"
 CONF_CHORE_PUBLISH_CALENDARS: Final = "publish_calendar_entities"
+CONF_CHORE_REQUIRE_AVAILABILITY: Final = "require_availability"
 
 # Calendar projection: how many days ahead each chore's assignment is pushed
 # into the configured HA calendars. 14 days balances planning visibility with

--- a/custom_components/taskmate/coordinator.py
+++ b/custom_components/taskmate/coordinator.py
@@ -40,6 +40,7 @@ class TaskMateCoordinator(DataUpdateCoordinator):
         self.entry_id = entry_id
         self._unsub_midnight: Callable[[], None] | None = None
         self._unsub_prune: Callable[[], None] | None = None
+        self._unsub_availability: Callable[[], None] | None = None
 
     async def async_initialize(self) -> None:
         """Initialize the coordinator."""
@@ -53,6 +54,12 @@ class TaskMateCoordinator(DataUpdateCoordinator):
         self._unsub_prune = async_track_time_change(
             self.hass, self._async_scheduled_prune, hour=0, minute=1, second=0
         )
+        # Re-evaluate availability-aware chore assignments when any HA entity
+        # state changes. The callback filters cheaply on entity id so only
+        # relevant flips trigger a recompute.
+        self._unsub_availability = self.hass.bus.async_listen(
+            "state_changed", self._availability_state_changed
+        )
 
     async def async_shutdown(self) -> None:
         """Shutdown the coordinator and clean up listeners."""
@@ -62,6 +69,9 @@ class TaskMateCoordinator(DataUpdateCoordinator):
         if self._unsub_prune:
             self._unsub_prune()
             self._unsub_prune = None
+        if self._unsub_availability:
+            self._unsub_availability()
+            self._unsub_availability = None
 
     @callback
     def _async_midnight_streak_check(self, now: datetime) -> None:
@@ -80,6 +90,59 @@ class TaskMateCoordinator(DataUpdateCoordinator):
         """Scheduled callback to prune old completion history."""
         days = int(self.storage.get_setting("history_days", "90"))
         self.hass.async_create_task(self.async_prune_history(days))
+
+    @callback
+    def _availability_state_changed(self, event: Any) -> None:
+        """Cheap bus-filter: only dispatch a re-eval when a tracked availability entity changes."""
+        data = getattr(event, "data", None) or {}
+        entity_id = data.get("entity_id")
+        if not entity_id:
+            return
+        tracked = {
+            c.availability_entity
+            for c in self.storage.get_children()
+            if getattr(c, "availability_entity", "")
+        }
+        if entity_id not in tracked:
+            return
+        self.hass.async_create_task(self._async_reevaluate_availability())
+
+    async def _async_reevaluate_availability(self) -> None:
+        """Re-run assignment for require_availability chores when availability flips.
+
+        Skips chores that already have a completion today so we don't phantom-
+        reassign a chore a child already ticked off. Only non-`everyone` modes
+        cache a single current child on the chore; `everyone` mode resolves
+        availability at read-time via `_compute_active_children`.
+        """
+        today = dt_util.as_local(dt_util.now()).date()
+        completions_today: set[str] = set()
+        for comp in self.storage.get_completions():
+            try:
+                comp_date = dt_util.as_local(comp.completed_at).date()
+            except (AttributeError, TypeError, ValueError):
+                continue
+            if comp_date == today:
+                completions_today.add(comp.chore_id)
+
+        changed = False
+        for chore in self.storage.get_chores():
+            if not getattr(chore, "require_availability", False):
+                continue
+            if getattr(chore, "assignment_mode", "everyone") == "everyone":
+                continue
+            if chore.id in completions_today:
+                continue
+            active = self._compute_active_children(chore, today)
+            desired = active[0] if active else ""
+            if getattr(chore, "assignment_current_child_id", "") != desired:
+                chore.assignment_current_child_id = desired
+                self.storage.update_chore(chore)
+                changed = True
+
+        if changed:
+            await self.storage.async_save()
+            await self.async_refresh()
 
     async def _async_check_perfect_week(self) -> None:
         """Award perfect week bonus to children who completed at least one chore every day last week."""
@@ -224,9 +287,14 @@ class TaskMateCoordinator(DataUpdateCoordinator):
         }
 
     # Child operations
-    async def async_add_child(self, name: str, avatar: str = "mdi:account-circle") -> Child:
+    async def async_add_child(
+        self,
+        name: str,
+        avatar: str = "mdi:account-circle",
+        availability_entity: str = "",
+    ) -> Child:
         """Add a new child."""
-        child = Child(name=name, avatar=avatar)
+        child = Child(name=name, avatar=avatar, availability_entity=availability_entity)
         self.storage.add_child(child)
         await self.storage.async_save()
         await self.async_refresh()
@@ -283,6 +351,7 @@ class TaskMateCoordinator(DataUpdateCoordinator):
         assignment_mode: str = "everyone",
         assignment_rotation_anchor: str = "",
         publish_calendar_entities: list[str] | None = None,
+        require_availability: bool = False,
     ) -> Chore:
         """Add a new chore."""
         # One-shot chores: force daily_limit=1, set created_date to today
@@ -314,6 +383,7 @@ class TaskMateCoordinator(DataUpdateCoordinator):
             assignment_mode=assignment_mode if assignment_mode in ("everyone", "alternating", "random") else "everyone",
             assignment_rotation_anchor=assignment_rotation_anchor,
             publish_calendar_entities=list(publish_calendar_entities or []),
+            require_availability=require_availability,
         )
         # Cache today's active child so the card can show it immediately
         today = dt_util.as_local(dt_util.now()).date()
@@ -526,6 +596,38 @@ class TaskMateCoordinator(DataUpdateCoordinator):
 
         return False
 
+    _AVAILABLE_STATES: frozenset[str] = frozenset({
+        "on", "home", "available", "present", "true",
+    })
+
+    def _is_child_available(self, child_id: str) -> bool:
+        """Return True if the child's availability entity reports them as available.
+
+        Rules:
+          - Empty/missing availability_entity on the child → True (no opinion).
+          - Entity not registered, or state is unavailable/unknown/None → True
+            (fail-open; don't block on a broken sensor).
+          - State (case-insensitive) in {"on", "home", "available", "present",
+            "true"} → True. Everything else (e.g. "off", "not_home", "away")
+            → False.
+        """
+        child = self.storage.get_child(child_id)
+        if not child:
+            return True
+        entity_id = getattr(child, "availability_entity", "") or ""
+        if not entity_id:
+            return True
+        state_obj = self.hass.states.get(entity_id)
+        if state_obj is None:
+            return True
+        raw = getattr(state_obj, "state", None)
+        if raw is None:
+            return True
+        value = str(raw).strip().lower()
+        if value in ("unavailable", "unknown", "none", ""):
+            return True
+        return value in self._AVAILABLE_STATES
+
     def _chore_assignment_pool(self, chore: Chore) -> list[str]:
         """Resolve the ordered pool of child IDs this chore rotates through.
 
@@ -548,8 +650,14 @@ class TaskMateCoordinator(DataUpdateCoordinator):
           chores across 2 children always land 5/5 (11 lands 6/5, etc.).
         """
         mode = getattr(chore, "assignment_mode", "everyone")
+        require_availability = getattr(chore, "require_availability", False)
+
         if mode not in ("alternating", "random", "balanced"):
-            return list(chore.assigned_to or [])
+            assigned = list(chore.assigned_to or [])
+            if require_availability and assigned:
+                filtered = [cid for cid in assigned if self._is_child_available(cid)]
+                return filtered if filtered else assigned
+            return assigned
 
         pool = self._chore_assignment_pool(chore)
         if not pool:
@@ -566,13 +674,13 @@ class TaskMateCoordinator(DataUpdateCoordinator):
                 anchor = today
             offset = (today - anchor).days
             idx = offset % len(pool)
-            return [pool[idx]]
+            return [self._skip_unavailable(pool, idx, require_availability)]
 
         if mode == "random":
             # random: stable per (chore.id, date) so the frontend and backend agree
             digest = hashlib.sha256(f"{chore.id}:{today.toordinal()}".encode()).digest()
             idx = int.from_bytes(digest[:8], "big") % len(pool)
-            return [pool[idx]]
+            return [self._skip_unavailable(pool, idx, require_availability)]
 
         # balanced: group today's balanced-mode chores that share this exact pool,
         # sort them by id for determinism, then round-robin across the pool. A
@@ -591,7 +699,34 @@ class TaskMateCoordinator(DataUpdateCoordinator):
             position = 0
         start_digest = hashlib.sha256(f"balanced:{pool_key}:{today.toordinal()}".encode()).digest()
         start = int.from_bytes(start_digest[:4], "big") % len(pool)
-        return [pool[(start + position) % len(pool)]]
+        idx = (start + position) % len(pool)
+        return [self._skip_unavailable(pool, idx, require_availability)]
+
+    def _skip_unavailable(self, pool: list[str], start_idx: int, enabled: bool) -> str:
+        """Walk forward from `start_idx` through `pool` looking for an available
+        child. If none of the pool is available (or the skip is disabled), return
+        the originally picked child so the chore is still visible to someone.
+        """
+        original = pool[start_idx]
+        if not enabled:
+            return original
+        size = len(pool)
+        # Cache per-call so the same child isn't queried twice in a scan.
+        cache: dict[str, bool] = {}
+        def available(cid: str) -> bool:
+            if cid not in cache:
+                cache[cid] = self._is_child_available(cid)
+            return cache[cid]
+        for step in range(size):
+            cid = pool[(start_idx + step) % size]
+            if available(cid):
+                return cid
+        _LOGGER.debug(
+            "Availability skip: no available child in pool %s for chore, "
+            "falling back to original pick %s",
+            pool, original,
+        )
+        return original
 
     # time_category -> (start_time, end_time). None means "anytime" -> all-day event.
     _TIME_CATEGORY_WINDOWS: dict[str, tuple[time, time] | None] = {

--- a/custom_components/taskmate/models.py
+++ b/custom_components/taskmate/models.py
@@ -75,6 +75,7 @@ class Child:
     streak_paused: bool = False  # True if streak is paused due to missed day (pause mode)
     streak_milestones_achieved: list[int] = field(default_factory=list)
     awarded_perfect_weeks: list[str] = field(default_factory=list)
+    availability_entity: str = ""  # HA entity id; empty = always available
     id: str = field(default_factory=generate_id)
 
     @classmethod
@@ -94,6 +95,7 @@ class Child:
             streak_paused=data.get("streak_paused", False),
             streak_milestones_achieved=list(data.get("streak_milestones_achieved", [])),
             awarded_perfect_weeks=list(data.get("awarded_perfect_weeks", [])),
+            availability_entity=data.get("availability_entity", ""),
             id=data.get("id", generate_id()),
         )
 
@@ -113,6 +115,7 @@ class Child:
             "streak_paused": self.streak_paused,
             "streak_milestones_achieved": self.streak_milestones_achieved,
             "awarded_perfect_weeks": self.awarded_perfect_weeks,
+            "availability_entity": self.availability_entity,
             "id": self.id,
         }
 
@@ -152,6 +155,7 @@ class Chore:
     assignment_mode: str = "everyone"  # everyone | alternating | random
     assignment_rotation_anchor: str = ""  # ISO date; day-0 of the rotation for alternating
     assignment_current_child_id: str = ""  # cached active child ID for today (computed at midnight and on create/update)
+    require_availability: bool = False  # When True, skip children whose availability entity says they're unavailable
     # Calendar publish: list of HA calendar entity ids to mirror the chore to. Any number supported.
     publish_calendar_entities: list[str] = field(default_factory=list)
     # ISO dates already written to the configured calendars. Used for both
@@ -195,6 +199,7 @@ class Chore:
             assignment_mode=data.get("assignment_mode", "everyone"),
             assignment_rotation_anchor=data.get("assignment_rotation_anchor", ""),
             assignment_current_child_id=data.get("assignment_current_child_id", ""),
+            require_availability=data.get("require_availability", False),
             publish_calendar_entities=list(data.get("publish_calendar_entities", [])),
             # Back-compat: old records stored a single ISO date in
             # `publish_calendar_last_date`. Seed the new list with it so we
@@ -233,6 +238,7 @@ class Chore:
             "assignment_mode": self.assignment_mode,
             "assignment_rotation_anchor": self.assignment_rotation_anchor,
             "assignment_current_child_id": self.assignment_current_child_id,
+            "require_availability": self.require_availability,
             "publish_calendar_entities": self.publish_calendar_entities,
             "publish_calendar_published_dates": self.publish_calendar_published_dates,
             "id": self.id,

--- a/custom_components/taskmate/strings.json
+++ b/custom_components/taskmate/strings.json
@@ -41,7 +41,11 @@
         "description": "Enter the child's information",
         "data": {
           "name": "Child's Name",
-          "avatar": "Avatar"
+          "avatar": "Avatar",
+          "availability_entity": "Availability Sensor (optional)"
+        },
+        "data_description": {
+          "availability_entity": "Optional Home Assistant entity whose state tells TaskMate whether this child is available. States 'on', 'home', 'available', 'present', or 'true' mean available; anything else (e.g. 'off', 'not_home', 'away') means unavailable. Leave blank to treat the child as always available. For calendars, wire up a template binary sensor since a calendar event usually means 'busy / unavailable'."
         }
       },
       "edit_child": {
@@ -50,7 +54,11 @@
         "data": {
           "name": "Child's Name",
           "avatar": "Avatar",
+          "availability_entity": "Availability Sensor (optional)",
           "action": "Action"
+        },
+        "data_description": {
+          "availability_entity": "Optional Home Assistant entity whose state tells TaskMate whether this child is available. States 'on', 'home', 'available', 'present', or 'true' mean available; anything else (e.g. 'off', 'not_home', 'away') means unavailable. Leave blank to treat the child as always available."
         }
       },
       "manage_chores": {
@@ -82,6 +90,7 @@
           "visibility_state": "Value to compare",
           "assignment_mode": "Assignment Mode",
           "assignment_rotation_anchor": "Rotation start date (alternating only)",
+          "require_availability": "Skip unavailable children",
           "publish_calendar_entities": "Publish to calendars (optional)"
         },
         "data_description": {
@@ -94,6 +103,7 @@
           "visibility_state": "The value to compare against. For 'Equals' or 'Not Equal': any text value (e.g., 'on', 'off', 'home', 'away'). For numeric operators (≥, ≤, >, <): enter a number (e.g., 25, 50.5, 100). Example: Entity 'sensor.temperature', Operator '>=', Value '20' shows chore when temperature is 20°C or higher.",
           "assignment_mode": "Everyone = every assigned child sees this chore. Alternating = one child at a time, rotating by day. Random = one randomly picked child per day (stable within the day). Balanced = today's balanced chores are split evenly across the assigned children — no one child ends up with everything.",
           "assignment_rotation_anchor": "Day-0 of the alternating rotation. Leave blank to start today. Only used when Assignment Mode is 'Alternating'.",
+          "require_availability": "When on, an unavailable child (based on the Availability Sensor in their profile) is skipped and the next available sibling takes the chore. Re-evaluated at midnight and whenever an availability sensor flips. Chores already completed today are not reassigned.",
           "publish_calendar_entities": "Pick one or more Home Assistant calendar entities. Whenever this chore is created, updated, or rolls over at midnight, today's assigned child is added as a calendar event on each selected calendar. Works with any number of calendars."
         }
       },
@@ -146,6 +156,7 @@
           "visibility_state": "Value to compare",
           "assignment_mode": "Assignment Mode",
           "assignment_rotation_anchor": "Rotation start date (alternating only)",
+          "require_availability": "Skip unavailable children",
           "publish_calendar_entities": "Publish to calendars (optional)"
         },
         "data_description": {
@@ -158,6 +169,7 @@
           "visibility_state": "The value to compare against. For 'Equals' or 'Not Equal': any text value (e.g., 'on', 'off', 'home', 'away'). For numeric operators (≥, ≤, >, <): enter a number (e.g., 25, 50.5, 100). Example: Entity 'sensor.temperature', Operator '>=', Value '20' shows chore when temperature is 20°C or higher.",
           "assignment_mode": "Everyone = every assigned child sees this chore. Alternating = one child at a time, rotating by day. Random = one randomly picked child per day (stable within the day). Balanced = today's balanced chores are split evenly across the assigned children — no one child ends up with everything.",
           "assignment_rotation_anchor": "Day-0 of the alternating rotation. Leave blank to start today. Only used when Assignment Mode is 'Alternating'.",
+          "require_availability": "When on, an unavailable child (based on the Availability Sensor in their profile) is skipped and the next available sibling takes the chore. Re-evaluated at midnight and whenever an availability sensor flips. Chores already completed today are not reassigned.",
           "publish_calendar_entities": "Pick one or more Home Assistant calendar entities. Whenever this chore is created, updated, or rolls over at midnight, today's assigned child is added as a calendar event on each selected calendar. Works with any number of calendars."
         }
       },

--- a/custom_components/taskmate/translations/en-GB.json
+++ b/custom_components/taskmate/translations/en-GB.json
@@ -41,7 +41,11 @@
         "description": "Enter the child's information",
         "data": {
           "name": "Child's Name",
-          "avatar": "Avatar"
+          "avatar": "Avatar",
+          "availability_entity": "Availability Sensor (optional)"
+        },
+        "data_description": {
+          "availability_entity": "Optional Home Assistant entity whose state tells TaskMate whether this child is available. States 'on', 'home', 'available', 'present', or 'true' mean available; anything else (e.g. 'off', 'not_home', 'away') means unavailable. Leave blank to treat the child as always available. For calendars, wire up a template binary sensor since a calendar event usually means 'busy / unavailable'."
         }
       },
       "edit_child": {
@@ -50,7 +54,11 @@
         "data": {
           "name": "Child's Name",
           "avatar": "Avatar",
+          "availability_entity": "Availability Sensor (optional)",
           "action": "Action"
+        },
+        "data_description": {
+          "availability_entity": "Optional Home Assistant entity whose state tells TaskMate whether this child is available. States 'on', 'home', 'available', 'present', or 'true' mean available; anything else (e.g. 'off', 'not_home', 'away') means unavailable. Leave blank to treat the child as always available."
         }
       },
       "manage_chores": {
@@ -82,6 +90,7 @@
           "visibility_state": "The value to compare against",
           "assignment_mode": "Assignment Mode",
           "assignment_rotation_anchor": "Rotation start date (alternating only)",
+          "require_availability": "Skip unavailable children",
           "publish_calendar_entities": "Publish to calendars (optional)"
         },
         "data_description": {
@@ -94,6 +103,7 @@
           "visibility_state": "The value to compare against. For 'Equals' or 'Not Equal': any text value (e.g., 'on', 'off', 'home', 'away'). For numeric operators (≥, ≤, >, <): enter a number (e.g., 25, 50.5, 100). Example: Entity 'sensor.temperature', Operator '≥', Value '20' shows chore when temperature is 20°C or higher.",
           "assignment_mode": "Everyone = every assigned child sees this chore. Alternating = one child at a time, rotating by day. Random = one randomly picked child per day (stable within the day). Balanced = today's balanced chores are split evenly across the assigned children — no one child ends up with everything.",
           "assignment_rotation_anchor": "Day-0 of the alternating rotation. Leave blank to start today. Only used when Assignment Mode is 'Alternating'.",
+          "require_availability": "When on, an unavailable child (based on the Availability Sensor in their profile) is skipped and the next available sibling takes the chore. Re-evaluated at midnight and whenever an availability sensor flips. Chores already completed today are not reassigned.",
           "publish_calendar_entities": "Pick one or more Home Assistant calendar entities. Whenever this chore is created, updated, or rolls over at midnight, today's assigned child is added as a calendar event on each selected calendar. Works with any number of calendars."
         }
       },
@@ -146,6 +156,7 @@
           "visibility_state": "The value to compare against",
           "assignment_mode": "Assignment Mode",
           "assignment_rotation_anchor": "Rotation start date (alternating only)",
+          "require_availability": "Skip unavailable children",
           "publish_calendar_entities": "Publish to calendars (optional)"
         },
         "data_description": {
@@ -158,6 +169,7 @@
           "visibility_state": "The value to compare against. For 'Equals' or 'Not Equal': any text value (e.g., 'on', 'off', 'home', 'away'). For numeric operators (≥, ≤, >, <): enter a number (e.g., 25, 50.5, 100). Example: Entity 'sensor.temperature', Operator '≥', Value '20' shows chore when temperature is 20°C or higher.",
           "assignment_mode": "Everyone = every assigned child sees this chore. Alternating = one child at a time, rotating by day. Random = one randomly picked child per day (stable within the day). Balanced = today's balanced chores are split evenly across the assigned children — no one child ends up with everything.",
           "assignment_rotation_anchor": "Day-0 of the alternating rotation. Leave blank to start today. Only used when Assignment Mode is 'Alternating'.",
+          "require_availability": "When on, an unavailable child (based on the Availability Sensor in their profile) is skipped and the next available sibling takes the chore. Re-evaluated at midnight and whenever an availability sensor flips. Chores already completed today are not reassigned.",
           "publish_calendar_entities": "Pick one or more Home Assistant calendar entities. Whenever this chore is created, updated, or rolls over at midnight, today's assigned child is added as a calendar event on each selected calendar. Works with any number of calendars."
         }
       },

--- a/custom_components/taskmate/translations/en.json
+++ b/custom_components/taskmate/translations/en.json
@@ -41,7 +41,11 @@
         "description": "Enter the child's information",
         "data": {
           "name": "Child's Name",
-          "avatar": "Avatar"
+          "avatar": "Avatar",
+          "availability_entity": "Availability Sensor (optional)"
+        },
+        "data_description": {
+          "availability_entity": "Optional Home Assistant entity whose state tells TaskMate whether this child is available. States 'on', 'home', 'available', 'present', or 'true' mean available; anything else (e.g. 'off', 'not_home', 'away') means unavailable. Leave blank to treat the child as always available. For calendars, wire up a template binary sensor since a calendar event usually means 'busy / unavailable'."
         }
       },
       "edit_child": {
@@ -50,7 +54,11 @@
         "data": {
           "name": "Child's Name",
           "avatar": "Avatar",
+          "availability_entity": "Availability Sensor (optional)",
           "action": "Action"
+        },
+        "data_description": {
+          "availability_entity": "Optional Home Assistant entity whose state tells TaskMate whether this child is available. States 'on', 'home', 'available', 'present', or 'true' mean available; anything else (e.g. 'off', 'not_home', 'away') means unavailable. Leave blank to treat the child as always available."
         }
       },
       "manage_chores": {
@@ -82,6 +90,7 @@
           "visibility_state": "Value to compare",
           "assignment_mode": "Assignment Mode",
           "assignment_rotation_anchor": "Rotation start date (alternating only)",
+          "require_availability": "Skip unavailable children",
           "publish_calendar_entities": "Publish to calendars (optional)"
         },
         "data_description": {
@@ -94,6 +103,7 @@
           "visibility_state": "The value to compare against. For 'Equals' or 'Not Equal': any text value (e.g., 'on', 'off', 'home', 'away'). For numeric operators (≥, ≤, >, <): enter a number (e.g., 25, 50.5, 100). Example: Entity 'sensor.temperature', Operator '>=', Value '20' shows chore when temperature is 20°C or higher.",
           "assignment_mode": "Everyone = every assigned child sees this chore. Alternating = one child at a time, rotating by day. Random = one randomly picked child per day (stable within the day). Balanced = today's balanced chores are split evenly across the assigned children — no one child ends up with everything.",
           "assignment_rotation_anchor": "Day-0 of the alternating rotation. Leave blank to start today. Only used when Assignment Mode is 'Alternating'.",
+          "require_availability": "When on, an unavailable child (based on the Availability Sensor in their profile) is skipped and the next available sibling takes the chore. Re-evaluated at midnight and whenever an availability sensor flips. Chores already completed today are not reassigned.",
           "publish_calendar_entities": "Pick one or more Home Assistant calendar entities. Whenever this chore is created, updated, or rolls over at midnight, today's assigned child is added as a calendar event on each selected calendar. Works with any number of calendars."
         }
       },
@@ -146,6 +156,7 @@
           "visibility_state": "Value to compare",
           "assignment_mode": "Assignment Mode",
           "assignment_rotation_anchor": "Rotation start date (alternating only)",
+          "require_availability": "Skip unavailable children",
           "publish_calendar_entities": "Publish to calendars (optional)"
         },
         "data_description": {
@@ -158,6 +169,7 @@
           "visibility_state": "The value to compare against. For 'Equals' or 'Not Equal': any text value (e.g., 'on', 'off', 'home', 'away'). For numeric operators (≥, ≤, >, <): enter a number (e.g., 25, 50.5, 100). Example: Entity 'sensor.temperature', Operator '>=', Value '20' shows chore when temperature is 20°C or higher.",
           "assignment_mode": "Everyone = every assigned child sees this chore. Alternating = one child at a time, rotating by day. Random = one randomly picked child per day (stable within the day). Balanced = today's balanced chores are split evenly across the assigned children — no one child ends up with everything.",
           "assignment_rotation_anchor": "Day-0 of the alternating rotation. Leave blank to start today. Only used when Assignment Mode is 'Alternating'.",
+          "require_availability": "When on, an unavailable child (based on the Availability Sensor in their profile) is skipped and the next available sibling takes the chore. Re-evaluated at midnight and whenever an availability sensor flips. Chores already completed today are not reassigned.",
           "publish_calendar_entities": "Pick one or more Home Assistant calendar entities. Whenever this chore is created, updated, or rolls over at midnight, today's assigned child is added as a calendar event on each selected calendar. Works with any number of calendars."
         }
       },

--- a/tests/test_assignment_modes.py
+++ b/tests/test_assignment_modes.py
@@ -435,3 +435,249 @@ def test_chore_from_dict_defaults_are_legacy_safe():
     # Back-compat: legacy records with the old scalar seed the new list
     migrated = Chore.from_dict({"name": "Old", "publish_calendar_last_date": "2026-04-20"})
     assert migrated.publish_calendar_published_dates == ["2026-04-20"]
+
+
+# ---------------------------------------------------------------------------
+# Availability-aware assignment
+# ---------------------------------------------------------------------------
+
+
+class _FakeState:
+    """Minimal stand-in for homeassistant.core.State used by hass.states.get."""
+
+    def __init__(self, state: str) -> None:
+        self.state = state
+
+
+class _FakeEvent:
+    """Minimal stand-in for an HA Event — coordinator only reads .data."""
+
+    def __init__(self, entity_id: str) -> None:
+        self.data = {"entity_id": entity_id}
+
+
+def _states_lookup(mapping: dict[str, str]):
+    """Build a hass.states.get(entity_id) stub from an {entity_id: state} dict."""
+    return MagicMock(side_effect=lambda eid: (_FakeState(mapping[eid]) if eid in mapping else None))
+
+
+class TestAvailabilityAwareAssignment:
+    def test_require_availability_off_ignores_entity(self):
+        # Even with an availability sensor saying "off", a chore without
+        # require_availability rotates normally.
+        a = Child(name="A", availability_entity="binary_sensor.a", id="kidA")
+        b = Child(name="B", id="kidB")
+        coord = _coord([a, b])
+        coord.hass.states.get = _states_lookup({"binary_sensor.a": "off"})
+        anchor = date(2026, 4, 20)
+        chore = Chore(
+            name="X", assigned_to=[a.id, b.id],
+            assignment_mode="alternating",
+            assignment_rotation_anchor=anchor.isoformat(),
+        )
+        # Day 0 normally picks A — and does, because the skip is disabled.
+        assert coord._compute_active_children(chore, anchor) == [a.id]
+
+    def test_alternating_skips_unavailable_child(self):
+        a = Child(name="A", availability_entity="binary_sensor.a", id="kidA")
+        b = Child(name="B", id="kidB")
+        coord = _coord([a, b])
+        coord.hass.states.get = _states_lookup({"binary_sensor.a": "off"})
+        anchor = date(2026, 4, 20)
+        chore = Chore(
+            name="X", assigned_to=[a.id, b.id],
+            assignment_mode="alternating",
+            assignment_rotation_anchor=anchor.isoformat(),
+            require_availability=True,
+        )
+        # Day 0 would be A; A is away so we skip to B.
+        assert coord._compute_active_children(chore, anchor) == [b.id]
+        # Day 1 naturally falls on B too; stays B.
+        assert coord._compute_active_children(chore, anchor + dt.timedelta(days=1)) == [b.id]
+
+    def test_random_skips_unavailable_child(self):
+        # Deterministic seed: random picks are stable per (chore.id, date).
+        # We pick a fake chore id whose hash lands on 'A' for this date, then
+        # flip A's sensor off and assert it reroutes. The test is stable
+        # because _skip_unavailable walks forward from the original idx.
+        a = Child(name="A", availability_entity="binary_sensor.a", id="kidA")
+        b = Child(name="B", id="kidB")
+        coord = _coord([a, b])
+        coord.hass.states.get = _states_lookup({"binary_sensor.a": "on"})
+        today = date(2026, 4, 20)
+        base = Chore(
+            name="R", assigned_to=[a.id, b.id],
+            assignment_mode="random", require_availability=True,
+            id="reward_alpha",
+        )
+        original_pick = coord._compute_active_children(base, today)[0]
+        coord.hass.states.get = _states_lookup({
+            "binary_sensor.a": "off" if original_pick == a.id else "on",
+        })
+        # Only flip the originally picked child away — if it was A, A's sensor
+        # is off; if it was B, A stays on and we'd expect no change.
+        result = coord._compute_active_children(base, today)[0]
+        if original_pick == a.id:
+            assert result == b.id
+        else:
+            assert result == b.id  # unchanged; B was already picked
+
+    def test_balanced_skips_unavailable_child(self):
+        a = Child(name="A", availability_entity="binary_sensor.a", id="kidA")
+        b = Child(name="B", id="kidB")
+        coord = _coord([a, b])
+        coord.hass.states.get = _states_lookup({"binary_sensor.a": "off"})
+        today = date(2026, 4, 20)
+        chores = [
+            Chore(name=f"C{i}", assigned_to=[a.id, b.id],
+                  assignment_mode="balanced", require_availability=True,
+                  id=f"c{i}")
+            for i in range(4)
+        ]
+        for c in chores:
+            coord.storage.add_chore(c)
+        picks = [coord._compute_active_children(c, today)[0] for c in chores]
+        # With A unavailable, every balanced chore must land on B.
+        assert all(p == b.id for p in picks)
+
+    def test_everyone_filters_unavailable_children(self):
+        a = Child(name="A", availability_entity="binary_sensor.a", id="kidA")
+        b = Child(name="B", id="kidB")
+        coord = _coord([a, b])
+        coord.hass.states.get = _states_lookup({"binary_sensor.a": "off"})
+        chore = Chore(name="X", assigned_to=[a.id, b.id], require_availability=True)
+        # Everyone mode with require_availability filters A out.
+        assert coord._compute_active_children(chore, date(2026, 4, 20)) == [b.id]
+
+    def test_all_unavailable_falls_back_to_original_pick(self):
+        a = Child(name="A", availability_entity="binary_sensor.a", id="kidA")
+        b = Child(name="B", availability_entity="binary_sensor.b", id="kidB")
+        coord = _coord([a, b])
+        coord.hass.states.get = _states_lookup(
+            {"binary_sensor.a": "off", "binary_sensor.b": "off"}
+        )
+        anchor = date(2026, 4, 20)
+        chore = Chore(
+            name="X", assigned_to=[a.id, b.id],
+            assignment_mode="alternating",
+            assignment_rotation_anchor=anchor.isoformat(),
+            require_availability=True,
+        )
+        # Day 0 originally picks A — keep A so the chore is still visible.
+        assert coord._compute_active_children(chore, anchor) == [a.id]
+
+    def test_missing_entity_treated_as_available(self):
+        a = Child(name="A", availability_entity="binary_sensor.not_registered", id="kidA")
+        b = Child(name="B", id="kidB")
+        coord = _coord([a, b])
+        coord.hass.states.get = _states_lookup({})  # nothing registered
+        anchor = date(2026, 4, 20)
+        chore = Chore(
+            name="X", assigned_to=[a.id, b.id],
+            assignment_mode="alternating",
+            assignment_rotation_anchor=anchor.isoformat(),
+            require_availability=True,
+        )
+        # Broken sensor → fail-open; A stays picked.
+        assert coord._compute_active_children(chore, anchor) == [a.id]
+
+    def test_unknown_state_treated_as_available(self):
+        a = Child(name="A", availability_entity="binary_sensor.a", id="kidA")
+        b = Child(name="B", id="kidB")
+        coord = _coord([a, b])
+        coord.hass.states.get = _states_lookup({"binary_sensor.a": "unknown"})
+        anchor = date(2026, 4, 20)
+        chore = Chore(
+            name="X", assigned_to=[a.id, b.id],
+            assignment_mode="alternating",
+            assignment_rotation_anchor=anchor.isoformat(),
+            require_availability=True,
+        )
+        assert coord._compute_active_children(chore, anchor) == [a.id]
+
+    def test_child_without_availability_entity_always_available(self):
+        a = Child(name="A", id="kidA")  # no availability_entity
+        b = Child(name="B", id="kidB")
+        coord = _coord([a, b])
+        coord.hass.states.get = MagicMock(return_value=None)
+        anchor = date(2026, 4, 20)
+        chore = Chore(
+            name="X", assigned_to=[a.id, b.id],
+            assignment_mode="alternating",
+            assignment_rotation_anchor=anchor.isoformat(),
+            require_availability=True,
+        )
+        assert coord._compute_active_children(chore, anchor) == [a.id]
+
+    def test_state_change_event_reassigns_chore(self):
+        a = Child(name="A", availability_entity="binary_sensor.a", id="kidA")
+        b = Child(name="B", id="kidB")
+        coord = _coord([a, b])
+        anchor = date(2026, 4, 20)
+        # Seed: A is home, chore picks A.
+        coord.hass.states.get = _states_lookup({"binary_sensor.a": "on"})
+        chore = Chore(
+            name="X", assigned_to=[a.id, b.id],
+            assignment_mode="alternating",
+            assignment_rotation_anchor=anchor.isoformat(),
+            require_availability=True,
+            assignment_current_child_id=a.id,
+            id="chore1",
+        )
+        coord.storage.add_chore(chore)
+        coord.storage.get_completions = MagicMock(return_value=[])
+        # A leaves → reevaluate should move the chore to B.
+        coord.hass.states.get = _states_lookup({"binary_sensor.a": "off"})
+        run_async(coord._async_reevaluate_availability())
+        updated = coord.storage.get_chore("chore1")
+        assert updated.assignment_current_child_id == b.id
+
+    def test_state_change_event_skips_completed_chore(self):
+        import datetime as dt2
+        a = Child(name="A", availability_entity="binary_sensor.a", id="kidA")
+        b = Child(name="B", id="kidB")
+        coord = _coord([a, b])
+        anchor = date(2026, 4, 20)
+        coord.hass.states.get = _states_lookup({"binary_sensor.a": "off"})
+        chore = Chore(
+            name="X", assigned_to=[a.id, b.id],
+            assignment_mode="alternating",
+            assignment_rotation_anchor=anchor.isoformat(),
+            require_availability=True,
+            assignment_current_child_id=a.id,
+            id="chore1",
+        )
+        coord.storage.add_chore(chore)
+
+        # Today in dt_util_mock is 2024-03-20 (see conftest).
+        from custom_components.taskmate.models import ChoreCompletion
+        today_dt = dt_util_mock.now()
+        completion = ChoreCompletion(
+            chore_id="chore1", child_id=a.id,
+            completed_at=today_dt, approved=True,
+        )
+        coord.storage.get_completions = MagicMock(return_value=[completion])
+
+        run_async(coord._async_reevaluate_availability())
+        # Chore stays on A because it's already done today.
+        updated = coord.storage.get_chore("chore1")
+        assert updated.assignment_current_child_id == a.id
+
+    def test_state_change_for_unrelated_entity_is_ignored(self):
+        a = Child(name="A", availability_entity="binary_sensor.a", id="kidA")
+        b = Child(name="B", id="kidB")
+        coord = _coord([a, b])
+        coord.hass.states.get = _states_lookup({"binary_sensor.a": "on"})
+        # Filter: fire an event for an entity no child is linked to.
+        event = _FakeEvent("binary_sensor.something_else")
+        # Callback does not schedule a reeval (hass.async_create_task is the
+        # FakeHass no-op anyway, but we still assert the tracked filter
+        # short-circuits before scheduling).
+        called = []
+        original = coord.hass.async_create_task
+        def _capture(coro):
+            called.append(coro)
+            return original(coro) if callable(original) else None
+        coord.hass.async_create_task = _capture
+        coord._availability_state_changed(event)
+        assert called == []

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -148,6 +148,27 @@ class TestChild:
 
 
 # ---------------------------------------------------------------------------
+# Child availability field
+# ---------------------------------------------------------------------------
+
+
+class TestChildAvailability:
+    def test_default_is_empty(self):
+        child = Child(name="Alice")
+        assert child.availability_entity == ""
+
+    def test_serialises_availability_entity(self):
+        child = Child(name="Alice", availability_entity="binary_sensor.alice_home", id="kid1")
+        restored = Child.from_dict(child.to_dict())
+        assert restored.availability_entity == "binary_sensor.alice_home"
+
+    def test_legacy_missing_availability_entity_backcompat(self):
+        legacy = {"name": "Alice"}
+        child = Child.from_dict(legacy)
+        assert child.availability_entity == ""
+
+
+# ---------------------------------------------------------------------------
 # Chore
 # ---------------------------------------------------------------------------
 
@@ -196,6 +217,22 @@ class TestChore:
         restored = Chore.from_dict(chore.to_dict())
         assert restored.schedule_mode == "recurring"
         assert restored.recurrence == "weekly"
+
+
+class TestChoreRequireAvailability:
+    def test_default_is_false(self):
+        chore = Chore(name="Any")
+        assert chore.require_availability is False
+
+    def test_serialises_require_availability(self):
+        chore = Chore(name="Dishes", require_availability=True, id="c1")
+        restored = Chore.from_dict(chore.to_dict())
+        assert restored.require_availability is True
+
+    def test_legacy_missing_require_availability_backcompat(self):
+        legacy = {"name": "Old chore"}
+        chore = Chore.from_dict(legacy)
+        assert chore.require_availability is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Layers an optional availability check over the existing dynamic chore-assignment system so a child who isn't home gets skipped in the rotation.

### New fields

- `Child.availability_entity` — optional HA entity (`binary_sensor.*`, `person.*`, `device_tracker.*`, etc.). States `on` / `home` / `available` / `present` / `true` mean available; anything else means away. Empty, missing, `unavailable`, or `unknown` → treated as available (fail-open on broken sensors).
- `Chore.require_availability` — boolean, off by default. When on, the chore's rotation skips unavailable children.

### How it works

- `_is_child_available(child_id)` reads `hass.states.get(...)` using the same access pattern as the existing visibility helper.
- `_compute_active_children` now threads the skip through all four modes (`everyone` / `alternating` / `random` / `balanced`). For the rotating modes it walks forward from the originally computed index until it finds an available child; for `everyone` it filters `assigned_to`.
- **Fallback:** if nobody in the pool is available, the originally picked child is kept so the chore is still visible to someone. Logged at DEBUG.
- **Same-day re-evaluation:** the coordinator listens on the HA `state_changed` event bus. When any tracked availability entity flips, it recomputes `assignment_current_child_id` for all `require_availability` chores and saves if anything changed. Chores with a completion record for today are skipped to avoid phantom reassignments.

Back-compatible: all new fields are optional, the toggle is off by default, and legacy storage round-trips unchanged.

## Test plan

- [x] `pytest tests/` — 248 passing (was 230; +4 model back-compat tests and +11 availability-aware assignment tests, +3 state-change event tests).
- [x] Python + JSON syntax checks on all modified files.
- [ ] Manual: link `binary_sensor.noah_home` to Noah; create an alternating chore with "Skip unavailable children" on; flip the sensor off mid-day via Developer Tools and confirm the chore immediately reassigns to Sister (without waiting for midnight).
- [ ] Manual: complete the chore as Noah, then flip Noah's sensor off — chore must stay on Noah (already done today).
- [ ] Manual: with the toggle off, confirm the sensor is ignored (back-compat).
