### PR TITLE
fix(frontend): register shared util modules as Lovelace resources

### DIFF
--- a/custom_components/taskmate/frontend.py
+++ b/custom_components/taskmate/frontend.py
@@ -17,8 +17,14 @@ _LOGGER = logging.getLogger(__name__)
 # URL base path for serving static files
 URL_BASE: Final = "/taskmate"
 
-# List of card files to register as Lovelace resources
+# Lovelace resources. Listed in load order: shared utilities first so that
+# window.__taskmate_attrs / __taskmate_localize are reliably defined by the
+# time card modules execute. Without this, a cold-cache load could render
+# cards before the utility globals existed, producing empty chore lists and
+# raw localisation keys for non-admin users.
 CARDS: Final = [
+    "taskmate-attr-resolver.js",
+    "taskmate-localize.js",
     "taskmate-child-card.js",
     "taskmate-rewards-card.js",
     "taskmate-approvals-card.js",
@@ -38,12 +44,9 @@ CARDS: Final = [
     "taskmate-calendar-card.js",
 ]
 
-# JS modules to load globally (for config flow sound preview + i18n +
-# split-sensor attribute resolver used by every TaskMate Lovelace card).
+# JS modules loaded on every HA frontend page (config flow sound preview).
 GLOBAL_MODULES: Final = [
-    "taskmate-localize.js",
     "taskmate-config-sounds.js",
-    "taskmate-attr-resolver.js",
 ]
 
 # Track if frontend is registered

--- a/custom_components/taskmate/www/taskmate-attr-resolver.js
+++ b/custom_components/taskmate/www/taskmate-attr-resolver.js
@@ -95,4 +95,28 @@
   }
 
   window.__taskmate_find_button = findButtonEntity;
+
+  // Cold-cache fix: if any TaskMate cards already mounted before this module
+  // finished loading, they fell back to entity.attributes (overview-only) and
+  // rendered empty chore lists. Walk the DOM (crossing shadow roots, since HA
+  // nests Lovelace inside several shadow trees) and force a re-render now
+  // that window.__taskmate_attrs is defined.
+  function _refreshTaskMateCards() {
+    const stack = [document];
+    while (stack.length) {
+      const node = stack.pop();
+      if (!node) continue;
+      if (node.tagName && node.tagName.startsWith("TASKMATE-")) {
+        if (typeof node.requestUpdate === "function") {
+          try { node.requestUpdate(); } catch (_e) { /* ignore */ }
+        }
+      }
+      if (node.shadowRoot) stack.push(node.shadowRoot);
+      const children = node.children;
+      if (children) {
+        for (let i = 0; i < children.length; i++) stack.push(children[i]);
+      }
+    }
+  }
+  queueMicrotask(_refreshTaskMateCards);
 })();

--- a/custom_components/taskmate/www/taskmate-localize.js
+++ b/custom_components/taskmate/www/taskmate-localize.js
@@ -120,6 +120,30 @@ async function loadTranslations(hass) {
 }
 
 // Expose globally so cards can access without ES module imports
-// (HA custom cards are loaded as classic scripts, not ES modules)
 window.__taskmate_localize = localize;
 window.__taskmate_loadTranslations = loadTranslations;
+
+// Cold-cache fix: any TaskMate cards that mounted before this module loaded
+// rendered raw translation keys ("common.today" instead of "Today"). Walk
+// the DOM across shadow roots and trigger a re-render now that the
+// localizer is defined.
+(function _refreshTaskMateCards() {
+  function walk() {
+    const stack = [document];
+    while (stack.length) {
+      const node = stack.pop();
+      if (!node) continue;
+      if (node.tagName && node.tagName.startsWith('TASKMATE-')) {
+        if (typeof node.requestUpdate === 'function') {
+          try { node.requestUpdate(); } catch (_e) { /* ignore */ }
+        }
+      }
+      if (node.shadowRoot) stack.push(node.shadowRoot);
+      const children = node.children;
+      if (children) {
+        for (let i = 0; i < children.length; i++) stack.push(children[i]);
+      }
+    }
+  }
+  queueMicrotask(walk);
+})();


### PR DESCRIPTION
## Summary

Fixes the cold-cache bug where non-admin users on a fresh device saw empty chore lists and raw translation keys (e.g. `common.today`) on TaskMate cards.

## Root cause

`taskmate-attr-resolver.js` and `taskmate-localize.js` were registered only via `add_extra_js_url`. On a cold cache, dashboard cards (also `<script type="module">`) could finish loading and render before the utility globals were defined. With `window.__taskmate_attrs` undefined, child cards fell back to `entity.attributes` (overview sensor only, which has no `chores` key) and other cards rendered raw localisation keys instead of translated strings.

## Fix

- Promote both utility files from `GLOBAL_MODULES` to `CARDS` in `frontend.py` so they register as Lovelace resources, listed first in load order.
- After each utility finishes evaluating, walk the DOM (crossing shadow roots) and call `requestUpdate()` on any `TASKMATE-*` elements that mounted before the global was available, so they re-render with the now-loaded resolver / localiser.

## Test plan

- [ ] Update install in HACS, hard-refresh browser to clear cache
- [ ] Log in as a non-admin HA user on a device that has never loaded TaskMate
- [ ] Navigate directly to a dashboard view containing `taskmate-child-card` — verify chores render and labels are translated
- [ ] Repeat on a warm cache — verify no regressions
- [ ] Verify config flow sound preview still works (uses `taskmate-config-sounds.js`, still in GLOBAL_MODULES)