### PR TITLE
fix(chores): clear shared rotation chore for whole pool on completion

### DIFF
--- a/custom_components/taskmate/coordinator.py
+++ b/custom_components/taskmate/coordinator.py
@@ -1039,6 +1039,38 @@ class TaskMateCoordinator(DataUpdateCoordinator):
             await self.storage.async_save()
             await self.async_refresh()
 
+    def _is_rotation_done_today(self, chore) -> bool:
+        """Return True when a non-everyone-mode chore has been completed
+        enough times today (across the whole rotation pool) to fill its
+        daily_limit. Once that quota is met the chore is "done for the
+        rotation" and should disappear from every pool member's list — not
+        just the child who happened to complete it. Returns False for
+        everyone-mode chores since they don't share a single daily quota.
+        """
+        if getattr(chore, 'assignment_mode', 'everyone') == 'everyone':
+            return False
+        pool = set(self._chore_assignment_pool(chore))
+        if not pool:
+            return False
+        today = dt_util.as_local(dt_util.now()).date()
+        completions_today = 0
+        for comp in self.storage.get_completions():
+            if comp.chore_id != chore.id:
+                continue
+            if comp.child_id not in pool:
+                continue
+            comp_dt = comp.completed_at
+            try:
+                if hasattr(comp_dt, 'astimezone'):
+                    comp_dt = dt_util.as_local(comp_dt)
+                comp_date = comp_dt.date() if hasattr(comp_dt, 'date') else None
+            except (AttributeError, TypeError, ValueError):
+                continue
+            if comp_date == today:
+                completions_today += 1
+        daily_limit = getattr(chore, 'daily_limit', 1) or 1
+        return completions_today >= daily_limit
+
     def is_chore_available_for_child(self, chore, child_id: str) -> bool:
         """Check if a recurring chore is available for a child to complete.
 
@@ -1062,6 +1094,11 @@ class TaskMateCoordinator(DataUpdateCoordinator):
         if getattr(chore, 'assignment_mode', 'everyone') != 'everyone':
             active = self._compute_active_children(chore)
             if child_id not in active:
+                return False
+            # Once anyone in the rotation pool has completed it today (e.g. a
+            # parent ticked it off for the off-rotation child), the chore is
+            # done for the whole pool — including today's active child.
+            if self._is_rotation_done_today(chore):
                 return False
 
         # Check visibility entity first — if not visible, chore is not available

--- a/custom_components/taskmate/sensor.py
+++ b/custom_components/taskmate/sensor.py
@@ -853,13 +853,18 @@ class ChildStatsSensor(TaskMateBaseSensor):
             return {}
 
         # Get chores assigned to this child. For alternating/random assignment,
-        # only include a chore when this child is the active one today.
+        # only include a chore when this child is the active one today — and
+        # drop it once any pool member has completed it today (so a parent
+        # crediting the off-rotation child clears the chore for everyone).
         chores = self.coordinator.data.get("chores", [])
         def _included(c):
             if not (child.id in c.assigned_to or not c.assigned_to):
                 return False
             if getattr(c, "assignment_mode", "everyone") != "everyone":
-                return getattr(c, "assignment_current_child_id", "") == child.id
+                if getattr(c, "assignment_current_child_id", "") != child.id:
+                    return False
+                if self.coordinator._is_rotation_done_today(c):
+                    return False
             return True
         assigned_chores = [c for c in chores if _included(c)]
 

--- a/custom_components/taskmate/www/taskmate-child-card.js
+++ b/custom_components/taskmate/www/taskmate-child-card.js
@@ -1341,6 +1341,7 @@ class TaskMateChildCard extends LitElement {
 
     // Get today's day of week from sensor (set by backend) or compute client-side
     const entity = this.hass?.states?.[this.config.entity];
+    const attrs = (window.__taskmate_attrs && window.__taskmate_attrs(this.hass, this.config.entity)) || entity?.attributes || {};
     const todayDow = entity?.attributes?.today_day_of_week ||
       new Date().toLocaleDateString('en-US', { weekday: 'long' }).toLowerCase();
 
@@ -1377,10 +1378,27 @@ class TaskMateChildCard extends LitElement {
 
       // Dynamic assignment (alternating / random): only the currently-active child
       // sees the chore. The backend caches today's pick in assignment_current_child_id.
+      // Once any eligible pool member has completed the chore today (e.g. a parent
+      // credited the off-rotation child), the chore is done for the whole pool and
+      // should disappear for everyone — including today's active child.
       const assignmentMode = chore.assignment_mode || 'everyone';
       if (assignmentMode !== 'everyone' && isAssignedToChild) {
         const activeId = chore.assignment_current_child_id ? String(chore.assignment_current_child_id) : '';
         isAssignedToChild = activeId !== '' && activeId === String(childId);
+        if (isAssignedToChild) {
+          const poolIds = assignedToStrings.length > 0
+            ? assignedToStrings
+            : (attrs.children || []).map(c => String(c.id));
+          const poolSet = new Set(poolIds);
+          const dailyLimit = chore.daily_limit || 1;
+          const allTodayCompletions = attrs.todays_completions || [];
+          const poolCompletionsToday = allTodayCompletions.filter(
+            comp => comp.chore_id === chore.id && poolSet.has(String(comp.child_id))
+          ).length;
+          if (poolCompletionsToday >= dailyLimit) {
+            isAssignedToChild = false;
+          }
+        }
       }
 
       // Check visibility_entity — if set, chore is only visible if entity matches visibility_state

--- a/tests/test_assignment_modes.py
+++ b/tests/test_assignment_modes.py
@@ -132,6 +132,7 @@ def test_is_chore_available_respects_dynamic_assignment():
     coord = _coord([a, b])
     # needs storage.get_last_completed for is_chore_available_for_child
     coord.storage.get_last_completed = MagicMock(return_value={})
+    coord.storage.get_completions = MagicMock(return_value=[])
     anchor = date(2026, 4, 20)
     dt_util_mock._now = dt.datetime.combine(anchor, dt.time(12, 0), tzinfo=UTC)
     chore = Chore(
@@ -145,6 +146,63 @@ def test_is_chore_available_respects_dynamic_assignment():
     # Everyone mode is unchanged
     chore.assignment_mode = "everyone"
     assert coord.is_chore_available_for_child(chore, a.id) is True
+    assert coord.is_chore_available_for_child(chore, b.id) is True
+
+
+def test_rotation_chore_clears_for_pool_when_off_rotation_child_completes():
+    """Regression for issue where a parent crediting User B (off rotation)
+    leaves the chore visible on User A (today's active child)."""
+    from custom_components.taskmate.models import ChoreCompletion
+
+    a, b = Child(name="A"), Child(name="B")
+    coord = _coord([a, b])
+    coord.storage.get_last_completed = MagicMock(return_value={})
+    anchor = date(2026, 4, 20)
+    dt_util_mock._now = dt.datetime.combine(anchor, dt.time(12, 0), tzinfo=UTC)
+    chore = Chore(
+        name="Bins",
+        assigned_to=[a.id, b.id],
+        assignment_mode="alternating",
+        assignment_rotation_anchor=anchor.isoformat(),
+    )
+    # A is the active child today, B is off-rotation.
+    assert coord._compute_active_children(chore, anchor) == [a.id]
+
+    # Parent credits B (off-rotation) — completion lands on B today.
+    completion = ChoreCompletion(
+        chore_id=chore.id, child_id=b.id,
+        completed_at=dt_util_mock.now(), approved=True,
+    )
+    coord.storage.get_completions = MagicMock(return_value=[completion])
+
+    # Chore is now done for the whole rotation pool — invisible to A as well.
+    assert coord._is_rotation_done_today(chore) is True
+    assert coord.is_chore_available_for_child(chore, a.id) is False
+    assert coord.is_chore_available_for_child(chore, b.id) is False
+
+    # Sanity: with daily_limit=2 and only one completion so far, A still sees it.
+    chore.daily_limit = 2
+    assert coord._is_rotation_done_today(chore) is False
+    assert coord.is_chore_available_for_child(chore, a.id) is True
+
+
+def test_everyone_mode_unaffected_by_rotation_done_helper():
+    """Everyone-mode chores share no single daily quota across the pool, so
+    the helper must not retire them after one child completes."""
+    from custom_components.taskmate.models import ChoreCompletion
+
+    a, b = Child(name="A"), Child(name="B")
+    coord = _coord([a, b])
+    coord.storage.get_last_completed = MagicMock(return_value={})
+    today = date(2026, 4, 20)
+    dt_util_mock._now = dt.datetime.combine(today, dt.time(12, 0), tzinfo=UTC)
+    chore = Chore(name="Brush teeth", assigned_to=[a.id, b.id])  # default everyone
+    completion = ChoreCompletion(
+        chore_id=chore.id, child_id=a.id,
+        completed_at=dt_util_mock.now(), approved=True,
+    )
+    coord.storage.get_completions = MagicMock(return_value=[completion])
+    assert coord._is_rotation_done_today(chore) is False
     assert coord.is_chore_available_for_child(chore, b.id) is True
 
 


### PR DESCRIPTION
## Summary
- Shared chores in `alternating`/`random`/`balanced` mode now disappear from every pool member's list once any eligible child completes them today (matching the per-pool `daily_limit`), instead of stranding the chore as pending on whichever child happened to be today's active assignee.
- Adds a single `_is_rotation_done_today` helper on the coordinator and reuses it from `is_chore_available_for_child`, the child-stats sensor's `_included` filter, and the child card's `_filterAndSortChores`.
- Regression tests cover the off-rotation completion case (Parent credits User B while User A is the active child today) and confirm `everyone`-mode chores still allow each child their own completion.

Fixes the user-reported bug where a parent or automation crediting an off-rotation user (e.g. Noah) left the chore pending on the active user's dashboard (e.g. Lisa).

## Test plan
- [ ] Create a chore with `assignment_mode=alternating` (or random/balanced) and assign it to two children.
- [ ] On a day where Lisa is the active assignee, complete it for Noah via the Parent dashboard or the `taskmate.complete_chore` service.
- [ ] Confirm Noah is credited and the chore disappears from Lisa's child card.
- [ ] Repeat in `everyone` mode and confirm Lisa still sees her copy after Noah completes his.
- [ ] Bump `daily_limit` to 2 on the rotation chore — confirm one pool completion does not retire the chore for Lisa.