### PR TITLE
fix(cards): lock chores in any future time period (#164)

### DIFF
--- a/custom_components/taskmate/www/taskmate-child-card.js
+++ b/custom_components/taskmate/www/taskmate-child-card.js
@@ -1357,7 +1357,7 @@ class TaskMateChildCard extends LitElement {
 
       // Check time category. The card's configured filter matches as before;
       // on top of that, chores currently in their claim window (including the
-      // post-period grace) and next-period preview chores are let through so
+      // post-period grace) and any future-period chores are let through so
       // they can render as locked previews or keep claimable during grace.
       const isLockedPreview = this._isChorePreviewLocked(chore);
       const inClaimWindow = this._isChoreInClaimWindow(chore);
@@ -1587,8 +1587,9 @@ class TaskMateChildCard extends LitElement {
     return { hour, minute };
   }
 
-  // True iff the chore's period is the immediate next period after the current
-  // one. Never true for "anytime"; no cross-midnight preview.
+  // True iff the chore's period is strictly later than the current period
+  // (any future period today, not just the immediately next one). Never true
+  // for "anytime"; no cross-midnight preview.
   _isChorePreviewLocked(chore) {
     const cat = chore?.time_category;
     if (!cat || cat === 'anytime') return false;
@@ -1596,7 +1597,7 @@ class TaskMateChildCard extends LitElement {
     const choreIndex = order.indexOf(cat);
     const currentIndex = order.indexOf(this._getCurrentTimePeriod());
     if (choreIndex < 0 || currentIndex < 0) return false;
-    return choreIndex === currentIndex + 1;
+    return choreIndex > currentIndex;
   }
 
   // True iff the current HA-local time is within the chore's claim window,


### PR DESCRIPTION
## Summary
- `_isChorePreviewLocked` previously only locked chores whose `time_category` was the *immediately next* period. During Morning, that locked Afternoon chores but left Evening (and Night) chores interactive.
- Broadened the check to any future period so Morning/Afternoon/Evening/Night chores are strictly confined to their own slot (plus the existing claim-window grace).

Closes #164

## Test plan
- [ ] With `time_category: all` during Morning, confirm Afternoon, Evening and Night chores all render locked with `Available at HH:00`.
- [ ] During Afternoon, confirm Morning chores are marked time-elapsed and Evening/Night are locked.
- [ ] During Night, confirm no cross-midnight preview (next-day Morning stays hidden, not locked).