### PR TITLE
fix(tests): drop unused datetime import in availability test

### DIFF
--- a/tests/test_assignment_modes.py
+++ b/tests/test_assignment_modes.py
@@ -633,7 +633,6 @@ class TestAvailabilityAwareAssignment:
         assert updated.assignment_current_child_id == b.id
 
     def test_state_change_event_skips_completed_chore(self):
-        import datetime as dt2
         a = Child(name="A", availability_entity="binary_sensor.a", id="kidA")
         b = Child(name="B", id="kidB")
         coord = _coord([a, b])


### PR DESCRIPTION
## Summary

Fixes the Lint (ruff) CI failure on #155. The test
`test_state_change_event_skips_completed_chore` had a leftover
`import datetime as dt2` from an earlier draft — the final test uses
`dt_util_mock.now()` directly, so the import was unused and ruff's F401
flagged it.

## Test plan

- [x] `ruff check custom_components/taskmate tests` — all checks passed.
- [x] `pytest tests/` — 248 passing.
