### PR TITLE
feat(chores): manual override, skip, and task groups

### DIFF
--- a/custom_components/taskmate/__init__.py
+++ b/custom_components/taskmate/__init__.py
@@ -58,6 +58,16 @@ from .const import (
     SERVICE_SET_CHORE_ORDER,
     SERVICE_UPDATE_BONUS,
     SERVICE_UPDATE_PENALTY,
+    SERVICE_SKIP_CHORE,
+    SERVICE_SET_CHORE_MANUAL_START,
+    SERVICE_ADD_TASK_GROUP,
+    SERVICE_UPDATE_TASK_GROUP,
+    SERVICE_REMOVE_TASK_GROUP,
+    CONF_TASK_GROUP_ID,
+    CONF_TASK_GROUP_NAME,
+    CONF_TASK_GROUP_POLICY,
+    CONF_TASK_GROUP_CHORE_IDS,
+    TASK_GROUP_POLICIES,
     TIME_CATEGORIES,
 )
 from .coordinator import TaskMateCoordinator
@@ -345,6 +355,73 @@ async def _async_register_services(hass: HomeAssistant) -> None:
             child_id=call.data[ATTR_CHILD_ID],
         )
 
+    async def handle_skip_chore(call: ServiceCall) -> None:
+        """Handle the skip_chore service call."""
+        coordinator = _get_coordinator(hass)
+        if not coordinator:
+            _LOGGER.error("No TaskMate coordinator available")
+            return
+        try:
+            await coordinator.async_skip_chore(call.data[ATTR_CHORE_ID])
+        except ValueError as err:
+            _LOGGER.warning("skip_chore rejected: %s", err)
+            raise
+
+    async def handle_set_chore_manual_start(call: ServiceCall) -> None:
+        """Handle the set_chore_manual_start service call."""
+        coordinator = _get_coordinator(hass)
+        if not coordinator:
+            _LOGGER.error("No TaskMate coordinator available")
+            return
+        try:
+            await coordinator.async_set_chore_manual_start(
+                call.data[ATTR_CHORE_ID], call.data[ATTR_CHILD_ID]
+            )
+        except ValueError as err:
+            _LOGGER.warning("set_chore_manual_start rejected: %s", err)
+            raise
+
+    async def handle_add_task_group(call: ServiceCall) -> None:
+        """Handle the add_task_group service call."""
+        coordinator = _get_coordinator(hass)
+        if not coordinator:
+            _LOGGER.error("No TaskMate coordinator available")
+            return
+        try:
+            await coordinator.async_add_task_group(
+                name=call.data[CONF_TASK_GROUP_NAME],
+                policy=call.data[CONF_TASK_GROUP_POLICY],
+                chore_ids=call.data.get(CONF_TASK_GROUP_CHORE_IDS, []),
+            )
+        except ValueError as err:
+            _LOGGER.warning("add_task_group rejected: %s", err)
+            raise
+
+    async def handle_update_task_group(call: ServiceCall) -> None:
+        """Handle the update_task_group service call."""
+        coordinator = _get_coordinator(hass)
+        if not coordinator:
+            _LOGGER.error("No TaskMate coordinator available")
+            return
+        try:
+            await coordinator.async_update_task_group(
+                group_id=call.data[CONF_TASK_GROUP_ID],
+                name=call.data.get(CONF_TASK_GROUP_NAME),
+                policy=call.data.get(CONF_TASK_GROUP_POLICY),
+                chore_ids=call.data.get(CONF_TASK_GROUP_CHORE_IDS),
+            )
+        except ValueError as err:
+            _LOGGER.warning("update_task_group rejected: %s", err)
+            raise
+
+    async def handle_remove_task_group(call: ServiceCall) -> None:
+        """Handle the remove_task_group service call."""
+        coordinator = _get_coordinator(hass)
+        if not coordinator:
+            _LOGGER.error("No TaskMate coordinator available")
+            return
+        await coordinator.async_remove_task_group(call.data[CONF_TASK_GROUP_ID])
+
     async def handle_add_chore(call: ServiceCall) -> None:
         """Handle the add_chore service call."""
         coordinator = _get_coordinator(hass)
@@ -597,6 +674,53 @@ async def _async_register_services(hass: HomeAssistant) -> None:
         }),
     )
 
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_SKIP_CHORE,
+        handle_skip_chore,
+        schema=vol.Schema({vol.Required(ATTR_CHORE_ID): cv.string}),
+    )
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_SET_CHORE_MANUAL_START,
+        handle_set_chore_manual_start,
+        schema=vol.Schema({
+            vol.Required(ATTR_CHORE_ID): cv.string,
+            vol.Required(ATTR_CHILD_ID): cv.string,
+        }),
+    )
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_ADD_TASK_GROUP,
+        handle_add_task_group,
+        schema=vol.Schema({
+            vol.Required(CONF_TASK_GROUP_NAME): cv.string,
+            vol.Required(CONF_TASK_GROUP_POLICY): vol.In(TASK_GROUP_POLICIES),
+            vol.Optional(CONF_TASK_GROUP_CHORE_IDS, default=[]): vol.All(cv.ensure_list, [cv.string]),
+        }),
+    )
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_UPDATE_TASK_GROUP,
+        handle_update_task_group,
+        schema=vol.Schema({
+            vol.Required(CONF_TASK_GROUP_ID): cv.string,
+            vol.Optional(CONF_TASK_GROUP_NAME): cv.string,
+            vol.Optional(CONF_TASK_GROUP_POLICY): vol.In(TASK_GROUP_POLICIES),
+            vol.Optional(CONF_TASK_GROUP_CHORE_IDS): vol.All(cv.ensure_list, [cv.string]),
+        }),
+    )
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_REMOVE_TASK_GROUP,
+        handle_remove_task_group,
+        schema=vol.Schema({vol.Required(CONF_TASK_GROUP_ID): cv.string}),
+    )
+
 
 def _async_unregister_services(hass: HomeAssistant) -> None:
     """Unregister TaskMate services."""
@@ -621,6 +745,11 @@ def _async_unregister_services(hass: HomeAssistant) -> None:
         SERVICE_REMOVE_BONUS,
         SERVICE_APPLY_BONUS,
         SERVICE_ADD_CHORE,
+        SERVICE_SKIP_CHORE,
+        SERVICE_SET_CHORE_MANUAL_START,
+        SERVICE_ADD_TASK_GROUP,
+        SERVICE_UPDATE_TASK_GROUP,
+        SERVICE_REMOVE_TASK_GROUP,
     ]
     for service in services:
         hass.services.async_remove(DOMAIN, service)

--- a/custom_components/taskmate/config_flow.py
+++ b/custom_components/taskmate/config_flow.py
@@ -22,11 +22,13 @@ from .const import (
     DEFAULT_COMPLETION_SOUND,
     DEFAULT_POINTS_ICON,
     DEFAULT_POINTS_NAME,
+    DEFAULT_TASK_GROUP_POLICY,
     DOMAIN,
     MAX_CALENDAR_PROJECTION_DAYS,
     MIN_CALENDAR_PROJECTION_DAYS,
     RECURRENCE_OPTIONS,
     REWARD_ICON_OPTIONS,
+    TASK_GROUP_POLICIES,
     TIME_CATEGORIES,
 )
 
@@ -115,6 +117,7 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
         self._chore_step1_data: dict | None = None  # Holds step 1 data while user completes step 2
         self._edited_chore = None  # Holds the chore object during edit flow across steps
         self._translations: dict | None = None
+        self._selected_task_group_id: str | None = None
 
     @property
     def coordinator(self):
@@ -216,6 +219,7 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
             menu_options=[
                 "manage_children",
                 "manage_chores",
+                "manage_task_groups",
                 "manage_rewards",
                 "settings",
             ],
@@ -345,6 +349,24 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
 
     # ==================== CHORES MANAGEMENT ====================
 
+    async def _maybe_apply_manual_start(self, chore_id: str) -> None:
+        """Apply a manual start selection from step 1 after the chore is saved.
+
+        Called by the edit-chore schedule sub-steps. No-op when the dropdown
+        was left at "(auto)".
+        """
+        s1 = self._chore_step1_data or {}
+        manual_start = (s1.get("manual_start_child_id") or "").strip()
+        if not manual_start:
+            return
+        chore = self.coordinator.get_chore(chore_id)
+        if not chore or getattr(chore, "assignment_mode", "everyone") == "everyone":
+            return
+        try:
+            await self.coordinator.async_set_chore_manual_start(chore_id, manual_start)
+        except ValueError as err:
+            _LOGGER.debug("Manual start ignored: %s", err)
+
     async def async_step_manage_chores(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
@@ -463,6 +485,18 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
                     multiple=True,
                 )
             )
+            # Manual start: only meaningful for rotation modes with >1 child. We
+            # always render the dropdown (HA config flow is stateless between
+            # re-renders) but document that it's ignored for 'everyone' mode.
+            manual_start_options = [selector.SelectOptionDict(value="", label="(auto)")] + [
+                selector.SelectOptionDict(value=c.id, label=c.name) for c in children
+            ]
+            schema_dict[vol.Optional("manual_start_child_id", default="")] = selector.SelectSelector(
+                selector.SelectSelectorConfig(
+                    options=manual_start_options,
+                    mode=selector.SelectSelectorMode.DROPDOWN,
+                )
+            )
 
         return self.async_show_form(
             step_id="add_chore",
@@ -494,6 +528,7 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
                 assignment_rotation_anchor=s1.get("assignment_rotation_anchor", "") or "",
                 publish_calendar_entities=list(s1.get("publish_calendar_entities") or []),
                 require_availability=bool(s1.get("require_availability", False)),
+                manual_start_child_id=s1.get("manual_start_child_id", "") or "",
             )
             self._chore_step1_data = None
             return await self.async_step_manage_chores()
@@ -533,6 +568,7 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
             assignment_rotation_anchor=s1.get("assignment_rotation_anchor", "") or "",
             publish_calendar_entities=list(s1.get("publish_calendar_entities") or []),
             require_availability=bool(s1.get("require_availability", False)),
+            manual_start_child_id=s1.get("manual_start_child_id", "") or "",
         )
         self._chore_step1_data = None
         return await self.async_step_manage_chores()
@@ -577,6 +613,7 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
                 assignment_rotation_anchor=s1.get("assignment_rotation_anchor", "") or "",
                 publish_calendar_entities=list(s1.get("publish_calendar_entities") or []),
                 require_availability=bool(s1.get("require_availability", False)),
+                manual_start_child_id=s1.get("manual_start_child_id", "") or "",
             )
             self._chore_step1_data = None
             return await self.async_step_manage_chores()
@@ -927,6 +964,15 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
                     multiple=True,
                 )
             )
+            manual_start_options = [selector.SelectOptionDict(value="", label="(auto)")] + [
+                selector.SelectOptionDict(value=c.id, label=c.name) for c in children
+            ]
+            schema_dict[vol.Optional("manual_start_child_id", default="")] = selector.SelectSelector(
+                selector.SelectSelectorConfig(
+                    options=manual_start_options,
+                    mode=selector.SelectSelectorMode.DROPDOWN,
+                )
+            )
 
         return self.async_show_form(
             step_id="edit_chore",
@@ -962,6 +1008,7 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
             chore.recurrence_start = ""
             chore.first_occurrence_mode = "available_immediately"
             await self.coordinator.async_update_chore(chore)
+            await self._maybe_apply_manual_start(chore.id)
             self._chore_step1_data = None
             self._edited_chore = None
             return await self.async_step_manage_chores()
@@ -1003,6 +1050,7 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
             from homeassistant.util import dt as dt_util
             chore.created_date = dt_util.as_local(dt_util.now()).date().isoformat()
         await self.coordinator.async_update_chore(chore)
+        await self._maybe_apply_manual_start(chore.id)
         self._chore_step1_data = None
         self._edited_chore = None
         return await self.async_step_manage_chores()
@@ -1035,6 +1083,7 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
                 chore.name, chore.visibility_entity, chore.visibility_operator, chore.visibility_state
             )
             await self.coordinator.async_update_chore(chore)
+            await self._maybe_apply_manual_start(chore.id)
             self._chore_step1_data = None
             self._edited_chore = None
             return await self.async_step_manage_chores()
@@ -1447,6 +1496,141 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
             ),
         )
 
+    # ==================== TASK GROUPS MANAGEMENT ====================
+
+    async def async_step_manage_task_groups(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Task groups menu."""
+        await self._async_load_translations()
+        groups = self.coordinator.storage.get_task_groups()
+        _m = lambda key, default: self._t(f"options.step.manage_task_groups.menu_options.{key}", default)
+        menu_options = {"add_task_group": _m("add_task_group", "Add New Group")}
+        for group in groups:
+            count = len(group.chore_ids or [])
+            menu_options[f"edit_task_group_{group.id}"] = f"{group.name} ({group.policy}, {count} chores)"
+        menu_options["init"] = _m("init", "Back to Main Menu")
+        return self.async_show_menu(
+            step_id="manage_task_groups",
+            menu_options=menu_options,
+        )
+
+    def _rotation_chore_options(self):
+        """Return select options for chores that can legally join a group."""
+        options = []
+        for c in self.coordinator.storage.get_chores():
+            if getattr(c, "assignment_mode", "everyone") == "everyone":
+                continue
+            options.append(selector.SelectOptionDict(value=c.id, label=f"{c.name} ({c.assignment_mode})"))
+        return options
+
+    async def async_step_add_task_group(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Add a new task group."""
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            name = (user_input.get("name") or "").strip()
+            policy = user_input.get("policy", DEFAULT_TASK_GROUP_POLICY)
+            chore_ids = user_input.get("chore_ids", []) or []
+            if not name:
+                errors["name"] = "name_required"
+            else:
+                try:
+                    await self.coordinator.async_add_task_group(
+                        name=name, policy=policy, chore_ids=list(chore_ids)
+                    )
+                    return await self.async_step_manage_task_groups()
+                except ValueError as err:
+                    _LOGGER.warning("add_task_group validation failed: %s", err)
+                    errors["base"] = "task_group_invalid"
+
+        chore_options = self._rotation_chore_options()
+        return self.async_show_form(
+            step_id="add_task_group",
+            data_schema=vol.Schema({
+                vol.Required("name"): str,
+                vol.Required("policy", default=DEFAULT_TASK_GROUP_POLICY): selector.SelectSelector(
+                    selector.SelectSelectorConfig(
+                        options=list(TASK_GROUP_POLICIES),
+                        translation_key="task_group_policy",
+                        mode=selector.SelectSelectorMode.LIST,
+                    )
+                ),
+                vol.Optional("chore_ids", default=[]): selector.SelectSelector(
+                    selector.SelectSelectorConfig(
+                        options=chore_options,
+                        mode=selector.SelectSelectorMode.DROPDOWN,
+                        multiple=True,
+                    )
+                ),
+            }),
+            errors=errors,
+        )
+
+    async def async_step_edit_task_group(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Edit an existing task group."""
+        group = self.coordinator.storage.get_task_group(self._selected_task_group_id or "")
+        if not group:
+            return await self.async_step_manage_task_groups()
+
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            action = user_input.get("action", "save")
+            if action == "delete":
+                await self.coordinator.async_remove_task_group(group.id)
+                return await self.async_step_manage_task_groups()
+            name = (user_input.get("name") or "").strip()
+            policy = user_input.get("policy", group.policy)
+            chore_ids = user_input.get("chore_ids", []) or []
+            if not name:
+                errors["name"] = "name_required"
+            else:
+                try:
+                    await self.coordinator.async_update_task_group(
+                        group_id=group.id,
+                        name=name,
+                        policy=policy,
+                        chore_ids=list(chore_ids),
+                    )
+                    return await self.async_step_manage_task_groups()
+                except ValueError as err:
+                    _LOGGER.warning("update_task_group validation failed: %s", err)
+                    errors["base"] = "task_group_invalid"
+
+        chore_options = self._rotation_chore_options()
+        return self.async_show_form(
+            step_id="edit_task_group",
+            data_schema=vol.Schema({
+                vol.Required("name", default=group.name): str,
+                vol.Required("policy", default=group.policy): selector.SelectSelector(
+                    selector.SelectSelectorConfig(
+                        options=list(TASK_GROUP_POLICIES),
+                        translation_key="task_group_policy",
+                        mode=selector.SelectSelectorMode.LIST,
+                    )
+                ),
+                vol.Optional("chore_ids", default=list(group.chore_ids or [])): selector.SelectSelector(
+                    selector.SelectSelectorConfig(
+                        options=chore_options,
+                        mode=selector.SelectSelectorMode.DROPDOWN,
+                        multiple=True,
+                    )
+                ),
+                vol.Required("action", default="save"): selector.SelectSelector(
+                    selector.SelectSelectorConfig(
+                        options=["save", "delete"],
+                        translation_key="task_group_action",
+                        mode=selector.SelectSelectorMode.LIST,
+                    )
+                ),
+            }),
+            errors=errors,
+            description_placeholders={"group_name": group.name},
+        )
+
     # ==================== DYNAMIC STEP ROUTING ====================
 
     def __getattr__(self, name: str):
@@ -1466,4 +1650,9 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
             if self.coordinator.storage.get_reward(reward_id):
                 self._selected_reward_id = reward_id
                 return self.async_step_edit_reward
+        elif name.startswith("async_step_edit_task_group_"):
+            group_id = name.replace("async_step_edit_task_group_", "")
+            if self.coordinator.storage.get_task_group(group_id):
+                self._selected_task_group_id = group_id
+                return self.async_step_edit_task_group
         raise AttributeError(f"'{type(self).__name__}' object has no attribute '{name}'")

--- a/custom_components/taskmate/const.py
+++ b/custom_components/taskmate/const.py
@@ -31,6 +31,16 @@ CONF_CHORE_ASSIGNMENT_MODE: Final = "assignment_mode"
 CONF_CHORE_ASSIGNMENT_ROTATION_ANCHOR: Final = "assignment_rotation_anchor"
 CONF_CHORE_PUBLISH_CALENDARS: Final = "publish_calendar_entities"
 CONF_CHORE_REQUIRE_AVAILABILITY: Final = "require_availability"
+CONF_CHORE_MANUAL_START_CHILD: Final = "manual_start_child_id"
+
+# Task groups
+CONF_TASK_GROUPS: Final = "task_groups"
+CONF_TASK_GROUP_ID: Final = "group_id"
+CONF_TASK_GROUP_NAME: Final = "name"
+CONF_TASK_GROUP_POLICY: Final = "policy"
+CONF_TASK_GROUP_CHORE_IDS: Final = "chore_ids"
+TASK_GROUP_POLICIES: Final = ["sticky", "spread"]
+DEFAULT_TASK_GROUP_POLICY: Final = "sticky"
 
 # Calendar projection: how many days ahead each chore's assignment is pushed
 # into the configured HA calendars. 14 days balances planning visibility with
@@ -234,6 +244,11 @@ SERVICE_REMOVE_BONUS: Final = "remove_bonus"
 SERVICE_APPLY_BONUS: Final = "apply_bonus"
 SERVICE_ADD_CHORE: Final = "add_chore"
 SERVICE_ALLOCATE_POINTS_TO_POOL: Final = "allocate_points_to_pool"
+SERVICE_SKIP_CHORE: Final = "skip_chore"
+SERVICE_SET_CHORE_MANUAL_START: Final = "set_chore_manual_start"
+SERVICE_ADD_TASK_GROUP: Final = "add_task_group"
+SERVICE_UPDATE_TASK_GROUP: Final = "update_task_group"
+SERVICE_REMOVE_TASK_GROUP: Final = "remove_task_group"
 
 # Events
 EVENT_PREVIEW_SOUND: Final = "taskmate_preview_sound"

--- a/custom_components/taskmate/coordinator.py
+++ b/custom_components/taskmate/coordinator.py
@@ -125,6 +125,10 @@ class TaskMateCoordinator(DataUpdateCoordinator):
             if comp_date == today:
                 completions_today.add(comp.chore_id)
 
+        # Use the group-aware daily map so sticky/spread policies are honored
+        # when an availability flip causes a shift.
+        daily = self._compute_daily_assignments(today)
+
         changed = False
         for chore in self.storage.get_chores():
             if not getattr(chore, "require_availability", False):
@@ -133,8 +137,7 @@ class TaskMateCoordinator(DataUpdateCoordinator):
                 continue
             if chore.id in completions_today:
                 continue
-            active = self._compute_active_children(chore, today)
-            desired = active[0] if active else ""
+            desired = daily.get(chore.id, "")
             if getattr(chore, "assignment_current_child_id", "") != desired:
                 chore.assignment_current_child_id = desired
                 self.storage.update_chore(chore)
@@ -352,6 +355,7 @@ class TaskMateCoordinator(DataUpdateCoordinator):
         assignment_rotation_anchor: str = "",
         publish_calendar_entities: list[str] | None = None,
         require_availability: bool = False,
+        manual_start_child_id: str = "",
     ) -> Chore:
         """Add a new chore."""
         # One-shot chores: force daily_limit=1, set created_date to today
@@ -360,11 +364,22 @@ class TaskMateCoordinator(DataUpdateCoordinator):
             if not created_date:
                 created_date = dt_util.as_local(dt_util.now()).date().isoformat()
 
+        resolved_mode = assignment_mode if assignment_mode in ("everyone", "alternating", "random", "balanced") else "everyone"
+        today = dt_util.as_local(dt_util.now()).date()
+
+        # Apply manual start: for alternating, reorder pool + reset anchor so the
+        # chosen child is day-0 of the rotation. For random/balanced, we pin the
+        # cached assignment below after the chore is constructed.
+        pool = list(assigned_to or [])
+        if manual_start_child_id and resolved_mode == "alternating" and manual_start_child_id in pool:
+            pool = [manual_start_child_id] + [c for c in pool if c != manual_start_child_id]
+            assignment_rotation_anchor = today.isoformat()
+
         chore = Chore(
             name=name,
             points=points,
             description=description,
-            assigned_to=assigned_to or [],
+            assigned_to=pool,
             requires_approval=requires_approval,
             time_category=time_category,
             claim_allowance_minutes=max(0, int(claim_allowance_minutes or 0)),
@@ -380,16 +395,21 @@ class TaskMateCoordinator(DataUpdateCoordinator):
             visibility_state=visibility_state,
             visibility_operator=visibility_operator,
             created_date=created_date,
-            assignment_mode=assignment_mode if assignment_mode in ("everyone", "alternating", "random") else "everyone",
+            assignment_mode=resolved_mode,
             assignment_rotation_anchor=assignment_rotation_anchor,
             publish_calendar_entities=list(publish_calendar_entities or []),
             require_availability=require_availability,
         )
         # Cache today's active child so the card can show it immediately
-        today = dt_util.as_local(dt_util.now()).date()
         active = self._compute_active_children(chore, today)
         if active and chore.assignment_mode != "everyone":
             chore.assignment_current_child_id = active[0]
+        # For random/balanced manual-start, override today's cached child so
+        # the parent sees the chosen child immediately.
+        if manual_start_child_id and resolved_mode in ("random", "balanced"):
+            resolved_pool = self._chore_assignment_pool(chore) if chore.assigned_to else [c.id for c in self.storage.get_children()]
+            if manual_start_child_id in resolved_pool:
+                chore.assignment_current_child_id = manual_start_child_id
         self.storage.add_chore(chore)
         # Publish to any configured calendars ASAP — before save so we persist the last_date stamp
         await self._publish_chore_to_calendars(chore, today)
@@ -447,9 +467,15 @@ class TaskMateCoordinator(DataUpdateCoordinator):
     async def async_update_chore(self, chore: Chore) -> None:
         """Update a chore."""
         today = dt_util.as_local(dt_util.now()).date()
-        active = self._compute_active_children(chore, today)
+        # Capture pre-update state before storage is mutated below.
+        existing = self.storage.get_chore(chore.id)
+        prev_entities = list(getattr(existing, "publish_calendar_entities", []) or []) if existing else []
+        # Persist the incoming chore so _compute_daily_assignments sees the
+        # latest pool / mode / etc. when applying group policies.
+        self.storage.update_chore(chore)
+        daily = self._compute_daily_assignments(today)
         if getattr(chore, "assignment_mode", "everyone") != "everyone":
-            chore.assignment_current_child_id = active[0] if active else ""
+            chore.assignment_current_child_id = daily.get(chore.id, "")
         else:
             chore.assignment_current_child_id = ""
         # Any edit to a chore with calendar publishing can shift which dates
@@ -457,8 +483,6 @@ class TaskMateCoordinator(DataUpdateCoordinator):
         # recurrence, rename, time_category, entity list, etc.), so purge the
         # entire horizon from both the old and new calendar sets and let the
         # following publish pass re-write the projection.
-        existing = self.storage.get_chore(chore.id)
-        prev_entities = list(getattr(existing, "publish_calendar_entities", []) or []) if existing else []
         new_entities = list(chore.publish_calendar_entities or [])
         cleanup_entities = list({*prev_entities, *new_entities})
         if cleanup_entities:
@@ -476,6 +500,8 @@ class TaskMateCoordinator(DataUpdateCoordinator):
         self.storage.remove_chore(chore_id)
         self.storage.remove_completions_for_chore(chore_id)
         self.storage.remove_last_completed_for_chore(chore_id)
+        # Strip chore from any task group it belonged to.
+        self.storage.remove_chore_from_task_groups(chore_id)
         # Remove chore from children's chore_order lists
         for child in self.storage.get_children():
             if chore_id in child.chore_order:
@@ -487,6 +513,195 @@ class TaskMateCoordinator(DataUpdateCoordinator):
     def get_chore(self, chore_id: str) -> Chore | None:
         """Get a chore by ID."""
         return self.storage.get_chore(chore_id)
+
+    async def async_skip_chore(self, chore_id: str) -> Chore:
+        """Advance today's rotation pointer past the current assignee.
+
+        Ephemeral: the skip applies only today. Tomorrow's midnight refresh
+        clears `skip_date` / `skip_count` so the rotation resumes its normal
+        schedule. Skip creates no completion record; the pool-wide daily_limit
+        count is unaffected.
+        """
+        chore = self.storage.get_chore(chore_id)
+        if not chore:
+            raise ValueError(f"Unknown chore: {chore_id}")
+        mode = getattr(chore, "assignment_mode", "everyone")
+        if mode == "everyone":
+            raise ValueError("Skip is not supported for 'everyone' assignment mode")
+
+        # Reject skipping a sticky group follower — the group would drift.
+        group = self.storage.get_task_group_for_chore(chore_id)
+        if group and group.policy == "sticky" and group.chore_ids and group.chore_ids[0] != chore_id:
+            raise ValueError(
+                "Cannot skip a sticky group follower; skip the leader chore instead"
+            )
+
+        pool = self._chore_assignment_pool(chore)
+        if len(pool) <= 1:
+            raise ValueError("Skip requires a rotation pool of 2 or more children")
+
+        today = dt_util.as_local(dt_util.now()).date()
+        today_iso = today.isoformat()
+
+        # Reset stale skip state.
+        if getattr(chore, "skip_date", "") != today_iso:
+            chore.skip_date = today_iso
+            chore.skip_count = 0
+
+        # Clamp: a full pool's worth of skips returns to the original child, so
+        # anything beyond pool_size-1 is a no-op.
+        if chore.skip_count >= len(pool) - 1:
+            return chore
+        chore.skip_count += 1
+
+        # Recompute with the group-aware map so sticky followers shift too.
+        self.storage.update_chore(chore)
+        daily = self._compute_daily_assignments(today)
+        chore.assignment_current_child_id = daily.get(chore_id, "")
+        self.storage.update_chore(chore)
+
+        # Propagate to sticky followers (their cached current_child_id shifts
+        # when the leader shifts).
+        if group and group.policy == "sticky" and group.chore_ids and group.chore_ids[0] == chore_id:
+            for follower_id in group.chore_ids[1:]:
+                follower = self.storage.get_chore(follower_id)
+                if not follower:
+                    continue
+                desired = daily.get(follower_id, "")
+                if getattr(follower, "assignment_current_child_id", "") != desired:
+                    follower.assignment_current_child_id = desired
+                    self.storage.update_chore(follower)
+
+        await self.storage.async_save()
+        await self.async_refresh()
+        return chore
+
+    async def async_set_chore_manual_start(self, chore_id: str, child_id: str) -> Chore:
+        """Set the chore's rotation to start with the given child today.
+
+        - alternating: reorder `assigned_to` so the chosen child is day-0, and
+          reset the rotation anchor to today.
+        - random / balanced: override today's cached assignment only; the
+          deterministic hash takes over tomorrow.
+        """
+        chore = self.storage.get_chore(chore_id)
+        if not chore:
+            raise ValueError(f"Unknown chore: {chore_id}")
+        mode = getattr(chore, "assignment_mode", "everyone")
+        if mode == "everyone":
+            raise ValueError("Manual start is not supported for 'everyone' assignment mode")
+
+        pool = self._chore_assignment_pool(chore)
+        if child_id not in pool:
+            raise ValueError(f"Child {child_id} is not in this chore's pool")
+
+        today = dt_util.as_local(dt_util.now()).date()
+
+        if mode == "alternating":
+            # Reorder only when assigned_to is explicit; fallback pool ordering
+            # matches storage.get_children() order, which we preserve by
+            # materializing assigned_to to the full pool here.
+            chore.assigned_to = [child_id] + [c for c in pool if c != child_id]
+            chore.assignment_rotation_anchor = today.isoformat()
+
+        # Any previous skip is wiped — manual start is an explicit reset.
+        chore.skip_date = ""
+        chore.skip_count = 0
+
+        if mode in ("random", "balanced"):
+            chore.assignment_current_child_id = child_id
+        else:
+            chore.assignment_current_child_id = child_id
+
+        self.storage.update_chore(chore)
+        await self.storage.async_save()
+        await self.async_refresh()
+        return chore
+
+    # Task group operations
+
+    def get_task_groups(self):
+        """Return all task groups."""
+        return self.storage.get_task_groups()
+
+    def get_task_group(self, group_id: str):
+        """Return a task group by ID."""
+        return self.storage.get_task_group(group_id)
+
+    def get_task_group_for_chore(self, chore_id: str):
+        """Return the (at most one) task group containing the given chore."""
+        return self.storage.get_task_group_for_chore(chore_id)
+
+    def _validate_task_group_members(self, chore_ids: list[str], exclude_group_id: str = "") -> None:
+        """Raise ValueError if any chore can't legally join a group.
+
+        Rules:
+        - chore must exist.
+        - chore.assignment_mode must be a rotation mode (not 'everyone').
+        - chore must not already belong to a different group.
+        """
+        seen: set[str] = set()
+        for chore_id in chore_ids:
+            if chore_id in seen:
+                raise ValueError(f"Duplicate chore in group: {chore_id}")
+            seen.add(chore_id)
+            chore = self.storage.get_chore(chore_id)
+            if not chore:
+                raise ValueError(f"Unknown chore: {chore_id}")
+            if getattr(chore, "assignment_mode", "everyone") == "everyone":
+                raise ValueError(
+                    f"Chore '{chore.name}' uses 'everyone' mode and cannot join a group"
+                )
+            existing_group = self.storage.get_task_group_for_chore(chore_id)
+            if existing_group and existing_group.id != exclude_group_id:
+                raise ValueError(
+                    f"Chore '{chore.name}' already belongs to group '{existing_group.name}'"
+                )
+
+    async def async_add_task_group(self, name: str, policy: str, chore_ids: list[str] | None = None):
+        """Create a task group."""
+        from .models import TaskGroup  # local import to avoid top-level cycles
+        if policy not in ("sticky", "spread"):
+            raise ValueError(f"Unknown task group policy: {policy}")
+        chore_ids = list(chore_ids or [])
+        self._validate_task_group_members(chore_ids)
+        group = TaskGroup(name=name, policy=policy, chore_ids=chore_ids)
+        self.storage.add_task_group(group)
+        await self.storage.async_save()
+        await self.async_refresh()
+        return group
+
+    async def async_update_task_group(
+        self,
+        group_id: str,
+        name: str | None = None,
+        policy: str | None = None,
+        chore_ids: list[str] | None = None,
+    ):
+        """Update an existing task group."""
+        group = self.storage.get_task_group(group_id)
+        if not group:
+            raise ValueError(f"Unknown task group: {group_id}")
+        if policy is not None:
+            if policy not in ("sticky", "spread"):
+                raise ValueError(f"Unknown task group policy: {policy}")
+            group.policy = policy
+        if name is not None:
+            group.name = name
+        if chore_ids is not None:
+            new_chore_ids = list(chore_ids)
+            self._validate_task_group_members(new_chore_ids, exclude_group_id=group_id)
+            group.chore_ids = new_chore_ids
+        self.storage.update_task_group(group)
+        await self.storage.async_save()
+        await self.async_refresh()
+        return group
+
+    async def async_remove_task_group(self, group_id: str) -> None:
+        """Delete a task group."""
+        self.storage.remove_task_group(group_id)
+        await self.storage.async_save()
+        await self.async_refresh()
 
     # Reward operations
 
@@ -648,6 +863,11 @@ class TaskMateCoordinator(DataUpdateCoordinator):
         - balanced: today's balanced-mode chores sharing this pool are evenly
           split across the pool via a round-robin anchored by the date — so 10
           chores across 2 children always land 5/5 (11 lands 6/5, etc.).
+
+        When `chore.skip_date` matches today, `chore.skip_count` is added to the
+        computed rotation index so the pointer advances past any children the
+        parent has skipped. Stale skip state (skip_date != today) is ignored at
+        read time and cleared during the midnight refresh.
         """
         mode = getattr(chore, "assignment_mode", "everyone")
         require_availability = getattr(chore, "require_availability", False)
@@ -666,6 +886,11 @@ class TaskMateCoordinator(DataUpdateCoordinator):
         if today is None:
             today = dt_util.as_local(dt_util.now()).date()
 
+        # Skip offset only applies when the skip was recorded today.
+        skip_offset = 0
+        if getattr(chore, "skip_date", "") == today.isoformat():
+            skip_offset = int(getattr(chore, "skip_count", 0) or 0)
+
         if mode == "alternating":
             anchor_iso = getattr(chore, "assignment_rotation_anchor", "") or ""
             try:
@@ -673,13 +898,13 @@ class TaskMateCoordinator(DataUpdateCoordinator):
             except ValueError:
                 anchor = today
             offset = (today - anchor).days
-            idx = offset % len(pool)
+            idx = (offset + skip_offset) % len(pool)
             return [self._skip_unavailable(pool, idx, require_availability)]
 
         if mode == "random":
             # random: stable per (chore.id, date) so the frontend and backend agree
             digest = hashlib.sha256(f"{chore.id}:{today.toordinal()}".encode()).digest()
-            idx = int.from_bytes(digest[:8], "big") % len(pool)
+            idx = (int.from_bytes(digest[:8], "big") + skip_offset) % len(pool)
             return [self._skip_unavailable(pool, idx, require_availability)]
 
         # balanced: group today's balanced-mode chores that share this exact pool,
@@ -699,8 +924,101 @@ class TaskMateCoordinator(DataUpdateCoordinator):
             position = 0
         start_digest = hashlib.sha256(f"balanced:{pool_key}:{today.toordinal()}".encode()).digest()
         start = int.from_bytes(start_digest[:4], "big") % len(pool)
-        idx = (start + position) % len(pool)
+        idx = (start + position + skip_offset) % len(pool)
         return [self._skip_unavailable(pool, idx, require_availability)]
+
+    def _compute_daily_assignments(self, today: date | None = None) -> dict[str, str]:
+        """Compute today's assignment per rotation-mode chore, honoring groups.
+
+        Returns a map of chore_id -> child_id. Only chores with a non-everyone
+        assignment_mode are present. Task group policies (sticky / spread) are
+        applied on top of the per-chore raw pick.
+        """
+        if today is None:
+            today = dt_util.as_local(dt_util.now()).date()
+
+        chores = self.storage.get_chores()
+        chore_by_id: dict[str, Chore] = {c.id: c for c in chores}
+
+        # Step 1: raw per-chore picks for rotation modes.
+        result: dict[str, str] = {}
+        for chore in chores:
+            mode = getattr(chore, "assignment_mode", "everyone")
+            if mode == "everyone":
+                continue
+            active = self._compute_active_children(chore, today)
+            if active:
+                result[chore.id] = active[0]
+
+        # Step 2: apply group policies.
+        for group in self.storage.get_task_groups():
+            if not group.chore_ids:
+                continue
+            if group.policy == "sticky":
+                self._apply_sticky_policy(group, chore_by_id, result)
+            elif group.policy == "spread":
+                self._apply_spread_policy(group, chore_by_id, result)
+
+        return result
+
+    def _apply_sticky_policy(
+        self, group, chore_by_id: dict[str, Chore], result: dict[str, str]
+    ) -> None:
+        """Force followers onto the leader chore's assignee (when in pool)."""
+        leader_id = group.chore_ids[0]
+        leader_child = result.get(leader_id)
+        if not leader_child:
+            return
+        for follower_id in group.chore_ids[1:]:
+            follower = chore_by_id.get(follower_id)
+            if not follower:
+                continue
+            if getattr(follower, "assignment_mode", "everyone") == "everyone":
+                continue
+            pool = self._chore_assignment_pool(follower)
+            if leader_child in pool:
+                result[follower_id] = leader_child
+            else:
+                _LOGGER.debug(
+                    "STICKY fallback: leader %s assigned to %s not in follower %s pool",
+                    leader_id, leader_child, follower_id,
+                )
+
+    def _apply_spread_policy(
+        self, group, chore_by_id: dict[str, Chore], result: dict[str, str]
+    ) -> None:
+        """Assign group members to distinct children; wraps when pool < group size."""
+        used: set[str] = set()
+        for chore_id in group.chore_ids:
+            chore = chore_by_id.get(chore_id)
+            if not chore:
+                continue
+            if getattr(chore, "assignment_mode", "everyone") == "everyone":
+                continue
+            pool = self._chore_assignment_pool(chore)
+            if not pool:
+                continue
+            # Wrap: once every child in this pool has been used, start over.
+            if len(used) >= len(pool) or all(p in used for p in pool):
+                used = set()
+            raw = result.get(chore_id) or pool[0]
+            if raw not in used:
+                result[chore_id] = raw
+                used.add(raw)
+                continue
+            # Walk pool from raw pick looking for an unused child.
+            try:
+                start_idx = pool.index(raw)
+            except ValueError:
+                start_idx = 0
+            picked = raw
+            for step in range(len(pool)):
+                cid = pool[(start_idx + step) % len(pool)]
+                if cid not in used:
+                    picked = cid
+                    break
+            result[chore_id] = picked
+            used.add(picked)
 
     def _skip_unavailable(self, pool: list[str], start_idx: int, enabled: bool) -> str:
         """Walk forward from `start_idx` through `pool` looking for an available
@@ -1013,16 +1331,29 @@ class TaskMateCoordinator(DataUpdateCoordinator):
 
         Runs at midnight. All chores are processed concurrently so the runtime
         is bounded by the slowest single publish, not the sum across chores.
+
+        Also clears stale skip state (skip_date != today) so yesterday's skip
+        doesn't bleed into the new day.
         """
         today = dt_util.as_local(dt_util.now()).date()
+        today_iso = today.isoformat()
         chores = self.storage.get_chores()
         if not chores:
             return
 
+        # Clear stale skip state in-memory (persisted via update_chore below).
+        for chore in chores:
+            if getattr(chore, "skip_date", "") and chore.skip_date != today_iso:
+                chore.skip_date = ""
+                chore.skip_count = 0
+
+        # Group-aware daily assignment map.
+        daily = self._compute_daily_assignments(today)
+
         async def _process(chore: Chore) -> bool:
             dirty = False
-            active = self._compute_active_children(chore, today)
-            desired = active[0] if active and getattr(chore, "assignment_mode", "everyone") != "everyone" else ""
+            mode = getattr(chore, "assignment_mode", "everyone")
+            desired = daily.get(chore.id, "") if mode != "everyone" else ""
             if getattr(chore, "assignment_current_child_id", "") != desired:
                 chore.assignment_current_child_id = desired
                 dirty = True
@@ -1030,6 +1361,11 @@ class TaskMateCoordinator(DataUpdateCoordinator):
             await self._publish_chore_to_calendars(chore, today)
             if list(getattr(chore, "publish_calendar_published_dates", []) or []) != before:
                 dirty = True
+            # Always persist if skip state was cleared above.
+            if getattr(chore, "skip_date", "") == "" and getattr(chore, "skip_count", 0) == 0:
+                stored = self.storage.get_chore(chore.id)
+                if stored and (stored.skip_date or stored.skip_count):
+                    dirty = True
             if dirty:
                 self.storage.update_chore(chore)
             return dirty

--- a/custom_components/taskmate/manifest.json
+++ b/custom_components/taskmate/manifest.json
@@ -15,5 +15,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/tempus2016/taskmate/issues",
   "requirements": [],
-  "version": "3.3.0"
+  "version": "3.4.0"
 }

--- a/custom_components/taskmate/models.py
+++ b/custom_components/taskmate/models.py
@@ -156,6 +156,9 @@ class Chore:
     assignment_rotation_anchor: str = ""  # ISO date; day-0 of the rotation for alternating
     assignment_current_child_id: str = ""  # cached active child ID for today (computed at midnight and on create/update)
     require_availability: bool = False  # When True, skip children whose availability entity says they're unavailable
+    # Skip state (ephemeral: cleared at midnight when skip_date != today)
+    skip_date: str = ""  # ISO date the skip applies to ("" = no active skip)
+    skip_count: int = 0  # number of times skipped today; added to rotation index
     # Calendar publish: list of HA calendar entity ids to mirror the chore to. Any number supported.
     publish_calendar_entities: list[str] = field(default_factory=list)
     # ISO dates already written to the configured calendars. Used for both
@@ -200,6 +203,8 @@ class Chore:
             assignment_rotation_anchor=data.get("assignment_rotation_anchor", ""),
             assignment_current_child_id=data.get("assignment_current_child_id", ""),
             require_availability=data.get("require_availability", False),
+            skip_date=data.get("skip_date", ""),
+            skip_count=int(data.get("skip_count", 0) or 0),
             publish_calendar_entities=list(data.get("publish_calendar_entities", [])),
             # Back-compat: old records stored a single ISO date in
             # `publish_calendar_last_date`. Seed the new list with it so we
@@ -239,6 +244,8 @@ class Chore:
             "assignment_rotation_anchor": self.assignment_rotation_anchor,
             "assignment_current_child_id": self.assignment_current_child_id,
             "require_availability": self.require_availability,
+            "skip_date": self.skip_date,
+            "skip_count": self.skip_count,
             "publish_calendar_entities": self.publish_calendar_entities,
             "publish_calendar_published_dates": self.publish_calendar_published_dates,
             "id": self.id,
@@ -503,5 +510,41 @@ class PointsTransaction:
             "points": self.points,
             "reason": self.reason,
             "created_at": format_datetime(self.created_at),
+            "id": self.id,
+        }
+
+
+@dataclass
+class TaskGroup:
+    """Groups chores so assignments stay coordinated across them.
+
+    Policies:
+    - sticky: followers are forced onto the leader chore's assignee today.
+    - spread: group members are assigned distinct children today (wraps when
+      there are more chores than children).
+
+    `chore_ids` order is meaningful: index 0 is the leader for sticky; for
+    spread it's the iteration order when walking the "already used" set.
+    """
+
+    name: str
+    policy: str = "sticky"  # sticky | spread
+    chore_ids: list[str] = field(default_factory=list)
+    id: str = field(default_factory=generate_id)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "TaskGroup":
+        return cls(
+            name=data.get("name", ""),
+            policy=data.get("policy", "sticky"),
+            chore_ids=list(data.get("chore_ids", [])),
+            id=data.get("id", generate_id()),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "policy": self.policy,
+            "chore_ids": self.chore_ids,
             "id": self.id,
         }

--- a/custom_components/taskmate/sensor.py
+++ b/custom_components/taskmate/sensor.py
@@ -633,9 +633,19 @@ class TaskMateChoresSensor(_CachedAttrsSensor):
 
     def _build_attributes(self) -> dict:
         common = _compute_common(self.coordinator)
+        task_groups = [
+            {
+                "id": g.id,
+                "name": g.name,
+                "policy": g.policy,
+                "chore_ids": list(g.chore_ids or []),
+            }
+            for g in self.coordinator.storage.get_task_groups()
+        ]
         return {
             "chores": _build_chores_list(self.coordinator, common),
             "todays_completions": _build_todays_completions(common),
+            "task_groups": task_groups,
         }
 
 

--- a/custom_components/taskmate/services.yaml
+++ b/custom_components/taskmate/services.yaml
@@ -480,3 +480,101 @@ add_chore:
       default: true
       selector:
         boolean:
+
+skip_chore:
+  name: Skip Chore
+  description: Skip today's assigned child for a rotating chore and move the pointer to the next child in the pool. Ephemeral — tomorrow the rotation resumes its normal schedule.
+  fields:
+    chore_id:
+      name: Chore ID
+      description: The ID of the chore to skip
+      required: true
+      selector:
+        text:
+
+set_chore_manual_start:
+  name: Set Manual Start Child
+  description: Set which child the rotation starts with for a rotating chore. For alternating mode this reorders the pool and resets the anchor; for random/balanced it overrides today's cached assignee only.
+  fields:
+    chore_id:
+      name: Chore ID
+      description: The ID of the chore to update
+      required: true
+      selector:
+        text:
+    child_id:
+      name: Child ID
+      description: The ID of the child who should start the rotation
+      required: true
+      selector:
+        text:
+
+add_task_group:
+  name: Add Task Group
+  description: Create a task group that coordinates assignments across chores (sticky = same child, spread = different children).
+  fields:
+    name:
+      name: Name
+      description: Display name for the group
+      required: true
+      selector:
+        text:
+    policy:
+      name: Policy
+      description: sticky (same child) or spread (different children)
+      required: true
+      default: sticky
+      selector:
+        select:
+          options:
+            - sticky
+            - spread
+    chore_ids:
+      name: Chore IDs
+      description: List of chore IDs to include in the group. For sticky, the first chore is the leader.
+      required: false
+      selector:
+        object:
+
+update_task_group:
+  name: Update Task Group
+  description: Update a task group's name, policy, or chore membership.
+  fields:
+    group_id:
+      name: Group ID
+      description: The ID of the group to update
+      required: true
+      selector:
+        text:
+    name:
+      name: Name
+      description: New display name
+      required: false
+      selector:
+        text:
+    policy:
+      name: Policy
+      description: New policy (sticky or spread)
+      required: false
+      selector:
+        select:
+          options:
+            - sticky
+            - spread
+    chore_ids:
+      name: Chore IDs
+      description: Replacement list of chore IDs. For sticky, the first chore is the leader.
+      required: false
+      selector:
+        object:
+
+remove_task_group:
+  name: Remove Task Group
+  description: Delete a task group. The member chores are not affected.
+  fields:
+    group_id:
+      name: Group ID
+      description: The ID of the group to delete
+      required: true
+      selector:
+        text:

--- a/custom_components/taskmate/storage.py
+++ b/custom_components/taskmate/storage.py
@@ -8,7 +8,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.storage import Store
 
 from .const import DOMAIN
-from .models import Bonus, Child, Chore, ChoreCompletion, Penalty, PoolAllocation, Reward, RewardClaim, PointsTransaction
+from .models import Bonus, Child, Chore, ChoreCompletion, Penalty, PoolAllocation, Reward, RewardClaim, PointsTransaction, TaskGroup
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -38,6 +38,7 @@ class TaskMateStorage:
                 "reward_claims": [],
                 "points_transactions": [],
                 "pool_allocations": [],
+                "task_groups": [],
                 "points_name": "Stars",
                 "points_icon": "mdi:star",
                 "last_completed": {},
@@ -51,6 +52,10 @@ class TaskMateStorage:
         # Ensure pool_allocations store exists (migration for v3.0 pool mode)
         if "pool_allocations" not in self._data:
             self._data["pool_allocations"] = []
+
+        # Ensure task_groups store exists (migration for existing installs)
+        if "task_groups" not in self._data:
+            self._data["task_groups"] = []
 
         # Run data migrations
         await self._migrate_assigned_to_child_ids()
@@ -394,6 +399,50 @@ class TaskMateStorage:
         self._data["bonuses"] = [
             b for b in self._data.get("bonuses", []) if b.get("id") != bonus_id
         ]
+
+    # Task groups management
+    def get_task_groups(self) -> list[TaskGroup]:
+        """Get all task groups."""
+        return [TaskGroup.from_dict(g) for g in self._data.get("task_groups", [])]
+
+    def get_task_group(self, group_id: str) -> TaskGroup | None:
+        """Get a task group by ID."""
+        for g in self._data.get("task_groups", []):
+            if g.get("id") == group_id:
+                return TaskGroup.from_dict(g)
+        return None
+
+    def get_task_group_for_chore(self, chore_id: str) -> TaskGroup | None:
+        """Return the group that contains this chore, or None."""
+        for g in self._data.get("task_groups", []):
+            if chore_id in g.get("chore_ids", []):
+                return TaskGroup.from_dict(g)
+        return None
+
+    def add_task_group(self, group: TaskGroup) -> None:
+        """Add a task group."""
+        self._data.setdefault("task_groups", []).append(group.to_dict())
+
+    def update_task_group(self, group: TaskGroup) -> None:
+        """Update an existing task group."""
+        groups = self._data.get("task_groups", [])
+        for i, g in enumerate(groups):
+            if g.get("id") == group.id:
+                groups[i] = group.to_dict()
+                return
+        groups.append(group.to_dict())
+
+    def remove_task_group(self, group_id: str) -> None:
+        """Remove a task group."""
+        self._data["task_groups"] = [
+            g for g in self._data.get("task_groups", []) if g.get("id") != group_id
+        ]
+
+    def remove_chore_from_task_groups(self, chore_id: str) -> None:
+        """Strip a chore ID from every group (used on chore delete)."""
+        for g in self._data.get("task_groups", []):
+            if chore_id in g.get("chore_ids", []):
+                g["chore_ids"] = [c for c in g["chore_ids"] if c != chore_id]
 
     # Points transactions management
     def get_points_transactions(self) -> list[PointsTransaction]:

--- a/custom_components/taskmate/strings.json
+++ b/custom_components/taskmate/strings.json
@@ -24,6 +24,7 @@
         "menu_options": {
           "manage_children": "Manage Children",
           "manage_chores": "Manage Chores",
+          "manage_task_groups": "Manage Task Groups",
           "manage_rewards": "Manage Rewards",
           "settings": "Settings"
         }
@@ -90,12 +91,13 @@
           "visibility_state": "Value to compare",
           "assignment_mode": "Assignment Mode",
           "assignment_rotation_anchor": "Rotation start date (alternating only)",
+          "manual_start_child_id": "Start rotation with (optional)",
           "require_availability": "Skip unavailable children",
           "publish_calendar_entities": "Publish to calendars (optional)"
         },
         "data_description": {
-          "daily_limit": "How many times per day this chore can be completed",
           "claim_allowance_minutes": "Extra minutes after this time-of-day window ends during which the chore can still be claimed. 0 disables the grace period. Night chores are always capped at midnight.",
+          "daily_limit": "How many times per day this chore can be completed",
           "schedule_mode": "Choose how this chore is scheduled — specific days of the week, or a repeating interval. The scheduling options will be configured on the next page.",
           "completion_sound": "Sound to play when this chore is completed",
           "visibility_entity": "Home Assistant entity ID that controls when this chore appears. Leave blank to always show the chore. Examples: binary_sensor.dishwasher, sensor.soil_moisture, input_boolean.guest_mode, switch.laundry_room. The chore only appears on the child card when the visibility condition is met.",
@@ -103,6 +105,7 @@
           "visibility_state": "The value to compare against. For 'Equals' or 'Not Equal': any text value (e.g., 'on', 'off', 'home', 'away'). For numeric operators (≥, ≤, >, <): enter a number (e.g., 25, 50.5, 100). Example: Entity 'sensor.temperature', Operator '>=', Value '20' shows chore when temperature is 20°C or higher.",
           "assignment_mode": "Everyone = every assigned child sees this chore. Alternating = one child at a time, rotating by day. Random = one randomly picked child per day (stable within the day). Balanced = today's balanced chores are split evenly across the assigned children — no one child ends up with everything.",
           "assignment_rotation_anchor": "Day-0 of the alternating rotation. Leave blank to start today. Only used when Assignment Mode is 'Alternating'.",
+          "manual_start_child_id": "Picks which child starts the rotation. For Alternating mode this permanently reorders the pool. For Random / Balanced it only overrides today's assignee — tomorrow's rotation resumes normally. Ignored for Everyone mode.",
           "require_availability": "When on, an unavailable child (based on the Availability Sensor in their profile) is skipped and the next available sibling takes the chore. Re-evaluated at midnight and whenever an availability sensor flips. Chores already completed today are not reassigned.",
           "publish_calendar_entities": "Pick one or more Home Assistant calendar entities. Whenever this chore is created, updated, or rolls over at midnight, today's assigned child is added as a calendar event on each selected calendar. Works with any number of calendars."
         }
@@ -126,8 +129,8 @@
           "visibility_state": "Value to compare"
         },
         "data_description": {
-          "daily_limit": "How many times per day this chore can be completed",
           "claim_allowance_minutes": "Extra minutes after this time-of-day window ends during which the chore can still be claimed. 0 disables the grace period. Night chores are always capped at midnight.",
+          "daily_limit": "How many times per day this chore can be completed",
           "schedule_mode": "Choose how this chore is scheduled",
           "completion_sound": "Sound to play when chores are completed",
           "visibility_entity": "Home Assistant entity ID that controls when these chores appear. Leave blank to always show them. Examples: binary_sensor.dishwasher, sensor.soil_moisture, input_boolean.guest_mode. The chores only appear on the child card when the visibility condition is met.",
@@ -156,12 +159,13 @@
           "visibility_state": "Value to compare",
           "assignment_mode": "Assignment Mode",
           "assignment_rotation_anchor": "Rotation start date (alternating only)",
+          "manual_start_child_id": "Start rotation with (optional)",
           "require_availability": "Skip unavailable children",
           "publish_calendar_entities": "Publish to calendars (optional)"
         },
         "data_description": {
-          "daily_limit": "How many times per day this chore can be completed",
           "claim_allowance_minutes": "Extra minutes after this time-of-day window ends during which the chore can still be claimed. 0 disables the grace period. Night chores are always capped at midnight.",
+          "daily_limit": "How many times per day this chore can be completed",
           "schedule_mode": "Choose how this chore is scheduled — specific days of the week, or a repeating interval. The scheduling options will be configured on the next page.",
           "completion_sound": "Sound to play when this chore is completed",
           "visibility_entity": "Home Assistant entity ID that controls when this chore appears. Leave blank to always show the chore. Examples: binary_sensor.dishwasher, sensor.soil_moisture, input_boolean.guest_mode, switch.laundry_room. The chore only appears on the child card when the visibility condition is met.",
@@ -169,8 +173,43 @@
           "visibility_state": "The value to compare against. For 'Equals' or 'Not Equal': any text value (e.g., 'on', 'off', 'home', 'away'). For numeric operators (≥, ≤, >, <): enter a number (e.g., 25, 50.5, 100). Example: Entity 'sensor.temperature', Operator '>=', Value '20' shows chore when temperature is 20°C or higher.",
           "assignment_mode": "Everyone = every assigned child sees this chore. Alternating = one child at a time, rotating by day. Random = one randomly picked child per day (stable within the day). Balanced = today's balanced chores are split evenly across the assigned children — no one child ends up with everything.",
           "assignment_rotation_anchor": "Day-0 of the alternating rotation. Leave blank to start today. Only used when Assignment Mode is 'Alternating'.",
+          "manual_start_child_id": "Picks which child starts the rotation. For Alternating mode this permanently reorders the pool and resets the anchor. For Random / Balanced it only overrides today's assignee — tomorrow's rotation resumes normally. Ignored for Everyone mode.",
           "require_availability": "When on, an unavailable child (based on the Availability Sensor in their profile) is skipped and the next available sibling takes the chore. Re-evaluated at midnight and whenever an availability sensor flips. Chores already completed today are not reassigned.",
           "publish_calendar_entities": "Pick one or more Home Assistant calendar entities. Whenever this chore is created, updated, or rolls over at midnight, today's assigned child is added as a calendar event on each selected calendar. Works with any number of calendars."
+        }
+      },
+      "manage_task_groups": {
+        "title": "Manage Task Groups",
+        "description": "Group chores so their assignments stay coordinated. Sticky forces all chores in the group onto the same child today. Spread gives each chore a different child.",
+        "menu_options": {
+          "add_task_group": "Add New Group",
+          "init": "Back to Main Menu"
+        }
+      },
+      "add_task_group": {
+        "title": "Add Task Group",
+        "description": "Only rotation-mode chores (alternating / random / balanced) can join a group, and each chore can belong to at most one group.",
+        "data": {
+          "name": "Group Name",
+          "policy": "Policy",
+          "chore_ids": "Member Chores"
+        },
+        "data_description": {
+          "policy": "Sticky — all chores in the group go to the same child today (the first chore in the list is the leader whose assignment the others follow). Spread — each chore is assigned to a different child today; if the group has more chores than children, it wraps.",
+          "chore_ids": "Pick the chores to include. The order matters: for Sticky, the first chore is the leader whose assignee the others follow."
+        }
+      },
+      "edit_task_group": {
+        "title": "Edit Group: {group_name}",
+        "description": "Update or delete this task group.",
+        "data": {
+          "name": "Group Name",
+          "policy": "Policy",
+          "chore_ids": "Member Chores",
+          "action": "Action"
+        },
+        "data_description": {
+          "policy": "Sticky — all chores in the group go to the same child today. Spread — each chore is assigned to a different child today; if the group has more chores than children, it wraps."
         }
       },
       "manage_rewards": {
@@ -311,7 +350,8 @@
       "name_required": "Name is required",
       "invalid_milestone_format": "Invalid milestone format — use days:points pairs, e.g. 3:5, 7:10, 14:20",
       "operator_required": "Operator is required when an entity is set",
-      "state_required": "Value is required when an entity is set"
+      "state_required": "Value is required when an entity is set",
+      "task_group_invalid": "Task group is invalid: a chore can't join more than one group, and 'everyone'-mode chores aren't allowed."
     }
   },
   "selector": {
@@ -374,14 +414,14 @@
     },
     "recurrence_day_option": {
       "options": {
-        "any_day": "Any day",
         "monday": "Monday",
         "tuesday": "Tuesday",
         "wednesday": "Wednesday",
         "thursday": "Thursday",
         "friday": "Friday",
         "saturday": "Saturday",
-        "sunday": "Sunday"
+        "sunday": "Sunday",
+        "any_day": "Any day"
       }
     },
     "first_occurrence_mode": {
@@ -413,6 +453,18 @@
         "alternating": "Alternating — rotate through the assigned children, one per day",
         "random": "Random — pick one assigned child at random each day",
         "balanced": "Balanced — split today's balanced chores evenly across the assigned children"
+      }
+    },
+    "task_group_policy": {
+      "options": {
+        "sticky": "Sticky — same child for all chores in the group",
+        "spread": "Spread — different children across the group today"
+      }
+    },
+    "task_group_action": {
+      "options": {
+        "save": "Save Changes",
+        "delete": "Delete Group"
       }
     }
   },
@@ -736,6 +788,80 @@
         "requires_approval": {
           "name": "Requires Approval",
           "description": "If true, a parent must approve the completion before points are awarded"
+        }
+      }
+    },
+    "skip_chore": {
+      "name": "Skip Chore",
+      "description": "Advance today's rotation past the current assignee. Ephemeral — tomorrow's rotation resumes as normal.",
+      "fields": {
+        "chore_id": {
+          "name": "Chore ID",
+          "description": "The ID of the chore to skip"
+        }
+      }
+    },
+    "set_chore_manual_start": {
+      "name": "Set Manual Start Child",
+      "description": "Set which child starts a rotating chore. For alternating mode this reorders the pool; for random/balanced it only overrides today's assignee.",
+      "fields": {
+        "chore_id": {
+          "name": "Chore ID",
+          "description": "The ID of the chore to update"
+        },
+        "child_id": {
+          "name": "Child ID",
+          "description": "The ID of the child who should start the rotation"
+        }
+      }
+    },
+    "add_task_group": {
+      "name": "Add Task Group",
+      "description": "Create a task group (sticky = same child, spread = different children).",
+      "fields": {
+        "name": {
+          "name": "Name",
+          "description": "Display name for the group"
+        },
+        "policy": {
+          "name": "Policy",
+          "description": "sticky (same child) or spread (different children)"
+        },
+        "chore_ids": {
+          "name": "Chore IDs",
+          "description": "List of chore IDs in the group. For sticky, the first chore is the leader."
+        }
+      }
+    },
+    "update_task_group": {
+      "name": "Update Task Group",
+      "description": "Update a task group's name, policy, or membership.",
+      "fields": {
+        "group_id": {
+          "name": "Group ID",
+          "description": "The ID of the group to update"
+        },
+        "name": {
+          "name": "Name",
+          "description": "New display name"
+        },
+        "policy": {
+          "name": "Policy",
+          "description": "New policy (sticky or spread)"
+        },
+        "chore_ids": {
+          "name": "Chore IDs",
+          "description": "Replacement chore ID list. For sticky, the first chore is the leader."
+        }
+      }
+    },
+    "remove_task_group": {
+      "name": "Remove Task Group",
+      "description": "Delete a task group. Member chores are not affected.",
+      "fields": {
+        "group_id": {
+          "name": "Group ID",
+          "description": "The ID of the group to delete"
         }
       }
     }

--- a/custom_components/taskmate/translations/en-GB.json
+++ b/custom_components/taskmate/translations/en-GB.json
@@ -25,7 +25,8 @@
           "manage_children": "Manage Children",
           "manage_chores": "Manage Chores",
           "manage_rewards": "Manage Rewards",
-          "settings": "Settings"
+          "settings": "Settings",
+          "manage_task_groups": "Manage Task Groups"
         }
       },
       "manage_children": {
@@ -91,7 +92,8 @@
           "assignment_mode": "Assignment Mode",
           "assignment_rotation_anchor": "Rotation start date (alternating only)",
           "require_availability": "Skip unavailable children",
-          "publish_calendar_entities": "Publish to calendars (optional)"
+          "publish_calendar_entities": "Publish to calendars (optional)",
+          "manual_start_child_id": "Start rotation with (optional)"
         },
         "data_description": {
           "claim_allowance_minutes": "Extra minutes after this time-of-day window ends during which the chore can still be claimed. 0 disables the grace period. Night chores are always capped at midnight.",
@@ -104,7 +106,8 @@
           "assignment_mode": "Everyone = every assigned child sees this chore. Alternating = one child at a time, rotating by day. Random = one randomly picked child per day (stable within the day). Balanced = today's balanced chores are split evenly across the assigned children — no one child ends up with everything.",
           "assignment_rotation_anchor": "Day-0 of the alternating rotation. Leave blank to start today. Only used when Assignment Mode is 'Alternating'.",
           "require_availability": "When on, an unavailable child (based on the Availability Sensor in their profile) is skipped and the next available sibling takes the chore. Re-evaluated at midnight and whenever an availability sensor flips. Chores already completed today are not reassigned.",
-          "publish_calendar_entities": "Pick one or more Home Assistant calendar entities. Whenever this chore is created, updated, or rolls over at midnight, today's assigned child is added as a calendar event on each selected calendar. Works with any number of calendars."
+          "publish_calendar_entities": "Pick one or more Home Assistant calendar entities. Whenever this chore is created, updated, or rolls over at midnight, today's assigned child is added as a calendar event on each selected calendar. Works with any number of calendars.",
+          "manual_start_child_id": "Picks which child starts the rotation. For Alternating mode this permanently reorders the pool. For Random / Balanced it only overrides today's assignee — tomorrow's rotation resumes normally. Ignored for Everyone mode."
         }
       },
       "add_chores_bulk": {
@@ -157,7 +160,8 @@
           "assignment_mode": "Assignment Mode",
           "assignment_rotation_anchor": "Rotation start date (alternating only)",
           "require_availability": "Skip unavailable children",
-          "publish_calendar_entities": "Publish to calendars (optional)"
+          "publish_calendar_entities": "Publish to calendars (optional)",
+          "manual_start_child_id": "Start rotation with (optional)"
         },
         "data_description": {
           "claim_allowance_minutes": "Extra minutes after this time-of-day window ends during which the chore can still be claimed. 0 disables the grace period. Night chores are always capped at midnight.",
@@ -170,7 +174,8 @@
           "assignment_mode": "Everyone = every assigned child sees this chore. Alternating = one child at a time, rotating by day. Random = one randomly picked child per day (stable within the day). Balanced = today's balanced chores are split evenly across the assigned children — no one child ends up with everything.",
           "assignment_rotation_anchor": "Day-0 of the alternating rotation. Leave blank to start today. Only used when Assignment Mode is 'Alternating'.",
           "require_availability": "When on, an unavailable child (based on the Availability Sensor in their profile) is skipped and the next available sibling takes the chore. Re-evaluated at midnight and whenever an availability sensor flips. Chores already completed today are not reassigned.",
-          "publish_calendar_entities": "Pick one or more Home Assistant calendar entities. Whenever this chore is created, updated, or rolls over at midnight, today's assigned child is added as a calendar event on each selected calendar. Works with any number of calendars."
+          "publish_calendar_entities": "Pick one or more Home Assistant calendar entities. Whenever this chore is created, updated, or rolls over at midnight, today's assigned child is added as a calendar event on each selected calendar. Works with any number of calendars.",
+          "manual_start_child_id": "Picks which child starts the rotation. For Alternating mode this permanently reorders the pool and resets the anchor. For Random / Balanced it only overrides today's assignee — tomorrow's rotation resumes normally. Ignored for Everyone mode."
         }
       },
       "manage_rewards": {
@@ -305,13 +310,48 @@
           "recurrence_start": "Every 2 Days only — anchor date in YYYY-MM-DD format. Ignored for all other recurrence types. Leave empty to use today.",
           "first_occurrence_mode": "Available Immediately — child can complete it straight away. Wait for First Occurrence — chore is locked until the first scheduled day arrives."
         }
+      },
+      "manage_task_groups": {
+        "title": "Manage Task Groups",
+        "description": "Group chores so their assignments stay coordinated. Sticky forces all chores in the group onto the same child today. Spread gives each chore a different child.",
+        "menu_options": {
+          "add_task_group": "Add New Group",
+          "init": "Back to Main Menu"
+        }
+      },
+      "add_task_group": {
+        "title": "Add Task Group",
+        "description": "Only rotation-mode chores (alternating / random / balanced) can join a group, and each chore can belong to at most one group.",
+        "data": {
+          "name": "Group Name",
+          "policy": "Policy",
+          "chore_ids": "Member Chores"
+        },
+        "data_description": {
+          "policy": "Sticky — all chores in the group go to the same child today (the first chore in the list is the leader whose assignment the others follow). Spread — each chore is assigned to a different child today; if the group has more chores than children, it wraps.",
+          "chore_ids": "Pick the chores to include. The order matters: for Sticky, the first chore is the leader whose assignee the others follow."
+        }
+      },
+      "edit_task_group": {
+        "title": "Edit Group: {group_name}",
+        "description": "Update or delete this task group.",
+        "data": {
+          "name": "Group Name",
+          "policy": "Policy",
+          "chore_ids": "Member Chores",
+          "action": "Action"
+        },
+        "data_description": {
+          "policy": "Sticky — all chores in the group go to the same child today. Spread — each chore is assigned to a different child today; if the group has more chores than children, it wraps."
+        }
       }
     },
     "error": {
       "name_required": "Name is required",
       "invalid_milestone_format": "Invalid milestone format — use days:points pairs, e.g. 3:5, 7:10, 14:20",
       "operator_required": "Operator is required when an entity is set",
-      "state_required": "Value is required when an entity is set"
+      "state_required": "Value is required when an entity is set",
+      "task_group_invalid": "Task group is invalid: a chore can't join more than one group, and 'everyone'-mode chores aren't allowed."
     }
   },
   "selector": {
@@ -413,6 +453,18 @@
         "alternating": "Alternating — rotate through the assigned children, one per day",
         "random": "Random — pick one assigned child at random each day",
         "balanced": "Balanced — split today's balanced chores evenly across the assigned children"
+      }
+    },
+    "task_group_policy": {
+      "options": {
+        "sticky": "Sticky — same child for all chores in the group",
+        "spread": "Spread — different children across the group today"
+      }
+    },
+    "task_group_action": {
+      "options": {
+        "save": "Save Changes",
+        "delete": "Delete Group"
       }
     }
   },
@@ -736,6 +788,80 @@
         "requires_approval": {
           "name": "Requires Approval",
           "description": "If true, a parent must approve the completion before points are awarded"
+        }
+      }
+    },
+    "skip_chore": {
+      "name": "Skip Chore",
+      "description": "Advance today's rotation past the current assignee. Ephemeral — tomorrow's rotation resumes as normal.",
+      "fields": {
+        "chore_id": {
+          "name": "Chore ID",
+          "description": "The ID of the chore to skip"
+        }
+      }
+    },
+    "set_chore_manual_start": {
+      "name": "Set Manual Start Child",
+      "description": "Set which child starts a rotating chore. For alternating mode this reorders the pool; for random/balanced it only overrides today's assignee.",
+      "fields": {
+        "chore_id": {
+          "name": "Chore ID",
+          "description": "The ID of the chore to update"
+        },
+        "child_id": {
+          "name": "Child ID",
+          "description": "The ID of the child who should start the rotation"
+        }
+      }
+    },
+    "add_task_group": {
+      "name": "Add Task Group",
+      "description": "Create a task group (sticky = same child, spread = different children).",
+      "fields": {
+        "name": {
+          "name": "Name",
+          "description": "Display name for the group"
+        },
+        "policy": {
+          "name": "Policy",
+          "description": "sticky (same child) or spread (different children)"
+        },
+        "chore_ids": {
+          "name": "Chore IDs",
+          "description": "List of chore IDs in the group. For sticky, the first chore is the leader."
+        }
+      }
+    },
+    "update_task_group": {
+      "name": "Update Task Group",
+      "description": "Update a task group's name, policy, or membership.",
+      "fields": {
+        "group_id": {
+          "name": "Group ID",
+          "description": "The ID of the group to update"
+        },
+        "name": {
+          "name": "Name",
+          "description": "New display name"
+        },
+        "policy": {
+          "name": "Policy",
+          "description": "New policy (sticky or spread)"
+        },
+        "chore_ids": {
+          "name": "Chore IDs",
+          "description": "Replacement chore ID list. For sticky, the first chore is the leader."
+        }
+      }
+    },
+    "remove_task_group": {
+      "name": "Remove Task Group",
+      "description": "Delete a task group. Member chores are not affected.",
+      "fields": {
+        "group_id": {
+          "name": "Group ID",
+          "description": "The ID of the group to delete"
         }
       }
     }

--- a/custom_components/taskmate/translations/en.json
+++ b/custom_components/taskmate/translations/en.json
@@ -24,6 +24,7 @@
         "menu_options": {
           "manage_children": "Manage Children",
           "manage_chores": "Manage Chores",
+          "manage_task_groups": "Manage Task Groups",
           "manage_rewards": "Manage Rewards",
           "settings": "Settings"
         }
@@ -90,6 +91,7 @@
           "visibility_state": "Value to compare",
           "assignment_mode": "Assignment Mode",
           "assignment_rotation_anchor": "Rotation start date (alternating only)",
+          "manual_start_child_id": "Start rotation with (optional)",
           "require_availability": "Skip unavailable children",
           "publish_calendar_entities": "Publish to calendars (optional)"
         },
@@ -103,6 +105,7 @@
           "visibility_state": "The value to compare against. For 'Equals' or 'Not Equal': any text value (e.g., 'on', 'off', 'home', 'away'). For numeric operators (≥, ≤, >, <): enter a number (e.g., 25, 50.5, 100). Example: Entity 'sensor.temperature', Operator '>=', Value '20' shows chore when temperature is 20°C or higher.",
           "assignment_mode": "Everyone = every assigned child sees this chore. Alternating = one child at a time, rotating by day. Random = one randomly picked child per day (stable within the day). Balanced = today's balanced chores are split evenly across the assigned children — no one child ends up with everything.",
           "assignment_rotation_anchor": "Day-0 of the alternating rotation. Leave blank to start today. Only used when Assignment Mode is 'Alternating'.",
+          "manual_start_child_id": "Picks which child starts the rotation. For Alternating mode this permanently reorders the pool. For Random / Balanced it only overrides today's assignee — tomorrow's rotation resumes normally. Ignored for Everyone mode.",
           "require_availability": "When on, an unavailable child (based on the Availability Sensor in their profile) is skipped and the next available sibling takes the chore. Re-evaluated at midnight and whenever an availability sensor flips. Chores already completed today are not reassigned.",
           "publish_calendar_entities": "Pick one or more Home Assistant calendar entities. Whenever this chore is created, updated, or rolls over at midnight, today's assigned child is added as a calendar event on each selected calendar. Works with any number of calendars."
         }
@@ -156,6 +159,7 @@
           "visibility_state": "Value to compare",
           "assignment_mode": "Assignment Mode",
           "assignment_rotation_anchor": "Rotation start date (alternating only)",
+          "manual_start_child_id": "Start rotation with (optional)",
           "require_availability": "Skip unavailable children",
           "publish_calendar_entities": "Publish to calendars (optional)"
         },
@@ -169,8 +173,43 @@
           "visibility_state": "The value to compare against. For 'Equals' or 'Not Equal': any text value (e.g., 'on', 'off', 'home', 'away'). For numeric operators (≥, ≤, >, <): enter a number (e.g., 25, 50.5, 100). Example: Entity 'sensor.temperature', Operator '>=', Value '20' shows chore when temperature is 20°C or higher.",
           "assignment_mode": "Everyone = every assigned child sees this chore. Alternating = one child at a time, rotating by day. Random = one randomly picked child per day (stable within the day). Balanced = today's balanced chores are split evenly across the assigned children — no one child ends up with everything.",
           "assignment_rotation_anchor": "Day-0 of the alternating rotation. Leave blank to start today. Only used when Assignment Mode is 'Alternating'.",
+          "manual_start_child_id": "Picks which child starts the rotation. For Alternating mode this permanently reorders the pool and resets the anchor. For Random / Balanced it only overrides today's assignee — tomorrow's rotation resumes normally. Ignored for Everyone mode.",
           "require_availability": "When on, an unavailable child (based on the Availability Sensor in their profile) is skipped and the next available sibling takes the chore. Re-evaluated at midnight and whenever an availability sensor flips. Chores already completed today are not reassigned.",
           "publish_calendar_entities": "Pick one or more Home Assistant calendar entities. Whenever this chore is created, updated, or rolls over at midnight, today's assigned child is added as a calendar event on each selected calendar. Works with any number of calendars."
+        }
+      },
+      "manage_task_groups": {
+        "title": "Manage Task Groups",
+        "description": "Group chores so their assignments stay coordinated. Sticky forces all chores in the group onto the same child today. Spread gives each chore a different child.",
+        "menu_options": {
+          "add_task_group": "Add New Group",
+          "init": "Back to Main Menu"
+        }
+      },
+      "add_task_group": {
+        "title": "Add Task Group",
+        "description": "Only rotation-mode chores (alternating / random / balanced) can join a group, and each chore can belong to at most one group.",
+        "data": {
+          "name": "Group Name",
+          "policy": "Policy",
+          "chore_ids": "Member Chores"
+        },
+        "data_description": {
+          "policy": "Sticky — all chores in the group go to the same child today (the first chore in the list is the leader whose assignment the others follow). Spread — each chore is assigned to a different child today; if the group has more chores than children, it wraps.",
+          "chore_ids": "Pick the chores to include. The order matters: for Sticky, the first chore is the leader whose assignee the others follow."
+        }
+      },
+      "edit_task_group": {
+        "title": "Edit Group: {group_name}",
+        "description": "Update or delete this task group.",
+        "data": {
+          "name": "Group Name",
+          "policy": "Policy",
+          "chore_ids": "Member Chores",
+          "action": "Action"
+        },
+        "data_description": {
+          "policy": "Sticky — all chores in the group go to the same child today. Spread — each chore is assigned to a different child today; if the group has more chores than children, it wraps."
         }
       },
       "manage_rewards": {
@@ -311,7 +350,8 @@
       "name_required": "Name is required",
       "invalid_milestone_format": "Invalid milestone format — use days:points pairs, e.g. 3:5, 7:10, 14:20",
       "operator_required": "Operator is required when an entity is set",
-      "state_required": "Value is required when an entity is set"
+      "state_required": "Value is required when an entity is set",
+      "task_group_invalid": "Task group is invalid: a chore can't join more than one group, and 'everyone'-mode chores aren't allowed."
     }
   },
   "selector": {
@@ -413,6 +453,18 @@
         "alternating": "Alternating — rotate through the assigned children, one per day",
         "random": "Random — pick one assigned child at random each day",
         "balanced": "Balanced — split today's balanced chores evenly across the assigned children"
+      }
+    },
+    "task_group_policy": {
+      "options": {
+        "sticky": "Sticky — same child for all chores in the group",
+        "spread": "Spread — different children across the group today"
+      }
+    },
+    "task_group_action": {
+      "options": {
+        "save": "Save Changes",
+        "delete": "Delete Group"
       }
     }
   },
@@ -736,6 +788,80 @@
         "requires_approval": {
           "name": "Requires Approval",
           "description": "If true, a parent must approve the completion before points are awarded"
+        }
+      }
+    },
+    "skip_chore": {
+      "name": "Skip Chore",
+      "description": "Advance today's rotation past the current assignee. Ephemeral — tomorrow's rotation resumes as normal.",
+      "fields": {
+        "chore_id": {
+          "name": "Chore ID",
+          "description": "The ID of the chore to skip"
+        }
+      }
+    },
+    "set_chore_manual_start": {
+      "name": "Set Manual Start Child",
+      "description": "Set which child starts a rotating chore. For alternating mode this reorders the pool; for random/balanced it only overrides today's assignee.",
+      "fields": {
+        "chore_id": {
+          "name": "Chore ID",
+          "description": "The ID of the chore to update"
+        },
+        "child_id": {
+          "name": "Child ID",
+          "description": "The ID of the child who should start the rotation"
+        }
+      }
+    },
+    "add_task_group": {
+      "name": "Add Task Group",
+      "description": "Create a task group (sticky = same child, spread = different children).",
+      "fields": {
+        "name": {
+          "name": "Name",
+          "description": "Display name for the group"
+        },
+        "policy": {
+          "name": "Policy",
+          "description": "sticky (same child) or spread (different children)"
+        },
+        "chore_ids": {
+          "name": "Chore IDs",
+          "description": "List of chore IDs in the group. For sticky, the first chore is the leader."
+        }
+      }
+    },
+    "update_task_group": {
+      "name": "Update Task Group",
+      "description": "Update a task group's name, policy, or membership.",
+      "fields": {
+        "group_id": {
+          "name": "Group ID",
+          "description": "The ID of the group to update"
+        },
+        "name": {
+          "name": "Name",
+          "description": "New display name"
+        },
+        "policy": {
+          "name": "Policy",
+          "description": "New policy (sticky or spread)"
+        },
+        "chore_ids": {
+          "name": "Chore IDs",
+          "description": "Replacement chore ID list. For sticky, the first chore is the leader."
+        }
+      }
+    },
+    "remove_task_group": {
+      "name": "Remove Task Group",
+      "description": "Delete a task group. Member chores are not affected.",
+      "fields": {
+        "group_id": {
+          "name": "Group ID",
+          "description": "The ID of the group to delete"
         }
       }
     }

--- a/custom_components/taskmate/translations/fr.json
+++ b/custom_components/taskmate/translations/fr.json
@@ -25,7 +25,8 @@
           "manage_children": "Gérer les enfants",
           "manage_chores": "Gérer les corvées",
           "manage_rewards": "Gérer les récompenses",
-          "settings": "Paramètres"
+          "settings": "Paramètres",
+          "manage_task_groups": "Gérer les groupes de tâches"
         }
       },
       "manage_children": {
@@ -91,7 +92,8 @@
           "assignment_mode": "Mode d'attribution",
           "assignment_rotation_anchor": "Date de début du roulement (alternance uniquement)",
           "require_availability": "Ignorer les enfants indisponibles",
-          "publish_calendar_entities": "Publier vers les calendriers (optionnel)"
+          "publish_calendar_entities": "Publier vers les calendriers (optionnel)",
+          "manual_start_child_id": "Commencer la rotation avec (optionnel)"
         },
         "data_description": {
           "claim_allowance_minutes": "Minutes supplémentaires après la fin de cette plage horaire pendant lesquelles la corvée peut encore être réclamée. 0 désactive le délai de grâce. Les corvées nocturnes sont toujours limitées à minuit.",
@@ -104,7 +106,8 @@
           "assignment_mode": "Tout le monde = chaque enfant assigné voit cette tâche. Alternance = un enfant à la fois, rotation par jour. Aléatoire = un enfant choisi au hasard chaque jour (stable dans la journée). Équilibré = les tâches en mode équilibré du jour sont réparties équitablement entre les enfants assignés — aucun enfant ne se retrouve avec tout.",
           "assignment_rotation_anchor": "Jour 0 du roulement alterné. Laissez vide pour commencer aujourd'hui. Utilisé uniquement avec le mode 'Alternance'.",
           "publish_calendar_entities": "Choisissez un ou plusieurs calendriers Home Assistant. À chaque création, mise à jour ou passage à minuit, l'enfant attribué du jour est ajouté comme événement sur chaque calendrier sélectionné. Fonctionne avec un nombre illimité de calendriers.",
-          "require_availability": "Lorsqu'activé, un enfant indisponible (selon le capteur de disponibilité de son profil) est ignoré et le prochain frère/sœur disponible prend la corvée. Réévalué à minuit et chaque fois qu'un capteur de disponibilité change d'état. Les corvées déjà terminées aujourd'hui ne sont pas réaffectées."
+          "require_availability": "Lorsqu'activé, un enfant indisponible (selon le capteur de disponibilité de son profil) est ignoré et le prochain frère/sœur disponible prend la corvée. Réévalué à minuit et chaque fois qu'un capteur de disponibilité change d'état. Les corvées déjà terminées aujourd'hui ne sont pas réaffectées.",
+          "manual_start_child_id": "Picks which child starts the rotation. For Alternating mode this permanently reorders the pool. For Random / Balanced it only overrides today's assignee — tomorrow's rotation resumes normally. Ignored for Everyone mode."
         }
       },
       "add_chores_bulk": {
@@ -157,7 +160,8 @@
           "assignment_mode": "Mode d'attribution",
           "assignment_rotation_anchor": "Date de début du roulement (alternance uniquement)",
           "require_availability": "Ignorer les enfants indisponibles",
-          "publish_calendar_entities": "Publier vers les calendriers (optionnel)"
+          "publish_calendar_entities": "Publier vers les calendriers (optionnel)",
+          "manual_start_child_id": "Commencer la rotation avec (optionnel)"
         },
         "data_description": {
           "claim_allowance_minutes": "Minutes supplémentaires après la fin de cette plage horaire pendant lesquelles la corvée peut encore être réclamée. 0 désactive le délai de grâce. Les corvées nocturnes sont toujours limitées à minuit.",
@@ -170,7 +174,8 @@
           "assignment_mode": "Tout le monde = chaque enfant assigné voit cette tâche. Alternance = un enfant à la fois, rotation par jour. Aléatoire = un enfant choisi au hasard chaque jour (stable dans la journée). Équilibré = les tâches en mode équilibré du jour sont réparties équitablement entre les enfants assignés — aucun enfant ne se retrouve avec tout.",
           "assignment_rotation_anchor": "Jour 0 du roulement alterné. Laissez vide pour commencer aujourd'hui. Utilisé uniquement avec le mode 'Alternance'.",
           "publish_calendar_entities": "Choisissez un ou plusieurs calendriers Home Assistant. À chaque création, mise à jour ou passage à minuit, l'enfant attribué du jour est ajouté comme événement sur chaque calendrier sélectionné. Fonctionne avec un nombre illimité de calendriers.",
-          "require_availability": "Lorsqu'activé, un enfant indisponible (selon le capteur de disponibilité de son profil) est ignoré et le prochain frère/sœur disponible prend la corvée. Réévalué à minuit et chaque fois qu'un capteur de disponibilité change d'état. Les corvées déjà terminées aujourd'hui ne sont pas réaffectées."
+          "require_availability": "Lorsqu'activé, un enfant indisponible (selon le capteur de disponibilité de son profil) est ignoré et le prochain frère/sœur disponible prend la corvée. Réévalué à minuit et chaque fois qu'un capteur de disponibilité change d'état. Les corvées déjà terminées aujourd'hui ne sont pas réaffectées.",
+          "manual_start_child_id": "Picks which child starts the rotation. For Alternating mode this permanently reorders the pool and resets the anchor. For Random / Balanced it only overrides today's assignee — tomorrow's rotation resumes normally. Ignored for Everyone mode."
         }
       },
       "manage_rewards": {
@@ -305,13 +310,48 @@
           "recurrence_start": "Date d'ancrage pour Tous les 2 jours.",
           "first_occurrence_mode": "Déterminer si la corvée est active immédiatement ou au prochain cycle."
         }
+      },
+      "manage_task_groups": {
+        "title": "Gérer les groupes de tâches",
+        "description": "Group chores so their assignments stay coordinated. Sticky forces all chores in the group onto the same child today. Spread gives each chore a different child.",
+        "menu_options": {
+          "add_task_group": "Ajouter un groupe",
+          "init": "Retour au menu principal"
+        }
+      },
+      "add_task_group": {
+        "title": "Ajouter un groupe de tâches",
+        "description": "Only rotation-mode chores (alternating / random / balanced) can join a group, and each chore can belong to at most one group.",
+        "data": {
+          "name": "Nom du groupe",
+          "policy": "Politique",
+          "chore_ids": "Tâches membres"
+        },
+        "data_description": {
+          "policy": "Sticky — all chores in the group go to the same child today (the first chore in the list is the leader whose assignment the others follow). Spread — each chore is assigned to a different child today; if the group has more chores than children, it wraps.",
+          "chore_ids": "Pick the chores to include. The order matters: for Sticky, the first chore is the leader whose assignee the others follow."
+        }
+      },
+      "edit_task_group": {
+        "title": "Modifier le groupe : {group_name}",
+        "description": "Update or delete this task group.",
+        "data": {
+          "name": "Nom du groupe",
+          "policy": "Politique",
+          "chore_ids": "Tâches membres",
+          "action": "Action"
+        },
+        "data_description": {
+          "policy": "Sticky — all chores in the group go to the same child today. Spread — each chore is assigned to a different child today; if the group has more chores than children, it wraps."
+        }
       }
     },
     "error": {
       "name_required": "Le nom est requis",
       "invalid_milestone_format": "Format de palier invalide — utilisez des paires jours:points, ex: 3:5, 7:10",
       "operator_required": "L'opérateur est requis lorsqu'une entité est définie",
-      "state_required": "La valeur est requise lorsqu'une entité est définie"
+      "state_required": "La valeur est requise lorsqu'une entité est définie",
+      "task_group_invalid": "Groupe invalide : une tâche ne peut pas appartenir à plus d'un groupe, et les tâches en mode 'everyone' ne sont pas autorisées."
     }
   },
   "selector": {
@@ -413,6 +453,18 @@
         "alternating": "Alternance — rotation entre les enfants assignés, un par jour",
         "random": "Aléatoire — un enfant assigné choisi au hasard chaque jour",
         "balanced": "Équilibré — répartit les tâches équilibrées du jour équitablement entre les enfants assignés"
+      }
+    },
+    "task_group_policy": {
+      "options": {
+        "sticky": "Sticky — même enfant pour toutes les tâches du groupe",
+        "spread": "Spread — enfants différents dans le groupe aujourd’hui"
+      }
+    },
+    "task_group_action": {
+      "options": {
+        "save": "Enregistrer",
+        "delete": "Supprimer le groupe"
       }
     }
   },
@@ -736,6 +788,80 @@
         "requires_approval": {
           "name": "Nécessite approbation",
           "description": "Si vrai, un parent doit approuver l'exécution avant que les points soient attribués"
+        }
+      }
+    },
+    "skip_chore": {
+      "name": "Skip Chore",
+      "description": "Advance today's rotation past the current assignee. Ephemeral — tomorrow's rotation resumes as normal.",
+      "fields": {
+        "chore_id": {
+          "name": "Chore ID",
+          "description": "The ID of the chore to skip"
+        }
+      }
+    },
+    "set_chore_manual_start": {
+      "name": "Set Manual Start Child",
+      "description": "Set which child starts a rotating chore. For alternating mode this reorders the pool; for random/balanced it only overrides today's assignee.",
+      "fields": {
+        "chore_id": {
+          "name": "Chore ID",
+          "description": "The ID of the chore to update"
+        },
+        "child_id": {
+          "name": "Child ID",
+          "description": "The ID of the child who should start the rotation"
+        }
+      }
+    },
+    "add_task_group": {
+      "name": "Add Task Group",
+      "description": "Create a task group (sticky = same child, spread = different children).",
+      "fields": {
+        "name": {
+          "name": "Name",
+          "description": "Display name for the group"
+        },
+        "policy": {
+          "name": "Policy",
+          "description": "sticky (same child) or spread (different children)"
+        },
+        "chore_ids": {
+          "name": "Chore IDs",
+          "description": "List of chore IDs in the group. For sticky, the first chore is the leader."
+        }
+      }
+    },
+    "update_task_group": {
+      "name": "Update Task Group",
+      "description": "Update a task group's name, policy, or membership.",
+      "fields": {
+        "group_id": {
+          "name": "Group ID",
+          "description": "The ID of the group to update"
+        },
+        "name": {
+          "name": "Name",
+          "description": "New display name"
+        },
+        "policy": {
+          "name": "Policy",
+          "description": "New policy (sticky or spread)"
+        },
+        "chore_ids": {
+          "name": "Chore IDs",
+          "description": "Replacement chore ID list. For sticky, the first chore is the leader."
+        }
+      }
+    },
+    "remove_task_group": {
+      "name": "Remove Task Group",
+      "description": "Delete a task group. Member chores are not affected.",
+      "fields": {
+        "group_id": {
+          "name": "Group ID",
+          "description": "The ID of the group to delete"
         }
       }
     }

--- a/custom_components/taskmate/translations/nb.json
+++ b/custom_components/taskmate/translations/nb.json
@@ -25,7 +25,8 @@
           "manage_children": "Administrer barn",
           "manage_chores": "Administrer oppgaver",
           "manage_rewards": "Administrer belønninger",
-          "settings": "Innstillinger"
+          "settings": "Innstillinger",
+          "manage_task_groups": "Administrer oppgavegrupper"
         }
       },
       "manage_children": {
@@ -91,7 +92,8 @@
           "assignment_mode": "Tildelingsmodus",
           "assignment_rotation_anchor": "Startdato for rotasjon (kun vekslende)",
           "require_availability": "Hopp over utilgjengelige barn",
-          "publish_calendar_entities": "Publiser til kalendere (valgfritt)"
+          "publish_calendar_entities": "Publiser til kalendere (valgfritt)",
+          "manual_start_child_id": "Start rotasjon med (valgfritt)"
         },
         "data_description": {
           "claim_allowance_minutes": "Extra minutes after this time-of-day window ends during which the chore can still be claimed. 0 disables the grace period. Night chores are always capped at midnight.",
@@ -104,7 +106,8 @@
           "assignment_mode": "Alle = hvert tilknyttet barn ser oppgaven. Vekslende = ett barn om gangen, roterer daglig. Tilfeldig = ett barn plukket tilfeldig hver dag (stabilt gjennom dagen). Balansert = dagens balanserte oppgaver fordeles jevnt mellom de tildelte barna — ingen ender opp med alt.",
           "assignment_rotation_anchor": "Dag 0 i den vekslende rotasjonen. La stå tom for å starte i dag. Brukes kun når tildelingsmodus er 'Vekslende'.",
           "publish_calendar_entities": "Velg én eller flere Home Assistant-kalenderentiteter. Hver gang oppgaven opprettes, oppdateres eller bytter ved midnatt legges dagens tildelte barn til som en kalenderoppføring i hver valgte kalender. Fungerer med et hvilket som helst antall kalendere.",
-          "require_availability": "Når aktivert, hoppes et utilgjengelig barn (basert på tilgjengelighetssensoren i profilen) over, og neste tilgjengelige søsken tar oppgaven. Revurderes ved midnatt og hver gang en tilgjengelighetssensor endrer tilstand. Oppgaver som allerede er fullført i dag, tildeles ikke på nytt."
+          "require_availability": "Når aktivert, hoppes et utilgjengelig barn (basert på tilgjengelighetssensoren i profilen) over, og neste tilgjengelige søsken tar oppgaven. Revurderes ved midnatt og hver gang en tilgjengelighetssensor endrer tilstand. Oppgaver som allerede er fullført i dag, tildeles ikke på nytt.",
+          "manual_start_child_id": "Picks which child starts the rotation. For Alternating mode this permanently reorders the pool. For Random / Balanced it only overrides today's assignee — tomorrow's rotation resumes normally. Ignored for Everyone mode."
         }
       },
       "add_chores_bulk": {
@@ -157,7 +160,8 @@
           "assignment_mode": "Tildelingsmodus",
           "assignment_rotation_anchor": "Startdato for rotasjon (kun vekslende)",
           "require_availability": "Hopp over utilgjengelige barn",
-          "publish_calendar_entities": "Publiser til kalendere (valgfritt)"
+          "publish_calendar_entities": "Publiser til kalendere (valgfritt)",
+          "manual_start_child_id": "Start rotasjon med (valgfritt)"
         },
         "data_description": {
           "claim_allowance_minutes": "Extra minutes after this time-of-day window ends during which the chore can still be claimed. 0 disables the grace period. Night chores are always capped at midnight.",
@@ -170,7 +174,8 @@
           "assignment_mode": "Alle = hvert tilknyttet barn ser oppgaven. Vekslende = ett barn om gangen, roterer daglig. Tilfeldig = ett barn plukket tilfeldig hver dag (stabilt gjennom dagen). Balansert = dagens balanserte oppgaver fordeles jevnt mellom de tildelte barna — ingen ender opp med alt.",
           "assignment_rotation_anchor": "Dag 0 i den vekslende rotasjonen. La stå tom for å starte i dag. Brukes kun når tildelingsmodus er 'Vekslende'.",
           "publish_calendar_entities": "Velg én eller flere Home Assistant-kalenderentiteter. Hver gang oppgaven opprettes, oppdateres eller bytter ved midnatt legges dagens tildelte barn til som en kalenderoppføring i hver valgte kalender. Fungerer med et hvilket som helst antall kalendere.",
-          "require_availability": "Når aktivert, hoppes et utilgjengelig barn (basert på tilgjengelighetssensoren i profilen) over, og neste tilgjengelige søsken tar oppgaven. Revurderes ved midnatt og hver gang en tilgjengelighetssensor endrer tilstand. Oppgaver som allerede er fullført i dag, tildeles ikke på nytt."
+          "require_availability": "Når aktivert, hoppes et utilgjengelig barn (basert på tilgjengelighetssensoren i profilen) over, og neste tilgjengelige søsken tar oppgaven. Revurderes ved midnatt og hver gang en tilgjengelighetssensor endrer tilstand. Oppgaver som allerede er fullført i dag, tildeles ikke på nytt.",
+          "manual_start_child_id": "Picks which child starts the rotation. For Alternating mode this permanently reorders the pool and resets the anchor. For Random / Balanced it only overrides today's assignee — tomorrow's rotation resumes normally. Ignored for Everyone mode."
         }
       },
       "manage_rewards": {
@@ -305,13 +310,48 @@
           "recurrence_start": "Kun annenhver dag — ankerdato i ÅÅÅÅ-MM-DD-format. Ignoreres for alle andre gjentakelsestyper. La stå tom for å bruke i dag.",
           "first_occurrence_mode": "Tilgjengelig umiddelbart — barnet kan fullføre den med en gang. Vent på første forekomst — oppgaven er låst til første planlagte dag."
         }
+      },
+      "manage_task_groups": {
+        "title": "Administrer oppgavegrupper",
+        "description": "Group chores so their assignments stay coordinated. Sticky forces all chores in the group onto the same child today. Spread gives each chore a different child.",
+        "menu_options": {
+          "add_task_group": "Legg til ny gruppe",
+          "init": "Tilbake til hovedmeny"
+        }
+      },
+      "add_task_group": {
+        "title": "Legg til oppgavegruppe",
+        "description": "Only rotation-mode chores (alternating / random / balanced) can join a group, and each chore can belong to at most one group.",
+        "data": {
+          "name": "Gruppenavn",
+          "policy": "Retningslinje",
+          "chore_ids": "Medlemsoppgaver"
+        },
+        "data_description": {
+          "policy": "Sticky — all chores in the group go to the same child today (the first chore in the list is the leader whose assignment the others follow). Spread — each chore is assigned to a different child today; if the group has more chores than children, it wraps.",
+          "chore_ids": "Pick the chores to include. The order matters: for Sticky, the first chore is the leader whose assignee the others follow."
+        }
+      },
+      "edit_task_group": {
+        "title": "Rediger gruppe: {group_name}",
+        "description": "Update or delete this task group.",
+        "data": {
+          "name": "Gruppenavn",
+          "policy": "Retningslinje",
+          "chore_ids": "Medlemsoppgaver",
+          "action": "Handling"
+        },
+        "data_description": {
+          "policy": "Sticky — all chores in the group go to the same child today. Spread — each chore is assigned to a different child today; if the group has more chores than children, it wraps."
+        }
       }
     },
     "error": {
       "name_required": "Navn er påkrevd",
       "invalid_milestone_format": "Ugyldig milepælformat — bruk dager:poeng-par, f.eks. 3:5, 7:10, 14:20",
       "operator_required": "Operator kreves når en entitet er satt",
-      "state_required": "Verdi kreves når en entitet er satt"
+      "state_required": "Verdi kreves når en entitet er satt",
+      "task_group_invalid": "Ugyldig gruppe: en oppgave kan ikke være i mer enn én gruppe, og oppgaver i 'everyone'-modus er ikke tillatt."
     }
   },
   "selector": {
@@ -413,6 +453,18 @@
         "alternating": "Vekslende — roter mellom de tildelte barna, ett per dag",
         "random": "Tilfeldig — plukk ett tildelt barn tilfeldig hver dag",
         "balanced": "Balansert — fordel dagens balanserte oppgaver jevnt mellom de tildelte barna"
+      }
+    },
+    "task_group_policy": {
+      "options": {
+        "sticky": "Sticky — samme barn for alle oppgaver i gruppen",
+        "spread": "Spread — ulike barn i gruppen i dag"
+      }
+    },
+    "task_group_action": {
+      "options": {
+        "save": "Lagre endringer",
+        "delete": "Slett gruppe"
       }
     }
   },
@@ -736,6 +788,80 @@
         "requires_approval": {
           "name": "Krever godkjenning",
           "description": "Hvis sann må en forelder godkjenne fullføringen før poeng tildeles"
+        }
+      }
+    },
+    "skip_chore": {
+      "name": "Skip Chore",
+      "description": "Advance today's rotation past the current assignee. Ephemeral — tomorrow's rotation resumes as normal.",
+      "fields": {
+        "chore_id": {
+          "name": "Chore ID",
+          "description": "The ID of the chore to skip"
+        }
+      }
+    },
+    "set_chore_manual_start": {
+      "name": "Set Manual Start Child",
+      "description": "Set which child starts a rotating chore. For alternating mode this reorders the pool; for random/balanced it only overrides today's assignee.",
+      "fields": {
+        "chore_id": {
+          "name": "Chore ID",
+          "description": "The ID of the chore to update"
+        },
+        "child_id": {
+          "name": "Child ID",
+          "description": "The ID of the child who should start the rotation"
+        }
+      }
+    },
+    "add_task_group": {
+      "name": "Add Task Group",
+      "description": "Create a task group (sticky = same child, spread = different children).",
+      "fields": {
+        "name": {
+          "name": "Name",
+          "description": "Display name for the group"
+        },
+        "policy": {
+          "name": "Policy",
+          "description": "sticky (same child) or spread (different children)"
+        },
+        "chore_ids": {
+          "name": "Chore IDs",
+          "description": "List of chore IDs in the group. For sticky, the first chore is the leader."
+        }
+      }
+    },
+    "update_task_group": {
+      "name": "Update Task Group",
+      "description": "Update a task group's name, policy, or membership.",
+      "fields": {
+        "group_id": {
+          "name": "Group ID",
+          "description": "The ID of the group to update"
+        },
+        "name": {
+          "name": "Name",
+          "description": "New display name"
+        },
+        "policy": {
+          "name": "Policy",
+          "description": "New policy (sticky or spread)"
+        },
+        "chore_ids": {
+          "name": "Chore IDs",
+          "description": "Replacement chore ID list. For sticky, the first chore is the leader."
+        }
+      }
+    },
+    "remove_task_group": {
+      "name": "Remove Task Group",
+      "description": "Delete a task group. Member chores are not affected.",
+      "fields": {
+        "group_id": {
+          "name": "Group ID",
+          "description": "The ID of the group to delete"
         }
       }
     }

--- a/custom_components/taskmate/translations/nn.json
+++ b/custom_components/taskmate/translations/nn.json
@@ -25,7 +25,8 @@
           "manage_children": "Administrer born",
           "manage_chores": "Administrer oppgåver",
           "manage_rewards": "Administrer løningar",
-          "settings": "Innstillingar"
+          "settings": "Innstillingar",
+          "manage_task_groups": "Administrer oppgåvegrupper"
         }
       },
       "manage_children": {
@@ -91,7 +92,8 @@
           "assignment_mode": "Tildelingsmodus",
           "assignment_rotation_anchor": "Startdato for rotasjon (berre vekslande)",
           "require_availability": "Hopp over utilgjengelege born",
-          "publish_calendar_entities": "Publiser til kalendrar (valfritt)"
+          "publish_calendar_entities": "Publiser til kalendrar (valfritt)",
+          "manual_start_child_id": "Start rotasjon med (valfritt)"
         },
         "data_description": {
           "claim_allowance_minutes": "Extra minutes after this time-of-day window ends during which the chore can still be claimed. 0 disables the grace period. Night chores are always capped at midnight.",
@@ -104,7 +106,8 @@
           "assignment_mode": "Alle = kvart tilknytt barn ser oppgåva. Vekslande = eitt barn om gongen, roterer dagleg. Tilfeldig = eitt barn plukka tilfeldig kvar dag (stabilt gjennom dagen). Balansert = dagens balanserte oppgåver vert fordelte jamt mellom dei tildelte barna — ingen endar opp med alt.",
           "assignment_rotation_anchor": "Dag 0 i den vekslande rotasjonen. Lat stå tom for å starte i dag. Vert brukt berre når tildelingsmodus er 'Vekslande'.",
           "publish_calendar_entities": "Vel ein eller fleire Home Assistant-kalenderentitetar. Kvar gong oppgåva vert oppretta, oppdatert eller skiftar ved midnatt vert dagens tildelte barn lagt til som ei kalenderoppføring i kvar valde kalender. Fungerer med eit kva som helst tal kalendrar.",
-          "require_availability": "Når slått på, vert eit utilgjengeleg born (basert på tilgjengesensoren i profilen) hoppa over, og neste tilgjengelege syskenet tek oppgåva. Vert vurdert på nytt ved midnatt og kvar gong ein tilgjengesensor endrar tilstand. Oppgåver som alt er fullførde i dag, vert ikkje tildelt på nytt."
+          "require_availability": "Når slått på, vert eit utilgjengeleg born (basert på tilgjengesensoren i profilen) hoppa over, og neste tilgjengelege syskenet tek oppgåva. Vert vurdert på nytt ved midnatt og kvar gong ein tilgjengesensor endrar tilstand. Oppgåver som alt er fullførde i dag, vert ikkje tildelt på nytt.",
+          "manual_start_child_id": "Picks which child starts the rotation. For Alternating mode this permanently reorders the pool. For Random / Balanced it only overrides today's assignee — tomorrow's rotation resumes normally. Ignored for Everyone mode."
         }
       },
       "add_chores_bulk": {
@@ -157,7 +160,8 @@
           "assignment_mode": "Tildelingsmodus",
           "assignment_rotation_anchor": "Startdato for rotasjon (berre vekslande)",
           "require_availability": "Hopp over utilgjengelege born",
-          "publish_calendar_entities": "Publiser til kalendrar (valfritt)"
+          "publish_calendar_entities": "Publiser til kalendrar (valfritt)",
+          "manual_start_child_id": "Start rotasjon med (valfritt)"
         },
         "data_description": {
           "claim_allowance_minutes": "Extra minutes after this time-of-day window ends during which the chore can still be claimed. 0 disables the grace period. Night chores are always capped at midnight.",
@@ -170,7 +174,8 @@
           "assignment_mode": "Alle = kvart tilknytt barn ser oppgåva. Vekslande = eitt barn om gongen, roterer dagleg. Tilfeldig = eitt barn plukka tilfeldig kvar dag (stabilt gjennom dagen). Balansert = dagens balanserte oppgåver vert fordelte jamt mellom dei tildelte barna — ingen endar opp med alt.",
           "assignment_rotation_anchor": "Dag 0 i den vekslande rotasjonen. Lat stå tom for å starte i dag. Vert brukt berre når tildelingsmodus er 'Vekslande'.",
           "publish_calendar_entities": "Vel ein eller fleire Home Assistant-kalenderentitetar. Kvar gong oppgåva vert oppretta, oppdatert eller skiftar ved midnatt vert dagens tildelte barn lagt til som ei kalenderoppføring i kvar valde kalender. Fungerer med eit kva som helst tal kalendrar.",
-          "require_availability": "Når slått på, vert eit utilgjengeleg born (basert på tilgjengesensoren i profilen) hoppa over, og neste tilgjengelege syskenet tek oppgåva. Vert vurdert på nytt ved midnatt og kvar gong ein tilgjengesensor endrar tilstand. Oppgåver som alt er fullførde i dag, vert ikkje tildelt på nytt."
+          "require_availability": "Når slått på, vert eit utilgjengeleg born (basert på tilgjengesensoren i profilen) hoppa over, og neste tilgjengelege syskenet tek oppgåva. Vert vurdert på nytt ved midnatt og kvar gong ein tilgjengesensor endrar tilstand. Oppgåver som alt er fullførde i dag, vert ikkje tildelt på nytt.",
+          "manual_start_child_id": "Picks which child starts the rotation. For Alternating mode this permanently reorders the pool and resets the anchor. For Random / Balanced it only overrides today's assignee — tomorrow's rotation resumes normally. Ignored for Everyone mode."
         }
       },
       "manage_rewards": {
@@ -305,13 +310,48 @@
           "recurrence_start": "Berre annakvar dag — ankerdato i ÅÅÅÅ-MM-DD-format. Vert ignorert for alle andre gjentakingstypar. Lat stå tom for å bruke i dag.",
           "first_occurrence_mode": "Tilgjengeleg med ein gong — bornet kan fullføre ho med det same. Vent på fyrste førekomst — oppgåva er låst til fyrste planlagde dag."
         }
+      },
+      "manage_task_groups": {
+        "title": "Administrer oppgåvegrupper",
+        "description": "Group chores so their assignments stay coordinated. Sticky forces all chores in the group onto the same child today. Spread gives each chore a different child.",
+        "menu_options": {
+          "add_task_group": "Legg til ny gruppe",
+          "init": "Tilbake til hovudmeny"
+        }
+      },
+      "add_task_group": {
+        "title": "Legg til oppgåvegruppe",
+        "description": "Only rotation-mode chores (alternating / random / balanced) can join a group, and each chore can belong to at most one group.",
+        "data": {
+          "name": "Gruppenamn",
+          "policy": "Retningsline",
+          "chore_ids": "Medlemsoppgåver"
+        },
+        "data_description": {
+          "policy": "Sticky — all chores in the group go to the same child today (the first chore in the list is the leader whose assignment the others follow). Spread — each chore is assigned to a different child today; if the group has more chores than children, it wraps.",
+          "chore_ids": "Pick the chores to include. The order matters: for Sticky, the first chore is the leader whose assignee the others follow."
+        }
+      },
+      "edit_task_group": {
+        "title": "Rediger gruppe: {group_name}",
+        "description": "Update or delete this task group.",
+        "data": {
+          "name": "Gruppenamn",
+          "policy": "Retningsline",
+          "chore_ids": "Medlemsoppgåver",
+          "action": "Handling"
+        },
+        "data_description": {
+          "policy": "Sticky — all chores in the group go to the same child today. Spread — each chore is assigned to a different child today; if the group has more chores than children, it wraps."
+        }
       }
     },
     "error": {
       "name_required": "Namn er påkravd",
       "invalid_milestone_format": "Ugyldig milepælformat — bruk dagar:poeng-par, t.d. 3:5, 7:10, 14:20",
       "operator_required": "Operator er påkravd når ein entitet er sett",
-      "state_required": "Verdi er påkravd når ein entitet er sett"
+      "state_required": "Verdi er påkravd når ein entitet er sett",
+      "task_group_invalid": "Ugyldig gruppe: ei oppgåve kan ikkje vere i meir enn éi gruppe, og oppgåver i 'everyone'-modus er ikkje tillatne."
     }
   },
   "selector": {
@@ -413,6 +453,18 @@
         "alternating": "Vekslande — roter mellom dei tildelte barna, eitt per dag",
         "random": "Tilfeldig — plukk eitt tildelt barn tilfeldig kvar dag",
         "balanced": "Balansert — fordel dagens balanserte oppgåver jamt mellom dei tildelte barna"
+      }
+    },
+    "task_group_policy": {
+      "options": {
+        "sticky": "Sticky — same barn for alle oppgåver i gruppa",
+        "spread": "Spread — ulike barn i gruppa i dag"
+      }
+    },
+    "task_group_action": {
+      "options": {
+        "save": "Lagre endringar",
+        "delete": "Slett gruppe"
       }
     }
   },
@@ -736,6 +788,80 @@
         "requires_approval": {
           "name": "Krev godkjenning",
           "description": "Om sann må ein forelder godkjenne fullføringa før poeng vert tildelte"
+        }
+      }
+    },
+    "skip_chore": {
+      "name": "Skip Chore",
+      "description": "Advance today's rotation past the current assignee. Ephemeral — tomorrow's rotation resumes as normal.",
+      "fields": {
+        "chore_id": {
+          "name": "Chore ID",
+          "description": "The ID of the chore to skip"
+        }
+      }
+    },
+    "set_chore_manual_start": {
+      "name": "Set Manual Start Child",
+      "description": "Set which child starts a rotating chore. For alternating mode this reorders the pool; for random/balanced it only overrides today's assignee.",
+      "fields": {
+        "chore_id": {
+          "name": "Chore ID",
+          "description": "The ID of the chore to update"
+        },
+        "child_id": {
+          "name": "Child ID",
+          "description": "The ID of the child who should start the rotation"
+        }
+      }
+    },
+    "add_task_group": {
+      "name": "Add Task Group",
+      "description": "Create a task group (sticky = same child, spread = different children).",
+      "fields": {
+        "name": {
+          "name": "Name",
+          "description": "Display name for the group"
+        },
+        "policy": {
+          "name": "Policy",
+          "description": "sticky (same child) or spread (different children)"
+        },
+        "chore_ids": {
+          "name": "Chore IDs",
+          "description": "List of chore IDs in the group. For sticky, the first chore is the leader."
+        }
+      }
+    },
+    "update_task_group": {
+      "name": "Update Task Group",
+      "description": "Update a task group's name, policy, or membership.",
+      "fields": {
+        "group_id": {
+          "name": "Group ID",
+          "description": "The ID of the group to update"
+        },
+        "name": {
+          "name": "Name",
+          "description": "New display name"
+        },
+        "policy": {
+          "name": "Policy",
+          "description": "New policy (sticky or spread)"
+        },
+        "chore_ids": {
+          "name": "Chore IDs",
+          "description": "Replacement chore ID list. For sticky, the first chore is the leader."
+        }
+      }
+    },
+    "remove_task_group": {
+      "name": "Remove Task Group",
+      "description": "Delete a task group. Member chores are not affected.",
+      "fields": {
+        "group_id": {
+          "name": "Group ID",
+          "description": "The ID of the group to delete"
         }
       }
     }

--- a/custom_components/taskmate/translations/pt-BR.json
+++ b/custom_components/taskmate/translations/pt-BR.json
@@ -25,7 +25,8 @@
           "manage_children": "Gerir crianças",
           "manage_chores": "Gerir tarefas",
           "manage_rewards": "Gerir recompensas",
-          "settings": "Definições"
+          "settings": "Definições",
+          "manage_task_groups": "Gerenciar grupos de tarefas"
         }
       },
       "manage_children": {
@@ -91,7 +92,8 @@
           "assignment_mode": "Modo de atribuição",
           "assignment_rotation_anchor": "Data de início da rotação (apenas alternância)",
           "require_availability": "Ignorar crianças indisponíveis",
-          "publish_calendar_entities": "Publicar nos calendários (opcional)"
+          "publish_calendar_entities": "Publicar nos calendários (opcional)",
+          "manual_start_child_id": "Iniciar rotação com (opcional)"
         },
         "data_description": {
           "claim_allowance_minutes": "Minutos extras após o fim desta janela horária durante os quais a tarefa ainda pode ser reivindicada. 0 desativa o período de tolerância. As tarefas noturnas são sempre limitadas à meia-noite.",
@@ -104,7 +106,8 @@
           "assignment_mode": "Todos = todas as crianças atribuídas veem esta tarefa. Alternado = uma criança de cada vez, alternando por dia. Aleatório = uma criança escolhida aleatoriamente por dia (estável durante o dia). Equilibrado = as tarefas no modo equilibrado do dia são divididas igualmente entre as crianças atribuídas — nenhuma fica com tudo.",
           "assignment_rotation_anchor": "Dia 0 da rotação alternada. Deixe em branco para começar hoje. Usado apenas quando o modo de atribuição é 'Alternado'.",
           "publish_calendar_entities": "Escolha uma ou mais entidades de calendário do Home Assistant. Sempre que esta tarefa for criada, atualizada ou passar da meia-noite, a criança atribuída do dia é adicionada como evento em cada calendário selecionado. Funciona com qualquer número de calendários.",
-          "require_availability": "Quando ativo, uma criança indisponível (com base no Sensor de disponibilidade do perfil dela) é ignorada e o próximo irmão/irmã disponível assume a tarefa. Reavaliado à meia-noite e sempre que um sensor de disponibilidade mudar de estado. Tarefas já concluídas hoje não são reatribuídas."
+          "require_availability": "Quando ativo, uma criança indisponível (com base no Sensor de disponibilidade do perfil dela) é ignorada e o próximo irmão/irmã disponível assume a tarefa. Reavaliado à meia-noite e sempre que um sensor de disponibilidade mudar de estado. Tarefas já concluídas hoje não são reatribuídas.",
+          "manual_start_child_id": "Picks which child starts the rotation. For Alternating mode this permanently reorders the pool. For Random / Balanced it only overrides today's assignee — tomorrow's rotation resumes normally. Ignored for Everyone mode."
         }
       },
       "add_chores_bulk": {
@@ -157,7 +160,8 @@
           "assignment_mode": "Modo de atribuição",
           "assignment_rotation_anchor": "Data de início da rotação (apenas alternância)",
           "require_availability": "Ignorar crianças indisponíveis",
-          "publish_calendar_entities": "Publicar nos calendários (opcional)"
+          "publish_calendar_entities": "Publicar nos calendários (opcional)",
+          "manual_start_child_id": "Iniciar rotação com (opcional)"
         },
         "data_description": {
           "claim_allowance_minutes": "Minutos extras após o fim desta janela horária durante os quais a tarefa ainda pode ser reivindicada. 0 desativa o período de tolerância. As tarefas noturnas são sempre limitadas à meia-noite.",
@@ -170,7 +174,8 @@
           "assignment_mode": "Todos = todas as crianças atribuídas veem esta tarefa. Alternado = uma criança de cada vez, alternando por dia. Aleatório = uma criança escolhida aleatoriamente por dia (estável durante o dia). Equilibrado = as tarefas no modo equilibrado do dia são divididas igualmente entre as crianças atribuídas — nenhuma fica com tudo.",
           "assignment_rotation_anchor": "Dia 0 da rotação alternada. Deixe em branco para começar hoje. Usado apenas quando o modo de atribuição é 'Alternado'.",
           "publish_calendar_entities": "Escolha uma ou mais entidades de calendário do Home Assistant. Sempre que esta tarefa for criada, atualizada ou passar da meia-noite, a criança atribuída do dia é adicionada como evento em cada calendário selecionado. Funciona com qualquer número de calendários.",
-          "require_availability": "Quando ativo, uma criança indisponível (com base no Sensor de disponibilidade do perfil dela) é ignorada e o próximo irmão/irmã disponível assume a tarefa. Reavaliado à meia-noite e sempre que um sensor de disponibilidade mudar de estado. Tarefas já concluídas hoje não são reatribuídas."
+          "require_availability": "Quando ativo, uma criança indisponível (com base no Sensor de disponibilidade do perfil dela) é ignorada e o próximo irmão/irmã disponível assume a tarefa. Reavaliado à meia-noite e sempre que um sensor de disponibilidade mudar de estado. Tarefas já concluídas hoje não são reatribuídas.",
+          "manual_start_child_id": "Picks which child starts the rotation. For Alternating mode this permanently reorders the pool and resets the anchor. For Random / Balanced it only overrides today's assignee — tomorrow's rotation resumes normally. Ignored for Everyone mode."
         }
       },
       "manage_rewards": {
@@ -305,13 +310,48 @@
           "recurrence_start": "Apenas a cada 2 dias — data âncora no formato AAAA-MM-DD. Ignorado para todos os outros tipos de recorrência. Deixe vazio para usar hoje.",
           "first_occurrence_mode": "Disponível imediatamente — a criança pode completar de imediato. Aguardar primeira ocorrência — a tarefa fica bloqueada até o primeiro dia agendado."
         }
+      },
+      "manage_task_groups": {
+        "title": "Gerenciar grupos de tarefas",
+        "description": "Group chores so their assignments stay coordinated. Sticky forces all chores in the group onto the same child today. Spread gives each chore a different child.",
+        "menu_options": {
+          "add_task_group": "Adicionar novo grupo",
+          "init": "Voltar ao menu principal"
+        }
+      },
+      "add_task_group": {
+        "title": "Adicionar grupo de tarefas",
+        "description": "Only rotation-mode chores (alternating / random / balanced) can join a group, and each chore can belong to at most one group.",
+        "data": {
+          "name": "Nome do grupo",
+          "policy": "Política",
+          "chore_ids": "Tarefas incluídas"
+        },
+        "data_description": {
+          "policy": "Sticky — all chores in the group go to the same child today (the first chore in the list is the leader whose assignment the others follow). Spread — each chore is assigned to a different child today; if the group has more chores than children, it wraps.",
+          "chore_ids": "Pick the chores to include. The order matters: for Sticky, the first chore is the leader whose assignee the others follow."
+        }
+      },
+      "edit_task_group": {
+        "title": "Editar grupo: {group_name}",
+        "description": "Update or delete this task group.",
+        "data": {
+          "name": "Nome do grupo",
+          "policy": "Política",
+          "chore_ids": "Tarefas incluídas",
+          "action": "Ação"
+        },
+        "data_description": {
+          "policy": "Sticky — all chores in the group go to the same child today. Spread — each chore is assigned to a different child today; if the group has more chores than children, it wraps."
+        }
       }
     },
     "error": {
       "name_required": "O nome é obrigatório",
       "invalid_milestone_format": "Formato de marco inválido — use pares dias:pontos, ex: 3:5, 7:10, 14:20",
       "operator_required": "O operador é obrigatório quando uma entidade está definida",
-      "state_required": "O valor é obrigatório quando uma entidade está definida"
+      "state_required": "O valor é obrigatório quando uma entidade está definida",
+      "task_group_invalid": "Grupo inválido: uma tarefa não pode pertencer a mais de um grupo, e tarefas no modo 'everyone' não são permitidas."
     }
   },
   "selector": {
@@ -413,6 +453,18 @@
         "alternating": "Alternado — alterna entre as crianças atribuídas, uma por dia",
         "random": "Aleatório — escolhe aleatoriamente uma criança atribuída por dia",
         "balanced": "Equilibrado — divide as tarefas equilibradas do dia igualmente entre as crianças atribuídas"
+      }
+    },
+    "task_group_policy": {
+      "options": {
+        "sticky": "Sticky — mesma criança para todas as tarefas do grupo",
+        "spread": "Spread — crianças diferentes no grupo hoje"
+      }
+    },
+    "task_group_action": {
+      "options": {
+        "save": "Salvar alterações",
+        "delete": "Excluir grupo"
       }
     }
   },
@@ -736,6 +788,80 @@
         "requires_approval": {
           "name": "Requer aprovação",
           "description": "Se verdadeiro, um pai/mãe deve aprovar a conclusão antes de os pontos serem concedidos"
+        }
+      }
+    },
+    "skip_chore": {
+      "name": "Skip Chore",
+      "description": "Advance today's rotation past the current assignee. Ephemeral — tomorrow's rotation resumes as normal.",
+      "fields": {
+        "chore_id": {
+          "name": "Chore ID",
+          "description": "The ID of the chore to skip"
+        }
+      }
+    },
+    "set_chore_manual_start": {
+      "name": "Set Manual Start Child",
+      "description": "Set which child starts a rotating chore. For alternating mode this reorders the pool; for random/balanced it only overrides today's assignee.",
+      "fields": {
+        "chore_id": {
+          "name": "Chore ID",
+          "description": "The ID of the chore to update"
+        },
+        "child_id": {
+          "name": "Child ID",
+          "description": "The ID of the child who should start the rotation"
+        }
+      }
+    },
+    "add_task_group": {
+      "name": "Add Task Group",
+      "description": "Create a task group (sticky = same child, spread = different children).",
+      "fields": {
+        "name": {
+          "name": "Name",
+          "description": "Display name for the group"
+        },
+        "policy": {
+          "name": "Policy",
+          "description": "sticky (same child) or spread (different children)"
+        },
+        "chore_ids": {
+          "name": "Chore IDs",
+          "description": "List of chore IDs in the group. For sticky, the first chore is the leader."
+        }
+      }
+    },
+    "update_task_group": {
+      "name": "Update Task Group",
+      "description": "Update a task group's name, policy, or membership.",
+      "fields": {
+        "group_id": {
+          "name": "Group ID",
+          "description": "The ID of the group to update"
+        },
+        "name": {
+          "name": "Name",
+          "description": "New display name"
+        },
+        "policy": {
+          "name": "Policy",
+          "description": "New policy (sticky or spread)"
+        },
+        "chore_ids": {
+          "name": "Chore IDs",
+          "description": "Replacement chore ID list. For sticky, the first chore is the leader."
+        }
+      }
+    },
+    "remove_task_group": {
+      "name": "Remove Task Group",
+      "description": "Delete a task group. Member chores are not affected.",
+      "fields": {
+        "group_id": {
+          "name": "Group ID",
+          "description": "The ID of the group to delete"
         }
       }
     }

--- a/custom_components/taskmate/translations/pt.json
+++ b/custom_components/taskmate/translations/pt.json
@@ -25,7 +25,8 @@
           "manage_children": "Gerir crianças",
           "manage_chores": "Gerir tarefas",
           "manage_rewards": "Gerir recompensas",
-          "settings": "Definições"
+          "settings": "Definições",
+          "manage_task_groups": "Gerir grupos de tarefas"
         }
       },
       "manage_children": {
@@ -91,7 +92,8 @@
           "assignment_mode": "Modo de atribuição",
           "assignment_rotation_anchor": "Data de início da rotação (apenas alternância)",
           "require_availability": "Ignorar crianças indisponíveis",
-          "publish_calendar_entities": "Publicar nos calendários (opcional)"
+          "publish_calendar_entities": "Publicar nos calendários (opcional)",
+          "manual_start_child_id": "Iniciar rotação com (opcional)"
         },
         "data_description": {
           "claim_allowance_minutes": "Minutos extra após o fim desta janela horária durante os quais a tarefa ainda pode ser reivindicada. 0 desativa o período de tolerância. As tarefas noturnas são sempre limitadas à meia-noite.",
@@ -104,7 +106,8 @@
           "assignment_mode": "Todos = todas as crianças atribuídas veem esta tarefa. Alternado = uma criança de cada vez, alternando por dia. Aleatório = uma criança escolhida aleatoriamente por dia (estável durante o dia). Equilibrado = as tarefas no modo equilibrado do dia são divididas igualmente entre as crianças atribuídas — nenhuma fica com tudo.",
           "assignment_rotation_anchor": "Dia 0 da rotação alternada. Deixe em branco para começar hoje. Usado apenas quando o modo de atribuição é 'Alternado'.",
           "publish_calendar_entities": "Escolha uma ou mais entidades de calendário do Home Assistant. Sempre que esta tarefa for criada, atualizada ou passar da meia-noite, a criança atribuída do dia é adicionada como evento em cada calendário selecionado. Funciona com qualquer número de calendários.",
-          "require_availability": "Quando ativo, uma criança indisponível (com base no Sensor de disponibilidade do seu perfil) é ignorada e o próximo irmão/irmã disponível fica com a tarefa. Reavaliado à meia-noite e sempre que um sensor de disponibilidade mudar de estado. Tarefas já concluídas hoje não são reatribuídas."
+          "require_availability": "Quando ativo, uma criança indisponível (com base no Sensor de disponibilidade do seu perfil) é ignorada e o próximo irmão/irmã disponível fica com a tarefa. Reavaliado à meia-noite e sempre que um sensor de disponibilidade mudar de estado. Tarefas já concluídas hoje não são reatribuídas.",
+          "manual_start_child_id": "Picks which child starts the rotation. For Alternating mode this permanently reorders the pool. For Random / Balanced it only overrides today's assignee — tomorrow's rotation resumes normally. Ignored for Everyone mode."
         }
       },
       "add_chores_bulk": {
@@ -157,7 +160,8 @@
           "assignment_mode": "Modo de atribuição",
           "assignment_rotation_anchor": "Data de início da rotação (apenas alternância)",
           "require_availability": "Ignorar crianças indisponíveis",
-          "publish_calendar_entities": "Publicar nos calendários (opcional)"
+          "publish_calendar_entities": "Publicar nos calendários (opcional)",
+          "manual_start_child_id": "Iniciar rotação com (opcional)"
         },
         "data_description": {
           "claim_allowance_minutes": "Minutos extra após o fim desta janela horária durante os quais a tarefa ainda pode ser reivindicada. 0 desativa o período de tolerância. As tarefas noturnas são sempre limitadas à meia-noite.",
@@ -170,7 +174,8 @@
           "assignment_mode": "Todos = todas as crianças atribuídas veem esta tarefa. Alternado = uma criança de cada vez, alternando por dia. Aleatório = uma criança escolhida aleatoriamente por dia (estável durante o dia). Equilibrado = as tarefas no modo equilibrado do dia são divididas igualmente entre as crianças atribuídas — nenhuma fica com tudo.",
           "assignment_rotation_anchor": "Dia 0 da rotação alternada. Deixe em branco para começar hoje. Usado apenas quando o modo de atribuição é 'Alternado'.",
           "publish_calendar_entities": "Escolha uma ou mais entidades de calendário do Home Assistant. Sempre que esta tarefa for criada, atualizada ou passar da meia-noite, a criança atribuída do dia é adicionada como evento em cada calendário selecionado. Funciona com qualquer número de calendários.",
-          "require_availability": "Quando ativo, uma criança indisponível (com base no Sensor de disponibilidade do seu perfil) é ignorada e o próximo irmão/irmã disponível fica com a tarefa. Reavaliado à meia-noite e sempre que um sensor de disponibilidade mudar de estado. Tarefas já concluídas hoje não são reatribuídas."
+          "require_availability": "Quando ativo, uma criança indisponível (com base no Sensor de disponibilidade do seu perfil) é ignorada e o próximo irmão/irmã disponível fica com a tarefa. Reavaliado à meia-noite e sempre que um sensor de disponibilidade mudar de estado. Tarefas já concluídas hoje não são reatribuídas.",
+          "manual_start_child_id": "Picks which child starts the rotation. For Alternating mode this permanently reorders the pool and resets the anchor. For Random / Balanced it only overrides today's assignee — tomorrow's rotation resumes normally. Ignored for Everyone mode."
         }
       },
       "manage_rewards": {
@@ -305,13 +310,48 @@
           "recurrence_start": "Apenas a cada 2 dias — data âncora no formato AAAA-MM-DD. Ignorado para todos os outros tipos de recorrência. Deixe vazio para usar hoje.",
           "first_occurrence_mode": "Disponível imediatamente — a criança pode completar de imediato. Aguardar primeira ocorrência — a tarefa fica bloqueada até o primeiro dia agendado."
         }
+      },
+      "manage_task_groups": {
+        "title": "Gerir grupos de tarefas",
+        "description": "Group chores so their assignments stay coordinated. Sticky forces all chores in the group onto the same child today. Spread gives each chore a different child.",
+        "menu_options": {
+          "add_task_group": "Adicionar novo grupo",
+          "init": "Voltar ao menu principal"
+        }
+      },
+      "add_task_group": {
+        "title": "Adicionar grupo de tarefas",
+        "description": "Only rotation-mode chores (alternating / random / balanced) can join a group, and each chore can belong to at most one group.",
+        "data": {
+          "name": "Nome do grupo",
+          "policy": "Política",
+          "chore_ids": "Tarefas incluídas"
+        },
+        "data_description": {
+          "policy": "Sticky — all chores in the group go to the same child today (the first chore in the list is the leader whose assignment the others follow). Spread — each chore is assigned to a different child today; if the group has more chores than children, it wraps.",
+          "chore_ids": "Pick the chores to include. The order matters: for Sticky, the first chore is the leader whose assignee the others follow."
+        }
+      },
+      "edit_task_group": {
+        "title": "Editar grupo: {group_name}",
+        "description": "Update or delete this task group.",
+        "data": {
+          "name": "Nome do grupo",
+          "policy": "Política",
+          "chore_ids": "Tarefas incluídas",
+          "action": "Ação"
+        },
+        "data_description": {
+          "policy": "Sticky — all chores in the group go to the same child today. Spread — each chore is assigned to a different child today; if the group has more chores than children, it wraps."
+        }
       }
     },
     "error": {
       "name_required": "O nome é obrigatório",
       "invalid_milestone_format": "Formato de marco inválido — use pares dias:pontos, ex: 3:5, 7:10, 14:20",
       "operator_required": "O operador é obrigatório quando uma entidade está definida",
-      "state_required": "O valor é obrigatório quando uma entidade está definida"
+      "state_required": "O valor é obrigatório quando uma entidade está definida",
+      "task_group_invalid": "Grupo inválido: uma tarefa não pode pertencer a mais de um grupo, e tarefas no modo 'everyone' não são permitidas."
     }
   },
   "selector": {
@@ -413,6 +453,18 @@
         "alternating": "Alternado — alterna entre as crianças atribuídas, uma por dia",
         "random": "Aleatório — escolhe aleatoriamente uma criança atribuída por dia",
         "balanced": "Equilibrado — divide as tarefas equilibradas do dia igualmente entre as crianças atribuídas"
+      }
+    },
+    "task_group_policy": {
+      "options": {
+        "sticky": "Sticky — mesma criança para todas as tarefas do grupo",
+        "spread": "Spread — crianças diferentes no grupo hoje"
+      }
+    },
+    "task_group_action": {
+      "options": {
+        "save": "Guardar alterações",
+        "delete": "Eliminar grupo"
       }
     }
   },
@@ -736,6 +788,80 @@
         "requires_approval": {
           "name": "Requer aprovação",
           "description": "Se verdadeiro, um pai/mãe deve aprovar a conclusão antes de os pontos serem atribuídos"
+        }
+      }
+    },
+    "skip_chore": {
+      "name": "Skip Chore",
+      "description": "Advance today's rotation past the current assignee. Ephemeral — tomorrow's rotation resumes as normal.",
+      "fields": {
+        "chore_id": {
+          "name": "Chore ID",
+          "description": "The ID of the chore to skip"
+        }
+      }
+    },
+    "set_chore_manual_start": {
+      "name": "Set Manual Start Child",
+      "description": "Set which child starts a rotating chore. For alternating mode this reorders the pool; for random/balanced it only overrides today's assignee.",
+      "fields": {
+        "chore_id": {
+          "name": "Chore ID",
+          "description": "The ID of the chore to update"
+        },
+        "child_id": {
+          "name": "Child ID",
+          "description": "The ID of the child who should start the rotation"
+        }
+      }
+    },
+    "add_task_group": {
+      "name": "Add Task Group",
+      "description": "Create a task group (sticky = same child, spread = different children).",
+      "fields": {
+        "name": {
+          "name": "Name",
+          "description": "Display name for the group"
+        },
+        "policy": {
+          "name": "Policy",
+          "description": "sticky (same child) or spread (different children)"
+        },
+        "chore_ids": {
+          "name": "Chore IDs",
+          "description": "List of chore IDs in the group. For sticky, the first chore is the leader."
+        }
+      }
+    },
+    "update_task_group": {
+      "name": "Update Task Group",
+      "description": "Update a task group's name, policy, or membership.",
+      "fields": {
+        "group_id": {
+          "name": "Group ID",
+          "description": "The ID of the group to update"
+        },
+        "name": {
+          "name": "Name",
+          "description": "New display name"
+        },
+        "policy": {
+          "name": "Policy",
+          "description": "New policy (sticky or spread)"
+        },
+        "chore_ids": {
+          "name": "Chore IDs",
+          "description": "Replacement chore ID list. For sticky, the first chore is the leader."
+        }
+      }
+    },
+    "remove_task_group": {
+      "name": "Remove Task Group",
+      "description": "Delete a task group. Member chores are not affected.",
+      "fields": {
+        "group_id": {
+          "name": "Group ID",
+          "description": "The ID of the group to delete"
         }
       }
     }

--- a/custom_components/taskmate/www/taskmate-parent-dashboard-card.js
+++ b/custom_components/taskmate/www/taskmate-parent-dashboard-card.js
@@ -381,14 +381,21 @@ class TaskMateParentDashboardCard extends LitElement {
     const pointsName = attrs.points_name || "Points";
     const totalPending = pendingCompletions.length + pendingRewardClaims.length;
 
+    const rotationChores = chores.filter(c => (c.assignment_mode || 'everyone') !== 'everyone');
+
     const tabs = [
       { id: "overview", label: this._t('dashboard.tab_overview'), icon: "mdi:view-dashboard" },
       { id: "approvals", label: this._t('dashboard.tab_approvals'), icon: "mdi:check-circle", count: pendingCompletions.length },
       { id: "points", label: this._t('dashboard.tab_points'), icon: "mdi:star-plus" },
     ];
 
+    if (rotationChores.length > 0) {
+      tabs.splice(1, 0, { id: "rotation", label: this._t('dashboard.tab_rotation', {}, 'Rotation'), icon: "mdi:rotate-3d-variant" });
+    }
+
     if (this.config.show_claims) {
-      tabs.splice(2, 0, { id: "claims", label: this._t('dashboard.tab_claims'), icon: "mdi:gift", count: pendingRewardClaims.length });
+      const insertAt = tabs.findIndex(t => t.id === "points");
+      tabs.splice(insertAt, 0, { id: "claims", label: this._t('dashboard.tab_claims'), icon: "mdi:gift", count: pendingRewardClaims.length });
     }
 
     return html`
@@ -422,6 +429,7 @@ class TaskMateParentDashboardCard extends LitElement {
 
         <div class="tab-content">
           ${this._activeSection === "overview" ? this._renderOverview(children, chores, completions, pointsIcon, pointsName) : ''}
+          ${this._activeSection === "rotation" ? this._renderRotation(rotationChores, children, attrs) : ''}
           ${this._activeSection === "approvals" ? this._renderApprovals(pendingCompletions, children, chores, pointsIcon) : ''}
           ${this._activeSection === "claims" ? this._renderClaims(pendingRewardClaims, pointsIcon) : ''}
           ${this._activeSection === "points" ? this._renderPoints(children, pointsIcon, pointsName) : ''}
@@ -490,6 +498,67 @@ class TaskMateParentDashboardCard extends LitElement {
                 </div>
                 <span class="progress-label">${approved}/${total}</span>
               </div>
+            </div>
+          </div>
+        `;
+      })}
+    `;
+  }
+
+  _renderRotation(rotationChores, children, attrs) {
+    if (!rotationChores.length) {
+      return html`
+        <div class="empty-section">
+          <ha-icon icon="mdi:rotate-3d-variant"></ha-icon>
+          <span>${this._t('dashboard.empty_rotation', {}, 'No rotating chores configured')}</span>
+        </div>
+      `;
+    }
+    const childById = Object.fromEntries((children || []).map(c => [c.id, c]));
+    const groups = attrs.task_groups || [];
+    const groupByChoreId = {};
+    for (const g of groups) {
+      for (const cid of (g.chore_ids || [])) {
+        groupByChoreId[cid] = g;
+      }
+    }
+    const unknown = this._t('dashboard.rotation_unassigned', {}, 'Nobody');
+    return html`
+      ${rotationChores.map(chore => {
+        const currentChildId = chore.assignment_current_child_id || '';
+        const currentChild = childById[currentChildId];
+        const pool = (chore.assigned_to && chore.assigned_to.length) ? chore.assigned_to : (children || []).map(c => c.id);
+        const poolSize = pool.length;
+        const isSticky = groupByChoreId[chore.id] && groupByChoreId[chore.id].policy === 'sticky';
+        const isStickyFollower = isSticky && groupByChoreId[chore.id].chore_ids[0] !== chore.id;
+        const skipDisabled = poolSize <= 1 || isStickyFollower;
+        const group = groupByChoreId[chore.id];
+        const key = `skip_${chore.id}`;
+        const loading = !!this._loading[key];
+        return html`
+          <div class="approval-item ${loading ? 'loading' : ''}">
+            <div class="approval-child-avatar" style="background: linear-gradient(135deg, #16a085, #1abc9c);">
+              <ha-icon icon="${currentChild?.avatar || 'mdi:rotate-3d-variant'}"></ha-icon>
+            </div>
+            <div class="approval-info">
+              <span class="approval-chore">${chore.name}</span>
+              <span class="approval-meta">
+                <ha-icon icon="mdi:account" style="--mdc-icon-size: 14px;"></ha-icon>
+                ${currentChild?.name || unknown}
+                · <span>${chore.assignment_mode}</span>
+                ${group ? html`· <span>${group.policy === 'sticky' ? '🔗' : '🔀'} ${group.name}</span>` : ''}
+              </span>
+            </div>
+            <div class="approval-actions">
+              <button
+                class="btn-reject"
+                title="${this._t('dashboard.rotation_skip_hint', {}, 'Skip current child and move to the next in rotation (today only)')}"
+                ?disabled="${skipDisabled}"
+                style="${skipDisabled ? 'opacity:0.4; cursor: not-allowed;' : ''}"
+                @click="${() => this._handleSkip(chore.id)}"
+              >
+                <ha-icon icon="mdi:skip-next"></ha-icon>
+              </button>
             </div>
           </div>
         `;
@@ -678,6 +747,26 @@ class TaskMateParentDashboardCard extends LitElement {
       this._notifyServiceError("reject_reward", e, `taskmate_dashboard_reject_reward_${claimId}`);
     } finally {
       this._loading = { ...this._loading, [claimId]: false };
+      this.requestUpdate();
+    }
+  }
+
+  async _handleSkip(choreId) {
+    const key = `skip_${choreId}`;
+    // Guard rail: ask before skipping — this affects today's rotation only,
+    // but parents often tap it by mistake.
+    if (typeof window !== 'undefined' && typeof window.confirm === 'function') {
+      const prompt = this._t('dashboard.rotation_skip_confirm', {}, "Skip today's assignee for this chore?");
+      if (!window.confirm(prompt)) return;
+    }
+    this._loading = { ...this._loading, [key]: true };
+    this.requestUpdate();
+    try {
+      await this.hass.callService("taskmate", "skip_chore", { chore_id: choreId });
+    } catch (e) {
+      this._notifyServiceError("skip_chore", e, `taskmate_dashboard_skip_${choreId}`);
+    } finally {
+      this._loading = { ...this._loading, [key]: false };
       this.requestUpdate();
     }
   }

--- a/tests/test_assignment_modes.py
+++ b/tests/test_assignment_modes.py
@@ -920,8 +920,7 @@ class TestManualStart:
         # Pool should now start with B (today's active child).
         assert chore.assigned_to[0] == b.id
         assert chore.assignment_current_child_id == b.id
-        # Day 1 in rotation → next in new pool order.
-        tomorrow = anchor + dt.timedelta(days=1)
+        # Day 1 in the rotation uses the new anchor + new pool order.
         new_anchor = date.fromisoformat(chore.assignment_rotation_anchor)
         assert coord._compute_active_children(chore, new_anchor + dt.timedelta(days=1))[0] == chore.assigned_to[1]
 

--- a/tests/test_assignment_modes.py
+++ b/tests/test_assignment_modes.py
@@ -40,6 +40,7 @@ def _coord(children: list[Child], projection_days: int = 1) -> TaskMateCoordinat
 
     by_id = {c.id: c for c in children}
     stored_chores: list[Chore] = []
+    stored_task_groups: list = []
     settings = {"calendar_projection_days": str(projection_days)}
 
     storage = MagicMock()
@@ -61,6 +62,41 @@ def _coord(children: list[Child], projection_days: int = 1) -> TaskMateCoordinat
         next(i for i, c in enumerate(stored_chores) if c.id == chore.id), chore
     ))
     storage.async_save = AsyncMock()
+
+    # Task group stubs — tests that don't touch groups still work because
+    # get_task_groups returns an empty list.
+    storage.get_task_groups = MagicMock(side_effect=lambda: list(stored_task_groups))
+
+    def _get_task_group(gid):
+        return next((g for g in stored_task_groups if g.id == gid), None)
+
+    def _get_task_group_for_chore(chore_id):
+        return next((g for g in stored_task_groups if chore_id in (g.chore_ids or [])), None)
+
+    storage.get_task_group = MagicMock(side_effect=_get_task_group)
+    storage.get_task_group_for_chore = MagicMock(side_effect=_get_task_group_for_chore)
+    storage.add_task_group = MagicMock(side_effect=stored_task_groups.append)
+
+    def _update_task_group(group):
+        for i, g in enumerate(stored_task_groups):
+            if g.id == group.id:
+                stored_task_groups[i] = group
+                return
+        stored_task_groups.append(group)
+
+    storage.update_task_group = MagicMock(side_effect=_update_task_group)
+    storage.remove_task_group = MagicMock(
+        side_effect=lambda gid: stored_task_groups.__setitem__(
+            slice(None),
+            [g for g in stored_task_groups if g.id != gid],
+        )
+    )
+    storage.remove_chore_from_task_groups = MagicMock(
+        side_effect=lambda cid: [
+            setattr(g, "chore_ids", [c for c in g.chore_ids if c != cid])
+            for g in stored_task_groups if cid in (g.chore_ids or [])
+        ]
+    )
 
     coord.storage = storage
     coord.async_refresh = AsyncMock()
@@ -738,3 +774,360 @@ class TestAvailabilityAwareAssignment:
         coord.hass.async_create_task = _capture
         coord._availability_state_changed(event)
         assert called == []
+
+
+# ---------------------------------------------------------------------------
+# Skip / Manual-start / Task group coverage
+# ---------------------------------------------------------------------------
+
+class TestSkipChore:
+    """Skip advances today's rotation pointer; tomorrow resumes original schedule."""
+
+    def test_skip_advances_alternating_pointer_today_only(self):
+        from custom_components.taskmate.models import TaskGroup  # noqa: F401 (ensure importable)
+        a, b, c = Child(name="A"), Child(name="B"), Child(name="C")
+        coord = _coord([a, b, c])
+        anchor = date(2026, 4, 20)
+        chore = Chore(
+            name="Bins",
+            assigned_to=[a.id, b.id, c.id],
+            assignment_mode="alternating",
+            assignment_rotation_anchor=anchor.isoformat(),
+        )
+        coord.storage.add_chore(chore)
+
+        # Today = anchor day → A.
+        dt_util_mock._now = dt.datetime.combine(anchor, dt.time(12, 0), tzinfo=UTC)
+        assert coord._compute_active_children(chore, anchor) == [a.id]
+
+        # Skip today → pointer advances to B.
+        run_async(coord.async_skip_chore(chore.id))
+        updated = coord.storage.get_chore(chore.id)
+        assert updated.skip_date == anchor.isoformat()
+        assert updated.skip_count == 1
+        assert coord._compute_active_children(updated, anchor) == [b.id]
+
+        # Skip again → C.
+        run_async(coord.async_skip_chore(chore.id))
+        updated = coord.storage.get_chore(chore.id)
+        assert updated.skip_count == 2
+        assert coord._compute_active_children(updated, anchor) == [c.id]
+
+        # Tomorrow's compute MUST ignore stale skip state (still set today)
+        # since skip_date != tomorrow.
+        tomorrow = anchor + dt.timedelta(days=1)
+        assert coord._compute_active_children(updated, tomorrow) == [b.id]
+
+    def test_skip_rejects_everyone_mode(self):
+        a, b = Child(name="A"), Child(name="B")
+        coord = _coord([a, b])
+        chore = Chore(name="Brush teeth", assigned_to=[a.id, b.id])  # mode = everyone
+        coord.storage.add_chore(chore)
+        try:
+            run_async(coord.async_skip_chore(chore.id))
+        except ValueError as err:
+            assert "everyone" in str(err)
+            return
+        raise AssertionError("Expected ValueError for everyone-mode skip")
+
+    def test_skip_rejects_pool_size_one(self):
+        a = Child(name="A")
+        coord = _coord([a])
+        chore = Chore(
+            name="Solo",
+            assigned_to=[a.id],
+            assignment_mode="alternating",
+            assignment_rotation_anchor="2026-04-20",
+        )
+        coord.storage.add_chore(chore)
+        try:
+            run_async(coord.async_skip_chore(chore.id))
+        except ValueError as err:
+            assert "pool" in str(err).lower()
+            return
+        raise AssertionError("Expected ValueError for single-child pool skip")
+
+    def test_skip_is_noop_past_pool_size(self):
+        a, b = Child(name="A"), Child(name="B")
+        coord = _coord([a, b])
+        chore = Chore(
+            name="Bins",
+            assigned_to=[a.id, b.id],
+            assignment_mode="alternating",
+            assignment_rotation_anchor="2026-04-20",
+        )
+        coord.storage.add_chore(chore)
+        dt_util_mock._now = dt.datetime(2026, 4, 20, 12, 0, tzinfo=UTC)
+        run_async(coord.async_skip_chore(chore.id))  # 0 → 1 (B)
+        # Second skip would wrap to A, same as original — clamp at pool-1.
+        run_async(coord.async_skip_chore(chore.id))  # still 1
+        updated = coord.storage.get_chore(chore.id)
+        assert updated.skip_count == 1
+
+    def test_skip_affects_random_mode(self):
+        a, b = Child(name="A"), Child(name="B")
+        coord = _coord([a, b])
+        today = date(2026, 4, 20)
+        chore = Chore(
+            name="Roulette",
+            assigned_to=[a.id, b.id],
+            assignment_mode="random",
+        )
+        coord.storage.add_chore(chore)
+        dt_util_mock._now = dt.datetime.combine(today, dt.time(12, 0), tzinfo=UTC)
+        before = coord._compute_active_children(chore, today)
+        run_async(coord.async_skip_chore(chore.id))
+        updated = coord.storage.get_chore(chore.id)
+        after = coord._compute_active_children(updated, today)
+        # Pool size 2 → skip must shift to the other child.
+        assert before != after
+
+    def test_midnight_refresh_clears_stale_skip_state(self):
+        a, b = Child(name="A"), Child(name="B")
+        coord = _coord([a, b])
+        chore = Chore(
+            name="Bins",
+            assigned_to=[a.id, b.id],
+            assignment_mode="alternating",
+            assignment_rotation_anchor="2026-04-20",
+            skip_date="2026-04-20",
+            skip_count=1,
+        )
+        coord.storage.add_chore(chore)
+        # Midnight rolls over to 2026-04-21 — skip state is stale.
+        dt_util_mock._now = dt.datetime(2026, 4, 21, 0, 0, 5, tzinfo=UTC)
+        run_async(coord._async_refresh_assignments_and_publish())
+        updated = coord.storage.get_chore(chore.id)
+        assert updated.skip_date == ""
+        assert updated.skip_count == 0
+
+
+class TestManualStart:
+    """Manual-start reorders alternating pool and pins cache for random/balanced."""
+
+    def test_manual_start_alternating_reorders_pool(self):
+        a, b, c = Child(name="A"), Child(name="B"), Child(name="C")
+        coord = _coord([a, b, c])
+        anchor = date(2026, 4, 20)
+        dt_util_mock._now = dt.datetime.combine(anchor, dt.time(12, 0), tzinfo=UTC)
+        chore = run_async(coord.async_add_chore(
+            name="Bins",
+            assigned_to=[a.id, b.id, c.id],
+            assignment_mode="alternating",
+            assignment_rotation_anchor=anchor.isoformat(),
+            manual_start_child_id=b.id,
+        ))
+        # Pool should now start with B (today's active child).
+        assert chore.assigned_to[0] == b.id
+        assert chore.assignment_current_child_id == b.id
+        # Day 1 in rotation → next in new pool order.
+        tomorrow = anchor + dt.timedelta(days=1)
+        new_anchor = date.fromisoformat(chore.assignment_rotation_anchor)
+        assert coord._compute_active_children(chore, new_anchor + dt.timedelta(days=1))[0] == chore.assigned_to[1]
+
+    def test_manual_start_random_pins_today_only(self):
+        a, b = Child(name="A"), Child(name="B")
+        coord = _coord([a, b])
+        today = date(2026, 4, 20)
+        dt_util_mock._now = dt.datetime.combine(today, dt.time(12, 0), tzinfo=UTC)
+        chore = run_async(coord.async_add_chore(
+            name="Roulette",
+            assigned_to=[a.id, b.id],
+            assignment_mode="random",
+            manual_start_child_id=a.id,
+        ))
+        assert chore.assignment_current_child_id == a.id
+
+
+class TestTaskGroups:
+    """Sticky & Spread policies, and group-aware daily assignment."""
+
+    def test_sticky_forces_followers_onto_leader_pick(self):
+        a, b = Child(name="A"), Child(name="B")
+        coord = _coord([a, b])
+        anchor = date(2026, 4, 20)
+        leader = Chore(
+            name="Vacuum",
+            assigned_to=[a.id, b.id],
+            assignment_mode="alternating",
+            assignment_rotation_anchor=anchor.isoformat(),
+        )
+        follower = Chore(
+            name="Mop",
+            assigned_to=[a.id, b.id],
+            assignment_mode="random",
+        )
+        coord.storage.add_chore(leader)
+        coord.storage.add_chore(follower)
+        run_async(coord.async_add_task_group(name="Clean", policy="sticky", chore_ids=[leader.id, follower.id]))
+
+        dt_util_mock._now = dt.datetime.combine(anchor, dt.time(12, 0), tzinfo=UTC)
+        daily = coord._compute_daily_assignments(anchor)
+        # Leader is A (alternating day-0). Follower must match.
+        assert daily[leader.id] == a.id
+        assert daily[follower.id] == a.id
+
+    def test_sticky_fallback_when_leader_pick_not_in_follower_pool(self):
+        a, b, c = Child(name="A"), Child(name="B"), Child(name="C")
+        coord = _coord([a, b, c])
+        anchor = date(2026, 4, 20)
+        leader = Chore(
+            name="Lead",
+            assigned_to=[a.id, b.id, c.id],  # can pick A
+            assignment_mode="alternating",
+            assignment_rotation_anchor=anchor.isoformat(),
+        )
+        follower = Chore(
+            name="Follow",
+            assigned_to=[b.id, c.id],  # NO A in pool
+            assignment_mode="alternating",
+            assignment_rotation_anchor=anchor.isoformat(),
+        )
+        coord.storage.add_chore(leader)
+        coord.storage.add_chore(follower)
+        run_async(coord.async_add_task_group(name="Grp", policy="sticky", chore_ids=[leader.id, follower.id]))
+
+        dt_util_mock._now = dt.datetime.combine(anchor, dt.time(12, 0), tzinfo=UTC)
+        daily = coord._compute_daily_assignments(anchor)
+        assert daily[leader.id] == a.id
+        # Follower keeps its raw pick (not A, since A isn't in pool).
+        assert daily[follower.id] in {b.id, c.id}
+
+    def test_spread_gives_distinct_children(self):
+        a, b = Child(name="A"), Child(name="B")
+        coord = _coord([a, b])
+        today = date(2026, 4, 20)
+        c1 = Chore(name="AM", assigned_to=[a.id, b.id], assignment_mode="alternating",
+                   assignment_rotation_anchor=today.isoformat())
+        c2 = Chore(name="PM", assigned_to=[a.id, b.id], assignment_mode="alternating",
+                   assignment_rotation_anchor=today.isoformat())
+        coord.storage.add_chore(c1)
+        coord.storage.add_chore(c2)
+        run_async(coord.async_add_task_group(name="Cat litter", policy="spread", chore_ids=[c1.id, c2.id]))
+
+        daily = coord._compute_daily_assignments(today)
+        assert daily[c1.id] != daily[c2.id]
+
+    def test_spread_wraps_when_group_larger_than_pool(self):
+        a, b = Child(name="A"), Child(name="B")
+        coord = _coord([a, b])
+        today = date(2026, 4, 20)
+        chores = []
+        for i in range(4):
+            ch = Chore(
+                name=f"C{i}",
+                assigned_to=[a.id, b.id],
+                assignment_mode="alternating",
+                assignment_rotation_anchor=today.isoformat(),
+            )
+            coord.storage.add_chore(ch)
+            chores.append(ch)
+        run_async(coord.async_add_task_group(
+            name="Big", policy="spread", chore_ids=[c.id for c in chores]
+        ))
+
+        daily = coord._compute_daily_assignments(today)
+        picks = [daily[c.id] for c in chores]
+        # Must alternate: both children used exactly twice.
+        assert picks.count(a.id) == 2
+        assert picks.count(b.id) == 2
+        # Adjacent entries differ (spread walks raw-indexed avoidance).
+        for i in range(len(picks) - 1):
+            assert picks[i] != picks[i + 1]
+
+    def test_everyone_mode_chore_cannot_join_group(self):
+        a, b = Child(name="A"), Child(name="B")
+        coord = _coord([a, b])
+        chore = Chore(name="Brush", assigned_to=[a.id, b.id])  # everyone
+        coord.storage.add_chore(chore)
+        try:
+            run_async(coord.async_add_task_group(
+                name="Bad", policy="sticky", chore_ids=[chore.id]
+            ))
+        except ValueError as err:
+            assert "everyone" in str(err).lower()
+            return
+        raise AssertionError("Expected ValueError for everyone-mode chore in group")
+
+    def test_chore_cannot_belong_to_two_groups(self):
+        a, b = Child(name="A"), Child(name="B")
+        coord = _coord([a, b])
+        c1 = Chore(name="C1", assigned_to=[a.id, b.id], assignment_mode="alternating",
+                   assignment_rotation_anchor="2026-04-20")
+        c2 = Chore(name="C2", assigned_to=[a.id, b.id], assignment_mode="alternating",
+                   assignment_rotation_anchor="2026-04-20")
+        coord.storage.add_chore(c1)
+        coord.storage.add_chore(c2)
+        run_async(coord.async_add_task_group(name="G1", policy="sticky", chore_ids=[c1.id, c2.id]))
+        try:
+            run_async(coord.async_add_task_group(
+                name="G2", policy="spread", chore_ids=[c1.id]
+            ))
+        except ValueError as err:
+            assert "group" in str(err).lower()
+            return
+        raise AssertionError("Expected ValueError for duplicate group membership")
+
+    def test_skip_on_sticky_follower_rejected(self):
+        a, b = Child(name="A"), Child(name="B")
+        coord = _coord([a, b])
+        leader = Chore(name="L", assigned_to=[a.id, b.id], assignment_mode="alternating",
+                       assignment_rotation_anchor="2026-04-20")
+        follower = Chore(name="F", assigned_to=[a.id, b.id], assignment_mode="alternating",
+                         assignment_rotation_anchor="2026-04-20")
+        coord.storage.add_chore(leader)
+        coord.storage.add_chore(follower)
+        run_async(coord.async_add_task_group(name="G", policy="sticky", chore_ids=[leader.id, follower.id]))
+
+        dt_util_mock._now = dt.datetime(2026, 4, 20, 12, 0, tzinfo=UTC)
+        try:
+            run_async(coord.async_skip_chore(follower.id))
+        except ValueError as err:
+            assert "leader" in str(err).lower() or "follower" in str(err).lower()
+            return
+        raise AssertionError("Expected ValueError for skipping sticky follower")
+
+    def test_skip_on_sticky_leader_propagates_to_followers(self):
+        a, b = Child(name="A"), Child(name="B")
+        coord = _coord([a, b])
+        anchor = date(2026, 4, 20)
+        leader = Chore(name="L", assigned_to=[a.id, b.id], assignment_mode="alternating",
+                       assignment_rotation_anchor=anchor.isoformat())
+        follower = Chore(name="F", assigned_to=[a.id, b.id], assignment_mode="random")
+        coord.storage.add_chore(leader)
+        coord.storage.add_chore(follower)
+        run_async(coord.async_add_task_group(name="G", policy="sticky", chore_ids=[leader.id, follower.id]))
+
+        dt_util_mock._now = dt.datetime.combine(anchor, dt.time(12, 0), tzinfo=UTC)
+        # Pre-skip: leader = A, follower = A (sticky).
+        daily = coord._compute_daily_assignments(anchor)
+        assert daily[leader.id] == a.id
+        assert daily[follower.id] == a.id
+
+        # Skip leader.
+        run_async(coord.async_skip_chore(leader.id))
+        updated_leader = coord.storage.get_chore(leader.id)
+        updated_follower = coord.storage.get_chore(follower.id)
+        assert updated_leader.assignment_current_child_id == b.id
+        assert updated_follower.assignment_current_child_id == b.id
+
+
+class TestRemoveChoreFromGroups:
+    """Deleting a chore strips its id from any group it was in."""
+
+    def test_remove_chore_strips_from_group(self):
+        a, b = Child(name="A"), Child(name="B")
+        coord = _coord([a, b])
+        c1 = Chore(name="C1", assigned_to=[a.id, b.id], assignment_mode="alternating",
+                   assignment_rotation_anchor="2026-04-20")
+        c2 = Chore(name="C2", assigned_to=[a.id, b.id], assignment_mode="alternating",
+                   assignment_rotation_anchor="2026-04-20")
+        coord.storage.add_chore(c1)
+        coord.storage.add_chore(c2)
+        run_async(coord.async_add_task_group(name="G", policy="sticky", chore_ids=[c1.id, c2.id]))
+
+        run_async(coord.async_remove_chore(c1.id))
+        groups = coord.storage.get_task_groups()
+        assert len(groups) == 1
+        assert c1.id not in groups[0].chore_ids
+        assert c2.id in groups[0].chore_ids

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -235,6 +235,43 @@ class TestChoreRequireAvailability:
         assert chore.require_availability is False
 
 
+class TestChoreSkipFields:
+    def test_defaults(self):
+        chore = Chore(name="Any")
+        assert chore.skip_date == ""
+        assert chore.skip_count == 0
+
+    def test_roundtrip_preserves_skip_state(self):
+        chore = Chore(name="Bins", skip_date="2026-04-24", skip_count=2, id="c1")
+        restored = Chore.from_dict(chore.to_dict())
+        assert restored.skip_date == "2026-04-24"
+        assert restored.skip_count == 2
+
+    def test_legacy_missing_skip_fields_backcompat(self):
+        legacy = {"name": "Old chore"}
+        chore = Chore.from_dict(legacy)
+        assert chore.skip_date == ""
+        assert chore.skip_count == 0
+
+
+class TestTaskGroup:
+    def test_defaults(self):
+        from custom_components.taskmate.models import TaskGroup
+        g = TaskGroup(name="Cat litter")
+        assert g.policy == "sticky"
+        assert g.chore_ids == []
+        assert g.id  # generated
+
+    def test_roundtrip(self):
+        from custom_components.taskmate.models import TaskGroup
+        g = TaskGroup(name="Cat litter", policy="spread", chore_ids=["c1", "c2"], id="g1")
+        restored = TaskGroup.from_dict(g.to_dict())
+        assert restored.name == g.name
+        assert restored.policy == "spread"
+        assert restored.chore_ids == ["c1", "c2"]
+        assert restored.id == "g1"
+
+
 # ---------------------------------------------------------------------------
 # Reward
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Skip**: parent can advance today's rotation past the current assignee (ephemeral — tomorrow resumes the normal schedule). New `taskmate.skip_chore` service; skip button on the Parent Dashboard's new Rotation tab.
- **Manual start**: chore add/edit gets a "Start rotation with" dropdown. For alternating this reorders the pool and resets the anchor; for random/balanced it only pins today's assignee.
- **Task groups**: new `TaskGroup` entity with `sticky` (same child across the group) and `spread` (distinct children) policies. Managed via a new "Manage Task Groups" options-flow menu.

Covers all three rotation modes (alternating, random, balanced). Group-aware assignments are computed once per midnight refresh via a new `_compute_daily_assignments`, which also runs on availability re-evaluation and chore create/update. Skip state is transient — `skip_date`/`skip_count` are reset at the midnight tick when the stored date is no longer today.

Edge cases handled:
- Skip rejected for `everyone` mode, pool size ≤ 1, and sticky-group followers (skip the leader instead).
- Sticky leader skip propagates to followers.
- Sticky follower whose leader picked a child outside the follower's pool falls back to its raw rotation pick.
- Spread wraps when the group has more chores than children in the pool.
- A chore belongs to at most one group (enforced in `_validate_task_group_members`).
- `everyone`-mode chores cannot join any group.
- Removing a chore strips its id from any group it belonged to.

## Test plan
- [x] New `Chore.skip_date` / `Chore.skip_count` fields round-trip through storage and default to `""` / `0` for legacy records.
- [x] `TaskGroup` dataclass round-trips through storage.
- [x] `async_skip_chore` advances pointer today, resets at midnight, rejects `everyone`/single-pool/sticky-follower, clamps past pool size, works for alternating and random.
- [x] Manual-start reorders alternating pool and resets anchor; pins cache for random.
- [x] Sticky policy forces followers onto leader; falls back when leader's child isn't in follower pool.
- [x] Spread policy gives distinct children and wraps cleanly when group > pool.
- [x] Skip on sticky leader propagates to followers.
- [x] Removing a chore scrubs it from any task group.
- [ ] End-to-end on HA instance: create sticky/spread groups, verify UI renders correctly, test calendar publishing is untouched, confirm existing non-grouped chores behave identically.

## Notes
- Parent Dashboard Rotation tab surfaces today's rotating chores with a confirm-then-skip button and a group badge.
- All 7 locale files updated with new strings (plus `strings.json`); service translations use English fallback in non-English locales.
- Version bumped to 3.4.0.
- Existing behaviour preserved: non-grouped chores with no skip state compute identically to before; pool-wide completion clearing from PR #168 is untouched.