### PR TITLE
fix: child delete blocked by avatar validation in config flow

### DIFF
--- a/.github/workflows/release-announcement.yml
+++ b/.github/workflows/release-announcement.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   announce:
     runs-on: ubuntu-latest
+    # Skip pre-releases entirely — only stable releases get a discussion thread.
+    # Without this, every -alpha.N / -beta.N pushed for testing posts noise.
+    if: github.event.release.prerelease == false
     permissions:
       discussions: write
 

--- a/custom_components/taskmate/__init__.py
+++ b/custom_components/taskmate/__init__.py
@@ -72,6 +72,8 @@ from .const import (
 )
 from .coordinator import TaskMateCoordinator
 from .frontend import async_register_cards, async_register_frontend
+from .panel import async_register_panel
+from .websocket import async_register_websocket_commands
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -107,6 +109,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Register and version-update Lovelace resources on every startup.
     # Only TaskMate's own resources (/taskmate/*) are ever touched.
     await async_register_cards(hass)
+
+    # Register the standalone admin panel (sidebar entry at /taskmate)
+    # and the WebSocket commands it talks to.
+    await async_register_panel(hass)
+    async_register_websocket_commands(hass)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/custom_components/taskmate/config_flow.py
+++ b/custom_components/taskmate/config_flow.py
@@ -237,7 +237,8 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
         menu_options = {"add_child": _m("add_child", "Add New Child")}
 
         for child in children:
-            menu_options[f"edit_child_{child.id}"] = f"{child.name}"
+            menu_options[f"edit_child_{child.id}"] = f"Edit: {child.name}"
+            menu_options[f"confirm_delete_child_{child.id}"] = f"Delete: {child.name}"
 
         menu_options["init"] = _m("init", "Back to Main Menu")
 
@@ -297,19 +298,15 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
         errors: dict[str, str] = {}
 
         if user_input is not None:
-            action = user_input.get("action")
-            if action == "delete":
-                await self.coordinator.async_remove_child(child.id)
-                return await self.async_step_manage_children()
-            elif action == "save":
-                child.name = user_input.get("name", child.name)
-                child.avatar = user_input.get("avatar", child.avatar)
-                child.availability_entity = (
-                    user_input.get("availability_entity", "") or ""
-                )
-                await self.coordinator.async_update_child(child)
-                return await self.async_step_manage_children()
+            child.name = user_input.get("name", child.name)
+            child.avatar = user_input.get("avatar", child.avatar)
+            child.availability_entity = (
+                user_input.get("availability_entity", "") or ""
+            )
+            await self.coordinator.async_update_child(child)
+            return await self.async_step_manage_children()
 
+        avatar_default = child.avatar if child.avatar in AVATAR_OPTIONS else "mdi:account-circle"
         availability_default = getattr(child, "availability_entity", "") or ""
         availability_key = (
             vol.Optional("availability_entity", default=availability_default)
@@ -322,7 +319,7 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
             data_schema=vol.Schema(
                 {
                     vol.Required("name", default=child.name): str,
-                    vol.Optional("avatar", default=child.avatar): selector.SelectSelector(
+                    vol.Optional("avatar", default=avatar_default): selector.SelectSelector(
                         selector.SelectSelectorConfig(
                             options=[
                                 selector.SelectOptionDict(value=icon, label=icon.replace("mdi:", "").replace("-", " ").title())
@@ -334,16 +331,32 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
                     availability_key: selector.EntitySelector(
                         selector.EntitySelectorConfig()
                     ),
-                    vol.Required("action", default="save"): selector.SelectSelector(
-                        selector.SelectSelectorConfig(
-                            options=["save", "delete"],
-                            translation_key="child_action",
-                            mode=selector.SelectSelectorMode.LIST,
-                        )
-                    ),
                 }
             ),
             errors=errors,
+            description_placeholders={"child_name": child.name},
+        )
+
+    async def async_step_confirm_delete_child(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Confirm deletion of a child."""
+        child = self.coordinator.get_child(self._selected_child_id)
+        if not child:
+            return await self.async_step_manage_children()
+
+        if user_input is not None:
+            if user_input.get("confirm"):
+                await self.coordinator.async_remove_child(child.id)
+            return await self.async_step_manage_children()
+
+        return self.async_show_form(
+            step_id="confirm_delete_child",
+            data_schema=vol.Schema(
+                {
+                    vol.Required("confirm", default=False): selector.BooleanSelector(),
+                }
+            ),
             description_placeholders={"child_name": child.name},
         )
 
@@ -1635,7 +1648,12 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
 
     def __getattr__(self, name: str):
         """Handle dynamic step routing for edit_child_*, edit_chore_*, etc."""
-        if name.startswith("async_step_edit_child_"):
+        if name.startswith("async_step_confirm_delete_child_"):
+            child_id = name.replace("async_step_confirm_delete_child_", "")
+            if self.coordinator.storage.get_child(child_id):
+                self._selected_child_id = child_id
+                return self.async_step_confirm_delete_child
+        elif name.startswith("async_step_edit_child_"):
             child_id = name.replace("async_step_edit_child_", "")
             if self.coordinator.storage.get_child(child_id):
                 self._selected_child_id = child_id

--- a/custom_components/taskmate/coordinator.py
+++ b/custom_components/taskmate/coordinator.py
@@ -470,6 +470,7 @@ class TaskMateCoordinator(DataUpdateCoordinator):
         # Capture pre-update state before storage is mutated below.
         existing = self.storage.get_chore(chore.id)
         prev_entities = list(getattr(existing, "publish_calendar_entities", []) or []) if existing else []
+        prev_name = (existing.name if existing else "") or ""
         # Persist the incoming chore so _compute_daily_assignments sees the
         # latest pool / mode / etc. when applying group policies.
         self.storage.update_chore(chore)
@@ -486,7 +487,16 @@ class TaskMateCoordinator(DataUpdateCoordinator):
         new_entities = list(chore.publish_calendar_entities or [])
         cleanup_entities = list({*prev_entities, *new_entities})
         if cleanup_entities:
-            await self._cleanup_chore_from_calendars(chore, cleanup_entities, today)
+            # Pass both the previous and current names so cleanup can fall back
+            # to summary-prefix matching when an integration's get_events
+            # response omits the description marker we use as primary key.
+            extra_prefixes = []
+            if prev_name and prev_name != chore.name:
+                extra_prefixes.append(f"{prev_name} — ")
+            extra_prefixes.append(f"{chore.name} — ")
+            await self._cleanup_chore_from_calendars(
+                chore, cleanup_entities, today, summary_prefixes=extra_prefixes,
+            )
         self.storage.update_chore(chore)
         await self._publish_chore_to_calendars(chore, today)
         await self.storage.async_save()
@@ -1252,6 +1262,7 @@ class TaskMateCoordinator(DataUpdateCoordinator):
         chore: Chore,
         entities: list[str] | None = None,
         today: date | None = None,
+        summary_prefixes: list[str] | None = None,
     ) -> None:
         """Best-effort delete of the chore's own events from each configured calendar.
 
@@ -1272,6 +1283,16 @@ class TaskMateCoordinator(DataUpdateCoordinator):
         window_start = datetime.combine(today, time(0, 0)).isoformat()
         window_end = datetime.combine(today + timedelta(days=window_days), time(0, 0)).isoformat()
         marker = self._chore_event_marker(chore)
+        # Fallback summary prefixes: covers integrations whose get_events
+        # response omits or strips the description field. Default to the
+        # current chore's name so deletes still work for unedited chores.
+        prefixes = list(summary_prefixes or [f"{chore.name} — "])
+
+        def _matches(event: dict) -> bool:
+            if marker in (event.get("description") or ""):
+                return True
+            summary = event.get("summary") or ""
+            return any(summary.startswith(p) for p in prefixes if p)
 
         async def _purge(entity_id: str) -> None:
             try:
@@ -1303,7 +1324,7 @@ class TaskMateCoordinator(DataUpdateCoordinator):
                     events = bucket
 
             for event in events:
-                if marker not in (event.get("description") or ""):
+                if not _matches(event):
                     continue
                 uid = event.get("uid") or event.get("recurrence_id") or event.get("id")
                 if not uid:

--- a/custom_components/taskmate/manifest.json
+++ b/custom_components/taskmate/manifest.json
@@ -17,5 +17,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/tempus2016/taskmate/issues",
   "requirements": [],
-  "version": "3.5.0-alpha.3"
+  "version": "3.5.0-alpha.4"
 }

--- a/custom_components/taskmate/manifest.json
+++ b/custom_components/taskmate/manifest.json
@@ -17,5 +17,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/tempus2016/taskmate/issues",
   "requirements": [],
-  "version": "3.5.0-alpha.5"
+  "version": "3.5.0-alpha.6"
 }

--- a/custom_components/taskmate/manifest.json
+++ b/custom_components/taskmate/manifest.json
@@ -17,5 +17,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/tempus2016/taskmate/issues",
   "requirements": [],
-  "version": "3.5.0-alpha.7"
+  "version": "3.5.0-alpha.8"
 }

--- a/custom_components/taskmate/manifest.json
+++ b/custom_components/taskmate/manifest.json
@@ -17,5 +17,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/tempus2016/taskmate/issues",
   "requirements": [],
-  "version": "3.5.0-alpha.2"
+  "version": "3.5.0-alpha.3"
 }

--- a/custom_components/taskmate/manifest.json
+++ b/custom_components/taskmate/manifest.json
@@ -17,5 +17,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/tempus2016/taskmate/issues",
   "requirements": [],
-  "version": "3.5.0-alpha.8"
+  "version": "3.5.0-alpha.9"
 }

--- a/custom_components/taskmate/manifest.json
+++ b/custom_components/taskmate/manifest.json
@@ -17,5 +17,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/tempus2016/taskmate/issues",
   "requirements": [],
-  "version": "3.5.0-alpha.1"
+  "version": "3.5.0-alpha.2"
 }

--- a/custom_components/taskmate/manifest.json
+++ b/custom_components/taskmate/manifest.json
@@ -17,5 +17,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/tempus2016/taskmate/issues",
   "requirements": [],
-  "version": "3.5.0-alpha.6"
+  "version": "3.5.0-alpha.7"
 }

--- a/custom_components/taskmate/manifest.json
+++ b/custom_components/taskmate/manifest.json
@@ -17,5 +17,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/tempus2016/taskmate/issues",
   "requirements": [],
-  "version": "3.5.0-alpha.4"
+  "version": "3.5.0-alpha.5"
 }

--- a/custom_components/taskmate/manifest.json
+++ b/custom_components/taskmate/manifest.json
@@ -8,12 +8,14 @@
   "dependencies": [
     "http",
     "lovelace",
-    "frontend"
+    "frontend",
+    "panel_custom",
+    "websocket_api"
   ],
   "documentation": "https://github.com/tempus2016/taskmate",
   "integration_type": "service",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/tempus2016/taskmate/issues",
   "requirements": [],
-  "version": "3.4.0"
+  "version": "3.5.0-alpha.1"
 }

--- a/custom_components/taskmate/panel.py
+++ b/custom_components/taskmate/panel.py
@@ -14,7 +14,10 @@ from .const import DOMAIN
 _LOGGER = logging.getLogger(__name__)
 
 PANEL_REGISTERED: Final = "panel_registered"
-PANEL_URL_PATH: Final = "taskmate"
+# URL slug must NOT collide with the /taskmate/ static-files prefix used by
+# frontend.py — a bare GET /taskmate gets caught by the static handler trying
+# to serve a directory and returns 403. Sidebar label is unaffected.
+PANEL_URL_PATH: Final = "taskmate-admin"
 PANEL_WEBCOMPONENT: Final = "taskmate-panel"
 PANEL_MODULE_FILE: Final = "taskmate-panel.js"
 

--- a/custom_components/taskmate/panel.py
+++ b/custom_components/taskmate/panel.py
@@ -1,0 +1,65 @@
+"""Sidebar panel registration for the TaskMate admin UI."""
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Final
+
+from homeassistant.components import panel_custom
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+PANEL_REGISTERED: Final = "panel_registered"
+PANEL_URL_PATH: Final = "taskmate"
+PANEL_WEBCOMPONENT: Final = "taskmate-panel"
+PANEL_MODULE_FILE: Final = "taskmate-panel.js"
+
+
+async def _async_get_version(hass: HomeAssistant) -> str:
+    """Read manifest.json version off the executor for cache busting."""
+    manifest_path = Path(__file__).parent / "manifest.json"
+    try:
+        content = await hass.async_add_executor_job(manifest_path.read_text, "utf-8")
+        return json.loads(content).get("version", "1.0.0")
+    except (OSError, json.JSONDecodeError, AttributeError):
+        return "1.0.0"
+
+
+async def async_register_panel(hass: HomeAssistant) -> None:
+    """Register the TaskMate sidebar panel.
+
+    Idempotent — running this on a second config-entry setup is a no-op.
+    The panel JS is served by frontend.async_register_frontend() out of the
+    integration's own www/ directory at /taskmate/.
+    """
+    if hass.data.get(DOMAIN, {}).get(PANEL_REGISTERED):
+        _LOGGER.debug("TaskMate panel already registered, skipping")
+        return
+
+    version = await _async_get_version(hass)
+    module_url = f"/taskmate/{PANEL_MODULE_FILE}?v={version}"
+
+    try:
+        await panel_custom.async_register_panel(
+            hass,
+            webcomponent_name=PANEL_WEBCOMPONENT,
+            frontend_url_path=PANEL_URL_PATH,
+            sidebar_title="TaskMate",
+            sidebar_icon="mdi:checkbox-marked-circle-plus-outline",
+            module_url=module_url,
+            embed_iframe=False,
+            require_admin=True,
+        )
+    except ValueError as err:
+        # async_register_panel raises ValueError if the url_path is taken —
+        # treat as already-registered and move on.
+        _LOGGER.warning("TaskMate panel registration skipped: %s", err)
+        hass.data.setdefault(DOMAIN, {})[PANEL_REGISTERED] = True
+        return
+
+    hass.data.setdefault(DOMAIN, {})[PANEL_REGISTERED] = True
+    _LOGGER.info("Registered TaskMate sidebar panel at /%s (module: %s)", PANEL_URL_PATH, module_url)

--- a/custom_components/taskmate/strings.json
+++ b/custom_components/taskmate/strings.json
@@ -52,15 +52,21 @@
       },
       "edit_child": {
         "title": "Edit Child: {child_name}",
-        "description": "Update or delete this child",
+        "description": "Update this child's details",
         "data": {
           "name": "Child's Name",
           "avatar": "Avatar",
-          "availability_entity": "Availability Sensor (optional)",
-          "action": "Action"
+          "availability_entity": "Availability Sensor (optional)"
         },
         "data_description": {
           "availability_entity": "Optional Home Assistant entity whose state tells TaskMate whether this child is available. States 'on', 'home', 'available', 'present', or 'true' mean available; anything else (e.g. 'off', 'not_home', 'away') means unavailable. Leave blank to treat the child as always available."
+        }
+      },
+      "confirm_delete_child": {
+        "title": "Delete Child: {child_name}",
+        "description": "This will permanently remove {child_name} and all of their completion history, reward claims, points transactions, and pool allocations. Chores assigned to them will be updated. This cannot be undone.",
+        "data": {
+          "confirm": "Yes, delete this child"
         }
       },
       "manage_chores": {
@@ -356,12 +362,6 @@
     }
   },
   "selector": {
-    "child_action": {
-      "options": {
-        "save": "Save Changes",
-        "delete": "Delete Child"
-      }
-    },
     "chore_action": {
       "options": {
         "save": "Save Changes",

--- a/custom_components/taskmate/strings.json
+++ b/custom_components/taskmate/strings.json
@@ -21,6 +21,7 @@
     "step": {
       "init": {
         "title": "TaskMate Settings",
+        "description": "⚠ TaskMate now has a dedicated admin panel in the sidebar (TaskMate → /taskmate-admin) which covers everything below in one place. This menu will be removed in v4.0 — please switch over.",
         "menu_options": {
           "manage_children": "Manage Children",
           "manage_chores": "Manage Chores",

--- a/custom_components/taskmate/translations/en-GB.json
+++ b/custom_components/taskmate/translations/en-GB.json
@@ -51,15 +51,21 @@
       },
       "edit_child": {
         "title": "Edit Child: {child_name}",
-        "description": "Update or delete this child",
+        "description": "Update this child's details",
         "data": {
           "name": "Child's Name",
           "avatar": "Avatar",
-          "availability_entity": "Availability Sensor (optional)",
-          "action": "Action"
+          "availability_entity": "Availability Sensor (optional)"
         },
         "data_description": {
           "availability_entity": "Optional Home Assistant entity whose state tells TaskMate whether this child is available. States 'on', 'home', 'available', 'present', or 'true' mean available; anything else (e.g. 'off', 'not_home', 'away') means unavailable. Leave blank to treat the child as always available."
+        }
+      },
+      "confirm_delete_child": {
+        "title": "Delete Child: {child_name}",
+        "description": "This will permanently remove {child_name} and all of their completion history, reward claims, points transactions, and pool allocations. Chores assigned to them will be updated. This cannot be undone.",
+        "data": {
+          "confirm": "Yes, delete this child"
         }
       },
       "manage_chores": {
@@ -355,12 +361,6 @@
     }
   },
   "selector": {
-    "child_action": {
-      "options": {
-        "save": "Save Changes",
-        "delete": "Delete Child"
-      }
-    },
     "chore_action": {
       "options": {
         "save": "Save Changes",

--- a/custom_components/taskmate/translations/en.json
+++ b/custom_components/taskmate/translations/en.json
@@ -51,15 +51,21 @@
       },
       "edit_child": {
         "title": "Edit Child: {child_name}",
-        "description": "Update or delete this child",
+        "description": "Update this child's details",
         "data": {
           "name": "Child's Name",
           "avatar": "Avatar",
-          "availability_entity": "Availability Sensor (optional)",
-          "action": "Action"
+          "availability_entity": "Availability Sensor (optional)"
         },
         "data_description": {
           "availability_entity": "Optional Home Assistant entity whose state tells TaskMate whether this child is available. States 'on', 'home', 'available', 'present', or 'true' mean available; anything else (e.g. 'off', 'not_home', 'away') means unavailable. Leave blank to treat the child as always available."
+        }
+      },
+      "confirm_delete_child": {
+        "title": "Delete Child: {child_name}",
+        "description": "This will permanently remove {child_name} and all of their completion history, reward claims, points transactions, and pool allocations. Chores assigned to them will be updated. This cannot be undone.",
+        "data": {
+          "confirm": "Yes, delete this child"
         }
       },
       "manage_chores": {
@@ -355,12 +361,6 @@
     }
   },
   "selector": {
-    "child_action": {
-      "options": {
-        "save": "Save Changes",
-        "delete": "Delete Child"
-      }
-    },
     "chore_action": {
       "options": {
         "save": "Save Changes",

--- a/custom_components/taskmate/translations/fr.json
+++ b/custom_components/taskmate/translations/fr.json
@@ -51,15 +51,21 @@
       },
       "edit_child": {
         "title": "Modifier l'enfant : {child_name}",
-        "description": "Mettre à jour ou supprimer cet enfant",
+        "description": "Mettre à jour les informations de cet enfant",
         "data": {
           "name": "Nom de l'enfant",
           "avatar": "Avatar",
-          "availability_entity": "Capteur de disponibilité (optionnel)",
-          "action": "Action"
+          "availability_entity": "Capteur de disponibilité (optionnel)"
         },
         "data_description": {
           "availability_entity": "Entité Home Assistant optionnelle dont l'état indique à TaskMate si cet enfant est disponible. Les états 'on', 'home', 'available', 'present' ou 'true' signifient disponible ; tout autre état (ex. 'off', 'not_home', 'away') signifie indisponible. Laissez vide pour considérer l'enfant comme toujours disponible."
+        }
+      },
+      "confirm_delete_child": {
+        "title": "Supprimer l'enfant : {child_name}",
+        "description": "Cela supprimera définitivement {child_name} ainsi que tout son historique de complétion, ses réclamations de récompenses, ses transactions de points et ses allocations de cagnotte. Les corvées qui lui sont assignées seront mises à jour. Cette action est irréversible.",
+        "data": {
+          "confirm": "Oui, supprimer cet enfant"
         }
       },
       "manage_chores": {
@@ -355,12 +361,6 @@
     }
   },
   "selector": {
-    "child_action": {
-      "options": {
-        "save": "Enregistrer les modifications",
-        "delete": "Supprimer l'enfant"
-      }
-    },
     "chore_action": {
       "options": {
         "save": "Enregistrer les modifications",

--- a/custom_components/taskmate/translations/nb.json
+++ b/custom_components/taskmate/translations/nb.json
@@ -51,15 +51,21 @@
       },
       "edit_child": {
         "title": "Rediger barn: {child_name}",
-        "description": "Oppdater eller slett dette barnet",
+        "description": "Oppdater dette barnets detaljer",
         "data": {
           "name": "Barnets navn",
           "avatar": "Avatar",
-          "availability_entity": "Tilgjengelighetssensor (valgfritt)",
-          "action": "Handling"
+          "availability_entity": "Tilgjengelighetssensor (valgfritt)"
         },
         "data_description": {
           "availability_entity": "Valgfri Home Assistant-entitet hvis tilstand forteller TaskMate om dette barnet er tilgjengelig. Tilstandene 'on', 'home', 'available', 'present' eller 'true' betyr tilgjengelig; alt annet (f.eks. 'off', 'not_home', 'away') betyr utilgjengelig. La stå tom for å behandle barnet som alltid tilgjengelig."
+        }
+      },
+      "confirm_delete_child": {
+        "title": "Slett barn: {child_name}",
+        "description": "Dette vil permanent fjerne {child_name} og all fullføringshistorikk, belønningskrav, poengtransaksjoner og sparegris-tildelinger. Oppgaver tildelt dem vil bli oppdatert. Dette kan ikke angres.",
+        "data": {
+          "confirm": "Ja, slett dette barnet"
         }
       },
       "manage_chores": {
@@ -355,12 +361,6 @@
     }
   },
   "selector": {
-    "child_action": {
-      "options": {
-        "save": "Lagre endringer",
-        "delete": "Slett barn"
-      }
-    },
     "chore_action": {
       "options": {
         "save": "Lagre endringer",

--- a/custom_components/taskmate/translations/nn.json
+++ b/custom_components/taskmate/translations/nn.json
@@ -51,15 +51,21 @@
       },
       "edit_child": {
         "title": "Rediger born: {child_name}",
-        "description": "Oppdater eller slett dette bornet",
+        "description": "Oppdater dette bornet sine detaljar",
         "data": {
           "name": "Namnet til bornet",
           "avatar": "Avatar",
-          "availability_entity": "Tilgjengesensor (valfritt)",
-          "action": "Handling"
+          "availability_entity": "Tilgjengesensor (valfritt)"
         },
         "data_description": {
           "availability_entity": "Valfri Home Assistant-entitet som med tilstanden si fortel TaskMate om dette bornet er tilgjengeleg. Tilstandane 'on', 'home', 'available', 'present' eller 'true' tyder tilgjengeleg; alt anna (t.d. 'off', 'not_home', 'away') tyder utilgjengeleg. Lat stå tom for å handsame bornet som alltid tilgjengeleg."
+        }
+      },
+      "confirm_delete_child": {
+        "title": "Slett born: {child_name}",
+        "description": "Dette vil permanent fjerne {child_name} og all fullføringshistorikk, løningskrav, poengtransaksjonar og sparegris-tildelingar. Oppgåver tildelte dei vil verte oppdaterte. Dette kan ikkje gjerast om.",
+        "data": {
+          "confirm": "Ja, slett dette bornet"
         }
       },
       "manage_chores": {
@@ -355,12 +361,6 @@
     }
   },
   "selector": {
-    "child_action": {
-      "options": {
-        "save": "Lagre endringar",
-        "delete": "Slett born"
-      }
-    },
     "chore_action": {
       "options": {
         "save": "Lagre endringar",

--- a/custom_components/taskmate/translations/pt-BR.json
+++ b/custom_components/taskmate/translations/pt-BR.json
@@ -51,15 +51,21 @@
       },
       "edit_child": {
         "title": "Editar criança: {child_name}",
-        "description": "Atualizar ou eliminar esta criança",
+        "description": "Atualizar as informações desta criança",
         "data": {
           "name": "Nome da criança",
           "avatar": "Avatar",
-          "availability_entity": "Sensor de disponibilidade (opcional)",
-          "action": "Ação"
+          "availability_entity": "Sensor de disponibilidade (opcional)"
         },
         "data_description": {
           "availability_entity": "Entidade opcional do Home Assistant cujo estado informa ao TaskMate se esta criança está disponível. Os estados 'on', 'home', 'available', 'present' ou 'true' significam disponível; qualquer outro (ex.: 'off', 'not_home', 'away') significa indisponível. Deixe em branco para tratar a criança como sempre disponível."
+        }
+      },
+      "confirm_delete_child": {
+        "title": "Excluir criança: {child_name}",
+        "description": "Isto irá remover permanentemente {child_name} e todo o seu histórico de conclusão, reivindicações de recompensas, transações de pontos e alocações de cofrinho. As tarefas atribuídas serão atualizadas. Esta ação não pode ser desfeita.",
+        "data": {
+          "confirm": "Sim, excluir esta criança"
         }
       },
       "manage_chores": {
@@ -355,12 +361,6 @@
     }
   },
   "selector": {
-    "child_action": {
-      "options": {
-        "save": "Guardar alterações",
-        "delete": "Eliminar criança"
-      }
-    },
     "chore_action": {
       "options": {
         "save": "Guardar alterações",

--- a/custom_components/taskmate/translations/pt.json
+++ b/custom_components/taskmate/translations/pt.json
@@ -51,15 +51,21 @@
       },
       "edit_child": {
         "title": "Editar criança: {child_name}",
-        "description": "Atualizar ou eliminar esta criança",
+        "description": "Atualizar as informações desta criança",
         "data": {
           "name": "Nome da criança",
           "avatar": "Avatar",
-          "availability_entity": "Sensor de disponibilidade (opcional)",
-          "action": "Ação"
+          "availability_entity": "Sensor de disponibilidade (opcional)"
         },
         "data_description": {
           "availability_entity": "Entidade opcional do Home Assistant cujo estado indica ao TaskMate se esta criança está disponível. Os estados 'on', 'home', 'available', 'present' ou 'true' significam disponível; qualquer outro (ex.: 'off', 'not_home', 'away') significa indisponível. Deixe vazio para tratar a criança como sempre disponível."
+        }
+      },
+      "confirm_delete_child": {
+        "title": "Eliminar criança: {child_name}",
+        "description": "Isto irá remover permanentemente {child_name} e todo o seu histórico de conclusão, reclamações de recompensas, transações de pontos e alocações de mealheiro. As tarefas atribuídas serão atualizadas. Esta ação não pode ser desfeita.",
+        "data": {
+          "confirm": "Sim, eliminar esta criança"
         }
       },
       "manage_chores": {
@@ -355,12 +361,6 @@
     }
   },
   "selector": {
-    "child_action": {
-      "options": {
-        "save": "Guardar alterações",
-        "delete": "Eliminar criança"
-      }
-    },
     "chore_action": {
       "options": {
         "save": "Guardar alterações",

--- a/custom_components/taskmate/websocket.py
+++ b/custom_components/taskmate/websocket.py
@@ -1,0 +1,83 @@
+"""WebSocket API for the TaskMate admin panel.
+
+The panel speaks to the integration via these commands rather than via HA
+services — services are intended for automation/templating consumers and
+would clutter the service registry with two dozen panel-only entries.
+
+Stage 1 ships only the read command (taskmate/get_state). Mutation commands
+land in subsequent stages alongside coordinator method coverage.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Final
+
+import voluptuous as vol
+from homeassistant.components import websocket_api
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN
+from .coordinator import TaskMateCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+WS_REGISTERED: Final = "ws_registered"
+
+WS_GET_STATE: Final = "taskmate/get_state"
+
+
+def _get_coordinator(hass: HomeAssistant) -> TaskMateCoordinator | None:
+    """Return the first available TaskMate coordinator, or None."""
+    for key, value in hass.data.get(DOMAIN, {}).items():
+        if isinstance(value, TaskMateCoordinator):
+            return value
+    return None
+
+
+def _build_state_snapshot(coordinator: TaskMateCoordinator) -> dict[str, Any]:
+    """Return the full editable state for the admin panel.
+
+    Pulls straight from the storage layer — every list is already a list of
+    plain dicts (dataclass.asdict shape) so no extra serialisation is needed.
+    """
+    data = coordinator.storage.data
+    return {
+        "version": "1",
+        "children":         list(data.get("children", [])),
+        "chores":           list(data.get("chores", [])),
+        "rewards":          list(data.get("rewards", [])),
+        "penalties":        list(data.get("penalties", [])),
+        "bonuses":          list(data.get("bonuses", [])),
+        "task_groups":      list(data.get("task_groups", [])),
+        "pool_allocations": list(data.get("pool_allocations", [])),
+        "settings": {
+            "points_name": data.get("points_name", "Stars"),
+            "points_icon": data.get("points_icon", "mdi:star"),
+        },
+    }
+
+
+@websocket_api.websocket_command(
+    {vol.Required("type"): WS_GET_STATE}
+)
+@websocket_api.async_response
+async def _ws_get_state(hass, connection, msg):
+    """Return the storage snapshot for admin users."""
+    if not connection.user.is_admin:
+        connection.send_error(msg["id"], websocket_api.const.ERR_UNAUTHORIZED, "Admin only")
+        return
+    coordinator = _get_coordinator(hass)
+    if not coordinator:
+        connection.send_error(msg["id"], "no_coordinator", "TaskMate not initialised")
+        return
+    connection.send_result(msg["id"], _build_state_snapshot(coordinator))
+
+
+def async_register_websocket_commands(hass: HomeAssistant) -> None:
+    """Register all TaskMate WebSocket commands. Idempotent."""
+    if hass.data.get(DOMAIN, {}).get(WS_REGISTERED):
+        _LOGGER.debug("TaskMate WS commands already registered, skipping")
+        return
+    websocket_api.async_register_command(hass, _ws_get_state)
+    hass.data.setdefault(DOMAIN, {})[WS_REGISTERED] = True
+    _LOGGER.info("Registered TaskMate WebSocket commands")

--- a/custom_components/taskmate/websocket.py
+++ b/custom_components/taskmate/websocket.py
@@ -89,6 +89,14 @@ WS_REMOVE_TASK_GROUP: Final   = "taskmate/remove_task_group"
 
 WS_UPDATE_SETTINGS: Final     = "taskmate/update_settings"
 
+# Operational
+WS_APPROVE_CHORE: Final       = "taskmate/approve_chore"
+WS_REJECT_CHORE: Final        = "taskmate/reject_chore"
+WS_APPROVE_REWARD: Final      = "taskmate/approve_reward"
+WS_REJECT_REWARD: Final       = "taskmate/reject_reward"
+WS_SET_CHORE_ORDER: Final     = "taskmate/set_chore_order"
+WS_ADD_CHORES_BULK: Final     = "taskmate/add_chores_bulk"
+
 
 def _get_coordinator(hass: HomeAssistant) -> TaskMateCoordinator | None:
     for value in hass.data.get(DOMAIN, {}).values():
@@ -146,8 +154,11 @@ def _opt_int(v: Any) -> int | None:
 
 def _build_state_snapshot(coordinator: TaskMateCoordinator) -> dict[str, Any]:
     data = coordinator.storage.data
+    completions = list(data.get("completions", []))
+    reward_claims = list(data.get("reward_claims", []))
+    transactions = list(data.get("points_transactions", []))
     return {
-        "version": "1",
+        "version": "2",
         "children":         list(data.get("children", [])),
         "chores":           list(data.get("chores", [])),
         "rewards":          list(data.get("rewards", [])),
@@ -155,6 +166,12 @@ def _build_state_snapshot(coordinator: TaskMateCoordinator) -> dict[str, Any]:
         "bonuses":          list(data.get("bonuses", [])),
         "task_groups":      list(data.get("task_groups", [])),
         "pool_allocations": list(data.get("pool_allocations", [])),
+        # Operational state — used by the panel's Activity tab + approval banner
+        "completions":          completions,           # all (panel slices for display)
+        "pending_completions":  [c for c in completions if not c.get("approved")],
+        "reward_claims":        reward_claims,
+        "pending_reward_claims": [c for c in reward_claims if not c.get("approved")],
+        "points_transactions":  transactions[-100:],   # most recent 100 for audit log
         "settings": {
             "points_name":       data.get("points_name", "Stars"),
             "points_icon":       data.get("points_icon", "mdi:star"),
@@ -721,6 +738,99 @@ async def _ws_update_settings(hass, connection, msg, coordinator):
 
 
 # ---------------------------------------------------------------------------
+# Operational — approval / rejection / reorder / bulk add
+# ---------------------------------------------------------------------------
+
+@websocket_api.websocket_command({
+    vol.Required("type"): WS_APPROVE_CHORE,
+    vol.Required("completion_id"): str,
+})
+@websocket_api.async_response
+@_admin_only
+async def _ws_approve_chore(hass, connection, msg, coordinator):
+    await coordinator.async_approve_chore(msg["completion_id"])
+    connection.send_result(msg["id"], {"completion_id": msg["completion_id"]})
+
+
+@websocket_api.websocket_command({
+    vol.Required("type"): WS_REJECT_CHORE,
+    vol.Required("completion_id"): str,
+})
+@websocket_api.async_response
+@_admin_only
+async def _ws_reject_chore(hass, connection, msg, coordinator):
+    await coordinator.async_reject_chore(msg["completion_id"])
+    connection.send_result(msg["id"], {"completion_id": msg["completion_id"]})
+
+
+@websocket_api.websocket_command({
+    vol.Required("type"): WS_APPROVE_REWARD,
+    vol.Required("claim_id"): str,
+})
+@websocket_api.async_response
+@_admin_only
+async def _ws_approve_reward(hass, connection, msg, coordinator):
+    await coordinator.async_approve_reward(msg["claim_id"])
+    connection.send_result(msg["id"], {"claim_id": msg["claim_id"]})
+
+
+@websocket_api.websocket_command({
+    vol.Required("type"): WS_REJECT_REWARD,
+    vol.Required("claim_id"): str,
+})
+@websocket_api.async_response
+@_admin_only
+async def _ws_reject_reward(hass, connection, msg, coordinator):
+    await coordinator.async_reject_reward(msg["claim_id"])
+    connection.send_result(msg["id"], {"claim_id": msg["claim_id"]})
+
+
+@websocket_api.websocket_command({
+    vol.Required("type"): WS_SET_CHORE_ORDER,
+    vol.Required("child_id"): str,
+    vol.Required("chore_order"): [str],
+})
+@websocket_api.async_response
+@_admin_only
+async def _ws_set_chore_order(hass, connection, msg, coordinator):
+    await coordinator.async_set_chore_order(msg["child_id"], list(msg["chore_order"]))
+    connection.send_result(msg["id"], {"child_id": msg["child_id"]})
+
+
+@websocket_api.websocket_command({
+    vol.Required("type"): WS_ADD_CHORES_BULK,
+    vol.Required("chore_names"): [str],
+    vol.Optional("points"): vol.All(int, vol.Range(min=0)),
+    vol.Optional("assigned_to"): [str],
+    vol.Optional("requires_approval"): bool,
+    vol.Optional("time_category"): str,
+    vol.Optional("schedule_mode"): vol.In(["specific_days", "recurring", "one_shot"]),
+    vol.Optional("due_days"): [str],
+    vol.Optional("daily_limit"): vol.All(int, vol.Range(min=1)),
+    vol.Optional("completion_sound"): str,
+})
+@websocket_api.async_response
+@_admin_only
+async def _ws_add_chores_bulk(hass, connection, msg, coordinator):
+    chore_names = [n.strip() for n in msg.get("chore_names", []) if n and n.strip()]
+    if not chore_names:
+        connection.send_error(msg["id"], "no_names", "At least one chore name is required")
+        return
+    chores = await coordinator.async_add_chores_bulk(
+        chore_names=chore_names,
+        points=msg.get("points", 10),
+        due_days=list(msg.get("due_days", []) or []),
+        assigned_to=list(msg.get("assigned_to", []) or []),
+        requires_approval=msg.get("requires_approval", True),
+        time_category=msg.get("time_category", "anytime"),
+        daily_limit=msg.get("daily_limit", 1),
+        schedule_mode=msg.get("schedule_mode", "specific_days"),
+        completion_sound=msg.get("completion_sound", "coin"),
+    )
+    connection.send_result(msg["id"], {"created": [c.id for c in chores], "count": len(chores)})
+
+
+# ---------------------------------------------------------------------------
 # Registration
 # ---------------------------------------------------------------------------
 
@@ -733,6 +843,8 @@ _COMMANDS = (
     _ws_add_bonus, _ws_update_bonus, _ws_remove_bonus, _ws_apply_bonus,
     _ws_add_task_group, _ws_update_task_group, _ws_remove_task_group,
     _ws_update_settings,
+    _ws_approve_chore, _ws_reject_chore, _ws_approve_reward, _ws_reject_reward,
+    _ws_set_chore_order, _ws_add_chores_bulk,
 )
 
 

--- a/custom_components/taskmate/websocket.py
+++ b/custom_components/taskmate/websocket.py
@@ -3,13 +3,11 @@
 The panel speaks to the integration via these commands rather than via HA
 services — services are intended for automation/templating consumers and
 would clutter the service registry with two dozen panel-only entries.
-
-Stage 1 ships only the read command (taskmate/get_state). Mutation commands
-land in subsequent stages alongside coordinator method coverage.
 """
 from __future__ import annotations
 
 import logging
+from functools import wraps
 from typing import Any, Final
 
 import voluptuous as vol
@@ -23,7 +21,13 @@ _LOGGER = logging.getLogger(__name__)
 
 WS_REGISTERED: Final = "ws_registered"
 
+# --- Read
 WS_GET_STATE: Final = "taskmate/get_state"
+
+# --- Children
+WS_ADD_CHILD: Final = "taskmate/add_child"
+WS_UPDATE_CHILD: Final = "taskmate/update_child"
+WS_REMOVE_CHILD: Final = "taskmate/remove_child"
 
 
 def _get_coordinator(hass: HomeAssistant) -> TaskMateCoordinator | None:
@@ -34,12 +38,29 @@ def _get_coordinator(hass: HomeAssistant) -> TaskMateCoordinator | None:
     return None
 
 
-def _build_state_snapshot(coordinator: TaskMateCoordinator) -> dict[str, Any]:
-    """Return the full editable state for the admin panel.
+def _admin_only(handler):
+    """Enforce admin access + coordinator availability on a WS handler."""
+    @wraps(handler)
+    async def wrapper(hass, connection, msg):
+        if not connection.user.is_admin:
+            connection.send_error(msg["id"], websocket_api.const.ERR_UNAUTHORIZED, "Admin only")
+            return
+        coordinator = _get_coordinator(hass)
+        if not coordinator:
+            connection.send_error(msg["id"], "no_coordinator", "TaskMate not initialised")
+            return
+        try:
+            await handler(hass, connection, msg, coordinator)
+        except vol.Invalid as err:
+            connection.send_error(msg["id"], "invalid_args", str(err))
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.exception("WS handler %s failed", msg.get("type"))
+            connection.send_error(msg["id"], "handler_failed", str(err))
+    return wrapper
 
-    Pulls straight from the storage layer — every list is already a list of
-    plain dicts (dataclass.asdict shape) so no extra serialisation is needed.
-    """
+
+def _build_state_snapshot(coordinator: TaskMateCoordinator) -> dict[str, Any]:
+    """Return the full editable state for the admin panel."""
     data = coordinator.storage.data
     return {
         "version": "1",
@@ -57,27 +78,92 @@ def _build_state_snapshot(coordinator: TaskMateCoordinator) -> dict[str, Any]:
     }
 
 
-@websocket_api.websocket_command(
-    {vol.Required("type"): WS_GET_STATE}
-)
+# ---------------------------------------------------------------------------
+# Read
+# ---------------------------------------------------------------------------
+
+@websocket_api.websocket_command({vol.Required("type"): WS_GET_STATE})
 @websocket_api.async_response
-async def _ws_get_state(hass, connection, msg):
-    """Return the storage snapshot for admin users."""
-    if not connection.user.is_admin:
-        connection.send_error(msg["id"], websocket_api.const.ERR_UNAUTHORIZED, "Admin only")
-        return
-    coordinator = _get_coordinator(hass)
-    if not coordinator:
-        connection.send_error(msg["id"], "no_coordinator", "TaskMate not initialised")
-        return
+@_admin_only
+async def _ws_get_state(hass, connection, msg, coordinator):
     connection.send_result(msg["id"], _build_state_snapshot(coordinator))
 
+
+# ---------------------------------------------------------------------------
+# Children
+# ---------------------------------------------------------------------------
+
+@websocket_api.websocket_command({
+    vol.Required("type"): WS_ADD_CHILD,
+    vol.Required("name"): vol.All(str, vol.Length(min=1, max=120)),
+    vol.Optional("avatar", default="mdi:account-circle"): str,
+    vol.Optional("availability_entity", default=""): str,
+})
+@websocket_api.async_response
+@_admin_only
+async def _ws_add_child(hass, connection, msg, coordinator):
+    child = await coordinator.async_add_child(
+        name=msg["name"].strip(),
+        avatar=msg.get("avatar") or "mdi:account-circle",
+        availability_entity=(msg.get("availability_entity") or "").strip(),
+    )
+    connection.send_result(msg["id"], {"id": child.id})
+
+
+@websocket_api.websocket_command({
+    vol.Required("type"): WS_UPDATE_CHILD,
+    vol.Required("child_id"): str,
+    vol.Optional("name"): vol.All(str, vol.Length(min=1, max=120)),
+    vol.Optional("avatar"): str,
+    vol.Optional("availability_entity"): str,
+})
+@websocket_api.async_response
+@_admin_only
+async def _ws_update_child(hass, connection, msg, coordinator):
+    existing = coordinator.storage.get_child(msg["child_id"])
+    if not existing:
+        connection.send_error(msg["id"], "not_found", f"Child {msg['child_id']} not found")
+        return
+    if "name" in msg:
+        existing.name = msg["name"].strip()
+    if "avatar" in msg:
+        existing.avatar = msg["avatar"] or "mdi:account-circle"
+    if "availability_entity" in msg:
+        existing.availability_entity = (msg["availability_entity"] or "").strip()
+    await coordinator.async_update_child(existing)
+    connection.send_result(msg["id"], {"id": existing.id})
+
+
+@websocket_api.websocket_command({
+    vol.Required("type"): WS_REMOVE_CHILD,
+    vol.Required("child_id"): str,
+})
+@websocket_api.async_response
+@_admin_only
+async def _ws_remove_child(hass, connection, msg, coordinator):
+    existing = coordinator.storage.get_child(msg["child_id"])
+    if not existing:
+        connection.send_error(msg["id"], "not_found", f"Child {msg['child_id']} not found")
+        return
+    await coordinator.async_remove_child(msg["child_id"])
+    connection.send_result(msg["id"], {"id": msg["child_id"]})
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
 
 def async_register_websocket_commands(hass: HomeAssistant) -> None:
     """Register all TaskMate WebSocket commands. Idempotent."""
     if hass.data.get(DOMAIN, {}).get(WS_REGISTERED):
         _LOGGER.debug("TaskMate WS commands already registered, skipping")
         return
-    websocket_api.async_register_command(hass, _ws_get_state)
+    for handler in (
+        _ws_get_state,
+        _ws_add_child,
+        _ws_update_child,
+        _ws_remove_child,
+    ):
+        websocket_api.async_register_command(hass, handler)
     hass.data.setdefault(DOMAIN, {})[WS_REGISTERED] = True
     _LOGGER.info("Registered TaskMate WebSocket commands")

--- a/custom_components/taskmate/websocket.py
+++ b/custom_components/taskmate/websocket.py
@@ -3,6 +3,42 @@
 The panel speaks to the integration via these commands rather than via HA
 services — services are intended for automation/templating consumers and
 would clutter the service registry with two dozen panel-only entries.
+
+Read:
+    taskmate/get_state          — full snapshot
+
+Children:
+    taskmate/add_child          — name, avatar?, availability_entity?
+    taskmate/update_child       — child_id + any of the above
+    taskmate/remove_child       — child_id
+
+Chores:
+    taskmate/add_chore          — name + many optional fields
+    taskmate/update_chore       — chore_id + any of the above
+    taskmate/remove_chore       — chore_id
+
+Rewards:
+    taskmate/add_reward         — name + cost + many optional fields
+    taskmate/update_reward      — reward_id + any of the above
+    taskmate/remove_reward      — reward_id
+
+Penalties / Bonuses (same shape):
+    taskmate/add_penalty        — name + points + optional
+    taskmate/update_penalty     — penalty_id + any of the above
+    taskmate/remove_penalty     — penalty_id
+    taskmate/apply_penalty      — penalty_id + child_id (operational, exposed for convenience)
+    (and the bonus equivalents)
+
+Task groups:
+    taskmate/add_task_group     — name, policy, chore_ids?
+    taskmate/update_task_group  — group_id + any of the above
+    taskmate/remove_task_group  — group_id
+
+Settings:
+    taskmate/update_settings    — partial dict of {points_name, points_icon, history_days, streak_reset_mode, ...}
+
+All commands require admin. Mutations write through coordinator methods so
+TaskMate's existing business logic (refunds, cleanup, recompute) runs.
 """
 from __future__ import annotations
 
@@ -16,30 +52,53 @@ from homeassistant.core import HomeAssistant
 
 from .const import DOMAIN
 from .coordinator import TaskMateCoordinator
+from .models import Reward
 
 _LOGGER = logging.getLogger(__name__)
 
 WS_REGISTERED: Final = "ws_registered"
 
-# --- Read
-WS_GET_STATE: Final = "taskmate/get_state"
+# --- command names ---------------------------------------------------------
+WS_GET_STATE: Final           = "taskmate/get_state"
 
-# --- Children
-WS_ADD_CHILD: Final = "taskmate/add_child"
-WS_UPDATE_CHILD: Final = "taskmate/update_child"
-WS_REMOVE_CHILD: Final = "taskmate/remove_child"
+WS_ADD_CHILD: Final           = "taskmate/add_child"
+WS_UPDATE_CHILD: Final        = "taskmate/update_child"
+WS_REMOVE_CHILD: Final        = "taskmate/remove_child"
+
+WS_ADD_CHORE: Final           = "taskmate/add_chore"
+WS_UPDATE_CHORE: Final        = "taskmate/update_chore"
+WS_REMOVE_CHORE: Final        = "taskmate/remove_chore"
+
+WS_ADD_REWARD: Final          = "taskmate/add_reward"
+WS_UPDATE_REWARD: Final       = "taskmate/update_reward"
+WS_REMOVE_REWARD: Final       = "taskmate/remove_reward"
+
+WS_ADD_PENALTY: Final         = "taskmate/add_penalty"
+WS_UPDATE_PENALTY: Final      = "taskmate/update_penalty"
+WS_REMOVE_PENALTY: Final      = "taskmate/remove_penalty"
+WS_APPLY_PENALTY: Final       = "taskmate/apply_penalty"
+
+WS_ADD_BONUS: Final           = "taskmate/add_bonus"
+WS_UPDATE_BONUS: Final        = "taskmate/update_bonus"
+WS_REMOVE_BONUS: Final        = "taskmate/remove_bonus"
+WS_APPLY_BONUS: Final         = "taskmate/apply_bonus"
+
+WS_ADD_TASK_GROUP: Final      = "taskmate/add_task_group"
+WS_UPDATE_TASK_GROUP: Final   = "taskmate/update_task_group"
+WS_REMOVE_TASK_GROUP: Final   = "taskmate/remove_task_group"
+
+WS_UPDATE_SETTINGS: Final     = "taskmate/update_settings"
 
 
 def _get_coordinator(hass: HomeAssistant) -> TaskMateCoordinator | None:
-    """Return the first available TaskMate coordinator, or None."""
-    for key, value in hass.data.get(DOMAIN, {}).items():
+    for value in hass.data.get(DOMAIN, {}).values():
         if isinstance(value, TaskMateCoordinator):
             return value
     return None
 
 
 def _admin_only(handler):
-    """Enforce admin access + coordinator availability on a WS handler."""
+    """Enforce admin + coordinator availability + uniform error reporting."""
     @wraps(handler)
     async def wrapper(hass, connection, msg):
         if not connection.user.is_admin:
@@ -53,14 +112,39 @@ def _admin_only(handler):
             await handler(hass, connection, msg, coordinator)
         except vol.Invalid as err:
             connection.send_error(msg["id"], "invalid_args", str(err))
+        except ValueError as err:
+            connection.send_error(msg["id"], "invalid", str(err))
         except Exception as err:  # noqa: BLE001
             _LOGGER.exception("WS handler %s failed", msg.get("type"))
             connection.send_error(msg["id"], "handler_failed", str(err))
     return wrapper
 
 
+# ---------------------------------------------------------------------------
+# Validators / coercers
+# ---------------------------------------------------------------------------
+
+_str_list = vol.All(vol.Any([str], None), lambda v: list(v or []))
+
+
+def _opt_str(v: Any) -> str:
+    """Coerce optional string field to stripped str (or empty)."""
+    if v is None:
+        return ""
+    return str(v).strip()
+
+
+def _opt_int(v: Any) -> int | None:
+    if v is None or v == "":
+        return None
+    return int(v)
+
+
+# ---------------------------------------------------------------------------
+# State snapshot
+# ---------------------------------------------------------------------------
+
 def _build_state_snapshot(coordinator: TaskMateCoordinator) -> dict[str, Any]:
-    """Return the full editable state for the admin panel."""
     data = coordinator.storage.data
     return {
         "version": "1",
@@ -72,15 +156,12 @@ def _build_state_snapshot(coordinator: TaskMateCoordinator) -> dict[str, Any]:
         "task_groups":      list(data.get("task_groups", [])),
         "pool_allocations": list(data.get("pool_allocations", [])),
         "settings": {
-            "points_name": data.get("points_name", "Stars"),
-            "points_icon": data.get("points_icon", "mdi:star"),
+            "points_name":       data.get("points_name", "Stars"),
+            "points_icon":       data.get("points_icon", "mdi:star"),
+            **(data.get("settings", {}) or {}),
         },
     }
 
-
-# ---------------------------------------------------------------------------
-# Read
-# ---------------------------------------------------------------------------
 
 @websocket_api.websocket_command({vol.Required("type"): WS_GET_STATE})
 @websocket_api.async_response
@@ -105,7 +186,7 @@ async def _ws_add_child(hass, connection, msg, coordinator):
     child = await coordinator.async_add_child(
         name=msg["name"].strip(),
         avatar=msg.get("avatar") or "mdi:account-circle",
-        availability_entity=(msg.get("availability_entity") or "").strip(),
+        availability_entity=_opt_str(msg.get("availability_entity")),
     )
     connection.send_result(msg["id"], {"id": child.id})
 
@@ -129,7 +210,7 @@ async def _ws_update_child(hass, connection, msg, coordinator):
     if "avatar" in msg:
         existing.avatar = msg["avatar"] or "mdi:account-circle"
     if "availability_entity" in msg:
-        existing.availability_entity = (msg["availability_entity"] or "").strip()
+        existing.availability_entity = _opt_str(msg["availability_entity"])
     await coordinator.async_update_child(existing)
     connection.send_result(msg["id"], {"id": existing.id})
 
@@ -141,8 +222,7 @@ async def _ws_update_child(hass, connection, msg, coordinator):
 @websocket_api.async_response
 @_admin_only
 async def _ws_remove_child(hass, connection, msg, coordinator):
-    existing = coordinator.storage.get_child(msg["child_id"])
-    if not existing:
+    if not coordinator.storage.get_child(msg["child_id"]):
         connection.send_error(msg["id"], "not_found", f"Child {msg['child_id']} not found")
         return
     await coordinator.async_remove_child(msg["child_id"])
@@ -150,20 +230,504 @@ async def _ws_remove_child(hass, connection, msg, coordinator):
 
 
 # ---------------------------------------------------------------------------
+# Chores
+# ---------------------------------------------------------------------------
+
+# Fields the panel is allowed to set directly. Anything else (skip_date,
+# assignment_current_child_id, publish_calendar_published_dates, etc.) is
+# coordinator-managed runtime state and intentionally not exposed.
+_CHORE_EDITABLE_FIELDS = {
+    "name", "description", "points", "assigned_to", "requires_approval",
+    "time_category", "claim_allowance_minutes", "daily_limit", "completion_sound",
+    "schedule_mode", "due_days", "recurrence", "recurrence_day",
+    "recurrence_start", "first_occurrence_mode", "visibility_entity",
+    "visibility_state", "visibility_operator", "enabled",
+    "assignment_mode", "assignment_rotation_anchor", "require_availability",
+    "publish_calendar_entities",
+}
+
+
+def _chore_payload_schema(*, require_name: bool):
+    """Build a vol.Schema for add/update chore. require_name=True for add."""
+    name_field = vol.Required("name") if require_name else vol.Optional("name")
+    return {
+        name_field: vol.All(str, vol.Length(min=1, max=200)),
+        vol.Optional("description"): str,
+        vol.Optional("points"): vol.All(int, vol.Range(min=0)),
+        vol.Optional("assigned_to"): [str],
+        vol.Optional("requires_approval"): bool,
+        vol.Optional("time_category"): str,
+        vol.Optional("claim_allowance_minutes"): vol.All(int, vol.Range(min=0)),
+        vol.Optional("daily_limit"): vol.All(int, vol.Range(min=1)),
+        vol.Optional("completion_sound"): str,
+        vol.Optional("schedule_mode"): vol.In(["specific_days", "recurring", "one_shot"]),
+        vol.Optional("due_days"): [str],
+        vol.Optional("recurrence"): str,
+        vol.Optional("recurrence_day"): str,
+        vol.Optional("recurrence_start"): str,
+        vol.Optional("first_occurrence_mode"): str,
+        vol.Optional("visibility_entity"): str,
+        vol.Optional("visibility_state"): str,
+        vol.Optional("visibility_operator"): str,
+        vol.Optional("enabled"): bool,
+        vol.Optional("assignment_mode"): vol.In(["everyone", "alternating", "random", "balanced"]),
+        vol.Optional("assignment_rotation_anchor"): str,
+        vol.Optional("require_availability"): bool,
+        vol.Optional("publish_calendar_entities"): [str],
+    }
+
+
+@websocket_api.websocket_command({
+    vol.Required("type"): WS_ADD_CHORE,
+    **_chore_payload_schema(require_name=True),
+})
+@websocket_api.async_response
+@_admin_only
+async def _ws_add_chore(hass, connection, msg, coordinator):
+    # The coordinator's async_add_chore signature accepts most of these fields
+    # natively, but a few (visibility_*, enabled, assignment_*, calendar) are
+    # set after creation by mutating the returned chore. Simpler path: build
+    # via async_add_chore for the bread-and-butter fields, then patch.
+    chore = await coordinator.async_add_chore(
+        name=msg["name"].strip(),
+        points=msg.get("points", 10),
+        description=msg.get("description", ""),
+        assigned_to=list(msg.get("assigned_to", []) or []),
+        requires_approval=msg.get("requires_approval", True),
+        time_category=msg.get("time_category", "anytime"),
+        claim_allowance_minutes=msg.get("claim_allowance_minutes", 0),
+        daily_limit=msg.get("daily_limit", 1),
+        completion_sound=msg.get("completion_sound", "coin"),
+        schedule_mode=msg.get("schedule_mode", "specific_days"),
+    )
+    # Apply any remaining editable fields and re-save.
+    extra_fields = (set(msg.keys()) & _CHORE_EDITABLE_FIELDS) - {
+        "name", "points", "description", "assigned_to", "requires_approval",
+        "time_category", "claim_allowance_minutes", "daily_limit",
+        "completion_sound", "schedule_mode",
+    }
+    if extra_fields:
+        for f in extra_fields:
+            setattr(chore, f, msg[f] if not isinstance(msg[f], list) else list(msg[f]))
+        await coordinator.async_update_chore(chore)
+    connection.send_result(msg["id"], {"id": chore.id})
+
+
+@websocket_api.websocket_command({
+    vol.Required("type"): WS_UPDATE_CHORE,
+    vol.Required("chore_id"): str,
+    **_chore_payload_schema(require_name=False),
+})
+@websocket_api.async_response
+@_admin_only
+async def _ws_update_chore(hass, connection, msg, coordinator):
+    existing = coordinator.storage.get_chore(msg["chore_id"])
+    if not existing:
+        connection.send_error(msg["id"], "not_found", f"Chore {msg['chore_id']} not found")
+        return
+    for field in _CHORE_EDITABLE_FIELDS:
+        if field in msg:
+            value = msg[field]
+            if isinstance(value, list):
+                value = list(value)
+            elif field == "name":
+                value = value.strip()
+            setattr(existing, field, value)
+    await coordinator.async_update_chore(existing)
+    connection.send_result(msg["id"], {"id": existing.id})
+
+
+@websocket_api.websocket_command({
+    vol.Required("type"): WS_REMOVE_CHORE,
+    vol.Required("chore_id"): str,
+})
+@websocket_api.async_response
+@_admin_only
+async def _ws_remove_chore(hass, connection, msg, coordinator):
+    if not coordinator.storage.get_chore(msg["chore_id"]):
+        connection.send_error(msg["id"], "not_found", f"Chore {msg['chore_id']} not found")
+        return
+    await coordinator.async_remove_chore(msg["chore_id"])
+    connection.send_result(msg["id"], {"id": msg["chore_id"]})
+
+
+# ---------------------------------------------------------------------------
+# Rewards
+# ---------------------------------------------------------------------------
+
+_REWARD_FIELDS = {"name", "cost", "description", "icon", "assigned_to",
+                  "is_jackpot", "pool_enabled", "quantity", "expires_at"}
+
+
+def _reward_payload_schema(*, require_name: bool):
+    name_field = vol.Required("name") if require_name else vol.Optional("name")
+    cost_field = vol.Required("cost") if require_name else vol.Optional("cost")
+    return {
+        name_field: vol.All(str, vol.Length(min=1, max=200)),
+        cost_field: vol.All(int, vol.Range(min=0)),
+        vol.Optional("description"): str,
+        vol.Optional("icon"): str,
+        vol.Optional("assigned_to"): [str],
+        vol.Optional("is_jackpot"): bool,
+        vol.Optional("pool_enabled"): bool,
+        vol.Optional("quantity"): vol.Any(None, vol.All(int, vol.Range(min=0))),
+        vol.Optional("expires_at"): vol.Any(None, str),
+    }
+
+
+@websocket_api.websocket_command({
+    vol.Required("type"): WS_ADD_REWARD,
+    **_reward_payload_schema(require_name=True),
+})
+@websocket_api.async_response
+@_admin_only
+async def _ws_add_reward(hass, connection, msg, coordinator):
+    # coordinator.async_add_reward accepts a subset; build a Reward dataclass
+    # to populate every editable field uniformly.
+    reward = Reward(
+        name=msg["name"].strip(),
+        cost=msg["cost"],
+        description=msg.get("description", ""),
+        icon=msg.get("icon", "mdi:gift"),
+        assigned_to=list(msg.get("assigned_to", []) or []),
+        is_jackpot=msg.get("is_jackpot", False),
+        pool_enabled=msg.get("pool_enabled", False),
+        quantity=msg.get("quantity"),
+        expires_at=msg.get("expires_at") or None,
+    )
+    coordinator.storage.add_reward(reward)
+    await coordinator.storage.async_save()
+    await coordinator.async_refresh()
+    connection.send_result(msg["id"], {"id": reward.id})
+
+
+@websocket_api.websocket_command({
+    vol.Required("type"): WS_UPDATE_REWARD,
+    vol.Required("reward_id"): str,
+    **_reward_payload_schema(require_name=False),
+})
+@websocket_api.async_response
+@_admin_only
+async def _ws_update_reward(hass, connection, msg, coordinator):
+    existing = coordinator.storage.get_reward(msg["reward_id"])
+    if not existing:
+        connection.send_error(msg["id"], "not_found", f"Reward {msg['reward_id']} not found")
+        return
+    for field in _REWARD_FIELDS:
+        if field in msg:
+            value = msg[field]
+            if field == "name" and value:
+                value = value.strip()
+            if field == "expires_at":
+                value = value or None
+            if isinstance(value, list):
+                value = list(value)
+            setattr(existing, field, value)
+    await coordinator.async_update_reward(existing)
+    connection.send_result(msg["id"], {"id": existing.id})
+
+
+@websocket_api.websocket_command({
+    vol.Required("type"): WS_REMOVE_REWARD,
+    vol.Required("reward_id"): str,
+})
+@websocket_api.async_response
+@_admin_only
+async def _ws_remove_reward(hass, connection, msg, coordinator):
+    if not coordinator.storage.get_reward(msg["reward_id"]):
+        connection.send_error(msg["id"], "not_found", f"Reward {msg['reward_id']} not found")
+        return
+    await coordinator.async_remove_reward(msg["reward_id"])
+    connection.send_result(msg["id"], {"id": msg["reward_id"]})
+
+
+# ---------------------------------------------------------------------------
+# Penalties
+# ---------------------------------------------------------------------------
+
+@websocket_api.websocket_command({
+    vol.Required("type"): WS_ADD_PENALTY,
+    vol.Required("name"): vol.All(str, vol.Length(min=1, max=200)),
+    vol.Required("points"): vol.All(int, vol.Range(min=1)),
+    vol.Optional("description", default=""): str,
+    vol.Optional("icon", default="mdi:alert-circle-outline"): str,
+    vol.Optional("assigned_to", default=[]): [str],
+})
+@websocket_api.async_response
+@_admin_only
+async def _ws_add_penalty(hass, connection, msg, coordinator):
+    pen = await coordinator.async_add_penalty(
+        name=msg["name"].strip(),
+        points=msg["points"],
+        description=msg.get("description", ""),
+        icon=msg.get("icon", "mdi:alert-circle-outline"),
+        assigned_to=list(msg.get("assigned_to", []) or []),
+    )
+    connection.send_result(msg["id"], {"id": pen.id})
+
+
+@websocket_api.websocket_command({
+    vol.Required("type"): WS_UPDATE_PENALTY,
+    vol.Required("penalty_id"): str,
+    vol.Optional("name"): vol.All(str, vol.Length(min=1, max=200)),
+    vol.Optional("points"): vol.All(int, vol.Range(min=1)),
+    vol.Optional("description"): str,
+    vol.Optional("icon"): str,
+    vol.Optional("assigned_to"): [str],
+})
+@websocket_api.async_response
+@_admin_only
+async def _ws_update_penalty(hass, connection, msg, coordinator):
+    existing = coordinator.storage.get_penalty(msg["penalty_id"])
+    if not existing:
+        connection.send_error(msg["id"], "not_found", f"Penalty {msg['penalty_id']} not found")
+        return
+    for k in ("name", "points", "description", "icon", "assigned_to"):
+        if k in msg:
+            val = msg[k]
+            if k == "name" and val:
+                val = val.strip()
+            if k == "assigned_to":
+                val = list(val)
+            setattr(existing, k, val)
+    await coordinator.async_update_penalty(existing)
+    connection.send_result(msg["id"], {"id": existing.id})
+
+
+@websocket_api.websocket_command({
+    vol.Required("type"): WS_REMOVE_PENALTY,
+    vol.Required("penalty_id"): str,
+})
+@websocket_api.async_response
+@_admin_only
+async def _ws_remove_penalty(hass, connection, msg, coordinator):
+    if not coordinator.storage.get_penalty(msg["penalty_id"]):
+        connection.send_error(msg["id"], "not_found", f"Penalty {msg['penalty_id']} not found")
+        return
+    await coordinator.async_remove_penalty(msg["penalty_id"])
+    connection.send_result(msg["id"], {"id": msg["penalty_id"]})
+
+
+@websocket_api.websocket_command({
+    vol.Required("type"): WS_APPLY_PENALTY,
+    vol.Required("penalty_id"): str,
+    vol.Required("child_id"): str,
+})
+@websocket_api.async_response
+@_admin_only
+async def _ws_apply_penalty(hass, connection, msg, coordinator):
+    await coordinator.async_apply_penalty(
+        penalty_id=msg["penalty_id"], child_id=msg["child_id"]
+    )
+    connection.send_result(msg["id"], {"penalty_id": msg["penalty_id"], "child_id": msg["child_id"]})
+
+
+# ---------------------------------------------------------------------------
+# Bonuses (mirror of penalties)
+# ---------------------------------------------------------------------------
+
+@websocket_api.websocket_command({
+    vol.Required("type"): WS_ADD_BONUS,
+    vol.Required("name"): vol.All(str, vol.Length(min=1, max=200)),
+    vol.Required("points"): vol.All(int, vol.Range(min=1)),
+    vol.Optional("description", default=""): str,
+    vol.Optional("icon", default="mdi:star-circle-outline"): str,
+    vol.Optional("assigned_to", default=[]): [str],
+})
+@websocket_api.async_response
+@_admin_only
+async def _ws_add_bonus(hass, connection, msg, coordinator):
+    b = await coordinator.async_add_bonus(
+        name=msg["name"].strip(),
+        points=msg["points"],
+        description=msg.get("description", ""),
+        icon=msg.get("icon", "mdi:star-circle-outline"),
+        assigned_to=list(msg.get("assigned_to", []) or []),
+    )
+    connection.send_result(msg["id"], {"id": b.id})
+
+
+@websocket_api.websocket_command({
+    vol.Required("type"): WS_UPDATE_BONUS,
+    vol.Required("bonus_id"): str,
+    vol.Optional("name"): vol.All(str, vol.Length(min=1, max=200)),
+    vol.Optional("points"): vol.All(int, vol.Range(min=1)),
+    vol.Optional("description"): str,
+    vol.Optional("icon"): str,
+    vol.Optional("assigned_to"): [str],
+})
+@websocket_api.async_response
+@_admin_only
+async def _ws_update_bonus(hass, connection, msg, coordinator):
+    existing = coordinator.storage.get_bonus(msg["bonus_id"])
+    if not existing:
+        connection.send_error(msg["id"], "not_found", f"Bonus {msg['bonus_id']} not found")
+        return
+    for k in ("name", "points", "description", "icon", "assigned_to"):
+        if k in msg:
+            val = msg[k]
+            if k == "name" and val:
+                val = val.strip()
+            if k == "assigned_to":
+                val = list(val)
+            setattr(existing, k, val)
+    await coordinator.async_update_bonus(existing)
+    connection.send_result(msg["id"], {"id": existing.id})
+
+
+@websocket_api.websocket_command({
+    vol.Required("type"): WS_REMOVE_BONUS,
+    vol.Required("bonus_id"): str,
+})
+@websocket_api.async_response
+@_admin_only
+async def _ws_remove_bonus(hass, connection, msg, coordinator):
+    if not coordinator.storage.get_bonus(msg["bonus_id"]):
+        connection.send_error(msg["id"], "not_found", f"Bonus {msg['bonus_id']} not found")
+        return
+    await coordinator.async_remove_bonus(msg["bonus_id"])
+    connection.send_result(msg["id"], {"id": msg["bonus_id"]})
+
+
+@websocket_api.websocket_command({
+    vol.Required("type"): WS_APPLY_BONUS,
+    vol.Required("bonus_id"): str,
+    vol.Required("child_id"): str,
+})
+@websocket_api.async_response
+@_admin_only
+async def _ws_apply_bonus(hass, connection, msg, coordinator):
+    await coordinator.async_apply_bonus(bonus_id=msg["bonus_id"], child_id=msg["child_id"])
+    connection.send_result(msg["id"], {"bonus_id": msg["bonus_id"], "child_id": msg["child_id"]})
+
+
+# ---------------------------------------------------------------------------
+# Task groups
+# ---------------------------------------------------------------------------
+
+@websocket_api.websocket_command({
+    vol.Required("type"): WS_ADD_TASK_GROUP,
+    vol.Required("name"): vol.All(str, vol.Length(min=1, max=200)),
+    vol.Required("policy"): vol.In(["sticky", "spread"]),
+    vol.Optional("chore_ids", default=[]): [str],
+})
+@websocket_api.async_response
+@_admin_only
+async def _ws_add_task_group(hass, connection, msg, coordinator):
+    g = await coordinator.async_add_task_group(
+        name=msg["name"].strip(),
+        policy=msg["policy"],
+        chore_ids=list(msg.get("chore_ids", []) or []),
+    )
+    connection.send_result(msg["id"], {"id": g.id})
+
+
+@websocket_api.websocket_command({
+    vol.Required("type"): WS_UPDATE_TASK_GROUP,
+    vol.Required("group_id"): str,
+    vol.Optional("name"): vol.All(str, vol.Length(min=1, max=200)),
+    vol.Optional("policy"): vol.In(["sticky", "spread"]),
+    vol.Optional("chore_ids"): [str],
+})
+@websocket_api.async_response
+@_admin_only
+async def _ws_update_task_group(hass, connection, msg, coordinator):
+    g = await coordinator.async_update_task_group(
+        group_id=msg["group_id"],
+        name=msg["name"].strip() if "name" in msg else None,
+        policy=msg.get("policy"),
+        chore_ids=list(msg["chore_ids"]) if "chore_ids" in msg else None,
+    )
+    connection.send_result(msg["id"], {"id": g.id if g else msg["group_id"]})
+
+
+@websocket_api.websocket_command({
+    vol.Required("type"): WS_REMOVE_TASK_GROUP,
+    vol.Required("group_id"): str,
+})
+@websocket_api.async_response
+@_admin_only
+async def _ws_remove_task_group(hass, connection, msg, coordinator):
+    if not coordinator.storage.get_task_group(msg["group_id"]):
+        connection.send_error(msg["id"], "not_found", f"Group {msg['group_id']} not found")
+        return
+    await coordinator.async_remove_task_group(msg["group_id"])
+    connection.send_result(msg["id"], {"id": msg["group_id"]})
+
+
+# ---------------------------------------------------------------------------
+# Settings — partial update of currency + the "settings" subkey
+# ---------------------------------------------------------------------------
+
+# Top-level fields stored at storage._data root
+_TOP_LEVEL_SETTINGS = {"points_name", "points_icon"}
+# Settings stored under storage._data["settings"][key]
+_SUBKEY_SETTINGS = {
+    "history_days", "streak_reset_mode",
+    "weekend_multiplier", "streak_milestones_enabled", "perfect_week_enabled",
+    "perfect_week_bonus", "streak_milestones",
+    "notify_service", "calendar_projection_days",
+}
+
+@websocket_api.websocket_command({
+    vol.Required("type"): WS_UPDATE_SETTINGS,
+    vol.Optional("points_name"): vol.All(str, vol.Length(min=1, max=120)),
+    vol.Optional("points_icon"): str,
+    vol.Optional("history_days"): vol.All(int, vol.Range(min=30, max=365)),
+    vol.Optional("streak_reset_mode"): vol.In(["reset", "pause"]),
+    vol.Optional("weekend_multiplier"): vol.All(vol.Coerce(float), vol.Range(min=1.0, max=5.0)),
+    vol.Optional("streak_milestones_enabled"): bool,
+    vol.Optional("perfect_week_enabled"): bool,
+    vol.Optional("perfect_week_bonus"): vol.All(int, vol.Range(min=0)),
+    vol.Optional("streak_milestones"): str,
+    vol.Optional("notify_service"): str,
+    vol.Optional("calendar_projection_days"): vol.All(int, vol.Range(min=1, max=90)),
+})
+@websocket_api.async_response
+@_admin_only
+async def _ws_update_settings(hass, connection, msg, coordinator):
+    storage = coordinator.storage
+    changed = []
+    for k, v in msg.items():
+        if k in {"id", "type"}:
+            continue
+        if k == "points_name":
+            storage.set_points_name(v.strip())
+            changed.append(k)
+        elif k == "points_icon":
+            storage.set_points_icon(v or "mdi:star")
+            changed.append(k)
+        elif k in _SUBKEY_SETTINGS:
+            storage.set_setting(k, v)
+            changed.append(k)
+    if changed:
+        await storage.async_save()
+        await coordinator.async_refresh()
+    connection.send_result(msg["id"], {"updated": changed})
+
+
+# ---------------------------------------------------------------------------
 # Registration
 # ---------------------------------------------------------------------------
+
+_COMMANDS = (
+    _ws_get_state,
+    _ws_add_child, _ws_update_child, _ws_remove_child,
+    _ws_add_chore, _ws_update_chore, _ws_remove_chore,
+    _ws_add_reward, _ws_update_reward, _ws_remove_reward,
+    _ws_add_penalty, _ws_update_penalty, _ws_remove_penalty, _ws_apply_penalty,
+    _ws_add_bonus, _ws_update_bonus, _ws_remove_bonus, _ws_apply_bonus,
+    _ws_add_task_group, _ws_update_task_group, _ws_remove_task_group,
+    _ws_update_settings,
+)
+
 
 def async_register_websocket_commands(hass: HomeAssistant) -> None:
     """Register all TaskMate WebSocket commands. Idempotent."""
     if hass.data.get(DOMAIN, {}).get(WS_REGISTERED):
         _LOGGER.debug("TaskMate WS commands already registered, skipping")
         return
-    for handler in (
-        _ws_get_state,
-        _ws_add_child,
-        _ws_update_child,
-        _ws_remove_child,
-    ):
-        websocket_api.async_register_command(hass, handler)
+    for cmd in _COMMANDS:
+        websocket_api.async_register_command(hass, cmd)
     hass.data.setdefault(DOMAIN, {})[WS_REGISTERED] = True
-    _LOGGER.info("Registered TaskMate WebSocket commands")
+    _LOGGER.info("Registered %d TaskMate WebSocket commands", len(_COMMANDS))

--- a/custom_components/taskmate/websocket.py
+++ b/custom_components/taskmate/websocket.py
@@ -277,17 +277,29 @@ def _chore_payload_schema(*, require_name: bool):
     }
 
 
+async def _maybe_apply_manual_start(coordinator, chore_id: str, child_id: str | None) -> None:
+    """If a manual rotation start was supplied, apply it via the coordinator.
+
+    The coordinator handles the "alternating reorders the pool / random+balanced
+    is ephemeral" semantics; we just pass through. Silently ignored for
+    'everyone' mode chores (the coordinator raises ValueError).
+    """
+    if not child_id:
+        return
+    try:
+        await coordinator.async_set_chore_manual_start(chore_id, child_id)
+    except ValueError as err:
+        _LOGGER.debug("manual start ignored for %s: %s", chore_id, err)
+
+
 @websocket_api.websocket_command({
     vol.Required("type"): WS_ADD_CHORE,
+    vol.Optional("manual_start_child_id"): vol.Any(str, None),
     **_chore_payload_schema(require_name=True),
 })
 @websocket_api.async_response
 @_admin_only
 async def _ws_add_chore(hass, connection, msg, coordinator):
-    # The coordinator's async_add_chore signature accepts most of these fields
-    # natively, but a few (visibility_*, enabled, assignment_*, calendar) are
-    # set after creation by mutating the returned chore. Simpler path: build
-    # via async_add_chore for the bread-and-butter fields, then patch.
     chore = await coordinator.async_add_chore(
         name=msg["name"].strip(),
         points=msg.get("points", 10),
@@ -300,7 +312,6 @@ async def _ws_add_chore(hass, connection, msg, coordinator):
         completion_sound=msg.get("completion_sound", "coin"),
         schedule_mode=msg.get("schedule_mode", "specific_days"),
     )
-    # Apply any remaining editable fields and re-save.
     extra_fields = (set(msg.keys()) & _CHORE_EDITABLE_FIELDS) - {
         "name", "points", "description", "assigned_to", "requires_approval",
         "time_category", "claim_allowance_minutes", "daily_limit",
@@ -310,12 +321,14 @@ async def _ws_add_chore(hass, connection, msg, coordinator):
         for f in extra_fields:
             setattr(chore, f, msg[f] if not isinstance(msg[f], list) else list(msg[f]))
         await coordinator.async_update_chore(chore)
+    await _maybe_apply_manual_start(coordinator, chore.id, msg.get("manual_start_child_id"))
     connection.send_result(msg["id"], {"id": chore.id})
 
 
 @websocket_api.websocket_command({
     vol.Required("type"): WS_UPDATE_CHORE,
     vol.Required("chore_id"): str,
+    vol.Optional("manual_start_child_id"): vol.Any(str, None),
     **_chore_payload_schema(require_name=False),
 })
 @websocket_api.async_response
@@ -334,6 +347,7 @@ async def _ws_update_chore(hass, connection, msg, coordinator):
                 value = value.strip()
             setattr(existing, field, value)
     await coordinator.async_update_chore(existing)
+    await _maybe_apply_manual_start(coordinator, existing.id, msg.get("manual_start_child_id"))
     connection.send_result(msg["id"], {"id": existing.id})
 
 

--- a/custom_components/taskmate/www/taskmate-panel.js
+++ b/custom_components/taskmate/www/taskmate-panel.js
@@ -1,22 +1,20 @@
 /**
  * TaskMate admin panel — sidebar entry at /taskmate-admin.
  *
- * v3.5.0-alpha.8 — Shopify-grade theme + 8 new features:
- *   - Light theme rebuilt from scratch (warm off-white bg, crisp white
- *     cards, layered shadows, Inter typography). Dark theme retained.
- *   - Backdrop blur reduced from 16/12/8 to 2px throughout.
- *   - New "Activity" tab: approval queue (chores + rewards) + recent
- *     events feed + full points-transaction audit log.
- *   - Approval pill in app bar — shows pending count, jumps to Activity.
- *   - Search/filter input on Children, Chores, Rewards, Penalties,
- *     Bonuses, Groups tabs. Filters by name (case-insensitive).
- *   - Bulk add chores: textarea + shared settings, one WS call.
- *   - Reorder chores per child: drag-and-drop dialog.
- *   - Inline chore rename: double-click the name in the table.
- *   - Confirm-on-leave when dialogs have unsaved changes.
+ * v3.5.0-alpha.9 — sidebar layout + connection recovery:
+ *   - Left-rail navigation replaces horizontal tabs (grouped by section).
+ *     Horizontal tab row falls back automatically on narrow screens.
+ *   - Slim topbar: breadcrumbs, approval pill, version chip.
+ *   - Refined token system: light is the primary aesthetic (cleaner
+ *     #fafafa/#fff palette, sharper #2563eb accent, less roundness,
+ *     border-first instead of shadow-heavy). Dark inverted to match.
+ *   - Connection recovery: refetch state when WS reconnects after a
+ *     drop and when the tab becomes visible again. Fixes blank-panel
+ *     after the tab has been idle for a while.
+ *   - _fetchState retries once on transient failure.
  */
 
-const PANEL_VERSION = "3.5.0-alpha.8";
+const PANEL_VERSION = "3.5.0-alpha.9";
 
 const TABS = [
   { id: "children",  label: "Children" },
@@ -124,12 +122,27 @@ class TaskMatePanel extends HTMLElement {
     this._onDragStart = this._onDragStart.bind(this);
     this._onDragOver = this._onDragOver.bind(this);
     this._onDrop = this._onDrop.bind(this);
+    this._onVisibilityChange = this._onVisibilityChange.bind(this);
+    this._lastConnected = null;
   }
 
   set hass(value) {
     const first = this._hass === null;
+    const prevConnected = this._lastConnected;
     this._hass = value;
-    if (first) this._fetchState();
+    const connNow = !!(value && value.connection && value.connection.connected !== false);
+    this._lastConnected = connNow;
+
+    if (first) {
+      this._fetchState();
+    } else if (connNow && prevConnected === false) {
+      // WS reconnected after a drop — refetch so the panel reflects current state.
+      this._fetchState();
+    } else if (connNow && this._error) {
+      // Recover from a previous fetch failure (e.g. WS was mid-handshake earlier).
+      this._error = null;
+      this._fetchState();
+    }
     if (!this._rendered) this._render();
     this._bindHaPickers();
   }
@@ -148,6 +161,7 @@ class TaskMatePanel extends HTMLElement {
     this.addEventListener("dragstart", this._onDragStart);
     this.addEventListener("dragover", this._onDragOver);
     this.addEventListener("drop", this._onDrop);
+    document.addEventListener("visibilitychange", this._onVisibilityChange);
     if (!this._rendered) this._render();
   }
   disconnectedCallback() {
@@ -160,10 +174,18 @@ class TaskMatePanel extends HTMLElement {
     this.removeEventListener("dragstart", this._onDragStart);
     this.removeEventListener("dragover", this._onDragOver);
     this.removeEventListener("drop", this._onDrop);
+    document.removeEventListener("visibilitychange", this._onVisibilityChange);
+  }
+
+  _onVisibilityChange() {
+    if (document.visibilityState !== "visible") return;
+    if (!this._hass) return;
+    // Tab woke up — if we're showing an error or have no state, refetch.
+    if (this._error || !this._state) this._fetchState();
   }
 
   // ---- state -----------------------------------------------------------
-  async _fetchState() {
+  async _fetchState(_attempt = 0) {
     if (!this._hass) return;
     this._loading = true;
     this._render();
@@ -171,6 +193,13 @@ class TaskMatePanel extends HTMLElement {
       this._state = await this._hass.callWS({ type: "taskmate/get_state" });
       this._error = null;
     } catch (err) {
+      // Retry once after a short delay — covers the race where the WS is
+      // still mid-reconnect when we make the call.
+      if (_attempt < 1) {
+        this._loading = false;
+        await new Promise(r => setTimeout(r, 800));
+        return this._fetchState(_attempt + 1);
+      }
       this._error = (err && err.message) || String(err);
       this._state = null;
     } finally {
@@ -836,13 +865,15 @@ class TaskMatePanel extends HTMLElement {
     this.innerHTML = `
       ${this._styles()}
       <div class="tm-shell">
-        <div class="tm-bg-glow"></div>
-        ${this._appbar()}
-        ${this._tabstrip()}
-        ${this._approvalBanner()}
-        <div class="tm-body">
-          <div class="tm-body-inner">
-            ${this._renderBody()}
+        ${this._sidebar()}
+        <div class="tm-main">
+          ${this._topbar()}
+          ${this._mobileTabs()}
+          ${this._approvalBanner()}
+          <div class="tm-body">
+            <div class="tm-body-inner">
+              ${this._renderBody()}
+            </div>
           </div>
         </div>
         ${this._dialog ? this._renderDialog() : ""}
@@ -852,30 +883,7 @@ class TaskMatePanel extends HTMLElement {
     this._bindHaPickers();
   }
 
-  _appbar() {
-    const crumb = (TABS.find(t => t.id === this._activeTab) || {}).label || "";
-    const crumbLabel = (this._activeTab === "settings") ? "Settings" : crumb;
-    const pendingCount = this._state
-      ? (this._state.pending_completions || []).length + (this._state.pending_reward_claims || []).length
-      : 0;
-    return `
-      <div class="tm-appbar">
-        <div class="tm-appbar-icon">
-          <ha-icon icon="mdi:checkbox-marked-circle-plus-outline"></ha-icon>
-        </div>
-        <h1 class="tm-appbar-title">TaskMate <span class="tm-sep">/</span> <span class="tm-crumb">${this._esc(crumbLabel)}</span></h1>
-        ${pendingCount > 0 ? `
-          <button class="tm-approval-pill" data-act="switch-to-activity" title="${pendingCount} pending — click to review">
-            <span class="tm-approval-dot"></span>
-            ${pendingCount} pending
-          </button>
-        ` : ""}
-        <span class="tm-version-chip">v${PANEL_VERSION}</span>
-      </div>
-    `;
-  }
-
-  _tabstrip() {
+  _sidebarGroups() {
     const counts = this._state ? {
       children:  (this._state.children || []).length,
       activity:  (this._state.pending_completions || []).length + (this._state.pending_reward_claims || []).length,
@@ -885,15 +893,97 @@ class TaskMatePanel extends HTMLElement {
       bonuses:   (this._state.bonuses || []).length,
       groups:    (this._state.task_groups || []).length,
     } : {};
+    return [
+      { head: "Today", items: [
+        { id: "activity", label: "Activity", icon: "mdi:pulse" },
+      ]},
+      { head: "Manage", items: [
+        { id: "children",  label: "Children",  icon: "mdi:account-multiple" },
+        { id: "chores",    label: "Chores",    icon: "mdi:check-circle-outline" },
+        { id: "rewards",   label: "Rewards",   icon: "mdi:gift-outline" },
+        { id: "penalties", label: "Penalties", icon: "mdi:alert-circle-outline" },
+        { id: "bonuses",   label: "Bonuses",   icon: "mdi:flash-outline" },
+        { id: "groups",    label: "Groups",    icon: "mdi:layers-outline" },
+      ]},
+      { head: "System", items: [
+        { id: "settings", label: "Settings", icon: "mdi:cog-outline" },
+      ]},
+    ].map(g => ({
+      ...g,
+      items: g.items.map(it => ({ ...it, count: counts[it.id] }))
+    }));
+  }
+
+  _sidebar() {
+    const groups = this._sidebarGroups();
     return `
-      <nav class="tm-tabs">
-        ${TABS.map(t => {
-          const cnt = counts[t.id];
-          const showCount = cnt != null && cnt > 0;
-          const urgent = t.id === "activity" && cnt > 0;
+      <aside class="tm-sidebar">
+        <div class="tm-brand">
+          <div class="tm-brand-mark"><ha-icon icon="mdi:checkbox-marked-circle-plus-outline"></ha-icon></div>
+          <div class="tm-brand-text">
+            TaskMate
+            <small>v${PANEL_VERSION}</small>
+          </div>
+        </div>
+        <nav class="tm-nav">
+          ${groups.map(g => `
+            <div class="tm-nav-group">
+              <div class="tm-nav-head">${this._esc(g.head)}</div>
+              ${g.items.map(it => {
+                const active = it.id === this._activeTab;
+                const urgent = it.id === "activity" && it.count > 0;
+                const showCount = it.count != null && it.count > 0;
+                return `
+                  <button class="tm-nav-item ${active ? "tm-nav-active" : ""}" data-act="tab" data-tab="${it.id}">
+                    <span class="tm-nav-icon"><ha-icon icon="${it.icon}"></ha-icon></span>
+                    <span class="tm-nav-label">${this._esc(it.label)}</span>
+                    ${showCount ? `<span class="tm-nav-badge ${urgent ? "tm-nav-badge-urgent" : ""}">${it.count}</span>` : ""}
+                  </button>
+                `;
+              }).join("")}
+            </div>
+          `).join("")}
+        </nav>
+      </aside>
+    `;
+  }
+
+  _topbar() {
+    const crumb = this._sidebarGroups()
+      .flatMap(g => g.items)
+      .find(i => i.id === this._activeTab);
+    const crumbLabel = crumb ? crumb.label : "";
+    const pendingCount = this._state
+      ? (this._state.pending_completions || []).length + (this._state.pending_reward_claims || []).length
+      : 0;
+    return `
+      <div class="tm-topbar">
+        <div class="tm-crumbs">
+          <span class="tm-crumbs-root">TaskMate</span>
+          <span class="tm-crumbs-sep">/</span>
+          <strong>${this._esc(crumbLabel)}</strong>
+        </div>
+        ${pendingCount > 0 && this._activeTab !== "activity" ? `
+          <button class="tm-approval-pill" data-act="switch-to-activity" title="${pendingCount} pending — click to review">
+            <span class="tm-approval-dot"></span>
+            ${pendingCount} pending
+          </button>
+        ` : ""}
+      </div>
+    `;
+  }
+
+  _mobileTabs() {
+    const groups = this._sidebarGroups();
+    return `
+      <nav class="tm-mobile-tabs">
+        ${groups.flatMap(g => g.items).map(it => {
+          const active = it.id === this._activeTab;
+          const urgent = it.id === "activity" && it.count > 0;
+          const showCount = it.count != null && it.count > 0;
           return `
-            <button class="tm-tab ${t.id === this._activeTab ? "tm-tab-active" : ""}" data-act="tab" data-tab="${t.id}" ${t.title ? `title="${t.title}"` : ""}>
-              ${this._esc(t.label)}${showCount ? `<span class="tm-tab-pill ${urgent ? "tm-tab-pill-urgent" : ""}">${cnt}</span>` : ""}
+            <button class="tm-mtab ${active ? "tm-mtab-active" : ""}" data-act="tab" data-tab="${it.id}">
+              ${this._esc(it.label)}${showCount ? `<span class="tm-mtab-pill ${urgent ? "tm-mtab-pill-urgent" : ""}">${it.count}</span>` : ""}
             </button>
           `;
         }).join("")}
@@ -1866,211 +1956,290 @@ class TaskMatePanel extends HTMLElement {
       taskmate-panel {
         display: block; height: 100%;
 
-        /* ===== Default token set (DARK) — overridden in light @media below */
-        --tm-bg:           var(--primary-background-color, #08090b);
-        --tm-text:         var(--primary-text-color,        #f4f5f7);
-        --tm-text-muted:   var(--secondary-text-color,      #a8aeb8);
-        --tm-text-faint:   var(--disabled-text-color,       #6b7280);
-        --tm-text-vfaint:  color-mix(in srgb, var(--tm-text), transparent 70%);
+        /* ===== Light is the default ===== */
+        --tm-bg:            #fafafa;
+        --tm-surface-0:     #ffffff;
+        --tm-surface-1:     #ffffff;
+        --tm-surface-2:     #f5f5f5;
+        --tm-surface-3:     #ebebeb;
+        --tm-surface-hover: #f5f5f5;
 
-        --tm-accent:       var(--primary-color,             #5eb1ff);
-        --tm-accent-press: color-mix(in srgb, var(--tm-accent), black 12%);
-        --tm-accent-soft:  color-mix(in srgb, var(--tm-accent), transparent 88%);
-        --tm-accent-glow:  color-mix(in srgb, var(--tm-accent), transparent 78%);
+        --tm-border:        #e5e5e5;
+        --tm-border-strong: #d4d4d4;
+        --tm-border-soft:   #ededed;
 
-        --tm-surface-0: color-mix(in srgb, var(--tm-bg), var(--tm-text) 3%);
-        --tm-surface-1: color-mix(in srgb, var(--tm-bg), var(--tm-text) 5%);
-        --tm-surface-2: color-mix(in srgb, var(--tm-bg), var(--tm-text) 9%);
-        --tm-surface-3: color-mix(in srgb, var(--tm-bg), var(--tm-text) 13%);
-        --tm-surface-hover: color-mix(in srgb, var(--tm-bg), var(--tm-text) 7%);
+        --tm-text:          #0a0a0a;
+        --tm-text-muted:    #525252;
+        --tm-text-faint:    #737373;
+        --tm-text-vfaint:   #a3a3a3;
 
-        --tm-border:        color-mix(in srgb, var(--tm-text), transparent 92%);
-        --tm-border-strong: color-mix(in srgb, var(--tm-text), transparent 86%);
-        --tm-border-soft:   color-mix(in srgb, var(--tm-text), transparent 95%);
+        --tm-accent:        #2563eb;
+        --tm-accent-hover:  #1d4ed8;
+        --tm-accent-press:  #1e40af;
+        --tm-accent-soft:   #eff6ff;
+        --tm-accent-border: #bfdbfe;
+        --tm-accent-text:   #1e40af;
+        --tm-accent-glow:   rgba(37,99,235,0.15);
 
-        --tm-positive:     var(--success-color,             #4ade80);
-        --tm-positive-soft: color-mix(in srgb, var(--tm-positive), transparent 90%);
-        --tm-warning:      var(--warning-color,             #fbbf24);
-        --tm-warning-soft: color-mix(in srgb, var(--tm-warning), transparent 90%);
-        --tm-danger:       var(--error-color,               #f87171);
-        --tm-danger-soft:  color-mix(in srgb, var(--tm-danger), transparent 90%);
+        --tm-positive:      #16a34a;
+        --tm-positive-soft: #f0fdf4;
+        --tm-positive-border:#bbf7d0;
+        --tm-warning:       #d97706;
+        --tm-warning-soft:  #fffbeb;
+        --tm-warning-border:#fde68a;
+        --tm-danger:        #dc2626;
+        --tm-danger-soft:   #fef2f2;
+        --tm-danger-border: #fecaca;
 
-        --tm-gold:   #f5b300;
-        --tm-pool:   #fb923c;
-        --tm-sticky: #c084fc;
+        --tm-gold:          #ca8a04;
+        --tm-gold-soft:     #fefce8;
+        --tm-pool:          #c2410c;
+        --tm-pool-soft:     #fff7ed;
+        --tm-sticky:        #7c3aed;
+        --tm-sticky-soft:   #f5f3ff;
 
-        --tm-radius-sm: 8px;
-        --tm-radius:    12px;
-        --tm-radius-lg: 16px;
+        --tm-radius-sm:     6px;
+        --tm-radius:        8px;
+        --tm-radius-lg:     12px;
 
-        --tm-shadow-sm: 0 1px 2px rgba(0,0,0,0.18);
-        --tm-shadow:    0 4px 12px rgba(0,0,0,0.22);
-        --tm-shadow-lg: 0 24px 48px -12px rgba(0,0,0,0.40);
-        --tm-easing:    cubic-bezier(0.16, 1, 0.3, 1);
+        --tm-shadow-xs:     0 1px 2px rgba(0,0,0,0.04);
+        --tm-shadow-sm:     0 1px 3px rgba(0,0,0,0.06), 0 1px 2px rgba(0,0,0,0.04);
+        --tm-shadow:        0 4px 12px rgba(0,0,0,0.06), 0 1px 3px rgba(0,0,0,0.04);
+        --tm-shadow-lg:     0 24px 48px -12px rgba(0,0,0,0.18), 0 8px 16px -4px rgba(0,0,0,0.06);
+        --tm-shadow-focus:  0 0 0 3px var(--tm-accent-glow);
+        --tm-easing:        cubic-bezier(0.16, 1, 0.3, 1);
+
+        --tm-sidebar-w:     240px;
 
         background: var(--tm-bg);
         color: var(--tm-text);
-        font-family: var(--paper-font-body1_-_font-family,
-                     -apple-system, BlinkMacSystemFont, "Inter", "SF Pro Display",
+        font-family: "Inter", var(--paper-font-body1_-_font-family,
+                     -apple-system, BlinkMacSystemFont, "SF Pro Text",
                      "Segoe UI", Roboto, sans-serif);
-        font-size: 14px;
+        font-size: 13px;
         line-height: 1.5;
-        letter-spacing: -0.005em;
+        letter-spacing: -0.003em;
         -webkit-font-smoothing: antialiased;
         -moz-osx-font-smoothing: grayscale;
-        font-feature-settings: "cv11", "ss01", "ss03";
+        font-feature-settings: "cv11", "ss01";
       }
 
-      /* ===== LIGHT theme — Shopify Polaris-inspired explicit overrides ===== */
-      @media (prefers-color-scheme: light) {
+      /* ===== Dark theme override ===== */
+      @media (prefers-color-scheme: dark) {
         taskmate-panel {
-          --tm-bg:            #f6f7f9;
-          --tm-text:          #1a1c1f;
-          --tm-text-muted:    #4b5563;
-          --tm-text-faint:    #6b7280;
-          --tm-text-vfaint:   #9ca3af;
+          --tm-bg:            #0a0a0a;
+          --tm-surface-0:     #111111;
+          --tm-surface-1:     #161616;
+          --tm-surface-2:     #1c1c1c;
+          --tm-surface-3:     #242424;
+          --tm-surface-hover: #1c1c1c;
 
-          /* Crisp white cards on warm off-white bg */
-          --tm-surface-0:     #ffffff;
-          --tm-surface-1:     #ffffff;
-          --tm-surface-2:     #f3f4f6;
-          --tm-surface-3:     #e5e7eb;
-          --tm-surface-hover: #fafbfc;
+          --tm-border:        #262626;
+          --tm-border-strong: #333333;
+          --tm-border-soft:   #1f1f1f;
 
-          --tm-border:        #e5e7eb;
-          --tm-border-strong: #d1d5db;
-          --tm-border-soft:   #f1f3f5;
+          --tm-text:          #fafafa;
+          --tm-text-muted:    #a3a3a3;
+          --tm-text-faint:    #737373;
+          --tm-text-vfaint:   #525252;
 
-          --tm-accent-soft:   color-mix(in srgb, var(--tm-accent), white 88%);
-          --tm-accent-glow:   color-mix(in srgb, var(--tm-accent), transparent 80%);
+          --tm-accent:        #60a5fa;
+          --tm-accent-hover:  #93c5fd;
+          --tm-accent-press:  #3b82f6;
+          --tm-accent-soft:   rgba(96,165,250,0.10);
+          --tm-accent-border: rgba(96,165,250,0.25);
+          --tm-accent-text:   #93c5fd;
+          --tm-accent-glow:   rgba(96,165,250,0.20);
 
-          /* Crisp layered shadows in the Shopify Polaris style */
-          --tm-shadow-sm:     0 1px 0 rgba(15,15,15,0.04), 0 0 0 1px rgba(15,15,15,0.04);
-          --tm-shadow:        0 1px 3px rgba(15,15,15,0.05), 0 4px 12px rgba(15,15,15,0.04);
-          --tm-shadow-lg:     0 12px 32px -8px rgba(15,15,15,0.18);
+          --tm-positive:      #4ade80;
+          --tm-positive-soft: rgba(74,222,128,0.10);
+          --tm-positive-border:rgba(74,222,128,0.25);
+          --tm-warning:       #fbbf24;
+          --tm-warning-soft:  rgba(251,191,36,0.10);
+          --tm-warning-border:rgba(251,191,36,0.25);
+          --tm-danger:        #f87171;
+          --tm-danger-soft:   rgba(248,113,113,0.10);
+          --tm-danger-border: rgba(248,113,113,0.25);
+
+          --tm-gold:          #f5b300;
+          --tm-gold-soft:     rgba(245,179,0,0.10);
+          --tm-pool:          #fb923c;
+          --tm-pool-soft:     rgba(251,146,60,0.10);
+          --tm-sticky:        #c084fc;
+          --tm-sticky-soft:   rgba(192,132,252,0.10);
+
+          --tm-shadow-xs:     0 1px 2px rgba(0,0,0,0.4);
+          --tm-shadow-sm:     0 1px 3px rgba(0,0,0,0.4), 0 1px 2px rgba(0,0,0,0.3);
+          --tm-shadow:        0 4px 12px rgba(0,0,0,0.5), 0 1px 3px rgba(0,0,0,0.3);
+          --tm-shadow-lg:     0 24px 48px -12px rgba(0,0,0,0.7), 0 8px 16px -4px rgba(0,0,0,0.3);
         }
       }
 
-      .tm-shell { display: flex; flex-direction: column; height: 100%; position: relative; overflow: hidden; }
-      .tm-bg-glow {
-        position: absolute; inset: 0;
-        background:
-          radial-gradient(900px 600px at 90% -10%, color-mix(in srgb, var(--tm-accent), transparent 92%), transparent 60%),
-          radial-gradient(700px 500px at -10% 110%, color-mix(in srgb, var(--tm-sticky), transparent 94%), transparent 60%);
-        pointer-events: none;
-      }
-
-      /* App bar */
-      .tm-appbar {
-        position: relative; z-index: 5;
-        height: 56px; padding: 0 24px;
-        display: flex; align-items: center; gap: 14px;
-        flex-shrink: 0;
-        border-bottom: 1px solid var(--tm-border);
-        background: color-mix(in srgb, var(--tm-bg), transparent 14%);
-        backdrop-filter: blur(2px);
-        -webkit-backdrop-filter: blur(2px);
-      }
-      .tm-appbar-icon {
-        width: 32px; height: 32px;
-        background: linear-gradient(135deg, var(--tm-accent), var(--tm-accent-press));
-        border-radius: 9px;
-        display: grid; place-items: center;
-        color: white;
-        box-shadow: 0 2px 8px var(--tm-accent-glow);
-      }
-      .tm-appbar-icon ha-icon { --mdc-icon-size: 18px; }
-      .tm-appbar-title {
-        margin: 0; font-size: 16px; font-weight: 600;
-        letter-spacing: -0.015em;
-        flex: 1;
-      }
-      .tm-sep   { color: var(--tm-text-vfaint); font-weight: 400; margin: 0 8px; }
-      .tm-crumb { color: var(--tm-text-muted); font-weight: 500; }
-      .tm-version-chip {
-        background: var(--tm-surface-2);
-        color: var(--tm-text-muted);
-        font-family: ui-monospace, "SF Mono", Menlo, monospace;
-        font-size: 11px;
-        padding: 4px 10px;
-        border-radius: 999px;
-        border: 1px solid var(--tm-border);
-      }
-      .tm-approval-pill {
-        background: var(--tm-warning-soft);
-        color: var(--tm-warning);
-        border: 1px solid color-mix(in srgb, var(--tm-warning), transparent 70%);
-        padding: 5px 12px 5px 10px;
-        border-radius: 999px;
-        font-size: 12px; font-weight: 600;
-        cursor: pointer;
-        font-family: inherit;
-        display: inline-flex; align-items: center; gap: 6px;
-        transition: all 0.12s var(--tm-easing);
-      }
-      .tm-approval-pill:hover { background: color-mix(in srgb, var(--tm-warning), transparent 80%); transform: translateY(-1px); }
-      .tm-approval-dot {
-        width: 8px; height: 8px; border-radius: 50%;
-        background: var(--tm-warning);
-        box-shadow: 0 0 8px var(--tm-warning);
-        animation: tm-pulse 2s ease-in-out infinite;
-      }
-      @keyframes tm-pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.45; } }
-
-      /* Tabs */
-      .tm-tabs {
-        position: relative; z-index: 4;
-        display: flex; padding: 0 16px;
-        border-bottom: 1px solid var(--tm-border);
-        background: color-mix(in srgb, var(--tm-bg), transparent 14%);
-        backdrop-filter: blur(2px);
-        -webkit-backdrop-filter: blur(2px);
-        overflow-x: auto; scrollbar-width: none;
-        flex-shrink: 0;
-      }
-      .tm-tabs::-webkit-scrollbar { display: none; }
-      .tm-tab {
+      /* ===== Shell ===== */
+      .tm-shell {
+        display: grid;
+        grid-template-columns: var(--tm-sidebar-w) 1fr;
+        height: 100%;
         position: relative;
-        background: transparent; border: 0;
-        color: var(--tm-text-faint);
+        overflow: hidden;
+      }
+      .tm-main { display: flex; flex-direction: column; min-width: 0; overflow: hidden; }
+
+      /* ===== Sidebar ===== */
+      .tm-sidebar {
+        background: var(--tm-surface-0);
+        border-right: 1px solid var(--tm-border);
+        display: flex; flex-direction: column;
+        overflow: hidden;
+      }
+      .tm-brand {
+        display: flex; align-items: center; gap: 10px;
         padding: 14px 16px;
+        border-bottom: 1px solid var(--tm-border-soft);
+      }
+      .tm-brand-mark {
+        width: 28px; height: 28px;
+        border-radius: 7px;
+        background: linear-gradient(135deg, var(--tm-accent), var(--tm-accent-press));
+        color: #fff;
+        display: grid; place-items: center;
+        flex-shrink: 0;
+        box-shadow: 0 1px 2px rgba(0,0,0,0.15), inset 0 1px 0 rgba(255,255,255,0.18);
+      }
+      .tm-brand-mark ha-icon { --mdc-icon-size: 16px; }
+      .tm-brand-text {
+        flex: 1; min-width: 0;
+        font-weight: 600; font-size: 14px;
+        letter-spacing: -0.01em;
+        line-height: 1.15;
+      }
+      .tm-brand-text small {
+        display: block;
+        font-weight: 400;
+        color: var(--tm-text-faint);
+        font-size: 11px;
+        font-family: ui-monospace, "SF Mono", "JetBrains Mono", Menlo, monospace;
+        margin-top: 1px;
+      }
+      .tm-nav {
+        padding: 10px 8px;
+        flex: 1;
+        overflow-y: auto;
+      }
+      .tm-nav-group { margin-bottom: 16px; }
+      .tm-nav-group:last-child { margin-bottom: 0; }
+      .tm-nav-head {
+        font-size: 10.5px;
+        font-weight: 600;
+        color: var(--tm-text-faint);
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+        padding: 4px 10px 6px;
+      }
+      .tm-nav-item {
+        display: flex; align-items: center; gap: 10px;
+        padding: 7px 10px;
+        border-radius: var(--tm-radius-sm);
+        color: var(--tm-text-muted);
         cursor: pointer;
-        font-size: 13px; font-weight: 500;
-        letter-spacing: -0.005em;
-        white-space: nowrap;
-        display: flex; align-items: center; gap: 6px;
+        font-size: 13px;
+        font-weight: 500;
         font-family: inherit;
-        transition: color 0.15s var(--tm-easing);
+        background: transparent; border: 0;
+        width: 100%; text-align: left;
+        position: relative;
+        transition: all 0.1s var(--tm-easing);
       }
-      .tm-tab:hover       { color: var(--tm-text); }
-      .tm-tab-active      { color: var(--tm-text); }
-      .tm-tab-active::after {
-        content: "";
-        position: absolute;
-        left: 16px; right: 16px; bottom: -1px;
-        height: 2px; border-radius: 2px 2px 0 0;
+      .tm-nav-item:hover { background: var(--tm-surface-2); color: var(--tm-text); }
+      .tm-nav-active {
+        background: var(--tm-surface-2);
+        color: var(--tm-text);
+        font-weight: 600;
+      }
+      .tm-nav-active::before {
+        content: ""; position: absolute;
+        left: -8px; top: 6px; bottom: 6px; width: 2px;
         background: var(--tm-accent);
+        border-radius: 0 2px 2px 0;
       }
-      .tm-tab-pill {
-        background: var(--tm-surface-2); color: var(--tm-text-muted);
-        font-size: 10px; font-weight: 600;
-        padding: 1px 7px; border-radius: 999px;
+      .tm-nav-icon {
+        width: 16px; height: 16px;
+        display: grid; place-items: center;
+        color: var(--tm-text-faint);
+        flex-shrink: 0;
+      }
+      .tm-nav-icon ha-icon { --mdc-icon-size: 16px; }
+      .tm-nav-active .tm-nav-icon { color: var(--tm-accent); }
+      .tm-nav-label { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; }
+      .tm-nav-badge {
+        font-size: 11px;
+        color: var(--tm-text-faint);
+        background: var(--tm-surface-3);
+        padding: 1px 7px;
+        border-radius: 999px;
+        font-variant-numeric: tabular-nums;
         line-height: 1.4;
       }
-      .tm-tab-active .tm-tab-pill { background: var(--tm-accent-soft); color: var(--tm-accent); }
-      .tm-tab-pill-urgent {
+      .tm-nav-active .tm-nav-badge {
+        background: var(--tm-accent-soft);
+        color: var(--tm-accent-text);
+      }
+      .tm-nav-badge-urgent {
         background: var(--tm-warning-soft) !important;
         color: var(--tm-warning) !important;
       }
 
+      /* ===== Topbar ===== */
+      .tm-topbar {
+        height: 52px;
+        display: flex; align-items: center; gap: 12px;
+        padding: 0 24px;
+        border-bottom: 1px solid var(--tm-border);
+        background: var(--tm-surface-0);
+        flex-shrink: 0;
+      }
+      .tm-crumbs {
+        display: flex; align-items: center; gap: 8px;
+        font-size: 13px;
+        color: var(--tm-text-faint);
+        flex: 1;
+      }
+      .tm-crumbs strong {
+        color: var(--tm-text);
+        font-weight: 600;
+        letter-spacing: -0.005em;
+      }
+      .tm-crumbs-sep { color: var(--tm-text-vfaint); }
+      .tm-approval-pill {
+        background: var(--tm-warning-soft);
+        color: var(--tm-warning);
+        border: 1px solid var(--tm-warning-border);
+        padding: 4px 12px 4px 10px;
+        border-radius: 999px;
+        font-size: 12px; font-weight: 500;
+        cursor: pointer;
+        font-family: inherit;
+        display: inline-flex; align-items: center; gap: 6px;
+        transition: all 0.1s var(--tm-easing);
+      }
+      .tm-approval-pill:hover { filter: brightness(0.97); }
+      .tm-approval-dot {
+        width: 6px; height: 6px; border-radius: 50%;
+        background: var(--tm-warning);
+        animation: tm-pulse 2s ease-in-out infinite;
+      }
+      @keyframes tm-pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.45; } }
+
+      /* ===== Mobile tabs (hidden by default, shown on narrow) ===== */
+      .tm-mobile-tabs { display: none; }
+
       /* Approval banner */
       .tm-approval-banner {
-        position: relative; z-index: 3;
         display: flex; align-items: center; gap: 12px;
         padding: 10px 24px;
         background: var(--tm-warning-soft);
-        border-bottom: 1px solid color-mix(in srgb, var(--tm-warning), transparent 70%);
-        color: color-mix(in srgb, var(--tm-warning), var(--tm-text) 50%);
+        border-bottom: 1px solid var(--tm-warning-border);
+        color: var(--tm-warning);
         font-size: 13px;
       }
       .tm-approval-banner ha-icon { --mdc-icon-size: 18px; color: var(--tm-warning); }
@@ -2078,19 +2247,20 @@ class TaskMatePanel extends HTMLElement {
       .tm-approval-banner strong { color: var(--tm-text); font-weight: 600; }
 
       /* Body */
-      .tm-body { flex: 1; overflow-y: auto; padding: 28px 32px 56px; position: relative; z-index: 1; }
-      .tm-body-inner { max-width: 1200px; margin: 0 auto; }
+      .tm-body { flex: 1; overflow-y: auto; padding: 24px 32px 56px; background: var(--tm-bg); }
+      .tm-body-inner { max-width: 1180px; margin: 0 auto; }
 
       /* Toolbar */
-      .tm-toolbar { display: flex; align-items: center; gap: 12px; margin-bottom: 24px; flex-wrap: wrap; }
+      .tm-toolbar { display: flex; align-items: center; gap: 10px; margin-bottom: 20px; flex-wrap: wrap; }
       .tm-toolbar-title {
-        margin: 0; font-size: 22px; font-weight: 600;
-        letter-spacing: -0.02em;
+        margin: 0; font-size: 20px; font-weight: 600;
+        letter-spacing: -0.018em;
       }
       .tm-toolbar-count {
         color: var(--tm-text-faint); font-weight: 400;
         margin-left: 6px;
-        font-feature-settings: "tnum";
+        font-variant-numeric: tabular-nums;
+        font-size: 16px;
       }
 
       /* Search input */
@@ -2100,32 +2270,34 @@ class TaskMatePanel extends HTMLElement {
       }
       .tm-search-icon {
         position: absolute; left: 10px; top: 50%; transform: translateY(-50%);
-        --mdc-icon-size: 16px; color: var(--tm-text-faint);
+        --mdc-icon-size: 14px; color: var(--tm-text-faint);
         pointer-events: none;
       }
       .tm-search {
         width: 100%;
-        background: var(--tm-surface-1);
+        background: var(--tm-surface-0);
         border: 1px solid var(--tm-border);
         border-radius: var(--tm-radius-sm);
-        padding: 8px 12px 8px 34px;
+        padding: 6px 10px 6px 32px;
         color: var(--tm-text);
         font-size: 13px;
         font-family: inherit;
-        transition: all 0.15s var(--tm-easing);
+        box-shadow: var(--tm-shadow-xs);
+        transition: all 0.1s var(--tm-easing);
       }
+      .tm-search:hover { border-color: var(--tm-border-strong); }
       .tm-search:focus {
         outline: 0;
         border-color: var(--tm-accent);
-        box-shadow: 0 0 0 3px var(--tm-accent-soft);
+        box-shadow: var(--tm-shadow-focus);
       }
-      .tm-search::placeholder { color: var(--tm-text-faint); }
+      .tm-search::placeholder { color: var(--tm-text-vfaint); }
       .tm-search-clear {
-        position: absolute; right: 8px; top: 50%; transform: translateY(-50%);
+        position: absolute; right: 6px; top: 50%; transform: translateY(-50%);
         background: var(--tm-surface-2);
         color: var(--tm-text-muted);
         border: 0;
-        width: 22px; height: 22px;
+        width: 20px; height: 20px;
         border-radius: 50%; cursor: pointer; font-size: 11px;
         display: grid; place-items: center;
       }
@@ -2133,59 +2305,73 @@ class TaskMatePanel extends HTMLElement {
 
       /* Buttons */
       .tm-btn {
-        background: linear-gradient(180deg, var(--tm-accent), var(--tm-accent-press));
-        color: white; border: 0;
-        padding: 8px 14px; border-radius: var(--tm-radius-sm);
+        background: var(--tm-accent);
+        color: white;
+        border: 1px solid var(--tm-accent);
+        padding: 6px 12px;
+        border-radius: var(--tm-radius-sm);
         font-size: 13px; font-weight: 500;
         letter-spacing: -0.005em;
         font-family: inherit;
         cursor: pointer;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.10), 0 0 0 1px rgba(255,255,255,0.06) inset;
-        transition: all 0.12s var(--tm-easing);
+        box-shadow: var(--tm-shadow-xs), inset 0 1px 0 rgba(255,255,255,0.15);
+        transition: all 0.1s var(--tm-easing);
         display: inline-flex; align-items: center; gap: 6px;
+        white-space: nowrap;
       }
-      .tm-btn:hover  { filter: brightness(1.08); transform: translateY(-1px); box-shadow: 0 2px 8px var(--tm-accent-glow), 0 0 0 1px rgba(255,255,255,0.06) inset; }
-      .tm-btn:active { transform: translateY(0); filter: brightness(0.95); }
-      .tm-btn-sm     { padding: 5px 10px; font-size: 12px; }
+      .tm-btn:hover  { background: var(--tm-accent-hover); border-color: var(--tm-accent-hover); }
+      .tm-btn:focus-visible { outline: 0; box-shadow: var(--tm-shadow-focus); }
+      .tm-btn:active { filter: brightness(0.95); }
+      .tm-btn-sm     { padding: 4px 9px; font-size: 12px; }
       .tm-btn-ghost {
-        background: var(--tm-surface-1);
+        background: var(--tm-surface-0);
         color: var(--tm-text);
-        box-shadow: 0 0 0 1px var(--tm-border) inset;
+        border: 1px solid var(--tm-border);
+        box-shadow: var(--tm-shadow-xs);
       }
-      .tm-btn-ghost:hover { background: var(--tm-surface-2); transform: translateY(-1px); }
+      .tm-btn-ghost:hover {
+        background: var(--tm-surface-2);
+        border-color: var(--tm-border-strong);
+        color: var(--tm-text);
+      }
       .tm-btn-danger {
-        background: transparent;
+        background: var(--tm-surface-0);
         color: var(--tm-danger);
-        box-shadow: 0 0 0 1px color-mix(in srgb, var(--tm-danger), transparent 75%) inset;
+        border: 1px solid var(--tm-danger-border);
+        box-shadow: var(--tm-shadow-xs);
       }
-      .tm-btn-danger:hover { background: var(--tm-danger-soft); transform: translateY(-1px); }
+      .tm-btn-danger:hover {
+        background: var(--tm-danger);
+        color: #fff;
+        border-color: var(--tm-danger);
+      }
       .tm-icon-btn {
-        width: 32px; height: 32px;
+        width: 28px; height: 28px;
         border: 0; background: transparent;
-        border-radius: 8px;
+        border-radius: var(--tm-radius-sm);
         display: grid; place-items: center;
-        color: var(--tm-text-muted);
-        font-size: 14px;
+        color: var(--tm-text-faint);
         cursor: pointer;
         font-family: inherit;
-        transition: all 0.12s var(--tm-easing);
+        transition: all 0.1s var(--tm-easing);
       }
+      .tm-icon-btn ha-icon { --mdc-icon-size: 16px; }
       .tm-icon-btn:hover { background: var(--tm-surface-2); color: var(--tm-text); }
 
       /* Cards */
-      .tm-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(320px, 1fr)); gap: 16px; }
+      .tm-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(320px, 1fr)); gap: 14px; }
       .tm-card {
         position: relative; overflow: hidden;
-        background: var(--tm-surface-1);
+        background: var(--tm-surface-0);
         border: 1px solid var(--tm-border);
-        border-radius: var(--tm-radius);
-        padding: 20px;
-        box-shadow: var(--tm-shadow-sm);
+        border-radius: var(--tm-radius-lg);
+        padding: 18px;
+        box-shadow: var(--tm-shadow-xs);
         transition: all 0.15s var(--tm-easing);
-        margin-bottom: 16px;
+        margin-bottom: 14px;
       }
       .tm-card:last-child { margin-bottom: 0; }
-      .tm-card:hover { border-color: var(--tm-border-strong); box-shadow: var(--tm-shadow); }
+      .tm-card:hover { border-color: var(--tm-border-strong); box-shadow: var(--tm-shadow-sm); }
       .tm-card-error { border-left: 3px solid var(--tm-danger); color: var(--tm-danger); }
       .tm-loading { color: var(--tm-text-muted); }
 
@@ -2197,70 +2383,79 @@ class TaskMatePanel extends HTMLElement {
       }
 
       /* Child / reward / group cards share head/avatar */
-      .tm-child-card { display: flex; flex-direction: column; gap: 16px; margin-bottom: 0; }
-      .tm-child-head { display: flex; align-items: center; gap: 14px; }
+      .tm-child-card { display: flex; flex-direction: column; gap: 14px; margin-bottom: 0; }
+      .tm-child-head { display: flex; align-items: center; gap: 12px; }
       .tm-avatar {
-        width: 48px; height: 48px;
-        border-radius: 14px;
-        background: linear-gradient(135deg, var(--tm-surface-3), var(--tm-surface-2));
+        width: 44px; height: 44px;
+        border-radius: 10px;
+        background: linear-gradient(135deg, var(--tm-accent-soft), var(--tm-surface-0));
+        border: 1px solid var(--tm-border);
         display: grid; place-items: center;
         flex-shrink: 0;
         color: var(--tm-accent);
-        box-shadow: 0 0 0 1px var(--tm-border) inset;
       }
-      .tm-avatar ha-icon { --mdc-icon-size: 26px; }
+      .tm-avatar ha-icon { --mdc-icon-size: 24px; }
       .tm-avatar-reward  { color: var(--tm-gold); }
       .tm-child-name { min-width: 0; flex: 1; }
-      .tm-child-name h3 { margin: 0; font-size: 16px; font-weight: 600; letter-spacing: -0.01em; }
+      .tm-child-name h3 { margin: 0; font-size: 15px; font-weight: 600; letter-spacing: -0.01em; }
       .tm-meta { color: var(--tm-text-faint); font-size: 12px; margin-top: 2px; word-break: break-word; }
       .tm-meta code { font-family: ui-monospace, "SF Mono", Menlo, monospace; background: var(--tm-surface-2); padding: 1px 6px; border-radius: 4px; font-size: 11px; color: var(--tm-text-muted); }
       .tm-text-muted { color: var(--tm-text-muted); }
 
-      .tm-stats-row { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 8px; }
+      .tm-stats-row {
+        display: grid;
+        grid-template-columns: 1fr 1fr 1fr;
+        gap: 1px;
+        background: var(--tm-border-soft);
+        border: 1px solid var(--tm-border-soft);
+        border-radius: var(--tm-radius);
+        overflow: hidden;
+      }
       .tm-stat {
-        background: var(--tm-surface-2);
-        border-radius: var(--tm-radius-sm);
+        background: var(--tm-surface-1);
         padding: 10px 12px;
-        box-shadow: 0 0 0 1px var(--tm-border-soft) inset;
       }
       .tm-stat-value {
-        font-size: 20px; font-weight: 600;
-        letter-spacing: -0.02em;
-        font-feature-settings: "tnum";
+        font-size: 17px; font-weight: 600;
+        letter-spacing: -0.01em;
+        font-variant-numeric: tabular-nums;
         color: var(--tm-text);
-        line-height: 1.1;
+        line-height: 1.15;
       }
       .tm-stat-label {
-        font-size: 10px; text-transform: uppercase; letter-spacing: 0.06em;
+        font-size: 11px;
         color: var(--tm-text-faint);
-        margin-top: 4px; font-weight: 500;
+        margin-top: 2px; font-weight: 400;
+        letter-spacing: 0.01em;
       }
-      .tm-stat-highlight .tm-stat-value { color: var(--tm-accent); }
+      .tm-stat-highlight .tm-stat-value { color: var(--tm-gold); }
 
       .tm-card-foot {
-        display: flex; gap: 8px;
+        display: flex; gap: 6px;
         margin-top: auto;
-        padding-top: 16px;
+        padding-top: 12px;
         border-top: 1px solid var(--tm-border-soft);
         flex-wrap: wrap;
+        align-items: center;
       }
 
       .tm-add-tile {
         background: transparent;
-        border: 1px dashed var(--tm-border-strong);
-        border-radius: var(--tm-radius);
+        border: 1.5px dashed var(--tm-border-strong);
+        border-radius: var(--tm-radius-lg);
         padding: 36px 18px;
         color: var(--tm-text-faint);
         text-align: center;
-        font-size: 13px;
+        font-size: 13px; font-weight: 500;
         cursor: pointer;
         font-family: inherit;
         display: grid; place-items: center; gap: 8px;
-        transition: all 0.15s var(--tm-easing);
+        transition: all 0.12s var(--tm-easing);
+        min-height: 200px;
       }
       .tm-add-tile:hover {
         border-color: var(--tm-accent);
-        color: var(--tm-accent);
+        color: var(--tm-accent-text);
         background: var(--tm-accent-soft);
       }
       .tm-add-plus {
@@ -2275,27 +2470,28 @@ class TaskMatePanel extends HTMLElement {
 
       /* Tables */
       .tm-table-wrap {
-        background: var(--tm-surface-1);
+        background: var(--tm-surface-0);
         border: 1px solid var(--tm-border);
-        border-radius: var(--tm-radius);
+        border-radius: var(--tm-radius-lg);
         overflow: hidden;
-        box-shadow: var(--tm-shadow-sm);
+        box-shadow: var(--tm-shadow-xs);
       }
-      .tm-table { width: 100%; border-collapse: collapse; }
+      .tm-table { width: 100%; border-collapse: collapse; font-size: 13px; }
       .tm-table th, .tm-table td {
-        text-align: left; padding: 12px 18px;
+        text-align: left;
+        padding: 11px 16px;
         border-bottom: 1px solid var(--tm-border-soft);
-        font-size: 13px;
+        vertical-align: middle;
       }
       .tm-table th {
         color: var(--tm-text-faint);
-        font-weight: 500; font-size: 10px;
-        text-transform: uppercase; letter-spacing: 0.06em;
+        font-weight: 500; font-size: 11.5px;
+        text-transform: uppercase; letter-spacing: 0.02em;
         background: var(--tm-surface-2);
         border-bottom: 1px solid var(--tm-border);
       }
       .tm-table tr:last-child td { border-bottom: 0; }
-      .tm-row { transition: background 0.12s var(--tm-easing); }
+      .tm-row { transition: background 0.1s var(--tm-easing); }
       .tm-row:hover { background: var(--tm-surface-hover); }
       .tm-row-disabled { opacity: 0.5; }
       .tm-row-icon { display: inline-flex; vertical-align: middle; margin-right: 10px; opacity: 0.7; --mdc-icon-size: 18px; color: var(--tm-text-muted); }
@@ -2323,46 +2519,47 @@ class TaskMatePanel extends HTMLElement {
 
       /* Pills */
       .tm-pill {
-        display: inline-flex; align-items: center; gap: 4px;
+        display: inline-flex; align-items: center; gap: 5px;
         padding: 2px 8px; border-radius: 999px;
-        font-size: 11px; font-weight: 500;
+        font-size: 11.5px; font-weight: 500;
         line-height: 1.5;
         background: var(--tm-surface-2); color: var(--tm-text-muted);
+        border: 1px solid var(--tm-border);
         margin-left: 4px; vertical-align: middle;
       }
-      .tm-pill-accent  { background: var(--tm-accent-soft);   color: var(--tm-accent); }
-      .tm-pill-success { background: var(--tm-positive-soft); color: var(--tm-positive); }
-      .tm-pill-warn    { background: var(--tm-warning-soft);  color: var(--tm-warning); }
-      .tm-pill-danger  { background: var(--tm-danger-soft);   color: var(--tm-danger); }
-      .tm-pill-pool    { background: color-mix(in srgb, var(--tm-pool), transparent 90%); color: var(--tm-pool); }
-      .tm-pill-sticky  { background: color-mix(in srgb, var(--tm-sticky), transparent 90%); color: var(--tm-sticky); }
-      .tm-pill-spread  { background: var(--tm-positive-soft); color: var(--tm-positive); }
-      .tm-pill-jackpot { background: color-mix(in srgb, var(--tm-gold), transparent 88%); color: var(--tm-gold); }
-      .tm-pill-alternating, .tm-pill-random, .tm-pill-balanced { background: var(--tm-accent-soft); color: var(--tm-accent); }
+      .tm-pill-accent  { background: var(--tm-accent-soft);   color: var(--tm-accent-text); border-color: var(--tm-accent-border); }
+      .tm-pill-success { background: var(--tm-positive-soft); color: var(--tm-positive);    border-color: var(--tm-positive-border); }
+      .tm-pill-warn    { background: var(--tm-warning-soft);  color: var(--tm-warning);     border-color: var(--tm-warning-border); }
+      .tm-pill-danger  { background: var(--tm-danger-soft);   color: var(--tm-danger);      border-color: var(--tm-danger-border); }
+      .tm-pill-pool    { background: var(--tm-pool-soft);     color: var(--tm-pool);        border-color: color-mix(in srgb, var(--tm-pool), transparent 75%); }
+      .tm-pill-sticky  { background: var(--tm-sticky-soft);   color: var(--tm-sticky);      border-color: color-mix(in srgb, var(--tm-sticky), transparent 75%); }
+      .tm-pill-spread  { background: var(--tm-positive-soft); color: var(--tm-positive);    border-color: var(--tm-positive-border); }
+      .tm-pill-jackpot { background: var(--tm-gold-soft);     color: var(--tm-gold);        border-color: color-mix(in srgb, var(--tm-gold), transparent 75%); }
+      .tm-pill-alternating, .tm-pill-random, .tm-pill-balanced { background: var(--tm-accent-soft); color: var(--tm-accent-text); border-color: var(--tm-accent-border); }
       .tm-pill-dot::before {
         content: ""; width: 5px; height: 5px; border-radius: 50%;
         background: currentColor;
       }
 
       /* Reward extras */
-      .tm-reward-card { display: flex; flex-direction: column; gap: 14px; margin-bottom: 0; }
+      .tm-reward-card { display: flex; flex-direction: column; gap: 12px; margin-bottom: 0; }
       .tm-progress {
-        height: 6px;
+        height: 8px;
         background: var(--tm-surface-2);
         border-radius: 999px;
         overflow: hidden;
         margin-top: 4px;
-        box-shadow: 0 0 0 1px var(--tm-border-soft) inset;
+        border: 1px solid var(--tm-border-soft);
       }
       .tm-progress > span {
         display: block; height: 100%;
-        background: linear-gradient(90deg, var(--tm-accent), color-mix(in srgb, var(--tm-accent), white 25%));
+        background: linear-gradient(90deg, var(--tm-accent), var(--tm-sticky));
         border-radius: 999px;
       }
       .tm-progress-text {
-        font-size: 12px; color: var(--tm-text-muted);
+        font-size: 12px; color: var(--tm-text-faint);
         display: flex; justify-content: space-between;
-        font-feature-settings: "tnum";
+        font-variant-numeric: tabular-nums;
         margin-top: 6px;
       }
       .tm-progress-text strong { color: var(--tm-text); font-weight: 600; }
@@ -2370,22 +2567,22 @@ class TaskMatePanel extends HTMLElement {
       /* Empty state */
       .tm-empty {
         text-align: center;
-        padding: 64px 24px;
-        background: var(--tm-surface-1);
+        padding: 56px 24px;
+        background: var(--tm-surface-0);
         border: 1px dashed var(--tm-border-strong);
-        border-radius: var(--tm-radius);
+        border-radius: var(--tm-radius-lg);
       }
       .tm-empty-icon {
-        width: 56px; height: 56px;
-        border-radius: 16px;
+        width: 48px; height: 48px;
+        border-radius: 12px;
         background: var(--tm-surface-2);
         display: inline-grid; place-items: center;
-        font-size: 26px;
-        margin-bottom: 16px;
-        box-shadow: 0 0 0 1px var(--tm-border) inset;
+        font-size: 22px;
+        margin-bottom: 12px;
+        border: 1px solid var(--tm-border);
       }
-      .tm-empty h3 { margin: 0 0 6px; font-size: 16px; font-weight: 600; letter-spacing: -0.01em; }
-      .tm-empty p  { margin: 0 0 20px; color: var(--tm-text-muted); font-size: 13px; }
+      .tm-empty h3 { margin: 0 0 4px; font-size: 14px; font-weight: 600; letter-spacing: -0.005em; color: var(--tm-text); }
+      .tm-empty p  { margin: 0 0 16px; color: var(--tm-text-muted); font-size: 13px; max-width: 360px; margin-left: auto; margin-right: auto; }
 
       /* Group list */
       .tm-group-list { margin: 8px 0 0; padding-left: 20px; color: var(--tm-text-muted); font-size: 13px; }
@@ -2438,101 +2635,102 @@ class TaskMatePanel extends HTMLElement {
       /* Settings */
       .tm-settings { display: flex; flex-direction: column; gap: 16px; }
       .tm-section {
-        background: var(--tm-surface-1);
+        background: var(--tm-surface-0);
         border: 1px solid var(--tm-border);
-        border-radius: var(--tm-radius);
+        border-radius: var(--tm-radius-lg);
         overflow: hidden;
-        box-shadow: var(--tm-shadow-sm);
+        box-shadow: var(--tm-shadow-xs);
       }
       .tm-section-head {
-        padding: 16px 20px;
-        border-bottom: 1px solid var(--tm-border-soft);
+        padding: 16px 20px 12px;
       }
-      .tm-section-head h3 { margin: 0 0 2px; font-size: 14px; font-weight: 600; letter-spacing: -0.005em; }
-      .tm-section-head p  { margin: 0; color: var(--tm-text-faint); font-size: 12px; }
-      .tm-section-body { padding: 8px 20px 16px; }
+      .tm-section-head h3 { margin: 0 0 3px; font-size: 14px; font-weight: 600; letter-spacing: -0.005em; }
+      .tm-section-head p  { margin: 0; color: var(--tm-text-faint); font-size: 12.5px; }
+      .tm-section-body { padding: 0; }
       .tm-setting-row {
-        display: grid; grid-template-columns: 240px 1fr;
-        gap: 24px; align-items: center;
-        padding: 12px 0;
-        border-bottom: 1px solid var(--tm-border-soft);
+        display: grid; grid-template-columns: 280px 1fr;
+        gap: 20px; align-items: center;
+        padding: 14px 20px;
+        border-top: 1px solid var(--tm-border-soft);
       }
-      .tm-setting-row:last-child { border-bottom: 0; }
+      .tm-setting-row:first-child { border-top: 0; }
       .tm-setting-label { color: var(--tm-text); font-size: 13px; font-weight: 500; }
       .tm-setting-label small { display: block; color: var(--tm-text-faint); font-weight: 400; font-size: 12px; margin-top: 2px; }
       .tm-setting-row input[type=text],
       .tm-setting-row input[type=number],
       .tm-setting-row select {
-        background: var(--tm-surface-1);
+        background: var(--tm-surface-0);
         border: 1px solid var(--tm-border);
         border-radius: var(--tm-radius-sm);
-        padding: 8px 12px;
+        padding: 6px 10px;
         color: var(--tm-text);
         font-size: 13px;
         font-family: inherit;
         max-width: 360px;
-        transition: all 0.15s var(--tm-easing);
+        box-shadow: var(--tm-shadow-xs);
+        transition: all 0.1s var(--tm-easing);
       }
       .tm-setting-row input:focus, .tm-setting-row select:focus {
         outline: 0;
         border-color: var(--tm-accent);
-        box-shadow: 0 0 0 3px var(--tm-accent-soft);
+        box-shadow: var(--tm-shadow-focus);
       }
       .tm-settings-foot {
         display: flex; justify-content: flex-end;
         padding-top: 8px;
       }
 
-      /* iOS-style switch */
+      /* Switch */
       .tm-switch {
         position: relative; display: inline-block;
-        width: 44px; height: 26px; flex-shrink: 0;
+        width: 34px; height: 20px; flex-shrink: 0;
       }
       .tm-switch input { opacity: 0; width: 0; height: 0; }
       .tm-slider {
         position: absolute; inset: 0;
-        background: var(--tm-surface-3);
+        background: var(--tm-border-strong);
         border-radius: 999px;
-        transition: background 0.2s var(--tm-easing);
+        transition: background 0.15s var(--tm-easing);
         cursor: pointer;
-        box-shadow: 0 0 0 1px var(--tm-border) inset;
       }
       .tm-slider::before {
         content: ''; position: absolute;
-        height: 20px; width: 20px;
-        left: 3px; top: 3px;
+        height: 16px; width: 16px;
+        left: 2px; top: 2px;
         background: white; border-radius: 50%;
-        transition: transform 0.2s var(--tm-easing);
-        box-shadow: 0 1px 3px rgba(0,0,0,0.2);
+        transition: transform 0.15s var(--tm-easing);
+        box-shadow: 0 1px 2px rgba(0,0,0,0.2);
       }
       .tm-switch input:checked + .tm-slider {
         background: var(--tm-accent);
-        box-shadow: 0 0 0 1px var(--tm-accent) inset;
       }
-      .tm-switch input:checked + .tm-slider::before { transform: translateX(18px); }
+      .tm-switch input:checked + .tm-slider::before { transform: translateX(14px); }
 
       /* Dialog */
       .tm-scrim {
         position: fixed; inset: 0;
-        background: color-mix(in srgb, var(--tm-bg), transparent 25%);
-        backdrop-filter: blur(2px);
-        -webkit-backdrop-filter: blur(2px);
+        background: rgba(10,10,10,0.4);
+        backdrop-filter: blur(4px);
+        -webkit-backdrop-filter: blur(4px);
         display: flex; align-items: flex-start; justify-content: center;
         padding: 60px 20px; z-index: 100;
         overflow-y: auto;
-        animation: tm-scrim-in 0.2s var(--tm-easing);
+        animation: tm-scrim-in 0.18s var(--tm-easing);
+      }
+      @media (prefers-color-scheme: dark) {
+        .tm-scrim { background: rgba(0,0,0,0.6); }
       }
       @keyframes tm-scrim-in { from { opacity: 0; } to { opacity: 1; } }
       .tm-dialog {
-        background: var(--tm-surface-1);
-        border: 1px solid var(--tm-border-strong);
+        background: var(--tm-surface-0);
+        border: 1px solid var(--tm-border);
         border-radius: var(--tm-radius-lg);
         width: 100%; max-width: 560px;
         box-shadow: var(--tm-shadow-lg);
         display: flex; flex-direction: column;
         max-height: calc(100vh - 120px);
         overflow: hidden;
-        animation: tm-dialog-in 0.25s var(--tm-easing);
+        animation: tm-dialog-in 0.2s var(--tm-easing);
       }
       @keyframes tm-dialog-in { from { opacity: 0; transform: translateY(8px) scale(0.985); } to { opacity: 1; transform: none; } }
 
@@ -2546,41 +2744,46 @@ class TaskMatePanel extends HTMLElement {
         letter-spacing: -0.01em;
         flex: 1;
       }
-      .tm-dialog-body { padding: 18px 22px; overflow-y: auto; }
+      .tm-dialog-body { padding: 16px 20px; overflow-y: auto; }
       .tm-dialog-foot {
-        padding: 14px 22px;
+        padding: 12px 20px;
         border-top: 1px solid var(--tm-border-soft);
-        background: var(--tm-surface-0);
+        background: var(--tm-surface-2);
         display: flex; justify-content: flex-end; gap: 8px;
       }
 
-      .tm-field { display: block; margin-bottom: 18px; }
-      .tm-field-label { display: block; color: var(--tm-text-muted); font-size: 12px; margin-bottom: 6px; font-weight: 500; }
+      .tm-field { display: block; margin-bottom: 14px; }
+      .tm-field-label {
+        display: block; color: var(--tm-text);
+        font-size: 12.5px; margin-bottom: 5px;
+        font-weight: 500;
+      }
       .tm-field input[type=text], .tm-field input[type=number], .tm-field input[type=date], .tm-field select, .tm-textarea {
         width: 100%;
         background: var(--tm-surface-0);
         border: 1px solid var(--tm-border);
         border-radius: var(--tm-radius-sm);
-        padding: 10px 12px;
+        padding: 7px 10px;
         color: var(--tm-text);
         font-size: 13px;
         font-family: inherit;
         box-sizing: border-box;
-        transition: all 0.15s var(--tm-easing);
+        box-shadow: var(--tm-shadow-xs);
+        transition: all 0.1s var(--tm-easing);
       }
       .tm-field input:focus, .tm-field select:focus, .tm-textarea:focus {
         outline: 0;
         border-color: var(--tm-accent);
-        box-shadow: 0 0 0 3px var(--tm-accent-soft);
+        box-shadow: var(--tm-shadow-focus);
       }
       .tm-field-hint {
         display: block; color: var(--tm-text-faint);
-        font-size: 11px; margin-top: 6px; line-height: 1.5;
+        font-size: 11.5px; margin-top: 4px; line-height: 1.5;
       }
       .tm-field-hint code {
         font-family: ui-monospace, "SF Mono", Menlo, monospace;
         background: var(--tm-surface-2); padding: 1px 5px;
-        border-radius: 3px; font-size: 10px;
+        border-radius: 3px; font-size: 11px;
       }
       .tm-field-row { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
       .tm-textarea { resize: vertical; min-height: 100px; line-height: 1.5; }
@@ -2593,33 +2796,36 @@ class TaskMatePanel extends HTMLElement {
       /* Chip multi-select */
       .tm-chip-row { display: flex; gap: 6px; flex-wrap: wrap; }
       .tm-chip-btn {
-        background: var(--tm-surface-1);
+        background: var(--tm-surface-0);
         color: var(--tm-text-muted);
         border: 1px solid var(--tm-border);
-        padding: 6px 12px; border-radius: 999px;
-        font-size: 12px; font-weight: 500;
+        padding: 4px 10px; border-radius: 999px;
+        font-size: 12.5px; font-weight: 500;
         font-family: inherit;
         cursor: pointer;
-        transition: all 0.12s var(--tm-easing);
+        transition: all 0.1s var(--tm-easing);
       }
       .tm-chip-btn:hover { color: var(--tm-text); border-color: var(--tm-border-strong); }
       .tm-chip-on {
         background: var(--tm-accent-soft);
-        color: var(--tm-accent);
-        border-color: var(--tm-accent);
+        color: var(--tm-accent-text);
+        border-color: var(--tm-accent-border);
       }
 
-      .tm-day-row { display: flex; gap: 6px; flex-wrap: wrap; }
+      .tm-day-row { display: grid; grid-template-columns: repeat(7, 1fr); gap: 6px; }
       .tm-day-btn {
-        width: 42px; height: 36px;
-        background: var(--tm-surface-1);
+        background: var(--tm-surface-0);
         color: var(--tm-text-muted);
         border: 1px solid var(--tm-border);
-        border-radius: 8px;
-        font-size: 12px; font-weight: 500;
+        border-radius: var(--tm-radius-sm);
+        padding: 8px 0;
+        font-size: 11.5px; font-weight: 600;
         font-family: inherit; cursor: pointer;
-        transition: all 0.12s var(--tm-easing);
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        transition: all 0.1s var(--tm-easing);
       }
+      .tm-day-btn:hover { color: var(--tm-text); border-color: var(--tm-border-strong); }
       .tm-day-on {
         background: var(--tm-accent); color: white;
         border-color: var(--tm-accent);
@@ -2680,24 +2886,74 @@ class TaskMatePanel extends HTMLElement {
       /* Toast */
       .tm-toast {
         position: fixed; bottom: 24px; left: 50%; transform: translateX(-50%);
-        padding: 10px 18px; border-radius: var(--tm-radius-sm);
+        padding: 10px 16px; border-radius: var(--tm-radius);
         font-size: 13px; font-weight: 500;
         box-shadow: var(--tm-shadow);
         z-index: 200;
-        animation: tm-toast-in 0.25s var(--tm-easing);
+        animation: tm-toast-in 0.2s var(--tm-easing);
       }
       @keyframes tm-toast-in { from { opacity: 0; transform: translate(-50%, 8px); } to { opacity: 1; transform: translateX(-50%); } }
-      .tm-toast-ok  { background: var(--tm-accent); color: white; box-shadow: 0 4px 16px var(--tm-accent-glow); }
+      .tm-toast-ok  { background: var(--tm-positive); color: white; }
       .tm-toast-err { background: var(--tm-danger); color: white; }
 
-      @media (max-width: 700px) {
+      /* ===== Mobile / narrow ===== */
+      @media (max-width: 900px) {
+        .tm-shell { grid-template-columns: 1fr; }
+        .tm-sidebar { display: none; }
+        .tm-mobile-tabs {
+          display: flex;
+          overflow-x: auto;
+          scrollbar-width: none;
+          padding: 0 12px;
+          background: var(--tm-surface-0);
+          border-bottom: 1px solid var(--tm-border);
+          flex-shrink: 0;
+        }
+        .tm-mobile-tabs::-webkit-scrollbar { display: none; }
+        .tm-mtab {
+          position: relative;
+          background: transparent;
+          border: 0;
+          color: var(--tm-text-faint);
+          padding: 12px 14px;
+          cursor: pointer;
+          font-size: 13px;
+          font-weight: 500;
+          font-family: inherit;
+          white-space: nowrap;
+          display: flex; align-items: center; gap: 6px;
+          transition: color 0.1s var(--tm-easing);
+        }
+        .tm-mtab:hover { color: var(--tm-text); }
+        .tm-mtab-active { color: var(--tm-text); }
+        .tm-mtab-active::after {
+          content: ""; position: absolute;
+          left: 14px; right: 14px; bottom: -1px;
+          height: 2px; background: var(--tm-accent);
+          border-radius: 2px 2px 0 0;
+        }
+        .tm-mtab-pill {
+          background: var(--tm-surface-2);
+          color: var(--tm-text-muted);
+          font-size: 10.5px; font-weight: 600;
+          padding: 1px 6px; border-radius: 999px;
+        }
+        .tm-mtab-active .tm-mtab-pill {
+          background: var(--tm-accent-soft);
+          color: var(--tm-accent-text);
+        }
+        .tm-mtab-pill-urgent {
+          background: var(--tm-warning-soft) !important;
+          color: var(--tm-warning) !important;
+        }
         .tm-body { padding: 16px; }
         .tm-toolbar { flex-direction: column; align-items: stretch; }
         .tm-search-wrap { max-width: none; }
         .tm-dialog { max-width: none; border-radius: 0; max-height: 100vh; height: 100vh; }
         .tm-scrim { padding: 0; }
         .tm-dialog-body .tm-field-row { grid-template-columns: 1fr; }
-        .tm-setting-row { grid-template-columns: 1fr; gap: 6px; }
+        .tm-setting-row { grid-template-columns: 1fr; gap: 6px; padding: 12px 16px; }
+        .tm-section-head, .tm-setting-row { padding-left: 16px; padding-right: 16px; }
         .tm-timeline-row { grid-template-columns: 1fr auto; }
         .tm-timeline-time, .tm-timeline-icon { display: none; }
       }

--- a/custom_components/taskmate/www/taskmate-panel.js
+++ b/custom_components/taskmate/www/taskmate-panel.js
@@ -8,7 +8,7 @@
  * Vanilla HTMLElement — no LitElement dependency.
  */
 
-const PANEL_VERSION = "3.5.0-alpha.3";
+const PANEL_VERSION = "3.5.0-alpha.4";
 
 const TABS = [
   { id: "children",  label: "Children" },
@@ -117,10 +117,20 @@ class TaskMatePanel extends HTMLElement {
       return;
     }
 
-    // Dialog open / close
-    if (act === "close-dialog" || act === "scrim") {
+    // Dialog close button — always closes
+    if (act === "close-dialog") {
       this._dialog = null;
       this._render();
+      return;
+    }
+    // Scrim — closes ONLY when the dark backdrop itself was clicked, not
+    // when a click inside the dialog bubbled up to it.
+    if (act === "scrim") {
+      const scrimEl = this.querySelector(".tm-scrim");
+      if (e.target === scrimEl) {
+        this._dialog = null;
+        this._render();
+      }
       return;
     }
 
@@ -380,7 +390,7 @@ class TaskMatePanel extends HTMLElement {
     const title = this._dialog.mode === "add" ? "Add child" : "Edit child";
     return `
       <div class="tm-scrim" data-act="scrim">
-        <div class="tm-dialog" onclick="event.stopPropagation()">
+        <div class="tm-dialog">
           <header class="tm-dialog-head">
             <h2>${title}</h2>
             <button class="tm-icon-btn" data-act="close-dialog" title="Close">&times;</button>

--- a/custom_components/taskmate/www/taskmate-panel.js
+++ b/custom_components/taskmate/www/taskmate-panel.js
@@ -1,16 +1,24 @@
 /**
- * TaskMate admin panel — sidebar entry at /taskmate.
+ * TaskMate admin panel — sidebar entry at /taskmate-admin.
  *
- * Stage 1: minimal element that confirms the panel registers, the JS module
- * loads, and the WebSocket round-trip works. The full multi-tab UI lands in
- * subsequent commits on this branch.
+ * Stage 2a: tab shell + working Children CRUD.
+ * Other tabs render a "coming soon" placeholder; they land in subsequent
+ * alpha releases on this branch.
  *
- * Vanilla HTMLElement (no LitElement dependency) — keeps the panel robust
- * against load-order issues when navigating directly to /taskmate before any
- * Lovelace view has been opened.
+ * Vanilla HTMLElement — no LitElement dependency.
  */
 
-const PANEL_VERSION = "3.5.0-alpha.2";
+const PANEL_VERSION = "3.5.0-alpha.3";
+
+const TABS = [
+  { id: "children",  label: "Children" },
+  { id: "chores",    label: "Chores" },
+  { id: "rewards",   label: "Rewards" },
+  { id: "penalties", label: "Penalties" },
+  { id: "bonuses",   label: "Bonuses" },
+  { id: "groups",    label: "Groups" },
+  { id: "settings",  label: "⚙",  title: "Settings" },
+];
 
 class TaskMatePanel extends HTMLElement {
   constructor() {
@@ -19,37 +27,51 @@ class TaskMatePanel extends HTMLElement {
     this._state = null;
     this._error = null;
     this._loading = false;
+    this._activeTab = "children";
+    this._dialog = null;        // { kind: "child", mode: "add"|"edit", data }
     this._rendered = false;
+    this._onClick = this._onClick.bind(this);
+    this._onInput = this._onInput.bind(this);
+    this._onChange = this._onChange.bind(this);
+    this._onKeyDown = this._onKeyDown.bind(this);
   }
 
+  // ---- HA-injected properties ----------------------------------------------
   set hass(value) {
     const first = this._hass === null;
     this._hass = value;
-    if (first) {
-      this._fetchState();
-    }
-    if (!this._rendered) {
-      this._render();
-    }
+    if (first) this._fetchState();
+    if (!this._rendered) this._render();
   }
   get hass() { return this._hass; }
 
-  // panel-custom also injects narrow/route/panel — we accept but ignore for now
   set narrow(_v) {}
   set route(_v) {}
   set panel(_v) {}
 
   connectedCallback() {
+    this.addEventListener("click", this._onClick);
+    this.addEventListener("input", this._onInput);
+    this.addEventListener("change", this._onChange);
+    this.addEventListener("keydown", this._onKeyDown);
     if (!this._rendered) this._render();
   }
 
+  disconnectedCallback() {
+    this.removeEventListener("click", this._onClick);
+    this.removeEventListener("input", this._onInput);
+    this.removeEventListener("change", this._onChange);
+    this.removeEventListener("keydown", this._onKeyDown);
+  }
+
+  // ---- state -----------------------------------------------------------
   async _fetchState() {
-    if (!this._hass || this._loading) return;
+    if (!this._hass) return;
     this._loading = true;
-    this._error = null;
     this._render();
     try {
       this._state = await this._hass.callWS({ type: "taskmate/get_state" });
+      this._error = null;
     } catch (err) {
       this._error = (err && err.message) || String(err);
       this._state = null;
@@ -59,90 +81,445 @@ class TaskMatePanel extends HTMLElement {
     }
   }
 
+  async _callWS(payload) {
+    try {
+      const res = await this._hass.callWS(payload);
+      return { ok: true, res };
+    } catch (err) {
+      return { ok: false, err: (err && err.message) || String(err) };
+    }
+  }
+
+  _showToast(kind, text) {
+    // Render toasts outside the innerHTML tree so hiding them doesn't
+    // tear down the current dialog's <input>s and blur what the user is typing.
+    const existing = this.querySelector(".tm-toast");
+    if (existing) existing.remove();
+    const node = document.createElement("div");
+    node.className = `tm-toast tm-toast-${kind}`;
+    node.textContent = text;
+    this.appendChild(node);
+    setTimeout(() => {
+      if (node.isConnected) node.remove();
+    }, 3500);
+  }
+
+  // ---- event delegation ------------------------------------------------
+  _onClick(e) {
+    const t = e.target.closest("[data-act]");
+    if (!t) return;
+    const act = t.dataset.act;
+
+    // Tab switching
+    if (act === "tab") {
+      this._activeTab = t.dataset.tab;
+      this._render();
+      return;
+    }
+
+    // Dialog open / close
+    if (act === "close-dialog" || act === "scrim") {
+      this._dialog = null;
+      this._render();
+      return;
+    }
+
+    // Children
+    if (act === "add-child") {
+      this._dialog = { kind: "child", mode: "add", data: { name: "", avatar: "mdi:account-circle", availability_entity: "" } };
+      this._render();
+      return;
+    }
+    if (act === "edit-child") {
+      const child = (this._state.children || []).find(c => c.id === t.dataset.id);
+      if (!child) return;
+      this._dialog = { kind: "child", mode: "edit", data: { id: child.id, name: child.name || "", avatar: child.avatar || "mdi:account-circle", availability_entity: child.availability_entity || "" } };
+      this._render();
+      return;
+    }
+    if (act === "delete-child") {
+      const id = t.dataset.id;
+      const child = (this._state.children || []).find(c => c.id === id);
+      if (!child) return;
+      if (!confirm(`Delete "${child.name}"?\n\nThis also removes all of their completion history, reward claims, points transactions, and pool allocations. Chores assigned to them will be updated. This cannot be undone.`)) return;
+      this._doRemoveChild(id);
+      return;
+    }
+    if (act === "save-child") {
+      this._doSaveChild();
+      return;
+    }
+    if (act === "retry") {
+      this._fetchState();
+      return;
+    }
+  }
+
+  _onInput(e) {
+    if (!this._dialog) return;
+    const t = e.target;
+    if (!t.dataset || !t.dataset.field) return;
+    this._dialog.data[t.dataset.field] = t.value;
+    // no re-render; live-bound fields shouldn't cause full rerender per keystroke
+  }
+
+  _onChange(e) {
+    if (!this._dialog) return;
+    const t = e.target;
+    if (!t.dataset || !t.dataset.field) return;
+    this._dialog.data[t.dataset.field] = t.value;
+  }
+
+  _onKeyDown(e) {
+    if (e.key === "Escape" && this._dialog) {
+      this._dialog = null;
+      this._render();
+    }
+  }
+
+  // ---- child actions ---------------------------------------------------
+  async _doSaveChild() {
+    const d = this._dialog.data;
+    if (!d.name || !d.name.trim()) {
+      this._showToast("err", "Name is required");
+      return;
+    }
+    let payload;
+    if (this._dialog.mode === "add") {
+      payload = {
+        type: "taskmate/add_child",
+        name: d.name.trim(),
+        avatar: d.avatar || "mdi:account-circle",
+        availability_entity: d.availability_entity || "",
+      };
+    } else {
+      payload = {
+        type: "taskmate/update_child",
+        child_id: d.id,
+        name: d.name.trim(),
+        avatar: d.avatar || "mdi:account-circle",
+        availability_entity: d.availability_entity || "",
+      };
+    }
+    const wasAdd = this._dialog.mode === "add";
+    const { ok, err } = await this._callWS(payload);
+    if (!ok) {
+      this._showToast("err", `Save failed: ${err}`);
+      return;
+    }
+    this._dialog = null;
+    await this._fetchState();
+    this._showToast("ok", wasAdd ? "Child added" : "Child updated");
+  }
+
+  async _doRemoveChild(child_id) {
+    const { ok, err } = await this._callWS({ type: "taskmate/remove_child", child_id });
+    if (!ok) {
+      this._showToast("err", `Delete failed: ${err}`);
+      return;
+    }
+    await this._fetchState();
+    this._showToast("ok", "Deleted");
+  }
+
+  // ---- rendering -------------------------------------------------------
   _render() {
     this._rendered = true;
-    const counts = this._state ? {
-      children:    (this._state.children || []).length,
-      chores:      (this._state.chores || []).length,
-      rewards:     (this._state.rewards || []).length,
-      penalties:   (this._state.penalties || []).length,
-      bonuses:     (this._state.bonuses || []).length,
-      task_groups: (this._state.task_groups || []).length,
-    } : null;
-
+    // Preserve any existing toast across re-renders (it's a transient DOM
+    // node appended outside the shell — see _showToast).
+    const existingToast = this.querySelector(".tm-toast");
     this.innerHTML = `
-      <style>
-        :host, taskmate-panel { display: block; height: 100%; background: var(--primary-background-color, #111418); color: var(--primary-text-color, #e1e3e6); }
-        .tm-shell { display: flex; flex-direction: column; height: 100%; font-family: var(--paper-font-body1_-_font-family, sans-serif); }
-        .tm-appbar { height: 56px; background: var(--app-header-background-color, #1a1d22); color: var(--app-header-text-color, #fff); display: flex; align-items: center; gap: 12px; padding: 0 16px; flex-shrink: 0; border-bottom: 1px solid var(--divider-color, #2a2e36); }
-        .tm-appbar h1 { margin: 0; font-size: 20px; font-weight: 400; flex: 1; }
-        .tm-chip { background: rgba(255,255,255,0.1); padding: 4px 10px; border-radius: 999px; font-size: 12px; }
-        .tm-body { flex: 1; overflow: auto; padding: 24px; max-width: 900px; margin: 0 auto; width: 100%; box-sizing: border-box; }
-        .tm-card { background: var(--card-background-color, #1c1f24); border: 1px solid var(--divider-color, #2a2e36); border-radius: 12px; padding: 20px 24px; margin-bottom: 16px; }
-        .tm-card h2 { margin: 0 0 12px; font-size: 18px; font-weight: 500; }
-        .tm-banner { background: rgba(3,169,244,0.08); border: 1px solid rgba(3,169,244,0.25); color: var(--primary-color, #03a9f4); padding: 12px 16px; border-radius: 8px; margin-bottom: 16px; }
-        .tm-counts { display: grid; grid-template-columns: repeat(auto-fit, minmax(120px, 1fr)); gap: 12px; }
-        .tm-count { background: var(--secondary-background-color, #242830); padding: 12px; border-radius: 8px; text-align: center; }
-        .tm-count strong { display: block; font-size: 24px; color: var(--primary-color, #03a9f4); }
-        .tm-count span { font-size: 12px; color: var(--secondary-text-color, #9aa0a6); text-transform: uppercase; letter-spacing: 0.5px; }
-        .tm-error { color: var(--error-color, #ef5350); }
-        .tm-btn { background: var(--primary-color, #03a9f4); color: var(--text-primary-color, #001a26); border: 0; padding: 8px 16px; border-radius: 8px; cursor: pointer; font-size: 14px; }
-        .tm-btn:hover { filter: brightness(1.1); }
-        pre { background: var(--code-editor-background-color, #0e1115); padding: 12px; border-radius: 8px; overflow: auto; font-size: 11px; max-height: 300px; }
-      </style>
+      ${this._styles()}
       <div class="tm-shell">
-        <div class="tm-appbar">
-          <h1>TaskMate</h1>
-          <span class="tm-chip">v${PANEL_VERSION}</span>
-        </div>
+        ${this._appbar()}
+        ${this._tabstrip()}
         <div class="tm-body">
-          <div class="tm-banner">
-            <strong>Stage 1 preview</strong> — backend wiring is in place. The full multi-tab admin UI (Children · Chores · Rewards · Penalties · Bonuses · Groups · Settings) lands in the next commits on this branch. Pull updates via HACS ⋮ → Redownload.
-          </div>
+          ${this._renderBody()}
+        </div>
+        ${this._dialog ? this._renderDialog() : ""}
+      </div>
+    `;
+    if (existingToast) this.appendChild(existingToast);
+  }
 
-          ${this._loading ? `
-            <div class="tm-card">Loading state…</div>
-          ` : this._error ? `
-            <div class="tm-card tm-error">
-              <h2>Failed to load state</h2>
-              <p>${this._escape(this._error)}</p>
-              <button class="tm-btn" id="tm-retry">Retry</button>
+  _appbar() {
+    return `
+      <div class="tm-appbar">
+        <h1>TaskMate</h1>
+        <span class="tm-chip">v${PANEL_VERSION}</span>
+      </div>
+    `;
+  }
+
+  _tabstrip() {
+    return `
+      <nav class="tm-tabs">
+        ${TABS.map(t => `
+          <button class="tm-tab ${t.id === this._activeTab ? "tm-tab-active" : ""}" data-act="tab" data-tab="${t.id}" ${t.title ? `title="${t.title}"` : ""}>
+            ${this._esc(t.label)}
+          </button>
+        `).join("")}
+      </nav>
+    `;
+  }
+
+  _renderBody() {
+    if (this._loading && !this._state) {
+      return `<div class="tm-card">Loading…</div>`;
+    }
+    if (this._error) {
+      return `
+        <div class="tm-card tm-card-error">
+          <h2>Failed to load state</h2>
+          <p>${this._esc(this._error)}</p>
+          <button class="tm-btn" data-act="retry">Retry</button>
+        </div>
+      `;
+    }
+    if (!this._state) {
+      return `<div class="tm-card">No state yet.</div>`;
+    }
+
+    switch (this._activeTab) {
+      case "children":  return this._renderChildrenTab();
+      case "chores":    return this._placeholderTab("Chores",    "alpha.4");
+      case "rewards":   return this._placeholderTab("Rewards",   "alpha.5");
+      case "penalties": return this._placeholderTab("Penalties", "alpha.6");
+      case "bonuses":   return this._placeholderTab("Bonuses",   "alpha.6");
+      case "groups":    return this._placeholderTab("Groups",    "alpha.7");
+      case "settings":  return this._placeholderTab("Settings",  "alpha.7");
+      default:          return `<div class="tm-card">Unknown tab</div>`;
+    }
+  }
+
+  _placeholderTab(name, when) {
+    return `
+      <div class="tm-card tm-card-info">
+        <h2>${this._esc(name)} — coming in the next alpha</h2>
+        <p>This tab will be wired up in <code>v3.5.0-${when}</code>. For now, continue to use
+           <strong>Settings → Devices &amp; Services → TaskMate → Configure</strong> for ${this._esc(name.toLowerCase())}.</p>
+      </div>
+    `;
+  }
+
+  // -- Children tab ------------------------------------------------------
+  _renderChildrenTab() {
+    const children = this._state.children || [];
+    const pointsName = (this._state.settings && this._state.settings.points_name) || "points";
+    return `
+      <div class="tm-toolbar">
+        <div class="tm-title-sub">Manage the children in your family. Their points balance and history stay intact when you edit details.</div>
+        <button class="tm-btn" data-act="add-child">+ Add child</button>
+      </div>
+
+      ${children.length === 0 ? `
+        <div class="tm-card tm-empty">
+          <h2>No children yet</h2>
+          <p>Add your first child to get started. You can assign chores and rewards to them on the next tabs.</p>
+          <button class="tm-btn" data-act="add-child">+ Add child</button>
+        </div>
+      ` : `
+        <div class="tm-grid">
+          ${children.map(c => this._renderChildCard(c, pointsName)).join("")}
+          <button class="tm-add-tile" data-act="add-child">
+            <span class="tm-add-plus">+</span>
+            Add child
+          </button>
+        </div>
+      `}
+    `;
+  }
+
+  _renderChildCard(child, pointsName) {
+    const avatar = child.avatar || "mdi:account-circle";
+    const availability = child.availability_entity || "";
+    const points = child.points || 0;
+    const total = child.total_points_earned || 0;
+    const completions = child.total_chores_completed || 0;
+    return `
+      <article class="tm-card tm-child-card">
+        <header class="tm-child-head">
+          <div class="tm-avatar">${this._mdi(avatar)}</div>
+          <div class="tm-child-name">
+            <h3>${this._esc(child.name || "(unnamed)")}</h3>
+            <div class="tm-sub">
+              ${availability ? `Availability: <code>${this._esc(availability)}</code>` : `<em>No availability sensor</em>`}
             </div>
-          ` : counts ? `
-            <div class="tm-card">
-              <h2>Storage snapshot</h2>
-              <div class="tm-counts">
-                <div class="tm-count"><strong>${counts.children}</strong><span>Children</span></div>
-                <div class="tm-count"><strong>${counts.chores}</strong><span>Chores</span></div>
-                <div class="tm-count"><strong>${counts.rewards}</strong><span>Rewards</span></div>
-                <div class="tm-count"><strong>${counts.penalties}</strong><span>Penalties</span></div>
-                <div class="tm-count"><strong>${counts.bonuses}</strong><span>Bonuses</span></div>
-                <div class="tm-count"><strong>${counts.task_groups}</strong><span>Groups</span></div>
-              </div>
-              <p style="margin-top: 16px; color: var(--secondary-text-color, #9aa0a6); font-size: 13px;">
-                Currency: <code>${this._escape(this._state.settings.points_name)}</code> &middot;
-                Icon: <code>${this._escape(this._state.settings.points_icon)}</code>
-              </p>
-              <details style="margin-top: 16px;">
-                <summary style="cursor: pointer; color: var(--secondary-text-color, #9aa0a6);">Raw state (JSON)</summary>
-                <pre>${this._escape(JSON.stringify(this._state, null, 2))}</pre>
-              </details>
-            </div>
-          ` : `
-            <div class="tm-card">No state yet.</div>
-          `}
+          </div>
+        </header>
+        <div class="tm-stats">
+          <div class="tm-stat">
+            <strong>${this._fmtNum(points)}</strong>
+            <span>spendable ${this._esc(pointsName)}</span>
+          </div>
+          <div class="tm-stat">
+            <strong>${this._fmtNum(total)}</strong>
+            <span>earned all-time</span>
+          </div>
+          <div class="tm-stat">
+            <strong>${this._fmtNum(completions)}</strong>
+            <span>chores done</span>
+          </div>
+        </div>
+        <footer class="tm-child-foot">
+          <button class="tm-btn tm-btn-ghost" data-act="edit-child" data-id="${this._esc(child.id)}">Edit</button>
+          <button class="tm-btn tm-btn-danger" data-act="delete-child" data-id="${this._esc(child.id)}">Delete</button>
+        </footer>
+      </article>
+    `;
+  }
+
+  // -- Dialogs -----------------------------------------------------------
+  _renderDialog() {
+    if (this._dialog.kind === "child") return this._renderChildDialog();
+    return "";
+  }
+
+  _renderChildDialog() {
+    const d = this._dialog.data;
+    const title = this._dialog.mode === "add" ? "Add child" : "Edit child";
+    return `
+      <div class="tm-scrim" data-act="scrim">
+        <div class="tm-dialog" onclick="event.stopPropagation()">
+          <header class="tm-dialog-head">
+            <h2>${title}</h2>
+            <button class="tm-icon-btn" data-act="close-dialog" title="Close">&times;</button>
+          </header>
+          <div class="tm-dialog-body">
+            <label class="tm-field">
+              <span class="tm-field-label">Name</span>
+              <input type="text" data-field="name" value="${this._esc(d.name || "")}" placeholder="e.g. Malia" autofocus>
+            </label>
+            <label class="tm-field">
+              <span class="tm-field-label">Avatar (MDI icon)</span>
+              <input type="text" data-field="avatar" value="${this._esc(d.avatar || "mdi:account-circle")}" placeholder="mdi:account-circle">
+              <span class="tm-field-hint">Any Material Design icon, e.g. <code>mdi:face-woman</code>, <code>mdi:face-man</code>.</span>
+            </label>
+            <label class="tm-field">
+              <span class="tm-field-label">Availability sensor <span class="tm-field-opt">(optional)</span></span>
+              <input type="text" data-field="availability_entity" value="${this._esc(d.availability_entity || "")}" placeholder="binary_sensor.malia_home">
+              <span class="tm-field-hint">HA entity that tells TaskMate whether this child is available. States <code>on</code>, <code>home</code>, <code>available</code>, <code>present</code>, <code>true</code> mean available. Leave blank to treat as always available.</span>
+            </label>
+          </div>
+          <footer class="tm-dialog-foot">
+            <button class="tm-btn tm-btn-ghost" data-act="close-dialog">Cancel</button>
+            <button class="tm-btn" data-act="save-child">Save</button>
+          </footer>
         </div>
       </div>
     `;
-
-    const retry = this.querySelector("#tm-retry");
-    if (retry) retry.addEventListener("click", () => this._fetchState());
   }
 
-  _escape(str) {
-    return String(str)
+  // ---- helpers ---------------------------------------------------------
+  _esc(str) {
+    return String(str == null ? "" : str)
       .replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
       .replace(/"/g, "&quot;").replace(/'/g, "&#39;");
+  }
+
+  _fmtNum(n) {
+    if (n == null) return "0";
+    return new Intl.NumberFormat().format(n);
+  }
+
+  _mdi(name) {
+    // Render an mdi: name as an <ha-icon>. HA's <ha-icon> custom element is
+    // globally registered by the frontend and tolerates us creating it before
+    // it's upgraded — it'll upgrade and render on its own.
+    const safe = this._esc(name || "mdi:account-circle");
+    return `<ha-icon icon="${safe}"></ha-icon>`;
+  }
+
+  // ---- styles ----------------------------------------------------------
+  _styles() {
+    return `<style>
+      :host, taskmate-panel { display: block; height: 100%; background: var(--primary-background-color, #111418); color: var(--primary-text-color, #e1e3e6); }
+      .tm-shell { display: flex; flex-direction: column; height: 100%; font-family: var(--paper-font-body1_-_font-family, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif); position: relative; }
+
+      .tm-appbar { height: 56px; background: var(--app-header-background-color, #1a1d22); color: var(--app-header-text-color, #fff); display: flex; align-items: center; gap: 12px; padding: 0 16px; flex-shrink: 0; border-bottom: 1px solid var(--divider-color, #2a2e36); }
+      .tm-appbar h1 { margin: 0; font-size: 20px; font-weight: 400; flex: 1; }
+      .tm-chip { background: rgba(255,255,255,0.1); padding: 4px 10px; border-radius: 999px; font-size: 12px; }
+
+      .tm-tabs { display: flex; background: var(--app-header-background-color, #1a1d22); border-bottom: 1px solid var(--divider-color, #2a2e36); padding: 0 8px; overflow-x: auto; flex-shrink: 0; scrollbar-width: none; }
+      .tm-tabs::-webkit-scrollbar { display: none; }
+      .tm-tab { border: 0; background: transparent; color: var(--secondary-text-color, #9aa0a6); padding: 14px 18px; cursor: pointer; font-size: 14px; font-weight: 500; border-bottom: 2px solid transparent; margin-bottom: -1px; white-space: nowrap; font-family: inherit; }
+      .tm-tab:hover { color: var(--primary-text-color, #e1e3e6); }
+      .tm-tab-active { color: var(--primary-color, #03a9f4); border-bottom-color: var(--primary-color, #03a9f4); }
+
+      .tm-body { flex: 1; overflow: auto; padding: 20px 24px 48px; }
+      .tm-toolbar { display: flex; align-items: center; gap: 16px; margin-bottom: 16px; flex-wrap: wrap; }
+      .tm-title-sub { flex: 1; color: var(--secondary-text-color, #9aa0a6); font-size: 13px; }
+
+      .tm-card { background: var(--card-background-color, #1c1f24); border: 1px solid var(--divider-color, #2a2e36); border-radius: 12px; padding: 20px 24px; margin-bottom: 16px; }
+      .tm-card h2 { margin: 0 0 12px; font-size: 18px; font-weight: 500; }
+      .tm-card p { margin: 8px 0; color: var(--secondary-text-color, #9aa0a6); }
+      .tm-card code { background: var(--code-editor-background-color, #0e1115); padding: 2px 6px; border-radius: 4px; font-size: 12px; }
+      .tm-card-info { border-left: 3px solid var(--primary-color, #03a9f4); }
+      .tm-card-error { border-left: 3px solid var(--error-color, #ef5350); color: var(--error-color, #ef5350); }
+      .tm-empty { text-align: center; padding: 40px 24px; }
+
+      .tm-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); gap: 16px; }
+      .tm-child-card { margin-bottom: 0; display: flex; flex-direction: column; }
+      .tm-child-head { display: flex; align-items: center; gap: 12px; margin-bottom: 14px; }
+      .tm-avatar { width: 48px; height: 48px; border-radius: 50%; background: var(--secondary-background-color, #242830); display: grid; place-items: center; flex-shrink: 0; font-size: 28px; color: var(--primary-color, #03a9f4); }
+      .tm-avatar ha-icon { --mdc-icon-size: 28px; }
+      .tm-child-name { min-width: 0; flex: 1; }
+      .tm-child-name h3 { margin: 0; font-size: 17px; font-weight: 600; }
+      .tm-sub { color: var(--secondary-text-color, #9aa0a6); font-size: 12px; margin-top: 2px; word-break: break-all; }
+      .tm-sub code { background: var(--code-editor-background-color, #0e1115); padding: 1px 6px; border-radius: 4px; font-size: 11px; }
+
+      .tm-stats { display: flex; gap: 14px; margin-bottom: 14px; flex-wrap: wrap; }
+      .tm-stat { background: var(--secondary-background-color, #242830); padding: 8px 12px; border-radius: 8px; flex: 1; min-width: 80px; }
+      .tm-stat strong { display: block; font-size: 20px; font-weight: 600; color: var(--primary-color, #03a9f4); }
+      .tm-stat span { font-size: 11px; color: var(--secondary-text-color, #9aa0a6); text-transform: uppercase; letter-spacing: 0.5px; }
+
+      .tm-child-foot { display: flex; gap: 8px; margin-top: auto; padding-top: 12px; border-top: 1px solid var(--divider-color, #2a2e36); }
+
+      .tm-add-tile { display: grid; place-items: center; gap: 6px; background: transparent; border: 2px dashed var(--divider-color, #2a2e36); border-radius: 12px; color: var(--secondary-text-color, #9aa0a6); cursor: pointer; min-height: 180px; font-size: 14px; font-family: inherit; transition: border-color .15s, color .15s, background .15s; }
+      .tm-add-tile:hover { border-color: var(--primary-color, #03a9f4); color: var(--primary-color, #03a9f4); background: rgba(3,169,244,0.06); }
+      .tm-add-plus { font-size: 32px; line-height: 1; }
+
+      .tm-btn { background: var(--primary-color, #03a9f4); color: var(--text-primary-color, #001a26); border: 0; padding: 8px 16px; border-radius: 8px; cursor: pointer; font-size: 14px; font-weight: 500; font-family: inherit; }
+      .tm-btn:hover { filter: brightness(1.1); }
+      .tm-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+      .tm-btn-ghost { background: transparent; color: var(--primary-text-color, #e1e3e6); border: 1px solid var(--divider-color, #2a2e36); }
+      .tm-btn-ghost:hover { background: var(--secondary-background-color, #242830); filter: none; }
+      .tm-btn-danger { background: transparent; color: var(--error-color, #ef5350); border: 1px solid rgba(239,83,80,0.4); }
+      .tm-btn-danger:hover { background: rgba(239,83,80,0.1); filter: none; }
+
+      .tm-icon-btn { width: 36px; height: 36px; border: 0; background: transparent; border-radius: 50%; cursor: pointer; display: grid; place-items: center; color: var(--secondary-text-color, #9aa0a6); font-size: 22px; line-height: 1; font-family: inherit; }
+      .tm-icon-btn:hover { background: var(--secondary-background-color, #242830); color: var(--primary-text-color, #e1e3e6); }
+
+      /* Dialog */
+      .tm-scrim { position: fixed; inset: 0; background: rgba(0,0,0,0.55); display: flex; align-items: flex-start; justify-content: center; padding: 60px 20px; z-index: 100; overflow-y: auto; }
+      .tm-dialog { background: var(--card-background-color, #1c1f24); border: 1px solid var(--divider-color, #2a2e36); border-radius: 12px; width: 100%; max-width: 520px; box-shadow: 0 10px 40px rgba(0,0,0,0.5); display: flex; flex-direction: column; max-height: calc(100vh - 120px); }
+      .tm-dialog-head { padding: 16px 20px; border-bottom: 1px solid var(--divider-color, #2a2e36); display: flex; align-items: center; }
+      .tm-dialog-head h2 { margin: 0; font-size: 18px; font-weight: 500; flex: 1; }
+      .tm-dialog-body { padding: 16px 20px; overflow-y: auto; }
+      .tm-dialog-foot { padding: 14px 20px; border-top: 1px solid var(--divider-color, #2a2e36); display: flex; justify-content: flex-end; gap: 10px; }
+
+      .tm-field { display: block; margin-bottom: 16px; }
+      .tm-field-label { display: block; color: var(--secondary-text-color, #9aa0a6); font-size: 12px; margin-bottom: 6px; }
+      .tm-field-opt { color: var(--secondary-text-color, #6a7079); font-weight: normal; }
+      .tm-field input[type=text] { width: 100%; background: var(--secondary-background-color, #242830); border: 1px solid var(--divider-color, #2a2e36); border-radius: 8px; padding: 9px 12px; color: var(--primary-text-color, #e1e3e6); font-size: 14px; box-sizing: border-box; font-family: inherit; }
+      .tm-field input[type=text]:focus { outline: 2px solid var(--primary-color, #03a9f4); outline-offset: -1px; border-color: transparent; }
+      .tm-field-hint { display: block; color: var(--secondary-text-color, #6a7079); font-size: 12px; margin-top: 6px; }
+      .tm-field-hint code { background: var(--code-editor-background-color, #0e1115); padding: 1px 5px; border-radius: 3px; font-size: 11px; }
+
+      /* Toast */
+      .tm-toast { position: fixed; bottom: 24px; left: 50%; transform: translateX(-50%); padding: 10px 18px; border-radius: 8px; font-size: 14px; box-shadow: 0 4px 16px rgba(0,0,0,0.4); z-index: 200; }
+      .tm-toast-ok { background: var(--primary-color, #03a9f4); color: var(--text-primary-color, #001a26); }
+      .tm-toast-err { background: var(--error-color, #ef5350); color: white; }
+
+      /* Narrow / mobile */
+      @media (max-width: 700px) {
+        .tm-body { padding: 16px; }
+        .tm-toolbar { flex-direction: column; align-items: stretch; }
+        .tm-dialog { max-width: none; }
+        .tm-scrim { padding: 0; }
+        .tm-dialog { border-radius: 0; max-height: 100vh; height: 100vh; }
+      }
+    </style>`;
   }
 }
 

--- a/custom_components/taskmate/www/taskmate-panel.js
+++ b/custom_components/taskmate/www/taskmate-panel.js
@@ -1,0 +1,149 @@
+/**
+ * TaskMate admin panel — sidebar entry at /taskmate.
+ *
+ * Stage 1: minimal element that confirms the panel registers, the JS module
+ * loads, and the WebSocket round-trip works. The full multi-tab UI lands in
+ * subsequent commits on this branch.
+ *
+ * Vanilla HTMLElement (no LitElement dependency) — keeps the panel robust
+ * against load-order issues when navigating directly to /taskmate before any
+ * Lovelace view has been opened.
+ */
+
+const PANEL_VERSION = "3.5.0-alpha.1";
+
+class TaskMatePanel extends HTMLElement {
+  constructor() {
+    super();
+    this._hass = null;
+    this._state = null;
+    this._error = null;
+    this._loading = false;
+    this._rendered = false;
+  }
+
+  set hass(value) {
+    const first = this._hass === null;
+    this._hass = value;
+    if (first) {
+      this._fetchState();
+    }
+    if (!this._rendered) {
+      this._render();
+    }
+  }
+  get hass() { return this._hass; }
+
+  // panel-custom also injects narrow/route/panel — we accept but ignore for now
+  set narrow(_v) {}
+  set route(_v) {}
+  set panel(_v) {}
+
+  connectedCallback() {
+    if (!this._rendered) this._render();
+  }
+
+  async _fetchState() {
+    if (!this._hass || this._loading) return;
+    this._loading = true;
+    this._error = null;
+    this._render();
+    try {
+      this._state = await this._hass.callWS({ type: "taskmate/get_state" });
+    } catch (err) {
+      this._error = (err && err.message) || String(err);
+      this._state = null;
+    } finally {
+      this._loading = false;
+      this._render();
+    }
+  }
+
+  _render() {
+    this._rendered = true;
+    const counts = this._state ? {
+      children:    (this._state.children || []).length,
+      chores:      (this._state.chores || []).length,
+      rewards:     (this._state.rewards || []).length,
+      penalties:   (this._state.penalties || []).length,
+      bonuses:     (this._state.bonuses || []).length,
+      task_groups: (this._state.task_groups || []).length,
+    } : null;
+
+    this.innerHTML = `
+      <style>
+        :host, taskmate-panel { display: block; height: 100%; background: var(--primary-background-color, #111418); color: var(--primary-text-color, #e1e3e6); }
+        .tm-shell { display: flex; flex-direction: column; height: 100%; font-family: var(--paper-font-body1_-_font-family, sans-serif); }
+        .tm-appbar { height: 56px; background: var(--app-header-background-color, #1a1d22); color: var(--app-header-text-color, #fff); display: flex; align-items: center; gap: 12px; padding: 0 16px; flex-shrink: 0; border-bottom: 1px solid var(--divider-color, #2a2e36); }
+        .tm-appbar h1 { margin: 0; font-size: 20px; font-weight: 400; flex: 1; }
+        .tm-chip { background: rgba(255,255,255,0.1); padding: 4px 10px; border-radius: 999px; font-size: 12px; }
+        .tm-body { flex: 1; overflow: auto; padding: 24px; max-width: 900px; margin: 0 auto; width: 100%; box-sizing: border-box; }
+        .tm-card { background: var(--card-background-color, #1c1f24); border: 1px solid var(--divider-color, #2a2e36); border-radius: 12px; padding: 20px 24px; margin-bottom: 16px; }
+        .tm-card h2 { margin: 0 0 12px; font-size: 18px; font-weight: 500; }
+        .tm-banner { background: rgba(3,169,244,0.08); border: 1px solid rgba(3,169,244,0.25); color: var(--primary-color, #03a9f4); padding: 12px 16px; border-radius: 8px; margin-bottom: 16px; }
+        .tm-counts { display: grid; grid-template-columns: repeat(auto-fit, minmax(120px, 1fr)); gap: 12px; }
+        .tm-count { background: var(--secondary-background-color, #242830); padding: 12px; border-radius: 8px; text-align: center; }
+        .tm-count strong { display: block; font-size: 24px; color: var(--primary-color, #03a9f4); }
+        .tm-count span { font-size: 12px; color: var(--secondary-text-color, #9aa0a6); text-transform: uppercase; letter-spacing: 0.5px; }
+        .tm-error { color: var(--error-color, #ef5350); }
+        .tm-btn { background: var(--primary-color, #03a9f4); color: var(--text-primary-color, #001a26); border: 0; padding: 8px 16px; border-radius: 8px; cursor: pointer; font-size: 14px; }
+        .tm-btn:hover { filter: brightness(1.1); }
+        pre { background: var(--code-editor-background-color, #0e1115); padding: 12px; border-radius: 8px; overflow: auto; font-size: 11px; max-height: 300px; }
+      </style>
+      <div class="tm-shell">
+        <div class="tm-appbar">
+          <h1>TaskMate</h1>
+          <span class="tm-chip">v${PANEL_VERSION}</span>
+        </div>
+        <div class="tm-body">
+          <div class="tm-banner">
+            <strong>Stage 1 preview</strong> — backend wiring is in place. The full multi-tab admin UI (Children · Chores · Rewards · Penalties · Bonuses · Groups · Settings) lands in the next commits on this branch. Pull updates via HACS ⋮ → Redownload.
+          </div>
+
+          ${this._loading ? `
+            <div class="tm-card">Loading state…</div>
+          ` : this._error ? `
+            <div class="tm-card tm-error">
+              <h2>Failed to load state</h2>
+              <p>${this._escape(this._error)}</p>
+              <button class="tm-btn" id="tm-retry">Retry</button>
+            </div>
+          ` : counts ? `
+            <div class="tm-card">
+              <h2>Storage snapshot</h2>
+              <div class="tm-counts">
+                <div class="tm-count"><strong>${counts.children}</strong><span>Children</span></div>
+                <div class="tm-count"><strong>${counts.chores}</strong><span>Chores</span></div>
+                <div class="tm-count"><strong>${counts.rewards}</strong><span>Rewards</span></div>
+                <div class="tm-count"><strong>${counts.penalties}</strong><span>Penalties</span></div>
+                <div class="tm-count"><strong>${counts.bonuses}</strong><span>Bonuses</span></div>
+                <div class="tm-count"><strong>${counts.task_groups}</strong><span>Groups</span></div>
+              </div>
+              <p style="margin-top: 16px; color: var(--secondary-text-color, #9aa0a6); font-size: 13px;">
+                Currency: <code>${this._escape(this._state.settings.points_name)}</code> &middot;
+                Icon: <code>${this._escape(this._state.settings.points_icon)}</code>
+              </p>
+              <details style="margin-top: 16px;">
+                <summary style="cursor: pointer; color: var(--secondary-text-color, #9aa0a6);">Raw state (JSON)</summary>
+                <pre>${this._escape(JSON.stringify(this._state, null, 2))}</pre>
+              </details>
+            </div>
+          ` : `
+            <div class="tm-card">No state yet.</div>
+          `}
+        </div>
+      </div>
+    `;
+
+    const retry = this.querySelector("#tm-retry");
+    if (retry) retry.addEventListener("click", () => this._fetchState());
+  }
+
+  _escape(str) {
+    return String(str)
+      .replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;").replace(/'/g, "&#39;");
+  }
+}
+
+customElements.define("taskmate-panel", TaskMatePanel);

--- a/custom_components/taskmate/www/taskmate-panel.js
+++ b/custom_components/taskmate/www/taskmate-panel.js
@@ -1,14 +1,17 @@
 /**
  * TaskMate admin panel — sidebar entry at /taskmate-admin.
  *
- * Stage 2a: tab shell + working Children CRUD.
- * Other tabs render a "coming soon" placeholder; they land in subsequent
- * alpha releases on this branch.
+ * All seven tabs (Children, Chores, Rewards, Penalties, Bonuses, Groups,
+ * Settings) are wired to WebSocket commands. The classic options-flow menu
+ * remains in place but is now redundant for everyday admin work.
  *
- * Vanilla HTMLElement — no LitElement dependency.
+ * Vanilla HTMLElement — no LitElement dependency. The panel hits a single
+ * read command (taskmate/get_state) on mount and after every mutation;
+ * mutations call dedicated WS commands which in turn call coordinator
+ * methods so existing business logic (refunds, cleanup, recompute) runs.
  */
 
-const PANEL_VERSION = "3.5.0-alpha.4";
+const PANEL_VERSION = "3.5.0-alpha.5";
 
 const TABS = [
   { id: "children",  label: "Children" },
@@ -20,6 +23,77 @@ const TABS = [
   { id: "settings",  label: "⚙",  title: "Settings" },
 ];
 
+const TIME_CATEGORIES = [
+  { v: "anytime",   l: "Anytime" },
+  { v: "morning",   l: "Morning" },
+  { v: "afternoon", l: "Afternoon" },
+  { v: "evening",   l: "Evening" },
+  { v: "night",     l: "Night" },
+];
+
+const SCHEDULE_MODES = [
+  { v: "specific_days", l: "Specific days of the week" },
+  { v: "recurring",     l: "Recurring (every N days/weeks/months)" },
+  { v: "one_shot",      l: "One-time task" },
+];
+
+const RECURRENCES = [
+  { v: "every_2_days",   l: "Every 2 days" },
+  { v: "weekly",         l: "Weekly" },
+  { v: "every_2_weeks",  l: "Every 2 weeks" },
+  { v: "monthly",        l: "Monthly" },
+  { v: "every_3_months", l: "Every 3 months" },
+  { v: "every_6_months", l: "Every 6 months" },
+];
+
+const FIRST_OCCURRENCE = [
+  { v: "available_immediately",     l: "Available immediately" },
+  { v: "wait_for_first_occurrence", l: "Wait for first scheduled occurrence" },
+];
+
+const ASSIGNMENT_MODES = [
+  { v: "everyone",    l: "Everyone — every assigned child sees the chore" },
+  { v: "alternating", l: "Alternating — rotate through children, one per day" },
+  { v: "random",      l: "Random — pick one assigned child each day" },
+  { v: "balanced",    l: "Balanced — split today's chores evenly across children" },
+];
+
+const VISIBILITY_OPS = [
+  { v: "equals",     l: "Equals" },
+  { v: "not_equals", l: "Not equal" },
+  { v: "gte",        l: "Greater than or equal (≥)" },
+  { v: "lte",        l: "Less than or equal (≤)" },
+  { v: "gt",         l: "Greater than (>)" },
+  { v: "lt",         l: "Less than (<)" },
+];
+
+const COMPLETION_SOUNDS = [
+  "none", "coin", "levelup", "fanfare", "chime", "powerup", "undo",
+  "fart1", "fart2", "fart3", "fart4", "fart5", "fart6", "fart7",
+  "fart8", "fart9", "fart10", "fart_random",
+];
+
+const DAYS = [
+  { v: "monday",    l: "Mon" },
+  { v: "tuesday",   l: "Tue" },
+  { v: "wednesday", l: "Wed" },
+  { v: "thursday",  l: "Thu" },
+  { v: "friday",    l: "Fri" },
+  { v: "saturday",  l: "Sat" },
+  { v: "sunday",    l: "Sun" },
+];
+
+const STREAK_MODES = [
+  { v: "reset", l: "Reset — streak goes to 0 on missed day" },
+  { v: "pause", l: "Pause — streak preserved until next completion" },
+];
+
+const TASK_GROUP_POLICIES = [
+  { v: "sticky", l: "Sticky — same child for all chores in the group today" },
+  { v: "spread", l: "Spread — different children across the group today" },
+];
+
+
 class TaskMatePanel extends HTMLElement {
   constructor() {
     super();
@@ -28,7 +102,7 @@ class TaskMatePanel extends HTMLElement {
     this._error = null;
     this._loading = false;
     this._activeTab = "children";
-    this._dialog = null;        // { kind: "child", mode: "add"|"edit", data }
+    this._dialog = null;        // { kind, mode: "add"|"edit", data }
     this._rendered = false;
     this._onClick = this._onClick.bind(this);
     this._onInput = this._onInput.bind(this);
@@ -36,7 +110,7 @@ class TaskMatePanel extends HTMLElement {
     this._onKeyDown = this._onKeyDown.bind(this);
   }
 
-  // ---- HA-injected properties ----------------------------------------------
+  // ---- HA injects these ------------------------------------------------
   set hass(value) {
     const first = this._hass === null;
     this._hass = value;
@@ -44,7 +118,6 @@ class TaskMatePanel extends HTMLElement {
     if (!this._rendered) this._render();
   }
   get hass() { return this._hass; }
-
   set narrow(_v) {}
   set route(_v) {}
   set panel(_v) {}
@@ -56,7 +129,6 @@ class TaskMatePanel extends HTMLElement {
     this.addEventListener("keydown", this._onKeyDown);
     if (!this._rendered) this._render();
   }
-
   disconnectedCallback() {
     this.removeEventListener("click", this._onClick);
     this.removeEventListener("input", this._onInput);
@@ -91,17 +163,13 @@ class TaskMatePanel extends HTMLElement {
   }
 
   _showToast(kind, text) {
-    // Render toasts outside the innerHTML tree so hiding them doesn't
-    // tear down the current dialog's <input>s and blur what the user is typing.
     const existing = this.querySelector(".tm-toast");
     if (existing) existing.remove();
     const node = document.createElement("div");
     node.className = `tm-toast tm-toast-${kind}`;
     node.textContent = text;
     this.appendChild(node);
-    setTimeout(() => {
-      if (node.isConnected) node.remove();
-    }, 3500);
+    setTimeout(() => { if (node.isConnected) node.remove(); }, 3500);
   }
 
   // ---- event delegation ------------------------------------------------
@@ -110,133 +178,382 @@ class TaskMatePanel extends HTMLElement {
     if (!t) return;
     const act = t.dataset.act;
 
-    // Tab switching
-    if (act === "tab") {
-      this._activeTab = t.dataset.tab;
-      this._render();
-      return;
-    }
-
-    // Dialog close button — always closes
-    if (act === "close-dialog") {
-      this._dialog = null;
-      this._render();
-      return;
-    }
-    // Scrim — closes ONLY when the dark backdrop itself was clicked, not
-    // when a click inside the dialog bubbled up to it.
+    if (act === "tab")           { this._activeTab = t.dataset.tab; this._render(); return; }
+    if (act === "close-dialog")  { this._dialog = null; this._render(); return; }
     if (act === "scrim") {
-      const scrimEl = this.querySelector(".tm-scrim");
-      if (e.target === scrimEl) {
-        this._dialog = null;
-        this._render();
-      }
+      if (e.target === this.querySelector(".tm-scrim")) { this._dialog = null; this._render(); }
       return;
     }
+    if (act === "retry")         { this._fetchState(); return; }
 
-    // Children
-    if (act === "add-child") {
-      this._dialog = { kind: "child", mode: "add", data: { name: "", avatar: "mdi:account-circle", availability_entity: "" } };
-      this._render();
-      return;
-    }
-    if (act === "edit-child") {
-      const child = (this._state.children || []).find(c => c.id === t.dataset.id);
-      if (!child) return;
-      this._dialog = { kind: "child", mode: "edit", data: { id: child.id, name: child.name || "", avatar: child.avatar || "mdi:account-circle", availability_entity: child.availability_entity || "" } };
-      this._render();
-      return;
-    }
-    if (act === "delete-child") {
-      const id = t.dataset.id;
-      const child = (this._state.children || []).find(c => c.id === id);
-      if (!child) return;
-      if (!confirm(`Delete "${child.name}"?\n\nThis also removes all of their completion history, reward claims, points transactions, and pool allocations. Chores assigned to them will be updated. This cannot be undone.`)) return;
-      this._doRemoveChild(id);
-      return;
-    }
-    if (act === "save-child") {
-      this._doSaveChild();
-      return;
-    }
-    if (act === "retry") {
-      this._fetchState();
-      return;
-    }
+    // -- Children --
+    if (act === "add-child")     { this._openChildDialog(null); return; }
+    if (act === "edit-child")    { this._openChildDialog(t.dataset.id); return; }
+    if (act === "delete-child")  { this._confirmDelete("child", t.dataset.id); return; }
+    if (act === "save-child")    { this._doSaveChild(); return; }
+
+    // -- Chores --
+    if (act === "add-chore")     { this._openChoreDialog(null); return; }
+    if (act === "edit-chore")    { this._openChoreDialog(t.dataset.id); return; }
+    if (act === "delete-chore")  { this._confirmDelete("chore", t.dataset.id); return; }
+    if (act === "save-chore")    { this._doSaveChore(); return; }
+    if (act === "toggle-day")    { this._toggleArrayField("due_days", t.dataset.day); return; }
+    if (act === "toggle-assigned") { this._toggleArrayField("assigned_to", t.dataset.id); return; }
+    if (act === "toggle-advanced") { const adv = this.querySelector(".tm-advanced"); if (adv) adv.toggleAttribute("open"); return; }
+
+    // -- Rewards --
+    if (act === "add-reward")    { this._openRewardDialog(null); return; }
+    if (act === "edit-reward")   { this._openRewardDialog(t.dataset.id); return; }
+    if (act === "delete-reward") { this._confirmDelete("reward", t.dataset.id); return; }
+    if (act === "save-reward")   { this._doSaveReward(); return; }
+    if (act === "toggle-reward-assigned") { this._toggleArrayField("assigned_to", t.dataset.id); return; }
+
+    // -- Penalties --
+    if (act === "add-penalty")    { this._openPenBonDialog("penalty", null); return; }
+    if (act === "edit-penalty")   { this._openPenBonDialog("penalty", t.dataset.id); return; }
+    if (act === "delete-penalty") { this._confirmDelete("penalty", t.dataset.id); return; }
+    if (act === "save-penalty")   { this._doSavePenBon("penalty"); return; }
+    if (act === "apply-penalty")  { this._openApplyDialog("penalty", t.dataset.id); return; }
+    if (act === "do-apply-penalty") { this._doApplyPenBon("penalty", t.dataset.id, t.dataset.child); return; }
+
+    // -- Bonuses --
+    if (act === "add-bonus")    { this._openPenBonDialog("bonus", null); return; }
+    if (act === "edit-bonus")   { this._openPenBonDialog("bonus", t.dataset.id); return; }
+    if (act === "delete-bonus") { this._confirmDelete("bonus", t.dataset.id); return; }
+    if (act === "save-bonus")   { this._doSavePenBon("bonus"); return; }
+    if (act === "apply-bonus")  { this._openApplyDialog("bonus", t.dataset.id); return; }
+    if (act === "do-apply-bonus") { this._doApplyPenBon("bonus", t.dataset.id, t.dataset.child); return; }
+
+    if (act === "toggle-penbon-assigned") { this._toggleArrayField("assigned_to", t.dataset.id); return; }
+
+    // -- Task groups --
+    if (act === "add-group")    { this._openGroupDialog(null); return; }
+    if (act === "edit-group")   { this._openGroupDialog(t.dataset.id); return; }
+    if (act === "delete-group") { this._confirmDelete("group", t.dataset.id); return; }
+    if (act === "save-group")   { this._doSaveGroup(); return; }
+    if (act === "toggle-group-chore") { this._toggleArrayField("chore_ids", t.dataset.id); return; }
+
+    // -- Settings --
+    if (act === "save-settings") { this._doSaveSettings(); return; }
   }
 
   _onInput(e) {
     if (!this._dialog) return;
     const t = e.target;
     if (!t.dataset || !t.dataset.field) return;
-    this._dialog.data[t.dataset.field] = t.value;
-    // no re-render; live-bound fields shouldn't cause full rerender per keystroke
+    const value = (t.type === "number") ? (t.value === "" ? null : Number(t.value)) : t.value;
+    this._dialog.data[t.dataset.field] = value;
   }
 
   _onChange(e) {
     if (!this._dialog) return;
     const t = e.target;
     if (!t.dataset || !t.dataset.field) return;
-    this._dialog.data[t.dataset.field] = t.value;
+    let value;
+    if (t.type === "checkbox") value = t.checked;
+    else if (t.type === "number") value = (t.value === "" ? null : Number(t.value));
+    else value = t.value;
+    this._dialog.data[t.dataset.field] = value;
   }
 
   _onKeyDown(e) {
-    if (e.key === "Escape" && this._dialog) {
-      this._dialog = null;
-      this._render();
-    }
+    if (e.key === "Escape" && this._dialog) { this._dialog = null; this._render(); }
   }
 
-  // ---- child actions ---------------------------------------------------
+  _toggleArrayField(field, value) {
+    if (!this._dialog || !this._dialog.data) return;
+    const arr = Array.isArray(this._dialog.data[field]) ? [...this._dialog.data[field]] : [];
+    const i = arr.indexOf(value);
+    if (i >= 0) arr.splice(i, 1); else arr.push(value);
+    this._dialog.data[field] = arr;
+    this._render();
+  }
+
+  _confirmDelete(kind, id) {
+    const labels = { child: "Child", chore: "Chore", reward: "Reward", penalty: "Penalty", bonus: "Bonus", group: "Group" };
+    const collectionKey = { child: "children", chore: "chores", reward: "rewards", penalty: "penalties", bonus: "bonuses", group: "task_groups" }[kind];
+    const item = (this._state[collectionKey] || []).find(x => x.id === id);
+    if (!item) return;
+    const extraWarn = kind === "child"
+      ? "\n\nThis also removes all of their completion history, reward claims, points transactions, and pool allocations. Chores assigned to them will be updated."
+      : kind === "reward"
+      ? "\n\nAny points children have pooled for this reward will be refunded to their balance."
+      : kind === "chore"
+      ? "\n\nThis also removes the chore from any task groups it belonged to."
+      : "";
+    if (!confirm(`Delete ${labels[kind].toLowerCase()} "${item.name}"?${extraWarn}\n\nThis cannot be undone.`)) return;
+    this._doRemove(kind, id);
+  }
+
+  async _doRemove(kind, id) {
+    const wsType = {
+      child:   "taskmate/remove_child",
+      chore:   "taskmate/remove_chore",
+      reward:  "taskmate/remove_reward",
+      penalty: "taskmate/remove_penalty",
+      bonus:   "taskmate/remove_bonus",
+      group:   "taskmate/remove_task_group",
+    }[kind];
+    const idField = {
+      child: "child_id", chore: "chore_id", reward: "reward_id",
+      penalty: "penalty_id", bonus: "bonus_id", group: "group_id",
+    }[kind];
+    const { ok, err } = await this._callWS({ type: wsType, [idField]: id });
+    if (!ok) { this._showToast("err", `Delete failed: ${err}`); return; }
+    await this._fetchState();
+    this._showToast("ok", "Deleted");
+  }
+
+  // ---- Children: dialog open / save ------------------------------------
+  _openChildDialog(id) {
+    if (id) {
+      const c = (this._state.children || []).find(x => x.id === id);
+      if (!c) return;
+      this._dialog = { kind: "child", mode: "edit", data: {
+        id: c.id, name: c.name || "", avatar: c.avatar || "mdi:account-circle",
+        availability_entity: c.availability_entity || "",
+      } };
+    } else {
+      this._dialog = { kind: "child", mode: "add", data: {
+        name: "", avatar: "mdi:account-circle", availability_entity: "",
+      } };
+    }
+    this._render();
+  }
+
   async _doSaveChild() {
     const d = this._dialog.data;
-    if (!d.name || !d.name.trim()) {
-      this._showToast("err", "Name is required");
-      return;
-    }
-    let payload;
-    if (this._dialog.mode === "add") {
-      payload = {
-        type: "taskmate/add_child",
-        name: d.name.trim(),
-        avatar: d.avatar || "mdi:account-circle",
-        availability_entity: d.availability_entity || "",
-      };
-    } else {
-      payload = {
-        type: "taskmate/update_child",
-        child_id: d.id,
-        name: d.name.trim(),
-        avatar: d.avatar || "mdi:account-circle",
-        availability_entity: d.availability_entity || "",
-      };
-    }
+    if (!d.name || !d.name.trim()) { this._showToast("err", "Name is required"); return; }
     const wasAdd = this._dialog.mode === "add";
+    const payload = wasAdd
+      ? { type: "taskmate/add_child", name: d.name.trim(), avatar: d.avatar || "mdi:account-circle", availability_entity: d.availability_entity || "" }
+      : { type: "taskmate/update_child", child_id: d.id, name: d.name.trim(), avatar: d.avatar || "mdi:account-circle", availability_entity: d.availability_entity || "" };
     const { ok, err } = await this._callWS(payload);
-    if (!ok) {
-      this._showToast("err", `Save failed: ${err}`);
-      return;
-    }
+    if (!ok) { this._showToast("err", `Save failed: ${err}`); return; }
     this._dialog = null;
     await this._fetchState();
     this._showToast("ok", wasAdd ? "Child added" : "Child updated");
   }
 
-  async _doRemoveChild(child_id) {
-    const { ok, err } = await this._callWS({ type: "taskmate/remove_child", child_id });
-    if (!ok) {
-      this._showToast("err", `Delete failed: ${err}`);
-      return;
+  // ---- Chores: dialog open / save --------------------------------------
+  _openChoreDialog(id) {
+    const blank = {
+      name: "", description: "", points: 10,
+      assigned_to: [], requires_approval: true,
+      time_category: "anytime", completion_sound: "coin", daily_limit: 1,
+      schedule_mode: "specific_days",
+      due_days: [], recurrence: "weekly", recurrence_day: "", recurrence_start: "",
+      first_occurrence_mode: "available_immediately",
+      assignment_mode: "everyone", assignment_rotation_anchor: "",
+      require_availability: false,
+      visibility_entity: "", visibility_state: "on", visibility_operator: "equals",
+      enabled: true,
+      publish_calendar_entities_csv: "",
+    };
+    if (id) {
+      const c = (this._state.chores || []).find(x => x.id === id);
+      if (!c) return;
+      this._dialog = { kind: "chore", mode: "edit", data: {
+        ...blank,
+        ...c,
+        assigned_to: [...(c.assigned_to || [])],
+        due_days: [...(c.due_days || [])],
+        publish_calendar_entities_csv: (c.publish_calendar_entities || []).join(", "),
+      } };
+    } else {
+      this._dialog = { kind: "chore", mode: "add", data: blank };
     }
+    this._render();
+  }
+
+  async _doSaveChore() {
+    const d = this._dialog.data;
+    if (!d.name || !d.name.trim()) { this._showToast("err", "Name is required"); return; }
+    const wasAdd = this._dialog.mode === "add";
+    const calCsv = (d.publish_calendar_entities_csv || "").split(",").map(s => s.trim()).filter(Boolean);
+    const base = {
+      name: d.name.trim(),
+      description: d.description || "",
+      points: Number(d.points) || 0,
+      assigned_to: d.assigned_to || [],
+      requires_approval: !!d.requires_approval,
+      time_category: d.time_category || "anytime",
+      completion_sound: d.completion_sound || "coin",
+      daily_limit: Number(d.daily_limit) || 1,
+      schedule_mode: d.schedule_mode || "specific_days",
+      due_days: d.due_days || [],
+      recurrence: d.recurrence || "weekly",
+      recurrence_day: d.recurrence_day || "",
+      recurrence_start: d.recurrence_start || "",
+      first_occurrence_mode: d.first_occurrence_mode || "available_immediately",
+      assignment_mode: d.assignment_mode || "everyone",
+      assignment_rotation_anchor: d.assignment_rotation_anchor || "",
+      require_availability: !!d.require_availability,
+      visibility_entity: d.visibility_entity || "",
+      visibility_state: d.visibility_state || "on",
+      visibility_operator: d.visibility_operator || "equals",
+      enabled: d.enabled !== false,
+      publish_calendar_entities: calCsv,
+    };
+    const payload = wasAdd
+      ? { type: "taskmate/add_chore", ...base }
+      : { type: "taskmate/update_chore", chore_id: d.id, ...base };
+    const { ok, err } = await this._callWS(payload);
+    if (!ok) { this._showToast("err", `Save failed: ${err}`); return; }
+    this._dialog = null;
     await this._fetchState();
-    this._showToast("ok", "Deleted");
+    this._showToast("ok", wasAdd ? "Chore added" : "Chore updated");
+  }
+
+  // ---- Rewards ---------------------------------------------------------
+  _openRewardDialog(id) {
+    const blank = { name: "", description: "", cost: 50, icon: "mdi:gift",
+      assigned_to: [], is_jackpot: false, pool_enabled: false,
+      quantity_str: "", expires_at: "" };
+    if (id) {
+      const r = (this._state.rewards || []).find(x => x.id === id);
+      if (!r) return;
+      this._dialog = { kind: "reward", mode: "edit", data: {
+        ...blank, ...r,
+        assigned_to: [...(r.assigned_to || [])],
+        quantity_str: r.quantity == null ? "" : String(r.quantity),
+        expires_at: r.expires_at || "",
+      } };
+    } else {
+      this._dialog = { kind: "reward", mode: "add", data: blank };
+    }
+    this._render();
+  }
+
+  async _doSaveReward() {
+    const d = this._dialog.data;
+    if (!d.name || !d.name.trim()) { this._showToast("err", "Name is required"); return; }
+    const wasAdd = this._dialog.mode === "add";
+    const qty = (d.quantity_str === "" || d.quantity_str == null) ? null : Math.max(0, Number(d.quantity_str));
+    const base = {
+      name: d.name.trim(),
+      cost: Number(d.cost) || 0,
+      description: d.description || "",
+      icon: d.icon || "mdi:gift",
+      assigned_to: d.assigned_to || [],
+      is_jackpot: !!d.is_jackpot,
+      pool_enabled: !!d.pool_enabled,
+      quantity: qty,
+      expires_at: (d.expires_at || "").trim() || null,
+    };
+    const payload = wasAdd ? { type: "taskmate/add_reward", ...base } : { type: "taskmate/update_reward", reward_id: d.id, ...base };
+    const { ok, err } = await this._callWS(payload);
+    if (!ok) { this._showToast("err", `Save failed: ${err}`); return; }
+    this._dialog = null;
+    await this._fetchState();
+    this._showToast("ok", wasAdd ? "Reward added" : "Reward updated");
+  }
+
+  // ---- Penalties / Bonuses (shared shape) ------------------------------
+  _openPenBonDialog(kind, id) {
+    const blank = { name: "", description: "", points: 10,
+      icon: kind === "penalty" ? "mdi:alert-circle-outline" : "mdi:star-circle-outline",
+      assigned_to: [] };
+    if (id) {
+      const item = ((kind === "penalty" ? this._state.penalties : this._state.bonuses) || []).find(x => x.id === id);
+      if (!item) return;
+      this._dialog = { kind, mode: "edit", data: { ...blank, ...item, assigned_to: [...(item.assigned_to || [])] } };
+    } else {
+      this._dialog = { kind, mode: "add", data: blank };
+    }
+    this._render();
+  }
+
+  async _doSavePenBon(kind) {
+    const d = this._dialog.data;
+    if (!d.name || !d.name.trim()) { this._showToast("err", "Name is required"); return; }
+    if (!d.points || d.points < 1) { this._showToast("err", "Points must be 1 or higher"); return; }
+    const wasAdd = this._dialog.mode === "add";
+    const wsBase = kind === "penalty" ? "penalty" : "bonus";
+    const idField = `${wsBase}_id`;
+    const wsType = wasAdd ? `taskmate/add_${wsBase}` : `taskmate/update_${wsBase}`;
+    const base = {
+      name: d.name.trim(),
+      points: Number(d.points),
+      description: d.description || "",
+      icon: d.icon || (kind === "penalty" ? "mdi:alert-circle-outline" : "mdi:star-circle-outline"),
+      assigned_to: d.assigned_to || [],
+    };
+    const payload = wasAdd ? { type: wsType, ...base } : { type: wsType, [idField]: d.id, ...base };
+    const { ok, err } = await this._callWS(payload);
+    if (!ok) { this._showToast("err", `Save failed: ${err}`); return; }
+    this._dialog = null;
+    await this._fetchState();
+    this._showToast("ok", `${wasAdd ? "Added" : "Updated"} ${kind}`);
+  }
+
+  _openApplyDialog(kind, id) {
+    const item = ((kind === "penalty" ? this._state.penalties : this._state.bonuses) || []).find(x => x.id === id);
+    if (!item) return;
+    this._dialog = { kind: `apply-${kind}`, mode: "apply", data: { id, item } };
+    this._render();
+  }
+
+  async _doApplyPenBon(kind, id, child_id) {
+    const wsType = kind === "penalty" ? "taskmate/apply_penalty" : "taskmate/apply_bonus";
+    const idField = `${kind}_id`;
+    const { ok, err } = await this._callWS({ type: wsType, [idField]: id, child_id });
+    if (!ok) { this._showToast("err", `Apply failed: ${err}`); return; }
+    this._dialog = null;
+    await this._fetchState();
+    this._showToast("ok", kind === "penalty" ? "Penalty applied" : "Bonus applied");
+  }
+
+  // ---- Task groups -----------------------------------------------------
+  _openGroupDialog(id) {
+    const blank = { name: "", policy: "sticky", chore_ids: [] };
+    if (id) {
+      const g = (this._state.task_groups || []).find(x => x.id === id);
+      if (!g) return;
+      this._dialog = { kind: "group", mode: "edit", data: { ...blank, ...g, chore_ids: [...(g.chore_ids || [])] } };
+    } else {
+      this._dialog = { kind: "group", mode: "add", data: blank };
+    }
+    this._render();
+  }
+
+  async _doSaveGroup() {
+    const d = this._dialog.data;
+    if (!d.name || !d.name.trim()) { this._showToast("err", "Name is required"); return; }
+    const wasAdd = this._dialog.mode === "add";
+    const base = { name: d.name.trim(), policy: d.policy || "sticky", chore_ids: d.chore_ids || [] };
+    const payload = wasAdd ? { type: "taskmate/add_task_group", ...base } : { type: "taskmate/update_task_group", group_id: d.id, ...base };
+    const { ok, err } = await this._callWS(payload);
+    if (!ok) { this._showToast("err", `Save failed: ${err}`); return; }
+    this._dialog = null;
+    await this._fetchState();
+    this._showToast("ok", wasAdd ? "Group added" : "Group updated");
+  }
+
+  // ---- Settings --------------------------------------------------------
+  async _doSaveSettings() {
+    // Settings tab uses inline inputs; gather values directly from DOM.
+    const root = this.querySelector(".tm-settings");
+    if (!root) return;
+    const fields = root.querySelectorAll("[data-setting]");
+    const payload = { type: "taskmate/update_settings" };
+    fields.forEach(el => {
+      const name = el.dataset.setting;
+      let v;
+      if (el.type === "checkbox") v = el.checked;
+      else if (el.type === "number") v = el.value === "" ? undefined : Number(el.value);
+      else v = el.value;
+      if (v !== undefined) payload[name] = v;
+    });
+    const { ok, err, res } = await this._callWS(payload);
+    if (!ok) { this._showToast("err", `Save failed: ${err}`); return; }
+    await this._fetchState();
+    this._showToast("ok", `Saved (${(res && res.updated || []).length} field${(res && res.updated || []).length === 1 ? "" : "s"})`);
   }
 
   // ---- rendering -------------------------------------------------------
   _render() {
     this._rendered = true;
-    // Preserve any existing toast across re-renders (it's a transient DOM
-    // node appended outside the shell — see _showToast).
     const existingToast = this.querySelector(".tm-toast");
     this.innerHTML = `
       ${this._styles()}
@@ -274,104 +591,67 @@ class TaskMatePanel extends HTMLElement {
   }
 
   _renderBody() {
-    if (this._loading && !this._state) {
-      return `<div class="tm-card">Loading…</div>`;
-    }
-    if (this._error) {
-      return `
-        <div class="tm-card tm-card-error">
-          <h2>Failed to load state</h2>
-          <p>${this._esc(this._error)}</p>
-          <button class="tm-btn" data-act="retry">Retry</button>
-        </div>
-      `;
-    }
-    if (!this._state) {
-      return `<div class="tm-card">No state yet.</div>`;
-    }
+    if (this._loading && !this._state) return `<div class="tm-card">Loading…</div>`;
+    if (this._error) return `
+      <div class="tm-card tm-card-error">
+        <h2>Failed to load state</h2>
+        <p>${this._esc(this._error)}</p>
+        <button class="tm-btn" data-act="retry">Retry</button>
+      </div>`;
+    if (!this._state) return `<div class="tm-card">No state yet.</div>`;
 
     switch (this._activeTab) {
       case "children":  return this._renderChildrenTab();
-      case "chores":    return this._placeholderTab("Chores",    "alpha.4");
-      case "rewards":   return this._placeholderTab("Rewards",   "alpha.5");
-      case "penalties": return this._placeholderTab("Penalties", "alpha.6");
-      case "bonuses":   return this._placeholderTab("Bonuses",   "alpha.6");
-      case "groups":    return this._placeholderTab("Groups",    "alpha.7");
-      case "settings":  return this._placeholderTab("Settings",  "alpha.7");
+      case "chores":    return this._renderChoresTab();
+      case "rewards":   return this._renderRewardsTab();
+      case "penalties": return this._renderPenBonTab("penalty");
+      case "bonuses":   return this._renderPenBonTab("bonus");
+      case "groups":    return this._renderGroupsTab();
+      case "settings":  return this._renderSettingsTab();
       default:          return `<div class="tm-card">Unknown tab</div>`;
     }
-  }
-
-  _placeholderTab(name, when) {
-    return `
-      <div class="tm-card tm-card-info">
-        <h2>${this._esc(name)} — coming in the next alpha</h2>
-        <p>This tab will be wired up in <code>v3.5.0-${when}</code>. For now, continue to use
-           <strong>Settings → Devices &amp; Services → TaskMate → Configure</strong> for ${this._esc(name.toLowerCase())}.</p>
-      </div>
-    `;
   }
 
   // -- Children tab ------------------------------------------------------
   _renderChildrenTab() {
     const children = this._state.children || [];
-    const pointsName = (this._state.settings && this._state.settings.points_name) || "points";
+    const pointsName = this._state.settings.points_name || "points";
     return `
       <div class="tm-toolbar">
-        <div class="tm-title-sub">Manage the children in your family. Their points balance and history stay intact when you edit details.</div>
+        <div class="tm-title-sub">Manage the children in your family. Points balance and history stay intact when you edit.</div>
         <button class="tm-btn" data-act="add-child">+ Add child</button>
       </div>
-
       ${children.length === 0 ? `
         <div class="tm-card tm-empty">
           <h2>No children yet</h2>
-          <p>Add your first child to get started. You can assign chores and rewards to them on the next tabs.</p>
+          <p>Add your first child to get started.</p>
           <button class="tm-btn" data-act="add-child">+ Add child</button>
         </div>
       ` : `
         <div class="tm-grid">
           ${children.map(c => this._renderChildCard(c, pointsName)).join("")}
-          <button class="tm-add-tile" data-act="add-child">
-            <span class="tm-add-plus">+</span>
-            Add child
-          </button>
+          <button class="tm-add-tile" data-act="add-child"><span class="tm-add-plus">+</span>Add child</button>
         </div>
       `}
     `;
   }
 
   _renderChildCard(child, pointsName) {
-    const avatar = child.avatar || "mdi:account-circle";
-    const availability = child.availability_entity || "";
-    const points = child.points || 0;
-    const total = child.total_points_earned || 0;
-    const completions = child.total_chores_completed || 0;
     return `
       <article class="tm-card tm-child-card">
         <header class="tm-child-head">
-          <div class="tm-avatar">${this._mdi(avatar)}</div>
+          <div class="tm-avatar">${this._mdi(child.avatar)}</div>
           <div class="tm-child-name">
             <h3>${this._esc(child.name || "(unnamed)")}</h3>
-            <div class="tm-sub">
-              ${availability ? `Availability: <code>${this._esc(availability)}</code>` : `<em>No availability sensor</em>`}
-            </div>
+            <div class="tm-sub">${child.availability_entity ? `Availability: <code>${this._esc(child.availability_entity)}</code>` : `<em>No availability sensor</em>`}</div>
           </div>
         </header>
         <div class="tm-stats">
-          <div class="tm-stat">
-            <strong>${this._fmtNum(points)}</strong>
-            <span>spendable ${this._esc(pointsName)}</span>
-          </div>
-          <div class="tm-stat">
-            <strong>${this._fmtNum(total)}</strong>
-            <span>earned all-time</span>
-          </div>
-          <div class="tm-stat">
-            <strong>${this._fmtNum(completions)}</strong>
-            <span>chores done</span>
-          </div>
+          <div class="tm-stat"><strong>${this._fmtNum(child.points || 0)}</strong><span>${this._esc(pointsName)}</span></div>
+          <div class="tm-stat"><strong>${this._fmtNum(child.total_points_earned || 0)}</strong><span>earned</span></div>
+          <div class="tm-stat"><strong>${this._fmtNum(child.total_chores_completed || 0)}</strong><span>chores done</span></div>
         </div>
-        <footer class="tm-child-foot">
+        <footer class="tm-card-foot">
           <button class="tm-btn tm-btn-ghost" data-act="edit-child" data-id="${this._esc(child.id)}">Edit</button>
           <button class="tm-btn tm-btn-danger" data-act="delete-child" data-id="${this._esc(child.id)}">Delete</button>
         </footer>
@@ -379,48 +659,561 @@ class TaskMatePanel extends HTMLElement {
     `;
   }
 
+  // -- Chores tab --------------------------------------------------------
+  _renderChoresTab() {
+    const chores = this._state.chores || [];
+    const childById = Object.fromEntries((this._state.children || []).map(c => [c.id, c]));
+    return `
+      <div class="tm-toolbar">
+        <div class="tm-title-sub">${chores.length} chore${chores.length === 1 ? "" : "s"} configured.</div>
+        <button class="tm-btn" data-act="add-chore">+ Add chore</button>
+      </div>
+      ${chores.length === 0 ? `
+        <div class="tm-card tm-empty">
+          <h2>No chores yet</h2>
+          <p>Add a chore — it'll appear on the assigned children's cards.</p>
+          <button class="tm-btn" data-act="add-chore">+ Add chore</button>
+        </div>
+      ` : `
+        <div class="tm-table-wrap">
+          <table class="tm-table">
+            <thead><tr>
+              <th>Name</th><th>Points</th><th>Assigned</th><th>Schedule</th><th>Approval</th><th></th>
+            </tr></thead>
+            <tbody>
+              ${chores.map(c => this._renderChoreRow(c, childById)).join("")}
+            </tbody>
+          </table>
+        </div>
+      `}
+    `;
+  }
+
+  _renderChoreRow(c, childById) {
+    const assignedNames = (c.assigned_to || []).map(id => (childById[id] && childById[id].name) || "?").join(", ") || "(unassigned)";
+    const schedLabel = c.schedule_mode === "recurring"
+      ? this._labelOf(RECURRENCES, c.recurrence) + (c.recurrence_day && c.recurrence_day !== "any_day" ? ` · ${c.recurrence_day}` : "")
+      : c.schedule_mode === "one_shot"
+      ? "One-shot"
+      : ((c.due_days || []).length === 0 ? "Daily" : (c.due_days || []).map(d => d.slice(0, 3)).join("/"));
+    const modeBadge = c.assignment_mode && c.assignment_mode !== "everyone"
+      ? `<span class="tm-pill tm-pill-${c.assignment_mode}">${c.assignment_mode}</span>` : "";
+    return `
+      <tr class="tm-row ${c.enabled === false ? "tm-row-disabled" : ""}">
+        <td><strong>${this._esc(c.name)}</strong>${c.enabled === false ? ` <span class="tm-pill">disabled</span>` : ""}</td>
+        <td><strong>${c.points}</strong></td>
+        <td>${this._esc(assignedNames)} ${modeBadge}</td>
+        <td>${this._esc(schedLabel)}</td>
+        <td>${c.requires_approval ? "<span class='tm-yes'>Yes</span>" : "<span class='tm-no'>No</span>"}</td>
+        <td class="tm-row-actions">
+          <button class="tm-icon-btn" data-act="edit-chore" data-id="${this._esc(c.id)}" title="Edit">✏</button>
+          <button class="tm-icon-btn" data-act="delete-chore" data-id="${this._esc(c.id)}" title="Delete">🗑</button>
+        </td>
+      </tr>
+    `;
+  }
+
+  // -- Rewards tab -------------------------------------------------------
+  _renderRewardsTab() {
+    const rewards = this._state.rewards || [];
+    const pointsName = this._state.settings.points_name || "points";
+    return `
+      <div class="tm-toolbar">
+        <div class="tm-title-sub">${rewards.length} reward${rewards.length === 1 ? "" : "s"} configured.</div>
+        <button class="tm-btn" data-act="add-reward">+ Add reward</button>
+      </div>
+      ${rewards.length === 0 ? `
+        <div class="tm-card tm-empty">
+          <h2>No rewards yet</h2>
+          <p>Add a reward children can spend their ${this._esc(pointsName.toLowerCase())} on.</p>
+          <button class="tm-btn" data-act="add-reward">+ Add reward</button>
+        </div>
+      ` : `
+        <div class="tm-grid">
+          ${rewards.map(r => this._renderRewardCard(r, pointsName)).join("")}
+          <button class="tm-add-tile" data-act="add-reward"><span class="tm-add-plus">+</span>Add reward</button>
+        </div>
+      `}
+    `;
+  }
+
+  _renderRewardCard(r, pointsName) {
+    const totalPooled = (this._state.pool_allocations || []).filter(a => a.reward_id === r.id).reduce((s, a) => s + (a.allocated_points || 0), 0);
+    const progressBar = r.pool_enabled && r.cost > 0
+      ? `<div class="tm-progress"><span style="width:${Math.min(100, Math.round(totalPooled / r.cost * 100))}%"></span></div>
+         <div class="tm-sub">${this._fmtNum(totalPooled)} / ${this._fmtNum(r.cost)} ${this._esc(pointsName)}</div>`
+      : "";
+    return `
+      <article class="tm-card tm-reward-card">
+        <header class="tm-child-head">
+          <div class="tm-avatar tm-reward-avatar">${this._mdi(r.icon || "mdi:gift")}</div>
+          <div class="tm-child-name">
+            <h3>${this._esc(r.name)} ${r.is_jackpot ? `<span class="tm-pill tm-pill-jackpot">🏆 Jackpot</span>` : ""} ${r.pool_enabled ? `<span class="tm-pill tm-pill-pool">Pool</span>` : ""}</h3>
+            <div class="tm-sub">${this._esc(r.description || "")}</div>
+          </div>
+        </header>
+        <div class="tm-stats">
+          <div class="tm-stat"><strong>${this._fmtNum(r.cost)}</strong><span>${this._esc(pointsName)} cost</span></div>
+          ${r.quantity != null ? `<div class="tm-stat"><strong>${r.quantity}</strong><span>remaining</span></div>` : ""}
+          ${r.expires_at ? `<div class="tm-stat"><strong>${this._esc(r.expires_at)}</strong><span>expires</span></div>` : ""}
+        </div>
+        ${progressBar}
+        <footer class="tm-card-foot">
+          <button class="tm-btn tm-btn-ghost" data-act="edit-reward" data-id="${this._esc(r.id)}">Edit</button>
+          <button class="tm-btn tm-btn-danger" data-act="delete-reward" data-id="${this._esc(r.id)}">Delete</button>
+        </footer>
+      </article>
+    `;
+  }
+
+  // -- Penalties / Bonuses tab -------------------------------------------
+  _renderPenBonTab(kind) {
+    const items = (kind === "penalty" ? this._state.penalties : this._state.bonuses) || [];
+    const childById = Object.fromEntries((this._state.children || []).map(c => [c.id, c]));
+    const labels = kind === "penalty" ? { plural: "Penalties", add: "+ Add penalty" } : { plural: "Bonuses", add: "+ Add bonus" };
+    return `
+      <div class="tm-toolbar">
+        <div class="tm-title-sub">${items.length} ${labels.plural.toLowerCase()} configured.</div>
+        <button class="tm-btn" data-act="add-${kind}">${labels.add}</button>
+      </div>
+      ${items.length === 0 ? `
+        <div class="tm-card tm-empty">
+          <h2>No ${labels.plural.toLowerCase()} yet</h2>
+          <p>${kind === "penalty" ? "Add a penalty to deduct points from a child for misbehaviour." : "Add a bonus to award points for going above and beyond."}</p>
+          <button class="tm-btn" data-act="add-${kind}">${labels.add}</button>
+        </div>
+      ` : `
+        <div class="tm-table-wrap">
+          <table class="tm-table">
+            <thead><tr><th>Name</th><th>Points</th><th>Assigned</th><th></th></tr></thead>
+            <tbody>
+              ${items.map(item => {
+                const assignedNames = (item.assigned_to || []).length === 0
+                  ? "Both / All"
+                  : (item.assigned_to || []).map(id => (childById[id] && childById[id].name) || "?").join(", ");
+                return `
+                  <tr class="tm-row">
+                    <td><span class="tm-row-icon">${this._mdi(item.icon)}</span><strong>${this._esc(item.name)}</strong>${item.description ? `<div class="tm-sub">${this._esc(item.description)}</div>` : ""}</td>
+                    <td><strong class="${kind === "penalty" ? "tm-neg" : "tm-pos"}">${kind === "penalty" ? "−" : "+"}${item.points}</strong></td>
+                    <td>${this._esc(assignedNames)}</td>
+                    <td class="tm-row-actions">
+                      <button class="tm-btn tm-btn-ghost" data-act="apply-${kind}" data-id="${this._esc(item.id)}">Apply…</button>
+                      <button class="tm-icon-btn" data-act="edit-${kind}" data-id="${this._esc(item.id)}" title="Edit">✏</button>
+                      <button class="tm-icon-btn" data-act="delete-${kind}" data-id="${this._esc(item.id)}" title="Delete">🗑</button>
+                    </td>
+                  </tr>
+                `;
+              }).join("")}
+            </tbody>
+          </table>
+        </div>
+      `}
+    `;
+  }
+
+  // -- Groups tab --------------------------------------------------------
+  _renderGroupsTab() {
+    const groups = this._state.task_groups || [];
+    const choreById = Object.fromEntries((this._state.chores || []).map(c => [c.id, c]));
+    return `
+      <div class="tm-toolbar">
+        <div class="tm-title-sub">Groups coordinate chore assignment across multiple chores. Sticky = same child for all; Spread = different children.</div>
+        <button class="tm-btn" data-act="add-group">+ Add group</button>
+      </div>
+      ${groups.length === 0 ? `
+        <div class="tm-card tm-empty">
+          <h2>No task groups yet</h2>
+          <p>Create a group to make chores rotate together (e.g. all the kitchen chores stay with one child each day).</p>
+          <button class="tm-btn" data-act="add-group">+ Add group</button>
+        </div>
+      ` : `
+        <div class="tm-grid">
+          ${groups.map(g => `
+            <article class="tm-card">
+              <h3 style="margin: 0 0 6px;">${this._esc(g.name)} <span class="tm-pill tm-pill-${g.policy}">${g.policy}</span></h3>
+              <div class="tm-sub" style="margin-bottom: 12px;">${(g.chore_ids || []).length} member chore${(g.chore_ids || []).length === 1 ? "" : "s"}</div>
+              <ul class="tm-group-list">
+                ${(g.chore_ids || []).map(id => `<li>${this._esc((choreById[id] && choreById[id].name) || `(missing chore ${id})`)}</li>`).join("")}
+              </ul>
+              <footer class="tm-card-foot" style="margin-top: 12px;">
+                <button class="tm-btn tm-btn-ghost" data-act="edit-group" data-id="${this._esc(g.id)}">Edit</button>
+                <button class="tm-btn tm-btn-danger" data-act="delete-group" data-id="${this._esc(g.id)}">Delete</button>
+              </footer>
+            </article>
+          `).join("")}
+          <button class="tm-add-tile" data-act="add-group"><span class="tm-add-plus">+</span>Add group</button>
+        </div>
+      `}
+    `;
+  }
+
+  // -- Settings tab ------------------------------------------------------
+  _renderSettingsTab() {
+    const s = this._state.settings || {};
+    return `
+      <div class="tm-card tm-settings">
+        <h2>Currency</h2>
+        <div class="tm-field-row">
+          <label class="tm-field-inline"><span>Points name</span>
+            <input type="text" data-setting="points_name" value="${this._esc(s.points_name || "Stars")}" placeholder="Stars">
+          </label>
+          <label class="tm-field-inline"><span>Points icon</span>
+            <input type="text" data-setting="points_icon" value="${this._esc(s.points_icon || "mdi:star")}" placeholder="mdi:star">
+          </label>
+        </div>
+
+        <h2>History &amp; streaks</h2>
+        <div class="tm-field-row">
+          <label class="tm-field-inline"><span>History days to retain (30–365)</span>
+            <input type="number" min="30" max="365" data-setting="history_days" value="${s.history_days || 90}">
+          </label>
+          <label class="tm-field-inline"><span>Streak reset mode</span>
+            <select data-setting="streak_reset_mode">
+              ${STREAK_MODES.map(m => `<option value="${m.v}" ${m.v === (s.streak_reset_mode || "reset") ? "selected" : ""}>${this._esc(m.l)}</option>`).join("")}
+            </select>
+          </label>
+        </div>
+        <div class="tm-field-row">
+          <label class="tm-field-inline"><span>Weekend points multiplier (1.0 = off)</span>
+            <input type="number" step="0.1" min="1" max="5" data-setting="weekend_multiplier" value="${s.weekend_multiplier || 1.0}">
+          </label>
+          <label class="tm-field-inline"><span>Calendar planning horizon (days)</span>
+            <input type="number" min="1" max="90" data-setting="calendar_projection_days" value="${s.calendar_projection_days || 14}">
+          </label>
+        </div>
+
+        <h2>Bonuses</h2>
+        <div class="tm-check-row">
+          <label class="tm-switch"><input type="checkbox" data-setting="streak_milestones_enabled" ${s.streak_milestones_enabled ? "checked" : ""}><span class="tm-slider"></span></label>
+          Award bonus points at streak milestones (3, 7, 14, 30, 60, 100 days)
+        </div>
+        <div class="tm-check-row">
+          <label class="tm-switch"><input type="checkbox" data-setting="perfect_week_enabled" ${s.perfect_week_enabled ? "checked" : ""}><span class="tm-slider"></span></label>
+          Award bonus for completing chores every day of a week
+        </div>
+        <div class="tm-field-row">
+          <label class="tm-field-inline"><span>Perfect week bonus points</span>
+            <input type="number" min="0" data-setting="perfect_week_bonus" value="${s.perfect_week_bonus || 50}">
+          </label>
+        </div>
+
+        <h2>Notifications</h2>
+        <div class="tm-field-row">
+          <label class="tm-field-inline"><span>Notify service for approval pings</span>
+            <input type="text" data-setting="notify_service" value="${this._esc(s.notify_service || "")}" placeholder="notify.mobile_app_your_phone">
+          </label>
+        </div>
+        <div class="tm-sub" style="margin-bottom: 16px;">Leave blank to use HA's persistent notifications only.</div>
+
+        <footer class="tm-card-foot" style="border-top: 1px solid var(--divider-color); padding-top: 16px; justify-content: flex-end;">
+          <button class="tm-btn" data-act="save-settings">Save settings</button>
+        </footer>
+      </div>
+    `;
+  }
+
   // -- Dialogs -----------------------------------------------------------
   _renderDialog() {
-    if (this._dialog.kind === "child") return this._renderChildDialog();
+    if (this._dialog.kind === "child")        return this._renderChildDialog();
+    if (this._dialog.kind === "chore")        return this._renderChoreDialog();
+    if (this._dialog.kind === "reward")       return this._renderRewardDialog();
+    if (this._dialog.kind === "penalty")      return this._renderPenBonDialog("penalty");
+    if (this._dialog.kind === "bonus")        return this._renderPenBonDialog("bonus");
+    if (this._dialog.kind === "group")        return this._renderGroupDialog();
+    if (this._dialog.kind === "apply-penalty") return this._renderApplyDialog("penalty");
+    if (this._dialog.kind === "apply-bonus")   return this._renderApplyDialog("bonus");
     return "";
   }
 
   _renderChildDialog() {
     const d = this._dialog.data;
-    const title = this._dialog.mode === "add" ? "Add child" : "Edit child";
+    return this._dialogShell(this._dialog.mode === "add" ? "Add child" : "Edit child",
+      [
+        this._field("Name", "name", d.name, "text", "e.g. Malia"),
+        this._field("Avatar (MDI icon)", "avatar", d.avatar, "text", "Examples: mdi:face-woman, mdi:face-man, mdi:dog"),
+        this._field("Availability sensor (optional)", "availability_entity", d.availability_entity, "text",
+          "HA entity that says whether the child is available. States <code>on</code>, <code>home</code>, <code>available</code>, <code>present</code>, <code>true</code> mean available. Leave blank to treat as always available."),
+      ].join(""),
+      `<button class="tm-btn tm-btn-ghost" data-act="close-dialog">Cancel</button>
+       <button class="tm-btn" data-act="save-child">Save</button>`
+    );
+  }
+
+  _renderChoreDialog() {
+    const d = this._dialog.data;
+    const children = this._state.children || [];
+    const groups = this._state.task_groups || [];
+    const memberInGroup = (d.id && groups.find(g => (g.chore_ids || []).includes(d.id))) || null;
+    const showSpecificDays = d.schedule_mode === "specific_days";
+    const showRecurring    = d.schedule_mode === "recurring";
+
+    return this._dialogShell(this._dialog.mode === "add" ? "Add chore" : "Edit chore",
+      [
+        this._field("Name", "name", d.name, "text"),
+        this._field("Description (optional)", "description", d.description, "text"),
+
+        `<div class="tm-field-row">
+          ${this._field("Points", "points", d.points, "number")}
+          ${this._field("Daily limit", "daily_limit", d.daily_limit, "number")}
+        </div>`,
+
+        // Assigned to (multi-checkbox)
+        children.length > 0 ? `
+          <div class="tm-field">
+            <span class="tm-field-label">Assigned to</span>
+            <div class="tm-multi">
+              ${children.map(c => `
+                <button type="button" class="tm-chip-btn ${(d.assigned_to || []).includes(c.id) ? "tm-chip-on" : ""}" data-act="toggle-assigned" data-id="${this._esc(c.id)}">
+                  ${this._esc(c.name)}
+                </button>
+              `).join("")}
+            </div>
+            <span class="tm-field-hint">Leave empty to assign to all children.</span>
+          </div>
+        ` : `<div class="tm-field"><span class="tm-field-hint">Add some children first to assign chores to them.</span></div>`,
+
+        this._select("Assignment mode", "assignment_mode", d.assignment_mode, ASSIGNMENT_MODES,
+          "Everyone = all assigned children see it. Alternating = rotate one per day. Random = pick one daily. Balanced = split evenly across the day."),
+
+        this._select("Time category", "time_category", d.time_category, TIME_CATEGORIES),
+
+        // Schedule mode
+        this._select("Schedule mode", "schedule_mode", d.schedule_mode, SCHEDULE_MODES),
+
+        showSpecificDays ? `
+          <div class="tm-field">
+            <span class="tm-field-label">Days of week (leave empty = every day)</span>
+            <div class="tm-day-row">
+              ${DAYS.map(day => `
+                <button type="button" class="tm-day-btn ${(d.due_days || []).includes(day.v) ? "tm-day-on" : ""}" data-act="toggle-day" data-day="${day.v}">${day.l}</button>
+              `).join("")}
+            </div>
+          </div>
+        ` : "",
+
+        showRecurring ? `
+          <div class="tm-field-row">
+            ${this._select("Recurrence", "recurrence", d.recurrence, RECURRENCES)}
+            ${this._field("Day of week (weekly only)", "recurrence_day", d.recurrence_day, "text", "e.g. monday — leave blank for any day")}
+          </div>
+          <div class="tm-field-row">
+            ${this._field("Start date (every-2-days only)", "recurrence_start", d.recurrence_start, "text", "YYYY-MM-DD; blank = today")}
+            ${this._select("First occurrence", "first_occurrence_mode", d.first_occurrence_mode, FIRST_OCCURRENCE)}
+          </div>
+        ` : "",
+
+        this._select("Completion sound", "completion_sound", d.completion_sound, COMPLETION_SOUNDS.map(s => ({ v: s, l: s }))),
+
+        // Switches
+        this._switch("Requires parent approval", "requires_approval", d.requires_approval),
+        this._switch("Skip unavailable children", "require_availability", d.require_availability,
+          "Uses each child's availability sensor (set on their profile)."),
+
+        memberInGroup ? `
+          <div class="tm-field">
+            <span class="tm-field-hint">Member of task group: <strong>${this._esc(memberInGroup.name)}</strong> (${memberInGroup.policy}). Manage membership on the Groups tab.</span>
+          </div>
+        ` : "",
+
+        // Advanced section
+        `<details class="tm-advanced">
+          <summary>Advanced</summary>
+          <div style="padding-top: 12px;">
+            ${this._field("Visibility entity (optional)", "visibility_entity", d.visibility_entity, "text", "Entity ID; chore only shows when its state matches the rule below.")}
+            <div class="tm-field-row">
+              ${this._select("Visibility operator", "visibility_operator", d.visibility_operator, VISIBILITY_OPS)}
+              ${this._field("Visibility value", "visibility_state", d.visibility_state, "text", 'e.g. "on", "home", "30"')}
+            </div>
+            ${this._field("Calendar entities to publish to (comma-separated)", "publish_calendar_entities_csv", d.publish_calendar_entities_csv, "text", "e.g. calendar.family, calendar.kids — blank = no calendar publishing")}
+            ${this._switch("Enabled", "enabled", d.enabled !== false)}
+          </div>
+        </details>`,
+      ].join(""),
+      `<button class="tm-btn tm-btn-ghost" data-act="close-dialog">Cancel</button>
+       <button class="tm-btn" data-act="save-chore">Save</button>`
+    );
+  }
+
+  _renderRewardDialog() {
+    const d = this._dialog.data;
+    const children = this._state.children || [];
+    const pointsName = this._state.settings.points_name || "points";
+    return this._dialogShell(this._dialog.mode === "add" ? "Add reward" : "Edit reward",
+      [
+        this._field("Name", "name", d.name, "text"),
+        this._field("Description (optional)", "description", d.description, "text"),
+        `<div class="tm-field-row">
+          ${this._field(`Cost (${pointsName})`, "cost", d.cost, "number")}
+          ${this._field("Icon (MDI)", "icon", d.icon, "text")}
+        </div>`,
+
+        children.length > 0 ? `
+          <div class="tm-field">
+            <span class="tm-field-label">Assigned to</span>
+            <div class="tm-multi">
+              ${children.map(c => `
+                <button type="button" class="tm-chip-btn ${(d.assigned_to || []).includes(c.id) ? "tm-chip-on" : ""}" data-act="toggle-reward-assigned" data-id="${this._esc(c.id)}">
+                  ${this._esc(c.name)}
+                </button>
+              `).join("")}
+            </div>
+            <span class="tm-field-hint">Leave empty to make available to all children.</span>
+          </div>
+        ` : "",
+
+        this._switch("Pool reward (savings jar)", "pool_enabled", d.pool_enabled,
+          "Children deposit points into this reward's dedicated pool rather than spending from their balance. Good for long-term savings goals."),
+        this._switch("Jackpot — pool from all assigned children", "is_jackpot", d.is_jackpot,
+          "Combine all children's contributions toward one shared reward."),
+
+        `<div class="tm-field-row">
+          ${this._field("Limited quantity (blank = unlimited)", "quantity_str", d.quantity_str, "text", "Each approved claim reduces by 1.")}
+          ${this._field("Expires (YYYY-MM-DD, blank = never)", "expires_at", d.expires_at, "text", "Pooled points are refunded at midnight.")}
+        </div>`,
+      ].join(""),
+      `<button class="tm-btn tm-btn-ghost" data-act="close-dialog">Cancel</button>
+       <button class="tm-btn" data-act="save-reward">Save</button>`
+    );
+  }
+
+  _renderPenBonDialog(kind) {
+    const d = this._dialog.data;
+    const children = this._state.children || [];
+    const isPenalty = kind === "penalty";
+    return this._dialogShell(`${this._dialog.mode === "add" ? "Add" : "Edit"} ${kind}`,
+      [
+        this._field("Name", "name", d.name, "text"),
+        this._field("Description (optional)", "description", d.description, "text"),
+        `<div class="tm-field-row">
+          ${this._field(`Points to ${isPenalty ? "deduct" : "award"}`, "points", d.points, "number")}
+          ${this._field("Icon (MDI)", "icon", d.icon, "text")}
+        </div>`,
+        children.length > 0 ? `
+          <div class="tm-field">
+            <span class="tm-field-label">Applies to</span>
+            <div class="tm-multi">
+              ${children.map(c => `
+                <button type="button" class="tm-chip-btn ${(d.assigned_to || []).includes(c.id) ? "tm-chip-on" : ""}" data-act="toggle-penbon-assigned" data-id="${this._esc(c.id)}">
+                  ${this._esc(c.name)}
+                </button>
+              `).join("")}
+            </div>
+            <span class="tm-field-hint">Leave empty to apply to all children.</span>
+          </div>
+        ` : "",
+      ].join(""),
+      `<button class="tm-btn tm-btn-ghost" data-act="close-dialog">Cancel</button>
+       <button class="tm-btn" data-act="save-${kind}">Save</button>`
+    );
+  }
+
+  _renderApplyDialog(kind) {
+    const d = this._dialog.data;
+    const item = d.item;
+    const children = this._state.children || [];
+    const isPenalty = kind === "penalty";
+    const eligible = (item.assigned_to || []).length === 0
+      ? children
+      : children.filter(c => (item.assigned_to || []).includes(c.id));
+    return this._dialogShell(`Apply ${kind}: ${item.name}`,
+      `<p>Choose which child to ${isPenalty ? "apply this penalty to (will deduct" : "award this bonus to (will add"} <strong>${item.points}</strong> points).</p>
+       ${eligible.length === 0 ? `<p class="tm-sub">No eligible children. Edit the ${kind} to set who it applies to.</p>` : `
+        <div class="tm-multi" style="margin-top: 12px;">
+          ${eligible.map(c => `
+            <button type="button" class="tm-btn tm-btn-ghost" data-act="do-apply-${kind}" data-id="${this._esc(item.id)}" data-child="${this._esc(c.id)}">
+              ${this._esc(c.name)}
+            </button>
+          `).join("")}
+        </div>
+       `}`,
+      `<button class="tm-btn tm-btn-ghost" data-act="close-dialog">Close</button>`
+    );
+  }
+
+  _renderGroupDialog() {
+    const d = this._dialog.data;
+    const chores = (this._state.chores || []).filter(c => c.assignment_mode && c.assignment_mode !== "everyone");
+    return this._dialogShell(this._dialog.mode === "add" ? "Add task group" : "Edit task group",
+      [
+        this._field("Name", "name", d.name, "text"),
+        this._select("Policy", "policy", d.policy, TASK_GROUP_POLICIES,
+          "Sticky = same child for all chores in the group today. Spread = different children today."),
+        chores.length === 0 ? `
+          <div class="tm-field">
+            <span class="tm-field-hint">Only rotation-mode chores (alternating / random / balanced) can join a group. Edit a chore's assignment mode first.</span>
+          </div>
+        ` : `
+          <div class="tm-field">
+            <span class="tm-field-label">Member chores (order matters for sticky — first is the leader)</span>
+            <div class="tm-multi">
+              ${chores.map(c => `
+                <button type="button" class="tm-chip-btn ${(d.chore_ids || []).includes(c.id) ? "tm-chip-on" : ""}" data-act="toggle-group-chore" data-id="${this._esc(c.id)}">
+                  ${this._esc(c.name)}
+                </button>
+              `).join("")}
+            </div>
+          </div>
+        `,
+      ].join(""),
+      `<button class="tm-btn tm-btn-ghost" data-act="close-dialog">Cancel</button>
+       <button class="tm-btn" data-act="save-group">Save</button>`
+    );
+  }
+
+  // ---- form-element helpers --------------------------------------------
+  _dialogShell(title, body, footer) {
     return `
       <div class="tm-scrim" data-act="scrim">
         <div class="tm-dialog">
           <header class="tm-dialog-head">
-            <h2>${title}</h2>
+            <h2>${this._esc(title)}</h2>
             <button class="tm-icon-btn" data-act="close-dialog" title="Close">&times;</button>
           </header>
-          <div class="tm-dialog-body">
-            <label class="tm-field">
-              <span class="tm-field-label">Name</span>
-              <input type="text" data-field="name" value="${this._esc(d.name || "")}" placeholder="e.g. Malia" autofocus>
-            </label>
-            <label class="tm-field">
-              <span class="tm-field-label">Avatar (MDI icon)</span>
-              <input type="text" data-field="avatar" value="${this._esc(d.avatar || "mdi:account-circle")}" placeholder="mdi:account-circle">
-              <span class="tm-field-hint">Any Material Design icon, e.g. <code>mdi:face-woman</code>, <code>mdi:face-man</code>.</span>
-            </label>
-            <label class="tm-field">
-              <span class="tm-field-label">Availability sensor <span class="tm-field-opt">(optional)</span></span>
-              <input type="text" data-field="availability_entity" value="${this._esc(d.availability_entity || "")}" placeholder="binary_sensor.malia_home">
-              <span class="tm-field-hint">HA entity that tells TaskMate whether this child is available. States <code>on</code>, <code>home</code>, <code>available</code>, <code>present</code>, <code>true</code> mean available. Leave blank to treat as always available.</span>
-            </label>
-          </div>
-          <footer class="tm-dialog-foot">
-            <button class="tm-btn tm-btn-ghost" data-act="close-dialog">Cancel</button>
-            <button class="tm-btn" data-act="save-child">Save</button>
-          </footer>
+          <div class="tm-dialog-body">${body}</div>
+          <footer class="tm-dialog-foot">${footer}</footer>
         </div>
-      </div>
-    `;
+      </div>`;
   }
 
-  // ---- helpers ---------------------------------------------------------
+  _field(label, name, value, type = "text", hint = "") {
+    return `
+      <label class="tm-field">
+        <span class="tm-field-label">${this._esc(label)}</span>
+        <input type="${type}" data-field="${name}" value="${this._esc(value == null ? "" : value)}">
+        ${hint ? `<span class="tm-field-hint">${hint}</span>` : ""}
+      </label>`;
+  }
+
+  _select(label, name, value, options, hint = "") {
+    return `
+      <label class="tm-field">
+        <span class="tm-field-label">${this._esc(label)}</span>
+        <select data-field="${name}">
+          ${options.map(o => `<option value="${this._esc(o.v)}" ${o.v === value ? "selected" : ""}>${this._esc(o.l)}</option>`).join("")}
+        </select>
+        ${hint ? `<span class="tm-field-hint">${hint}</span>` : ""}
+      </label>`;
+  }
+
+  _switch(label, name, checked, hint = "") {
+    return `
+      <div class="tm-check-row">
+        <label class="tm-switch">
+          <input type="checkbox" data-field="${name}" ${checked ? "checked" : ""}>
+          <span class="tm-slider"></span>
+        </label>
+        <div>
+          <div>${this._esc(label)}</div>
+          ${hint ? `<span class="tm-field-hint">${hint}</span>` : ""}
+        </div>
+      </div>`;
+  }
+
+  _labelOf(options, value) {
+    const o = options.find(x => x.v === value);
+    return o ? o.l : value;
+  }
+
   _esc(str) {
     return String(str == null ? "" : str)
       .replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
@@ -433,11 +1226,7 @@ class TaskMatePanel extends HTMLElement {
   }
 
   _mdi(name) {
-    // Render an mdi: name as an <ha-icon>. HA's <ha-icon> custom element is
-    // globally registered by the frontend and tolerates us creating it before
-    // it's upgraded — it'll upgrade and render on its own.
-    const safe = this._esc(name || "mdi:account-circle");
-    return `<ha-icon icon="${safe}"></ha-icon>`;
+    return `<ha-icon icon="${this._esc(name || "mdi:account-circle")}"></ha-icon>`;
   }
 
   // ---- styles ----------------------------------------------------------
@@ -461,18 +1250,19 @@ class TaskMatePanel extends HTMLElement {
       .tm-title-sub { flex: 1; color: var(--secondary-text-color, #9aa0a6); font-size: 13px; }
 
       .tm-card { background: var(--card-background-color, #1c1f24); border: 1px solid var(--divider-color, #2a2e36); border-radius: 12px; padding: 20px 24px; margin-bottom: 16px; }
-      .tm-card h2 { margin: 0 0 12px; font-size: 18px; font-weight: 500; }
+      .tm-card h2 { margin: 16px 0 12px; font-size: 14px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; color: var(--primary-text-color); }
+      .tm-card h2:first-child { margin-top: 0; }
       .tm-card p { margin: 8px 0; color: var(--secondary-text-color, #9aa0a6); }
       .tm-card code { background: var(--code-editor-background-color, #0e1115); padding: 2px 6px; border-radius: 4px; font-size: 12px; }
-      .tm-card-info { border-left: 3px solid var(--primary-color, #03a9f4); }
       .tm-card-error { border-left: 3px solid var(--error-color, #ef5350); color: var(--error-color, #ef5350); }
       .tm-empty { text-align: center; padding: 40px 24px; }
 
       .tm-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); gap: 16px; }
       .tm-child-card { margin-bottom: 0; display: flex; flex-direction: column; }
       .tm-child-head { display: flex; align-items: center; gap: 12px; margin-bottom: 14px; }
-      .tm-avatar { width: 48px; height: 48px; border-radius: 50%; background: var(--secondary-background-color, #242830); display: grid; place-items: center; flex-shrink: 0; font-size: 28px; color: var(--primary-color, #03a9f4); }
+      .tm-avatar { width: 48px; height: 48px; border-radius: 50%; background: var(--secondary-background-color, #242830); display: grid; place-items: center; flex-shrink: 0; color: var(--primary-color, #03a9f4); }
       .tm-avatar ha-icon { --mdc-icon-size: 28px; }
+      .tm-reward-avatar { color: var(--accent-color, #ffca28); }
       .tm-child-name { min-width: 0; flex: 1; }
       .tm-child-name h3 { margin: 0; font-size: 17px; font-weight: 600; }
       .tm-sub { color: var(--secondary-text-color, #9aa0a6); font-size: 12px; margin-top: 2px; word-break: break-all; }
@@ -483,7 +1273,7 @@ class TaskMatePanel extends HTMLElement {
       .tm-stat strong { display: block; font-size: 20px; font-weight: 600; color: var(--primary-color, #03a9f4); }
       .tm-stat span { font-size: 11px; color: var(--secondary-text-color, #9aa0a6); text-transform: uppercase; letter-spacing: 0.5px; }
 
-      .tm-child-foot { display: flex; gap: 8px; margin-top: auto; padding-top: 12px; border-top: 1px solid var(--divider-color, #2a2e36); }
+      .tm-card-foot { display: flex; gap: 8px; margin-top: auto; padding-top: 12px; border-top: 1px solid var(--divider-color, #2a2e36); }
 
       .tm-add-tile { display: grid; place-items: center; gap: 6px; background: transparent; border: 2px dashed var(--divider-color, #2a2e36); border-radius: 12px; color: var(--secondary-text-color, #9aa0a6); cursor: pointer; min-height: 180px; font-size: 14px; font-family: inherit; transition: border-color .15s, color .15s, background .15s; }
       .tm-add-tile:hover { border-color: var(--primary-color, #03a9f4); color: var(--primary-color, #03a9f4); background: rgba(3,169,244,0.06); }
@@ -491,43 +1281,96 @@ class TaskMatePanel extends HTMLElement {
 
       .tm-btn { background: var(--primary-color, #03a9f4); color: var(--text-primary-color, #001a26); border: 0; padding: 8px 16px; border-radius: 8px; cursor: pointer; font-size: 14px; font-weight: 500; font-family: inherit; }
       .tm-btn:hover { filter: brightness(1.1); }
-      .tm-btn:disabled { opacity: 0.5; cursor: not-allowed; }
       .tm-btn-ghost { background: transparent; color: var(--primary-text-color, #e1e3e6); border: 1px solid var(--divider-color, #2a2e36); }
       .tm-btn-ghost:hover { background: var(--secondary-background-color, #242830); filter: none; }
       .tm-btn-danger { background: transparent; color: var(--error-color, #ef5350); border: 1px solid rgba(239,83,80,0.4); }
       .tm-btn-danger:hover { background: rgba(239,83,80,0.1); filter: none; }
-
-      .tm-icon-btn { width: 36px; height: 36px; border: 0; background: transparent; border-radius: 50%; cursor: pointer; display: grid; place-items: center; color: var(--secondary-text-color, #9aa0a6); font-size: 22px; line-height: 1; font-family: inherit; }
+      .tm-icon-btn { width: 36px; height: 36px; border: 0; background: transparent; border-radius: 50%; cursor: pointer; display: grid; place-items: center; color: var(--secondary-text-color, #9aa0a6); font-size: 18px; line-height: 1; font-family: inherit; }
       .tm-icon-btn:hover { background: var(--secondary-background-color, #242830); color: var(--primary-text-color, #e1e3e6); }
+
+      /* Pills */
+      .tm-pill { display: inline-block; background: var(--secondary-background-color, #242830); color: var(--secondary-text-color, #9aa0a6); padding: 1px 8px; border-radius: 999px; font-size: 11px; margin-left: 4px; vertical-align: middle; }
+      .tm-pill-alternating, .tm-pill-random, .tm-pill-balanced { background: rgba(3,169,244,0.15); color: var(--primary-color, #03a9f4); }
+      .tm-pill-jackpot { background: rgba(255,202,40,0.15); color: var(--accent-color, #ffca28); }
+      .tm-pill-pool { background: rgba(255,167,38,0.15); color: #ffa726; }
+      .tm-pill-sticky { background: rgba(149,117,205,0.18); color: #b39ddb; }
+      .tm-pill-spread { background: rgba(102,187,106,0.15); color: var(--success-color, #66bb6a); }
+
+      /* Tables */
+      .tm-table-wrap { background: var(--card-background-color, #1c1f24); border: 1px solid var(--divider-color, #2a2e36); border-radius: 12px; overflow: hidden; }
+      .tm-table { width: 100%; border-collapse: collapse; font-size: 13px; }
+      .tm-table th, .tm-table td { padding: 12px 16px; text-align: left; border-bottom: 1px solid var(--divider-color, #2a2e36); }
+      .tm-table th { font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; color: var(--secondary-text-color, #9aa0a6); font-weight: 500; background: var(--app-header-background-color, #1a1d22); }
+      .tm-table tr:last-child td { border-bottom: 0; }
+      .tm-row:hover { background: var(--secondary-background-color, #242830); }
+      .tm-row-disabled { opacity: 0.5; }
+      .tm-row-icon { display: inline-flex; vertical-align: middle; margin-right: 8px; --mdc-icon-size: 18px; color: var(--secondary-text-color); }
+      .tm-row-actions { text-align: right; white-space: nowrap; display: flex; gap: 4px; justify-content: flex-end; align-items: center; }
+      .tm-yes { color: var(--success-color, #66bb6a); }
+      .tm-no  { color: var(--secondary-text-color, #6a7079); }
+      .tm-neg { color: var(--error-color, #ef5350); }
+      .tm-pos { color: var(--success-color, #66bb6a); }
+
+      .tm-progress { height: 8px; background: var(--secondary-background-color, #242830); border-radius: 999px; overflow: hidden; margin: 8px 0 4px; }
+      .tm-progress > span { display: block; height: 100%; background: linear-gradient(90deg, var(--primary-color, #03a9f4), #4fc3f7); }
+
+      .tm-group-list { margin: 0; padding-left: 20px; color: var(--secondary-text-color, #9aa0a6); font-size: 13px; }
+
+      /* Settings */
+      .tm-settings .tm-field-row { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; margin-bottom: 8px; }
+      .tm-field-inline { display: block; margin-bottom: 12px; }
+      .tm-field-inline span { display: block; color: var(--secondary-text-color, #9aa0a6); font-size: 12px; margin-bottom: 4px; }
+      .tm-field-inline input, .tm-field-inline select { width: 100%; background: var(--secondary-background-color, #242830); border: 1px solid var(--divider-color, #2a2e36); border-radius: 8px; padding: 8px 12px; color: var(--primary-text-color); font-size: 14px; box-sizing: border-box; font-family: inherit; }
 
       /* Dialog */
       .tm-scrim { position: fixed; inset: 0; background: rgba(0,0,0,0.55); display: flex; align-items: flex-start; justify-content: center; padding: 60px 20px; z-index: 100; overflow-y: auto; }
-      .tm-dialog { background: var(--card-background-color, #1c1f24); border: 1px solid var(--divider-color, #2a2e36); border-radius: 12px; width: 100%; max-width: 520px; box-shadow: 0 10px 40px rgba(0,0,0,0.5); display: flex; flex-direction: column; max-height: calc(100vh - 120px); }
+      .tm-dialog { background: var(--card-background-color, #1c1f24); border: 1px solid var(--divider-color, #2a2e36); border-radius: 12px; width: 100%; max-width: 560px; box-shadow: 0 10px 40px rgba(0,0,0,0.5); display: flex; flex-direction: column; max-height: calc(100vh - 120px); }
       .tm-dialog-head { padding: 16px 20px; border-bottom: 1px solid var(--divider-color, #2a2e36); display: flex; align-items: center; }
       .tm-dialog-head h2 { margin: 0; font-size: 18px; font-weight: 500; flex: 1; }
       .tm-dialog-body { padding: 16px 20px; overflow-y: auto; }
+      .tm-dialog-body .tm-field-row { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
       .tm-dialog-foot { padding: 14px 20px; border-top: 1px solid var(--divider-color, #2a2e36); display: flex; justify-content: flex-end; gap: 10px; }
 
       .tm-field { display: block; margin-bottom: 16px; }
-      .tm-field-label { display: block; color: var(--secondary-text-color, #9aa0a6); font-size: 12px; margin-bottom: 6px; }
-      .tm-field-opt { color: var(--secondary-text-color, #6a7079); font-weight: normal; }
-      .tm-field input[type=text] { width: 100%; background: var(--secondary-background-color, #242830); border: 1px solid var(--divider-color, #2a2e36); border-radius: 8px; padding: 9px 12px; color: var(--primary-text-color, #e1e3e6); font-size: 14px; box-sizing: border-box; font-family: inherit; }
-      .tm-field input[type=text]:focus { outline: 2px solid var(--primary-color, #03a9f4); outline-offset: -1px; border-color: transparent; }
-      .tm-field-hint { display: block; color: var(--secondary-text-color, #6a7079); font-size: 12px; margin-top: 6px; }
+      .tm-field-label { display: block; color: var(--secondary-text-color, #9aa0a6); font-size: 12px; margin-bottom: 6px; font-weight: 500; }
+      .tm-field input, .tm-field select { width: 100%; background: var(--secondary-background-color, #242830); border: 1px solid var(--divider-color, #2a2e36); border-radius: 8px; padding: 9px 12px; color: var(--primary-text-color, #e1e3e6); font-size: 14px; box-sizing: border-box; font-family: inherit; }
+      .tm-field input:focus, .tm-field select:focus { outline: 2px solid var(--primary-color, #03a9f4); outline-offset: -1px; border-color: transparent; }
+      .tm-field-hint { display: block; color: var(--secondary-text-color, #6a7079); font-size: 12px; margin-top: 6px; line-height: 1.4; }
       .tm-field-hint code { background: var(--code-editor-background-color, #0e1115); padding: 1px 5px; border-radius: 3px; font-size: 11px; }
+
+      .tm-multi { display: flex; gap: 6px; flex-wrap: wrap; }
+      .tm-chip-btn { background: var(--secondary-background-color, #242830); color: var(--secondary-text-color, #9aa0a6); border: 1px solid var(--divider-color, #2a2e36); padding: 6px 12px; border-radius: 999px; cursor: pointer; font-size: 13px; font-family: inherit; }
+      .tm-chip-btn:hover { color: var(--primary-text-color, #e1e3e6); }
+      .tm-chip-on { background: var(--primary-color, #03a9f4); color: var(--text-primary-color, #001a26); border-color: var(--primary-color, #03a9f4); }
+
+      .tm-day-row { display: flex; gap: 6px; flex-wrap: wrap; }
+      .tm-day-btn { width: 44px; height: 36px; background: var(--secondary-background-color, #242830); color: var(--secondary-text-color, #9aa0a6); border: 1px solid var(--divider-color, #2a2e36); border-radius: 6px; cursor: pointer; font-size: 12px; font-family: inherit; }
+      .tm-day-on { background: var(--primary-color, #03a9f4); color: var(--text-primary-color, #001a26); border-color: var(--primary-color, #03a9f4); }
+
+      .tm-check-row { display: flex; align-items: flex-start; gap: 12px; padding: 8px 0; color: var(--primary-text-color, #e1e3e6); font-size: 14px; }
+      .tm-check-row > div { flex: 1; }
+      .tm-switch { position: relative; display: inline-block; width: 38px; height: 22px; flex-shrink: 0; }
+      .tm-switch input { opacity: 0; width: 0; height: 0; }
+      .tm-slider { position: absolute; inset: 0; background: var(--secondary-background-color, #242830); border: 1px solid var(--divider-color, #2a2e36); border-radius: 999px; transition: background .15s; cursor: pointer; }
+      .tm-slider::before { content: ''; position: absolute; height: 16px; width: 16px; left: 2px; top: 2px; background: white; border-radius: 50%; transition: transform .15s; }
+      .tm-switch input:checked + .tm-slider { background: var(--primary-color, #03a9f4); border-color: var(--primary-color, #03a9f4); }
+      .tm-switch input:checked + .tm-slider::before { transform: translateX(16px); }
+
+      .tm-advanced { border: 1px dashed var(--divider-color, #2a2e36); border-radius: 8px; padding: 10px 14px; margin-top: 8px; }
+      .tm-advanced summary { cursor: pointer; color: var(--secondary-text-color, #9aa0a6); font-size: 13px; user-select: none; }
 
       /* Toast */
       .tm-toast { position: fixed; bottom: 24px; left: 50%; transform: translateX(-50%); padding: 10px 18px; border-radius: 8px; font-size: 14px; box-shadow: 0 4px 16px rgba(0,0,0,0.4); z-index: 200; }
       .tm-toast-ok { background: var(--primary-color, #03a9f4); color: var(--text-primary-color, #001a26); }
       .tm-toast-err { background: var(--error-color, #ef5350); color: white; }
 
-      /* Narrow / mobile */
       @media (max-width: 700px) {
         .tm-body { padding: 16px; }
         .tm-toolbar { flex-direction: column; align-items: stretch; }
         .tm-dialog { max-width: none; }
         .tm-scrim { padding: 0; }
         .tm-dialog { border-radius: 0; max-height: 100vh; height: 100vh; }
+        .tm-dialog-body .tm-field-row, .tm-settings .tm-field-row { grid-template-columns: 1fr; }
       }
     </style>`;
   }

--- a/custom_components/taskmate/www/taskmate-panel.js
+++ b/custom_components/taskmate/www/taskmate-panel.js
@@ -1,22 +1,26 @@
 /**
  * TaskMate admin panel — sidebar entry at /taskmate-admin.
  *
- * v3.5.0-alpha.6 — polished visual treatment + UX fixes:
- *   - Layered surfaces, frosted-glass app bar, refined typography
- *   - Light/dark mode adapts via HA theme tokens (no hard-coded blacks)
- *   - <ha-icon-picker> for icon fields (autocomplete with previews)
- *   - <input type=date> for date fields (locale-aware display)
- *   - Chip-multi-select for calendar entities (from hass.states)
- *   - Schedule-mode selector dynamically reveals options on change
- *   - Notify-service dropdown built from hass.services.notify
- *   - Empty assignments render as "All children", not "(unassigned)"
- *   - Adds Claim allowance, Start rotation with, "No filter" visibility
+ * v3.5.0-alpha.8 — Shopify-grade theme + 8 new features:
+ *   - Light theme rebuilt from scratch (warm off-white bg, crisp white
+ *     cards, layered shadows, Inter typography). Dark theme retained.
+ *   - Backdrop blur reduced from 16/12/8 to 2px throughout.
+ *   - New "Activity" tab: approval queue (chores + rewards) + recent
+ *     events feed + full points-transaction audit log.
+ *   - Approval pill in app bar — shows pending count, jumps to Activity.
+ *   - Search/filter input on Children, Chores, Rewards, Penalties,
+ *     Bonuses, Groups tabs. Filters by name (case-insensitive).
+ *   - Bulk add chores: textarea + shared settings, one WS call.
+ *   - Reorder chores per child: drag-and-drop dialog.
+ *   - Inline chore rename: double-click the name in the table.
+ *   - Confirm-on-leave when dialogs have unsaved changes.
  */
 
-const PANEL_VERSION = "3.5.0-alpha.6";
+const PANEL_VERSION = "3.5.0-alpha.8";
 
 const TABS = [
   { id: "children",  label: "Children" },
+  { id: "activity",  label: "Activity" },
   { id: "chores",    label: "Chores" },
   { id: "rewards",   label: "Rewards" },
   { id: "penalties", label: "Penalties" },
@@ -106,12 +110,20 @@ class TaskMatePanel extends HTMLElement {
     this._loading = false;
     this._activeTab = "children";
     this._dialog = null;
+    this._dialogInitialHash = null;  // for confirm-on-leave
+    this._filter = "";               // per-tab search/filter
+    this._inlineRename = null;       // { kind: "chore", id, value }
+    this._reorderDrag = null;        // tracks drag state during reorder
     this._rendered = false;
     this._onClick = this._onClick.bind(this);
+    this._onDblClick = this._onDblClick.bind(this);
     this._onInput = this._onInput.bind(this);
     this._onChange = this._onChange.bind(this);
     this._onValueChanged = this._onValueChanged.bind(this);
     this._onKeyDown = this._onKeyDown.bind(this);
+    this._onDragStart = this._onDragStart.bind(this);
+    this._onDragOver = this._onDragOver.bind(this);
+    this._onDrop = this._onDrop.bind(this);
   }
 
   set hass(value) {
@@ -119,7 +131,6 @@ class TaskMatePanel extends HTMLElement {
     this._hass = value;
     if (first) this._fetchState();
     if (!this._rendered) this._render();
-    // Keep ha-picker components fed with the latest hass on every update
     this._bindHaPickers();
   }
   get hass() { return this._hass; }
@@ -129,18 +140,26 @@ class TaskMatePanel extends HTMLElement {
 
   connectedCallback() {
     this.addEventListener("click", this._onClick);
+    this.addEventListener("dblclick", this._onDblClick);
     this.addEventListener("input", this._onInput);
     this.addEventListener("change", this._onChange);
     this.addEventListener("value-changed", this._onValueChanged);
     this.addEventListener("keydown", this._onKeyDown);
+    this.addEventListener("dragstart", this._onDragStart);
+    this.addEventListener("dragover", this._onDragOver);
+    this.addEventListener("drop", this._onDrop);
     if (!this._rendered) this._render();
   }
   disconnectedCallback() {
     this.removeEventListener("click", this._onClick);
+    this.removeEventListener("dblclick", this._onDblClick);
     this.removeEventListener("input", this._onInput);
     this.removeEventListener("change", this._onChange);
     this.removeEventListener("value-changed", this._onValueChanged);
     this.removeEventListener("keydown", this._onKeyDown);
+    this.removeEventListener("dragstart", this._onDragStart);
+    this.removeEventListener("dragover", this._onDragOver);
+    this.removeEventListener("drop", this._onDrop);
   }
 
   // ---- state -----------------------------------------------------------
@@ -179,39 +198,71 @@ class TaskMatePanel extends HTMLElement {
     setTimeout(() => { if (node.isConnected) node.remove(); }, 3500);
   }
 
+  _hashDialog() {
+    return this._dialog ? JSON.stringify(this._dialog.data) : "";
+  }
+
+  _closeDialog(force = false) {
+    if (!force && this._dialog && this._dialogInitialHash != null && this._hashDialog() !== this._dialogInitialHash) {
+      if (!confirm("You have unsaved changes — discard them?")) return;
+    }
+    this._dialog = null;
+    this._dialogInitialHash = null;
+    this._render();
+  }
+
+  _openDialog(d) {
+    this._dialog = d;
+    this._dialogInitialHash = this._hashDialog();
+    this._render();
+  }
+
   // ---- event delegation ------------------------------------------------
   _onClick(e) {
     const t = e.target.closest("[data-act]");
     if (!t) return;
     const act = t.dataset.act;
 
-    if (act === "tab")          { this._activeTab = t.dataset.tab; this._render(); return; }
-    if (act === "close-dialog") { this._dialog = null; this._render(); return; }
+    if (act === "tab")          { this._activeTab = t.dataset.tab; this._filter = ""; this._render(); return; }
+    if (act === "close-dialog") { this._closeDialog(); return; }
     if (act === "scrim") {
-      if (e.target === this.querySelector(".tm-scrim")) { this._dialog = null; this._render(); }
+      if (e.target === this.querySelector(".tm-scrim")) this._closeDialog();
       return;
     }
     if (act === "retry")        { this._fetchState(); return; }
+    if (act === "switch-to-activity") { this._activeTab = "activity"; this._render(); return; }
 
+    // Children
     if (act === "add-child")    { this._openChildDialog(null); return; }
     if (act === "edit-child")   { this._openChildDialog(t.dataset.id); return; }
     if (act === "delete-child") { this._confirmDelete("child", t.dataset.id); return; }
     if (act === "save-child")   { this._doSaveChild(); return; }
+    if (act === "reorder-chores-for-child") { this._openReorderDialog(t.dataset.id); return; }
+    if (act === "save-chore-order") { this._doSaveChoreOrder(); return; }
 
+    // Chores
     if (act === "add-chore")    { this._openChoreDialog(null); return; }
     if (act === "edit-chore")   { this._openChoreDialog(t.dataset.id); return; }
     if (act === "delete-chore") { this._confirmDelete("chore", t.dataset.id); return; }
     if (act === "save-chore")   { this._doSaveChore(); return; }
+    if (act === "bulk-add-chore") { this._openBulkAddDialog(); return; }
+    if (act === "save-bulk-chores") { this._doSaveBulkChores(); return; }
+    if (act === "rename-chore-start") { this._startInlineRename("chore", t.dataset.id); return; }
+    if (act === "rename-chore-commit") { this._commitInlineRename(); return; }
+    if (act === "rename-chore-cancel") { this._inlineRename = null; this._render(); return; }
     if (act === "toggle-day")        { this._toggleArrayField("due_days", t.dataset.day); return; }
+    if (act === "toggle-bulk-day")   { this._toggleArrayField("due_days", t.dataset.day); return; }
     if (act === "toggle-assigned")   { this._toggleArrayField("assigned_to", t.dataset.id); return; }
     if (act === "toggle-calendar")   { this._toggleArrayField("publish_calendar_entities", t.dataset.id); return; }
 
+    // Rewards
     if (act === "add-reward")    { this._openRewardDialog(null); return; }
     if (act === "edit-reward")   { this._openRewardDialog(t.dataset.id); return; }
     if (act === "delete-reward") { this._confirmDelete("reward", t.dataset.id); return; }
     if (act === "save-reward")   { this._doSaveReward(); return; }
     if (act === "toggle-reward-assigned") { this._toggleArrayField("assigned_to", t.dataset.id); return; }
 
+    // Penalties
     if (act === "add-penalty")    { this._openPenBonDialog("penalty", null); return; }
     if (act === "edit-penalty")   { this._openPenBonDialog("penalty", t.dataset.id); return; }
     if (act === "delete-penalty") { this._confirmDelete("penalty", t.dataset.id); return; }
@@ -219,6 +270,7 @@ class TaskMatePanel extends HTMLElement {
     if (act === "apply-penalty")  { this._openApplyDialog("penalty", t.dataset.id); return; }
     if (act === "do-apply-penalty") { this._doApplyPenBon("penalty", t.dataset.id, t.dataset.child); return; }
 
+    // Bonuses
     if (act === "add-bonus")    { this._openPenBonDialog("bonus", null); return; }
     if (act === "edit-bonus")   { this._openPenBonDialog("bonus", t.dataset.id); return; }
     if (act === "delete-bonus") { this._confirmDelete("bonus", t.dataset.id); return; }
@@ -228,21 +280,56 @@ class TaskMatePanel extends HTMLElement {
 
     if (act === "toggle-penbon-assigned") { this._toggleArrayField("assigned_to", t.dataset.id); return; }
 
+    // Groups
     if (act === "add-group")    { this._openGroupDialog(null); return; }
     if (act === "edit-group")   { this._openGroupDialog(t.dataset.id); return; }
     if (act === "delete-group") { this._confirmDelete("group", t.dataset.id); return; }
     if (act === "save-group")   { this._doSaveGroup(); return; }
     if (act === "toggle-group-chore") { this._toggleArrayField("chore_ids", t.dataset.id); return; }
 
+    // Settings
     if (act === "save-settings") { this._doSaveSettings(); return; }
+
+    // Activity / approvals
+    if (act === "approve-chore")  { this._doApprove("chore", t.dataset.id); return; }
+    if (act === "reject-chore")   { this._doReject("chore", t.dataset.id); return; }
+    if (act === "approve-reward") { this._doApprove("reward", t.dataset.id); return; }
+    if (act === "reject-reward")  { this._doReject("reward", t.dataset.id); return; }
+
+    // Filter clear
+    if (act === "clear-filter") { this._filter = ""; this._render(); return; }
+  }
+
+  _onDblClick(e) {
+    const t = e.target.closest("[data-rename]");
+    if (!t) return;
+    this._startInlineRename(t.dataset.rename, t.dataset.id);
   }
 
   _onInput(e) {
-    if (!this._dialog) return;
     const t = e.target;
-    if (!t.dataset || !t.dataset.field) return;
-    const value = (t.type === "number") ? (t.value === "" ? null : Number(t.value)) : t.value;
-    this._dialog.data[t.dataset.field] = value;
+    if (!t.dataset) return;
+    // Filter input
+    if (t.dataset.filter === "true") {
+      this._filter = t.value || "";
+      // Re-render only the visible tab body — but full re-render is fine for now.
+      this._render();
+      // Restore focus to the filter input
+      const f = this.querySelector("[data-filter='true']");
+      if (f) { f.focus(); f.setSelectionRange(this._filter.length, this._filter.length); }
+      return;
+    }
+    // Inline rename input
+    if (t.dataset.field === "_inlineRename") {
+      this._inlineRename.value = t.value;
+      return;
+    }
+    // Dialog field
+    if (this._dialog && t.dataset.field) {
+      const value = (t.type === "number") ? (t.value === "" ? null : Number(t.value)) : t.value;
+      this._dialog.data[t.dataset.field] = value;
+      return;
+    }
   }
 
   _onChange(e) {
@@ -257,7 +344,6 @@ class TaskMatePanel extends HTMLElement {
     if (t.dataset.rerender === "true") this._render();
   }
 
-  // <ha-icon-picker> + <ha-entity-picker> fire value-changed instead of change.
   _onValueChanged(e) {
     if (!this._dialog) return;
     const t = e.target;
@@ -267,7 +353,49 @@ class TaskMatePanel extends HTMLElement {
   }
 
   _onKeyDown(e) {
-    if (e.key === "Escape" && this._dialog) { this._dialog = null; this._render(); }
+    if (e.key === "Escape") {
+      if (this._inlineRename) { this._inlineRename = null; this._render(); return; }
+      if (this._dialog) { this._closeDialog(); return; }
+    }
+    if (e.key === "Enter" && this._inlineRename) {
+      e.preventDefault();
+      this._commitInlineRename();
+    }
+  }
+
+  // ---- Drag and drop (reorder dialog) ----------------------------------
+  _onDragStart(e) {
+    const t = e.target.closest("[data-drag-id]");
+    if (!t) return;
+    this._reorderDrag = { id: t.dataset.dragId };
+    t.classList.add("tm-dragging");
+    e.dataTransfer.effectAllowed = "move";
+    e.dataTransfer.setData("text/plain", t.dataset.dragId);
+  }
+
+  _onDragOver(e) {
+    const t = e.target.closest("[data-drag-id]");
+    if (!t || !this._reorderDrag) return;
+    e.preventDefault();
+    e.dataTransfer.dropEffect = "move";
+  }
+
+  _onDrop(e) {
+    const t = e.target.closest("[data-drag-id]");
+    if (!t || !this._reorderDrag || !this._dialog || this._dialog.kind !== "reorder") return;
+    e.preventDefault();
+    const fromId = this._reorderDrag.id;
+    const toId   = t.dataset.dragId;
+    if (fromId === toId) { this._reorderDrag = null; this._render(); return; }
+    const order = [...(this._dialog.data.order || [])];
+    const fromIdx = order.indexOf(fromId);
+    const toIdx   = order.indexOf(toId);
+    if (fromIdx < 0 || toIdx < 0) return;
+    order.splice(fromIdx, 1);
+    order.splice(toIdx, 0, fromId);
+    this._dialog.data.order = order;
+    this._reorderDrag = null;
+    this._render();
   }
 
   _toggleArrayField(field, value) {
@@ -314,21 +442,39 @@ class TaskMatePanel extends HTMLElement {
     this._showToast("ok", "Deleted");
   }
 
+  // ---- Approvals -------------------------------------------------------
+  async _doApprove(kind, id) {
+    const wsType = kind === "chore" ? "taskmate/approve_chore" : "taskmate/approve_reward";
+    const idField = kind === "chore" ? "completion_id" : "claim_id";
+    const { ok, err } = await this._callWS({ type: wsType, [idField]: id });
+    if (!ok) { this._showToast("err", `Approve failed: ${err}`); return; }
+    await this._fetchState();
+    this._showToast("ok", "Approved");
+  }
+
+  async _doReject(kind, id) {
+    const wsType = kind === "chore" ? "taskmate/reject_chore" : "taskmate/reject_reward";
+    const idField = kind === "chore" ? "completion_id" : "claim_id";
+    const { ok, err } = await this._callWS({ type: wsType, [idField]: id });
+    if (!ok) { this._showToast("err", `Reject failed: ${err}`); return; }
+    await this._fetchState();
+    this._showToast("ok", "Rejected");
+  }
+
   // ---- Children --------------------------------------------------------
   _openChildDialog(id) {
     if (id) {
       const c = (this._state.children || []).find(x => x.id === id);
       if (!c) return;
-      this._dialog = { kind: "child", mode: "edit", data: {
+      this._openDialog({ kind: "child", mode: "edit", data: {
         id: c.id, name: c.name || "", avatar: c.avatar || "mdi:account-circle",
         availability_entity: c.availability_entity || "",
-      } };
+      } });
     } else {
-      this._dialog = { kind: "child", mode: "add", data: {
+      this._openDialog({ kind: "child", mode: "add", data: {
         name: "", avatar: "mdi:account-circle", availability_entity: "",
-      } };
+      } });
     }
-    this._render();
   }
 
   async _doSaveChild() {
@@ -340,9 +486,100 @@ class TaskMatePanel extends HTMLElement {
       : { type: "taskmate/update_child", child_id: d.id, name: d.name.trim(), avatar: d.avatar || "mdi:account-circle", availability_entity: d.availability_entity || "" };
     const { ok, err } = await this._callWS(payload);
     if (!ok) { this._showToast("err", `Save failed: ${err}`); return; }
-    this._dialog = null;
+    this._closeDialog(true);
     await this._fetchState();
     this._showToast("ok", wasAdd ? "Child added" : "Child updated");
+  }
+
+  // ---- Chore reorder ---------------------------------------------------
+  _openReorderDialog(child_id) {
+    const child = (this._state.children || []).find(c => c.id === child_id);
+    if (!child) return;
+    const childChores = (this._state.chores || []).filter(c =>
+      (c.assigned_to || []).length === 0 || (c.assigned_to || []).includes(child_id)
+    );
+    // Use the child's stored chore_order if present, else fall back to the chore list order.
+    const existingOrder = (child.chore_order || []).filter(id => childChores.find(c => c.id === id));
+    const missing = childChores.map(c => c.id).filter(id => !existingOrder.includes(id));
+    const order = [...existingOrder, ...missing];
+    this._openDialog({ kind: "reorder", mode: "edit", data: { child_id, order, name: child.name } });
+  }
+
+  async _doSaveChoreOrder() {
+    const d = this._dialog.data;
+    const { ok, err } = await this._callWS({
+      type: "taskmate/set_chore_order",
+      child_id: d.child_id,
+      chore_order: d.order || [],
+    });
+    if (!ok) { this._showToast("err", `Save failed: ${err}`); return; }
+    this._closeDialog(true);
+    await this._fetchState();
+    this._showToast("ok", "Order saved");
+  }
+
+  // ---- Bulk add chores -------------------------------------------------
+  _openBulkAddDialog() {
+    this._openDialog({ kind: "bulk-chore", mode: "add", data: {
+      chore_names: "",
+      points: 10,
+      assigned_to: [],
+      requires_approval: true,
+      time_category: "anytime",
+      schedule_mode: "specific_days",
+      due_days: [],
+      daily_limit: 1,
+      completion_sound: "coin",
+    } });
+  }
+
+  async _doSaveBulkChores() {
+    const d = this._dialog.data;
+    const names = (d.chore_names || "").split(/[\n,]/).map(s => s.trim()).filter(Boolean);
+    if (names.length === 0) { this._showToast("err", "Enter at least one chore name"); return; }
+    const { ok, err, res } = await this._callWS({
+      type: "taskmate/add_chores_bulk",
+      chore_names: names,
+      points: Number(d.points) || 10,
+      assigned_to: d.assigned_to || [],
+      requires_approval: !!d.requires_approval,
+      time_category: d.time_category || "anytime",
+      schedule_mode: d.schedule_mode || "specific_days",
+      due_days: d.due_days || [],
+      daily_limit: Number(d.daily_limit) || 1,
+      completion_sound: d.completion_sound || "coin",
+    });
+    if (!ok) { this._showToast("err", `Bulk add failed: ${err}`); return; }
+    this._closeDialog(true);
+    await this._fetchState();
+    this._showToast("ok", `Added ${(res && res.count) || names.length} chore${((res && res.count) || names.length) === 1 ? "" : "s"}`);
+  }
+
+  // ---- Inline rename ---------------------------------------------------
+  _startInlineRename(kind, id) {
+    if (kind !== "chore") return;
+    const c = (this._state.chores || []).find(x => x.id === id);
+    if (!c) return;
+    this._inlineRename = { kind: "chore", id, value: c.name };
+    this._render();
+    const inp = this.querySelector("[data-field='_inlineRename']");
+    if (inp) { inp.focus(); inp.select(); }
+  }
+
+  async _commitInlineRename() {
+    if (!this._inlineRename) return;
+    const { kind, id, value } = this._inlineRename;
+    const newName = (value || "").trim();
+    if (!newName) { this._inlineRename = null; this._render(); return; }
+    if (kind === "chore") {
+      const c = (this._state.chores || []).find(x => x.id === id);
+      if (c && c.name === newName) { this._inlineRename = null; this._render(); return; }
+      const { ok, err } = await this._callWS({ type: "taskmate/update_chore", chore_id: id, name: newName });
+      this._inlineRename = null;
+      if (!ok) { this._showToast("err", `Rename failed: ${err}`); this._render(); return; }
+      await this._fetchState();
+      this._showToast("ok", "Renamed");
+    }
   }
 
   // ---- Chores ----------------------------------------------------------
@@ -365,19 +602,17 @@ class TaskMatePanel extends HTMLElement {
     if (id) {
       const c = (this._state.chores || []).find(x => x.id === id);
       if (!c) return;
-      this._dialog = { kind: "chore", mode: "edit", data: {
-        ...blank,
-        ...c,
+      this._openDialog({ kind: "chore", mode: "edit", data: {
+        ...blank, ...c,
         assigned_to: [...(c.assigned_to || [])],
         due_days: [...(c.due_days || [])],
         publish_calendar_entities: [...(c.publish_calendar_entities || [])],
         visibility_operator: c.visibility_operator || "none",
-        manual_start_child_id: "",  // ephemeral — only set if user picks one
-      } };
+        manual_start_child_id: "",
+      } });
     } else {
-      this._dialog = { kind: "chore", mode: "add", data: blank };
+      this._openDialog({ kind: "chore", mode: "add", data: blank });
     }
-    this._render();
   }
 
   async _doSaveChore() {
@@ -415,7 +650,7 @@ class TaskMatePanel extends HTMLElement {
       : { type: "taskmate/update_chore", chore_id: d.id, ...base };
     const { ok, err } = await this._callWS(payload);
     if (!ok) { this._showToast("err", `Save failed: ${err}`); return; }
-    this._dialog = null;
+    this._closeDialog(true);
     await this._fetchState();
     this._showToast("ok", wasAdd ? "Chore added" : "Chore updated");
   }
@@ -428,16 +663,15 @@ class TaskMatePanel extends HTMLElement {
     if (id) {
       const r = (this._state.rewards || []).find(x => x.id === id);
       if (!r) return;
-      this._dialog = { kind: "reward", mode: "edit", data: {
+      this._openDialog({ kind: "reward", mode: "edit", data: {
         ...blank, ...r,
         assigned_to: [...(r.assigned_to || [])],
         quantity_str: r.quantity == null ? "" : String(r.quantity),
         expires_at: r.expires_at || "",
-      } };
+      } });
     } else {
-      this._dialog = { kind: "reward", mode: "add", data: blank };
+      this._openDialog({ kind: "reward", mode: "add", data: blank });
     }
-    this._render();
   }
 
   async _doSaveReward() {
@@ -459,7 +693,7 @@ class TaskMatePanel extends HTMLElement {
     const payload = wasAdd ? { type: "taskmate/add_reward", ...base } : { type: "taskmate/update_reward", reward_id: d.id, ...base };
     const { ok, err } = await this._callWS(payload);
     if (!ok) { this._showToast("err", `Save failed: ${err}`); return; }
-    this._dialog = null;
+    this._closeDialog(true);
     await this._fetchState();
     this._showToast("ok", wasAdd ? "Reward added" : "Reward updated");
   }
@@ -472,11 +706,10 @@ class TaskMatePanel extends HTMLElement {
     if (id) {
       const item = ((kind === "penalty" ? this._state.penalties : this._state.bonuses) || []).find(x => x.id === id);
       if (!item) return;
-      this._dialog = { kind, mode: "edit", data: { ...blank, ...item, assigned_to: [...(item.assigned_to || [])] } };
+      this._openDialog({ kind, mode: "edit", data: { ...blank, ...item, assigned_to: [...(item.assigned_to || [])] } });
     } else {
-      this._dialog = { kind, mode: "add", data: blank };
+      this._openDialog({ kind, mode: "add", data: blank });
     }
-    this._render();
   }
 
   async _doSavePenBon(kind) {
@@ -497,7 +730,7 @@ class TaskMatePanel extends HTMLElement {
     const payload = wasAdd ? { type: wsType, ...base } : { type: wsType, [idField]: d.id, ...base };
     const { ok, err } = await this._callWS(payload);
     if (!ok) { this._showToast("err", `Save failed: ${err}`); return; }
-    this._dialog = null;
+    this._closeDialog(true);
     await this._fetchState();
     this._showToast("ok", `${wasAdd ? "Added" : "Updated"} ${kind}`);
   }
@@ -505,8 +738,7 @@ class TaskMatePanel extends HTMLElement {
   _openApplyDialog(kind, id) {
     const item = ((kind === "penalty" ? this._state.penalties : this._state.bonuses) || []).find(x => x.id === id);
     if (!item) return;
-    this._dialog = { kind: `apply-${kind}`, mode: "apply", data: { id, item } };
-    this._render();
+    this._openDialog({ kind: `apply-${kind}`, mode: "apply", data: { id, item } });
   }
 
   async _doApplyPenBon(kind, id, child_id) {
@@ -514,7 +746,7 @@ class TaskMatePanel extends HTMLElement {
     const idField = `${kind}_id`;
     const { ok, err } = await this._callWS({ type: wsType, [idField]: id, child_id });
     if (!ok) { this._showToast("err", `Apply failed: ${err}`); return; }
-    this._dialog = null;
+    this._closeDialog(true);
     await this._fetchState();
     this._showToast("ok", kind === "penalty" ? "Penalty applied" : "Bonus applied");
   }
@@ -525,11 +757,10 @@ class TaskMatePanel extends HTMLElement {
     if (id) {
       const g = (this._state.task_groups || []).find(x => x.id === id);
       if (!g) return;
-      this._dialog = { kind: "group", mode: "edit", data: { ...blank, ...g, chore_ids: [...(g.chore_ids || [])] } };
+      this._openDialog({ kind: "group", mode: "edit", data: { ...blank, ...g, chore_ids: [...(g.chore_ids || [])] } });
     } else {
-      this._dialog = { kind: "group", mode: "add", data: blank };
+      this._openDialog({ kind: "group", mode: "add", data: blank });
     }
-    this._render();
   }
 
   async _doSaveGroup() {
@@ -540,7 +771,7 @@ class TaskMatePanel extends HTMLElement {
     const payload = wasAdd ? { type: "taskmate/add_task_group", ...base } : { type: "taskmate/update_task_group", group_id: d.id, ...base };
     const { ok, err } = await this._callWS(payload);
     if (!ok) { this._showToast("err", `Save failed: ${err}`); return; }
-    this._dialog = null;
+    this._closeDialog(true);
     await this._fetchState();
     this._showToast("ok", wasAdd ? "Group added" : "Group updated");
   }
@@ -559,7 +790,6 @@ class TaskMatePanel extends HTMLElement {
       else v = el.value;
       if (v !== undefined) payload[name] = v;
     });
-    // ha-icon-picker: read .value
     root.querySelectorAll("ha-icon-picker[data-setting]").forEach(el => {
       payload[el.dataset.setting] = el.value || "";
     });
@@ -572,13 +802,11 @@ class TaskMatePanel extends HTMLElement {
   // ---- HA picker binding -----------------------------------------------
   _bindHaPickers() {
     if (!this._hass) return;
-    // <ha-icon-picker> needs hass + value via property
     this.querySelectorAll("ha-icon-picker").forEach(el => {
       el.hass = this._hass;
       const v = el.getAttribute("data-current") || "";
       if (el.value !== v) el.value = v;
     });
-    // <ha-entity-picker> needs hass + includeDomains + value
     this.querySelectorAll("ha-entity-picker").forEach(el => {
       el.hass = this._hass;
       const dom = el.getAttribute("data-domains");
@@ -586,6 +814,19 @@ class TaskMatePanel extends HTMLElement {
       const v = el.getAttribute("data-current") || "";
       if (el.value !== v) el.value = v;
     });
+  }
+
+  // ---- Time helpers ----------------------------------------------------
+  _timeAgo(iso) {
+    if (!iso) return "—";
+    const then = new Date(iso);
+    if (isNaN(then)) return iso;
+    const diffSec = Math.floor((Date.now() - then.getTime()) / 1000);
+    if (diffSec < 60)         return "just now";
+    if (diffSec < 3600)       return `${Math.floor(diffSec / 60)}m ago`;
+    if (diffSec < 86400)      return `${Math.floor(diffSec / 3600)}h ago`;
+    if (diffSec < 604800)     return `${Math.floor(diffSec / 86400)}d ago`;
+    return then.toLocaleDateString();
   }
 
   // ---- rendering -------------------------------------------------------
@@ -598,6 +839,7 @@ class TaskMatePanel extends HTMLElement {
         <div class="tm-bg-glow"></div>
         ${this._appbar()}
         ${this._tabstrip()}
+        ${this._approvalBanner()}
         <div class="tm-body">
           <div class="tm-body-inner">
             ${this._renderBody()}
@@ -607,19 +849,27 @@ class TaskMatePanel extends HTMLElement {
       </div>
     `;
     if (existingToast) this.appendChild(existingToast);
-    // After DOM is in place, bind hass to ha-* pickers
     this._bindHaPickers();
   }
 
   _appbar() {
     const crumb = (TABS.find(t => t.id === this._activeTab) || {}).label || "";
     const crumbLabel = (this._activeTab === "settings") ? "Settings" : crumb;
+    const pendingCount = this._state
+      ? (this._state.pending_completions || []).length + (this._state.pending_reward_claims || []).length
+      : 0;
     return `
       <div class="tm-appbar">
         <div class="tm-appbar-icon">
           <ha-icon icon="mdi:checkbox-marked-circle-plus-outline"></ha-icon>
         </div>
         <h1 class="tm-appbar-title">TaskMate <span class="tm-sep">/</span> <span class="tm-crumb">${this._esc(crumbLabel)}</span></h1>
+        ${pendingCount > 0 ? `
+          <button class="tm-approval-pill" data-act="switch-to-activity" title="${pendingCount} pending — click to review">
+            <span class="tm-approval-dot"></span>
+            ${pendingCount} pending
+          </button>
+        ` : ""}
         <span class="tm-version-chip">v${PANEL_VERSION}</span>
       </div>
     `;
@@ -628,6 +878,7 @@ class TaskMatePanel extends HTMLElement {
   _tabstrip() {
     const counts = this._state ? {
       children:  (this._state.children || []).length,
+      activity:  (this._state.pending_completions || []).length + (this._state.pending_reward_claims || []).length,
       chores:    (this._state.chores || []).length,
       rewards:   (this._state.rewards || []).length,
       penalties: (this._state.penalties || []).length,
@@ -638,13 +889,34 @@ class TaskMatePanel extends HTMLElement {
       <nav class="tm-tabs">
         ${TABS.map(t => {
           const cnt = counts[t.id];
+          const showCount = cnt != null && cnt > 0;
+          const urgent = t.id === "activity" && cnt > 0;
           return `
             <button class="tm-tab ${t.id === this._activeTab ? "tm-tab-active" : ""}" data-act="tab" data-tab="${t.id}" ${t.title ? `title="${t.title}"` : ""}>
-              ${this._esc(t.label)}${cnt != null ? `<span class="tm-tab-pill">${cnt}</span>` : ""}
+              ${this._esc(t.label)}${showCount ? `<span class="tm-tab-pill ${urgent ? "tm-tab-pill-urgent" : ""}">${cnt}</span>` : ""}
             </button>
           `;
         }).join("")}
       </nav>
+    `;
+  }
+
+  _approvalBanner() {
+    if (!this._state) return "";
+    if (this._activeTab === "activity") return "";
+    const completionsP = (this._state.pending_completions || []).length;
+    const rewardsP     = (this._state.pending_reward_claims || []).length;
+    const total = completionsP + rewardsP;
+    if (total === 0) return "";
+    const parts = [];
+    if (completionsP) parts.push(`<strong>${completionsP}</strong> chore${completionsP === 1 ? "" : "s"}`);
+    if (rewardsP)     parts.push(`<strong>${rewardsP}</strong> reward claim${rewardsP === 1 ? "" : "s"}`);
+    return `
+      <div class="tm-approval-banner">
+        <ha-icon icon="mdi:bell-ring-outline"></ha-icon>
+        <span>Awaiting your approval — ${parts.join(" · ")}</span>
+        <button class="tm-btn tm-btn-sm" data-act="switch-to-activity">Review</button>
+      </div>
     `;
   }
 
@@ -660,6 +932,7 @@ class TaskMatePanel extends HTMLElement {
 
     switch (this._activeTab) {
       case "children":  return this._renderChildrenTab();
+      case "activity":  return this._renderActivityTab();
       case "chores":    return this._renderChoresTab();
       case "rewards":   return this._renderRewardsTab();
       case "penalties": return this._renderPenBonTab("penalty");
@@ -670,16 +943,35 @@ class TaskMatePanel extends HTMLElement {
     }
   }
 
+  _searchBox(placeholder) {
+    return `
+      <div class="tm-search-wrap">
+        <ha-icon icon="mdi:magnify" class="tm-search-icon"></ha-icon>
+        <input class="tm-search" placeholder="${this._esc(placeholder)}" data-filter="true" value="${this._esc(this._filter)}">
+        ${this._filter ? `<button class="tm-search-clear" data-act="clear-filter" title="Clear">✕</button>` : ""}
+      </div>
+    `;
+  }
+
+  _filterByName(items) {
+    if (!this._filter) return items;
+    const q = this._filter.toLowerCase();
+    return items.filter(it => (it.name || "").toLowerCase().includes(q));
+  }
+
   // -- Children tab ------------------------------------------------------
   _renderChildrenTab() {
-    const children = this._state.children || [];
+    const all = this._state.children || [];
+    const children = this._filterByName(all);
     const pointsName = this._state.settings.points_name || "points";
     return `
       <div class="tm-toolbar">
-        <h2 class="tm-toolbar-title">Children <span class="tm-toolbar-count">${children.length}</span></h2>
+        <h2 class="tm-toolbar-title">Children <span class="tm-toolbar-count">${all.length}</span></h2>
+        ${all.length > 0 ? this._searchBox("Search children…") : ""}
         <button class="tm-btn" data-act="add-child">＋ Add child</button>
       </div>
-      ${children.length === 0 ? this._emptyState("👨‍👩‍👧‍👦", "No children yet", "Add your first child to get started.", "add-child", "+ Add child") : `
+      ${all.length === 0 ? this._emptyState("👨‍👩‍👧‍👦", "No children yet", "Add your first child to get started.", "add-child", "+ Add child") :
+        children.length === 0 ? `<div class="tm-card tm-empty"><p>No children match "<strong>${this._esc(this._filter)}</strong>".</p></div>` : `
         <div class="tm-grid">
           ${children.map(c => this._renderChildCard(c, pointsName)).join("")}
           <button class="tm-add-tile" data-act="add-child"><span class="tm-add-plus">＋</span>Add child</button>
@@ -705,22 +997,164 @@ class TaskMatePanel extends HTMLElement {
         </div>
         <div class="tm-card-foot">
           <button class="tm-btn tm-btn-ghost tm-btn-sm" data-act="edit-child" data-id="${this._esc(child.id)}">Edit</button>
+          <button class="tm-btn tm-btn-ghost tm-btn-sm" data-act="reorder-chores-for-child" data-id="${this._esc(child.id)}" title="Reorder this child's chores">⇅ Order</button>
           <button class="tm-btn tm-btn-danger tm-btn-sm" data-act="delete-child" data-id="${this._esc(child.id)}">Delete</button>
         </div>
       </article>
     `;
   }
 
+  // -- Activity tab ------------------------------------------------------
+  _renderActivityTab() {
+    const pendingCompletions = this._state.pending_completions || [];
+    const pendingClaims      = this._state.pending_reward_claims || [];
+    const transactions       = this._state.points_transactions || [];
+    const completions        = this._state.completions || [];
+    const claims             = this._state.reward_claims || [];
+
+    const childById = Object.fromEntries((this._state.children || []).map(c => [c.id, c]));
+    const choreById = Object.fromEntries((this._state.chores || []).map(c => [c.id, c]));
+    const rewardById = Object.fromEntries((this._state.rewards || []).map(r => [r.id, r]));
+
+    // Recent activity feed: merge approved completions + claims + transactions
+    const events = [];
+    completions.filter(c => c.approved).forEach(c => events.push({
+      ts: c.approved_at || c.completed_at, kind: "completion",
+      child: (childById[c.child_id] || {}).name || "?",
+      label: `Completed: ${(choreById[c.chore_id] || {}).name || "(deleted chore)"}`,
+      points: c.points_awarded,
+    }));
+    claims.filter(c => c.approved).forEach(c => events.push({
+      ts: c.approved_at || c.claimed_at, kind: "claim",
+      child: (childById[c.child_id] || {}).name || "?",
+      label: `Claimed: ${(rewardById[c.reward_id] || {}).name || "(deleted reward)"}`,
+      points: -((rewardById[c.reward_id] || {}).cost || 0),
+    }));
+    transactions.forEach(t => events.push({
+      ts: t.created_at, kind: "manual",
+      child: (childById[t.child_id] || {}).name || "?",
+      label: t.reason || (t.points >= 0 ? "Manual addition" : "Manual deduction"),
+      points: t.points,
+    }));
+    events.sort((a, b) => (b.ts || "").localeCompare(a.ts || ""));
+    const recent = events.slice(0, 30);
+
+    return `
+      <div class="tm-toolbar">
+        <h2 class="tm-toolbar-title">Activity</h2>
+      </div>
+
+      <!-- Pending approvals -->
+      <div class="tm-card">
+        <h3 class="tm-section-title">Pending approvals
+          ${(pendingCompletions.length + pendingClaims.length) > 0
+            ? `<span class="tm-pill tm-pill-warn">${pendingCompletions.length + pendingClaims.length}</span>`
+            : `<span class="tm-pill tm-pill-success">All clear</span>`}
+        </h3>
+        ${pendingCompletions.length === 0 && pendingClaims.length === 0 ? `
+          <p class="tm-meta">No items waiting for review.</p>
+        ` : `
+          <div class="tm-approval-list">
+            ${pendingCompletions.map(c => {
+              const chore = choreById[c.chore_id];
+              const child = childById[c.child_id];
+              return `
+                <div class="tm-approval-item">
+                  <div class="tm-approval-icon"><ha-icon icon="mdi:checkbox-marked-circle-outline"></ha-icon></div>
+                  <div class="tm-approval-body">
+                    <div class="tm-approval-line"><strong>${this._esc((child && child.name) || "?")}</strong> completed <strong>${this._esc((chore && chore.name) || "(deleted chore)")}</strong></div>
+                    <div class="tm-meta">${this._timeAgo(c.completed_at)}${chore ? ` · ${chore.points} points` : ""}</div>
+                  </div>
+                  <div class="tm-approval-actions">
+                    <button class="tm-btn tm-btn-ghost tm-btn-sm" data-act="reject-chore"  data-id="${this._esc(c.id)}">Reject</button>
+                    <button class="tm-btn tm-btn-sm" data-act="approve-chore" data-id="${this._esc(c.id)}">Approve</button>
+                  </div>
+                </div>
+              `;
+            }).join("")}
+            ${pendingClaims.map(c => {
+              const reward = rewardById[c.reward_id];
+              const child = childById[c.child_id];
+              return `
+                <div class="tm-approval-item">
+                  <div class="tm-approval-icon"><ha-icon icon="mdi:gift-outline"></ha-icon></div>
+                  <div class="tm-approval-body">
+                    <div class="tm-approval-line"><strong>${this._esc((child && child.name) || "?")}</strong> claimed reward <strong>${this._esc((reward && reward.name) || "(deleted reward)")}</strong></div>
+                    <div class="tm-meta">${this._timeAgo(c.claimed_at)}${reward ? ` · ${reward.cost} points` : ""}</div>
+                  </div>
+                  <div class="tm-approval-actions">
+                    <button class="tm-btn tm-btn-ghost tm-btn-sm" data-act="reject-reward"  data-id="${this._esc(c.id)}">Reject</button>
+                    <button class="tm-btn tm-btn-sm" data-act="approve-reward" data-id="${this._esc(c.id)}">Approve</button>
+                  </div>
+                </div>
+              `;
+            }).join("")}
+          </div>
+        `}
+      </div>
+
+      <!-- Recent activity feed -->
+      <div class="tm-card">
+        <h3 class="tm-section-title">Recent activity</h3>
+        ${recent.length === 0 ? `<p class="tm-meta">Nothing here yet — activity will appear as chores are completed and rewards claimed.</p>` : `
+          <div class="tm-timeline">
+            ${recent.map(ev => `
+              <div class="tm-timeline-row">
+                <div class="tm-timeline-time">${this._esc(this._timeAgo(ev.ts))}</div>
+                <div class="tm-timeline-icon tm-timeline-${ev.kind}"><ha-icon icon="${ev.kind === 'completion' ? 'mdi:check-circle' : ev.kind === 'claim' ? 'mdi:gift' : ev.points >= 0 ? 'mdi:plus-circle' : 'mdi:minus-circle'}"></ha-icon></div>
+                <div class="tm-timeline-body">
+                  <div><strong>${this._esc(ev.child)}</strong> · ${this._esc(ev.label)}</div>
+                </div>
+                <div class="tm-timeline-points ${ev.points >= 0 ? 'tm-pos' : 'tm-neg'} tm-numeric">${ev.points >= 0 ? '+' : ''}${ev.points || 0}</div>
+              </div>
+            `).join("")}
+          </div>
+        `}
+      </div>
+
+      <!-- Audit log -->
+      <div class="tm-card">
+        <h3 class="tm-section-title">Audit log
+          <span class="tm-pill">${transactions.length} transaction${transactions.length === 1 ? "" : "s"}</span>
+        </h3>
+        ${transactions.length === 0 ? `<p class="tm-meta">No points transactions yet.</p>` : `
+          <div class="tm-table-wrap">
+            <table class="tm-table">
+              <thead><tr><th>When</th><th>Child</th><th>Points</th><th>Reason</th></tr></thead>
+              <tbody>
+                ${[...transactions].reverse().map(t => {
+                  const child = childById[t.child_id];
+                  return `
+                    <tr class="tm-row">
+                      <td class="tm-meta">${this._esc(this._timeAgo(t.created_at))}</td>
+                      <td>${this._esc((child && child.name) || "?")}</td>
+                      <td><strong class="tm-numeric ${t.points >= 0 ? 'tm-pos' : 'tm-neg'}">${t.points >= 0 ? '+' : ''}${t.points}</strong></td>
+                      <td>${this._esc(t.reason || "—")}</td>
+                    </tr>
+                  `;
+                }).join("")}
+              </tbody>
+            </table>
+          </div>
+        `}
+      </div>
+    `;
+  }
+
   // -- Chores tab --------------------------------------------------------
   _renderChoresTab() {
-    const chores = this._state.chores || [];
+    const all = this._state.chores || [];
+    const chores = this._filterByName(all);
     const childById = Object.fromEntries((this._state.children || []).map(c => [c.id, c]));
     return `
       <div class="tm-toolbar">
-        <h2 class="tm-toolbar-title">Chores <span class="tm-toolbar-count">${chores.length}</span></h2>
+        <h2 class="tm-toolbar-title">Chores <span class="tm-toolbar-count">${all.length}</span></h2>
+        ${all.length > 0 ? this._searchBox("Filter chores…") : ""}
+        <button class="tm-btn tm-btn-ghost" data-act="bulk-add-chore">＋＋ Bulk add</button>
         <button class="tm-btn" data-act="add-chore">＋ Add chore</button>
       </div>
-      ${chores.length === 0 ? this._emptyState("📋", "No chores yet", "Add a chore — it'll show on the assigned children's cards.", "add-chore", "+ Add chore") : `
+      ${all.length === 0 ? this._emptyState("📋", "No chores yet", "Add a chore — it'll show on the assigned children's cards.", "add-chore", "+ Add chore") :
+        chores.length === 0 ? `<div class="tm-card tm-empty"><p>No chores match "<strong>${this._esc(this._filter)}</strong>".</p></div>` : `
         <div class="tm-table-wrap">
           <table class="tm-table">
             <thead><tr>
@@ -731,11 +1165,13 @@ class TaskMatePanel extends HTMLElement {
             </tbody>
           </table>
         </div>
+        <p class="tm-meta tm-table-hint">Tip: double-click a chore name to rename it inline.</p>
       `}
     `;
   }
 
   _renderChoreRow(c, childById) {
+    const renaming = this._inlineRename && this._inlineRename.kind === "chore" && this._inlineRename.id === c.id;
     const assignedNames = (c.assigned_to || []).length === 0
       ? `<span class="tm-text-muted">All children</span>`
       : this._esc((c.assigned_to || []).map(id => (childById[id] && childById[id].name) || "?").join(", "));
@@ -747,9 +1183,14 @@ class TaskMatePanel extends HTMLElement {
     const schedClass = c.schedule_mode === "recurring" ? "tm-pill-accent" : c.schedule_mode === "one_shot" ? "tm-pill-warn" : "tm-pill-success";
     const modeBadge = c.assignment_mode && c.assignment_mode !== "everyone"
       ? `<span class="tm-pill tm-pill-${c.assignment_mode}">${c.assignment_mode}</span>` : "";
+    const nameCell = renaming
+      ? `<input class="tm-inline-input" type="text" data-field="_inlineRename" value="${this._esc(this._inlineRename.value)}" autofocus>
+         <button class="tm-icon-btn" data-act="rename-chore-commit" title="Save">✓</button>
+         <button class="tm-icon-btn" data-act="rename-chore-cancel" title="Cancel">✕</button>`
+      : `<strong data-rename="chore" data-id="${this._esc(c.id)}" title="Double-click to rename">${this._esc(c.name)}</strong>${c.enabled === false ? ` <span class="tm-pill">disabled</span>` : ""}`;
     return `
       <tr class="tm-row ${c.enabled === false ? "tm-row-disabled" : ""}">
-        <td><strong>${this._esc(c.name)}</strong>${c.enabled === false ? ` <span class="tm-pill">disabled</span>` : ""}</td>
+        <td>${nameCell}</td>
         <td><strong class="tm-numeric">${c.points}</strong></td>
         <td>${assignedNames} ${modeBadge}</td>
         <td><span class="tm-pill ${schedClass} tm-pill-dot">${this._esc(schedLabel)}</span></td>
@@ -764,14 +1205,17 @@ class TaskMatePanel extends HTMLElement {
 
   // -- Rewards tab -------------------------------------------------------
   _renderRewardsTab() {
-    const rewards = this._state.rewards || [];
+    const all = this._state.rewards || [];
+    const rewards = this._filterByName(all);
     const pointsName = this._state.settings.points_name || "points";
     return `
       <div class="tm-toolbar">
-        <h2 class="tm-toolbar-title">Rewards <span class="tm-toolbar-count">${rewards.length}</span></h2>
+        <h2 class="tm-toolbar-title">Rewards <span class="tm-toolbar-count">${all.length}</span></h2>
+        ${all.length > 0 ? this._searchBox("Search rewards…") : ""}
         <button class="tm-btn" data-act="add-reward">＋ Add reward</button>
       </div>
-      ${rewards.length === 0 ? this._emptyState("🎁", "No rewards yet", `Add a reward children can spend their ${this._esc(pointsName.toLowerCase())} on.`, "add-reward", "+ Add reward") : `
+      ${all.length === 0 ? this._emptyState("🎁", "No rewards yet", `Add a reward children can spend their ${this._esc(pointsName.toLowerCase())} on.`, "add-reward", "+ Add reward") :
+        rewards.length === 0 ? `<div class="tm-card tm-empty"><p>No rewards match "<strong>${this._esc(this._filter)}</strong>".</p></div>` : `
         <div class="tm-grid">
           ${rewards.map(r => this._renderRewardCard(r, pointsName)).join("")}
           <button class="tm-add-tile" data-act="add-reward"><span class="tm-add-plus">＋</span>Add reward</button>
@@ -812,15 +1256,18 @@ class TaskMatePanel extends HTMLElement {
 
   // -- Penalties / Bonuses tab -------------------------------------------
   _renderPenBonTab(kind) {
-    const items = (kind === "penalty" ? this._state.penalties : this._state.bonuses) || [];
+    const allItems = (kind === "penalty" ? this._state.penalties : this._state.bonuses) || [];
+    const items = this._filterByName(allItems);
     const childById = Object.fromEntries((this._state.children || []).map(c => [c.id, c]));
     const labels = kind === "penalty" ? { plural: "Penalties", add: "+ Add penalty", icon: "⚠️" } : { plural: "Bonuses", add: "+ Add bonus", icon: "⭐" };
     return `
       <div class="tm-toolbar">
-        <h2 class="tm-toolbar-title">${labels.plural} <span class="tm-toolbar-count">${items.length}</span></h2>
+        <h2 class="tm-toolbar-title">${labels.plural} <span class="tm-toolbar-count">${allItems.length}</span></h2>
+        ${allItems.length > 0 ? this._searchBox(`Search ${labels.plural.toLowerCase()}…`) : ""}
         <button class="tm-btn" data-act="add-${kind}">＋ Add ${kind}</button>
       </div>
-      ${items.length === 0 ? this._emptyState(labels.icon, `No ${labels.plural.toLowerCase()} yet`, kind === "penalty" ? "Add a penalty to deduct points for misbehaviour." : "Add a bonus to award points for going above and beyond.", `add-${kind}`, labels.add) : `
+      ${allItems.length === 0 ? this._emptyState(labels.icon, `No ${labels.plural.toLowerCase()} yet`, kind === "penalty" ? "Add a penalty to deduct points for misbehaviour." : "Add a bonus to award points for going above and beyond.", `add-${kind}`, labels.add) :
+        items.length === 0 ? `<div class="tm-card tm-empty"><p>No ${labels.plural.toLowerCase()} match "<strong>${this._esc(this._filter)}</strong>".</p></div>` : `
         <div class="tm-table-wrap">
           <table class="tm-table">
             <thead><tr><th>Name</th><th>Points</th><th>Assigned</th><th></th></tr></thead>
@@ -851,14 +1298,17 @@ class TaskMatePanel extends HTMLElement {
 
   // -- Groups tab --------------------------------------------------------
   _renderGroupsTab() {
-    const groups = this._state.task_groups || [];
+    const all = this._state.task_groups || [];
+    const groups = this._filterByName(all);
     const choreById = Object.fromEntries((this._state.chores || []).map(c => [c.id, c]));
     return `
       <div class="tm-toolbar">
-        <h2 class="tm-toolbar-title">Task groups <span class="tm-toolbar-count">${groups.length}</span></h2>
+        <h2 class="tm-toolbar-title">Task groups <span class="tm-toolbar-count">${all.length}</span></h2>
+        ${all.length > 0 ? this._searchBox("Search groups…") : ""}
         <button class="tm-btn" data-act="add-group">＋ Add group</button>
       </div>
-      ${groups.length === 0 ? this._emptyState("🔗", "No task groups yet", "Create a group to make chores rotate together (e.g. all kitchen chores stay with one child each day).", "add-group", "+ Add group") : `
+      ${all.length === 0 ? this._emptyState("🔗", "No task groups yet", "Create a group to make chores rotate together (e.g. all kitchen chores stay with one child each day).", "add-group", "+ Add group") :
+        groups.length === 0 ? `<div class="tm-card tm-empty"><p>No groups match "<strong>${this._esc(this._filter)}</strong>".</p></div>` : `
         <div class="tm-grid">
           ${groups.map(g => `
             <article class="tm-card">
@@ -987,6 +1437,8 @@ class TaskMatePanel extends HTMLElement {
     if (this._dialog.kind === "group")        return this._renderGroupDialog();
     if (this._dialog.kind === "apply-penalty") return this._renderApplyDialog("penalty");
     if (this._dialog.kind === "apply-bonus")   return this._renderApplyDialog("bonus");
+    if (this._dialog.kind === "bulk-chore")    return this._renderBulkChoreDialog();
+    if (this._dialog.kind === "reorder")       return this._renderReorderDialog();
     return "";
   }
 
@@ -1012,8 +1464,6 @@ class TaskMatePanel extends HTMLElement {
     const showSpecificDays = d.schedule_mode === "specific_days";
     const showRecurring    = d.schedule_mode === "recurring";
     const showRotation     = ["alternating", "random", "balanced"].includes(d.assignment_mode);
-
-    // Calendar entities available in this HA
     const calendarEntities = Object.keys((this._hass && this._hass.states) || {})
       .filter(id => id.startsWith("calendar."))
       .sort();
@@ -1022,13 +1472,10 @@ class TaskMatePanel extends HTMLElement {
       [
         this._field("Name", "name", d.name, "text"),
         this._field("Description (optional)", "description", d.description, "text"),
-
         `<div class="tm-field-row">
           ${this._field("Points", "points", d.points, "number")}
           ${this._field("Daily limit", "daily_limit", d.daily_limit, "number")}
         </div>`,
-
-        // Assigned to
         children.length > 0 ? `
           <div class="tm-field">
             <span class="tm-field-label">Assigned to</span>
@@ -1042,25 +1489,17 @@ class TaskMatePanel extends HTMLElement {
             <span class="tm-field-hint">Leave empty to assign to <strong>all children</strong>.</span>
           </div>
         ` : `<div class="tm-field"><span class="tm-field-hint">Add some children first to assign chores to them.</span></div>`,
-
         this._select("Assignment mode", "assignment_mode", d.assignment_mode, ASSIGNMENT_MODES,
-          "Everyone = all assigned children see it. Alternating = rotate one per day. Random = pick one daily. Balanced = split evenly across the day.",
-          true /* rerender on change so the rotation field appears */),
-
+          "Everyone = all assigned children see it. Alternating = rotate one per day. Random = pick one daily. Balanced = split evenly across the day.", true),
         showRotation && children.length > 0 ? this._select(
           "Start rotation with (optional)", "manual_start_child_id", d.manual_start_child_id,
           [{ v: "", l: "(no override)" }, ...children.map(c => ({ v: c.id, l: c.name }))],
           "Alternating mode: permanently reorders the pool. Random/Balanced: only overrides today; tomorrow resumes normally."
         ) : "",
-
         this._select("Time category", "time_category", d.time_category, TIME_CATEGORIES),
-
         this._field("Claim allowance (minutes)", "claim_allowance_minutes", d.claim_allowance_minutes, "number",
           "Extra minutes after the time-of-day window ends during which the chore stays claimable. 0 = no grace. Night chores still cap at midnight."),
-
-        // Schedule mode — re-renders to reveal options
         this._select("Schedule mode", "schedule_mode", d.schedule_mode, SCHEDULE_MODES, "", true),
-
         showSpecificDays ? `
           <div class="tm-field">
             <span class="tm-field-label">Days of week (leave empty = every day)</span>
@@ -1071,7 +1510,6 @@ class TaskMatePanel extends HTMLElement {
             </div>
           </div>
         ` : "",
-
         showRecurring ? `
           <div class="tm-field-row">
             ${this._select("Recurrence", "recurrence", d.recurrence, RECURRENCES)}
@@ -1082,20 +1520,15 @@ class TaskMatePanel extends HTMLElement {
             ${this._select("First occurrence", "first_occurrence_mode", d.first_occurrence_mode, FIRST_OCCURRENCE)}
           </div>
         ` : "",
-
         this._select("Completion sound", "completion_sound", d.completion_sound, COMPLETION_SOUNDS.map(s => ({ v: s, l: s }))),
-
         this._switch("Requires parent approval", "requires_approval", d.requires_approval),
         this._switch("Skip unavailable children", "require_availability", d.require_availability,
           "Uses each child's availability sensor (set on their profile)."),
-
         memberInGroup ? `
           <div class="tm-field">
             <span class="tm-field-hint">Member of task group: <strong>${this._esc(memberInGroup.name)}</strong> (${memberInGroup.policy}). Manage membership on the Groups tab.</span>
           </div>
         ` : "",
-
-        // Advanced
         `<details class="tm-advanced">
           <summary>Advanced — visibility &amp; calendar publishing</summary>
           <div>
@@ -1105,7 +1538,6 @@ class TaskMatePanel extends HTMLElement {
               ${this._select("Visibility operator", "visibility_operator", d.visibility_operator, VISIBILITY_OPS)}
               ${this._field("Visibility value", "visibility_state", d.visibility_state, "text", 'e.g. "on", "home", "30"')}
             </div>
-
             <div class="tm-field">
               <span class="tm-field-label">Publish to calendars (optional)</span>
               ${calendarEntities.length === 0 ? `<span class="tm-field-hint">No calendar entities found in Home Assistant. Set one up first.</span>` : `
@@ -1119,7 +1551,6 @@ class TaskMatePanel extends HTMLElement {
                 <span class="tm-field-hint">Today's assignment will be added as a calendar event on each selected calendar.</span>
               `}
             </div>
-
             ${this._switch("Enabled", "enabled", d.enabled !== false)}
           </div>
         </details>`,
@@ -1141,7 +1572,6 @@ class TaskMatePanel extends HTMLElement {
           ${this._field(`Cost (${pointsName})`, "cost", d.cost, "number")}
           ${this._iconPickerField("Icon", "icon", d.icon)}
         </div>`,
-
         children.length > 0 ? `
           <div class="tm-field">
             <span class="tm-field-label">Assigned to</span>
@@ -1155,12 +1585,10 @@ class TaskMatePanel extends HTMLElement {
             <span class="tm-field-hint">Leave empty to make available to <strong>all children</strong>.</span>
           </div>
         ` : "",
-
         this._switch("Pool reward (savings jar)", "pool_enabled", d.pool_enabled,
-          "Children deposit points into this reward's dedicated pool rather than spending from their balance. Good for long-term goals."),
+          "Children deposit points into this reward's dedicated pool rather than spending from their balance."),
         this._switch("Jackpot — pool from all assigned children", "is_jackpot", d.is_jackpot,
           "Combine all children's contributions toward one shared reward."),
-
         `<div class="tm-field-row">
           ${this._field("Limited quantity (blank = unlimited)", "quantity_str", d.quantity_str, "text", "Each approved claim reduces by 1.")}
           ${this._dateField("Expires (blank = never)", "expires_at", d.expires_at, "Pooled points are refunded at midnight.")}
@@ -1255,6 +1683,76 @@ class TaskMatePanel extends HTMLElement {
     );
   }
 
+  _renderBulkChoreDialog() {
+    const d = this._dialog.data;
+    const children = this._state.children || [];
+    return this._dialogShell("Bulk add chores",
+      [
+        `<div class="tm-field">
+          <span class="tm-field-label">Chore names (one per line, or comma-separated)</span>
+          <textarea class="tm-textarea" data-field="chore_names" rows="6" placeholder="Make bed&#10;Empty dishwasher&#10;Feed dog">${this._esc(d.chore_names || "")}</textarea>
+          <span class="tm-field-hint">All chores will share the settings below.</span>
+        </div>`,
+        `<div class="tm-field-row">
+          ${this._field("Points (each)", "points", d.points, "number")}
+          ${this._field("Daily limit", "daily_limit", d.daily_limit, "number")}
+        </div>`,
+        children.length > 0 ? `
+          <div class="tm-field">
+            <span class="tm-field-label">Assigned to</span>
+            <div class="tm-chip-row">
+              ${children.map(c => `
+                <button type="button" class="tm-chip-btn ${(d.assigned_to || []).includes(c.id) ? "tm-chip-on" : ""}" data-act="toggle-assigned" data-id="${this._esc(c.id)}">
+                  ${this._esc(c.name)}
+                </button>
+              `).join("")}
+            </div>
+            <span class="tm-field-hint">Leave empty to assign to all children.</span>
+          </div>
+        ` : "",
+        this._select("Time category", "time_category", d.time_category, TIME_CATEGORIES),
+        this._select("Schedule mode", "schedule_mode", d.schedule_mode, SCHEDULE_MODES, "", true),
+        d.schedule_mode === "specific_days" ? `
+          <div class="tm-field">
+            <span class="tm-field-label">Days of week (empty = every day)</span>
+            <div class="tm-day-row">
+              ${DAYS.map(day => `
+                <button type="button" class="tm-day-btn ${(d.due_days || []).includes(day.v) ? "tm-day-on" : ""}" data-act="toggle-bulk-day" data-day="${day.v}">${day.l}</button>
+              `).join("")}
+            </div>
+          </div>
+        ` : "",
+        this._select("Completion sound", "completion_sound", d.completion_sound, COMPLETION_SOUNDS.map(s => ({ v: s, l: s }))),
+        this._switch("Requires parent approval", "requires_approval", d.requires_approval),
+      ].join(""),
+      `<button class="tm-btn tm-btn-ghost" data-act="close-dialog">Cancel</button>
+       <button class="tm-btn" data-act="save-bulk-chores">Create chores</button>`
+    );
+  }
+
+  _renderReorderDialog() {
+    const d = this._dialog.data;
+    const choreById = Object.fromEntries((this._state.chores || []).map(c => [c.id, c]));
+    return this._dialogShell(`Reorder chores · ${d.name}`,
+      `<p class="tm-meta">Drag rows to reorder how chores appear on this child's card. Save to apply.</p>
+       <div class="tm-reorder-list">
+         ${(d.order || []).map(id => {
+           const c = choreById[id];
+           if (!c) return "";
+           return `
+             <div class="tm-reorder-item" draggable="true" data-drag-id="${this._esc(id)}">
+               <div class="tm-reorder-handle">⠿</div>
+               <div class="tm-reorder-name">${this._esc(c.name)}</div>
+               <div class="tm-reorder-points tm-numeric">${c.points}</div>
+             </div>
+           `;
+         }).join("")}
+       </div>`,
+      `<button class="tm-btn tm-btn-ghost" data-act="close-dialog">Cancel</button>
+       <button class="tm-btn" data-act="save-chore-order">Save order</button>`
+    );
+  }
+
   // ---- form helpers ----------------------------------------------------
   _dialogShell(title, body, footer) {
     return `
@@ -1280,9 +1778,6 @@ class TaskMatePanel extends HTMLElement {
   }
 
   _dateField(label, name, value, hint = "") {
-    // <input type=date> — the displayed format follows the user's browser
-    // locale (DD/MM/YYYY in en-GB) but the underlying value is YYYY-MM-DD,
-    // which is what TaskMate's storage expects.
     return `
       <label class="tm-field">
         <span class="tm-field-label">${this._esc(label)}</span>
@@ -1365,15 +1860,13 @@ class TaskMatePanel extends HTMLElement {
     return `<ha-icon icon="${this._esc(name || "mdi:account-circle")}"></ha-icon>`;
   }
 
-  // ---- styles (HA-token-aware, light/dark adaptive) --------------------
+  // ---- styles (Shopify-grade light + polished dark, blur 2px) ----------
   _styles() {
     return `<style>
       taskmate-panel {
         display: block; height: 100%;
 
-        /* Source HA primaries with sensible dark fallbacks. Surfaces and
-           borders are derived from these via color-mix() so the panel
-           adapts to whatever HA theme is active. */
+        /* ===== Default token set (DARK) — overridden in light @media below */
         --tm-bg:           var(--primary-background-color, #08090b);
         --tm-text:         var(--primary-text-color,        #f4f5f7);
         --tm-text-muted:   var(--secondary-text-color,      #a8aeb8);
@@ -1385,7 +1878,6 @@ class TaskMatePanel extends HTMLElement {
         --tm-accent-soft:  color-mix(in srgb, var(--tm-accent), transparent 88%);
         --tm-accent-glow:  color-mix(in srgb, var(--tm-accent), transparent 78%);
 
-        /* Layered surfaces — shift toward text colour so works in both themes */
         --tm-surface-0: color-mix(in srgb, var(--tm-bg), var(--tm-text) 3%);
         --tm-surface-1: color-mix(in srgb, var(--tm-bg), var(--tm-text) 5%);
         --tm-surface-2: color-mix(in srgb, var(--tm-bg), var(--tm-text) 9%);
@@ -1426,14 +1918,36 @@ class TaskMatePanel extends HTMLElement {
         letter-spacing: -0.005em;
         -webkit-font-smoothing: antialiased;
         -moz-osx-font-smoothing: grayscale;
+        font-feature-settings: "cv11", "ss01", "ss03";
       }
 
-      /* Lighten shadows in light themes */
+      /* ===== LIGHT theme — Shopify Polaris-inspired explicit overrides ===== */
       @media (prefers-color-scheme: light) {
         taskmate-panel {
-          --tm-shadow-sm: 0 1px 2px rgba(15,15,15,0.06);
-          --tm-shadow:    0 2px 8px rgba(15,15,15,0.08);
-          --tm-shadow-lg: 0 16px 40px rgba(15,15,15,0.12);
+          --tm-bg:            #f6f7f9;
+          --tm-text:          #1a1c1f;
+          --tm-text-muted:    #4b5563;
+          --tm-text-faint:    #6b7280;
+          --tm-text-vfaint:   #9ca3af;
+
+          /* Crisp white cards on warm off-white bg */
+          --tm-surface-0:     #ffffff;
+          --tm-surface-1:     #ffffff;
+          --tm-surface-2:     #f3f4f6;
+          --tm-surface-3:     #e5e7eb;
+          --tm-surface-hover: #fafbfc;
+
+          --tm-border:        #e5e7eb;
+          --tm-border-strong: #d1d5db;
+          --tm-border-soft:   #f1f3f5;
+
+          --tm-accent-soft:   color-mix(in srgb, var(--tm-accent), white 88%);
+          --tm-accent-glow:   color-mix(in srgb, var(--tm-accent), transparent 80%);
+
+          /* Crisp layered shadows in the Shopify Polaris style */
+          --tm-shadow-sm:     0 1px 0 rgba(15,15,15,0.04), 0 0 0 1px rgba(15,15,15,0.04);
+          --tm-shadow:        0 1px 3px rgba(15,15,15,0.05), 0 4px 12px rgba(15,15,15,0.04);
+          --tm-shadow-lg:     0 12px 32px -8px rgba(15,15,15,0.18);
         }
       }
 
@@ -1453,9 +1967,9 @@ class TaskMatePanel extends HTMLElement {
         display: flex; align-items: center; gap: 14px;
         flex-shrink: 0;
         border-bottom: 1px solid var(--tm-border);
-        background: color-mix(in srgb, var(--tm-bg), transparent 20%);
-        backdrop-filter: blur(16px) saturate(180%);
-        -webkit-backdrop-filter: blur(16px) saturate(180%);
+        background: color-mix(in srgb, var(--tm-bg), transparent 14%);
+        backdrop-filter: blur(2px);
+        -webkit-backdrop-filter: blur(2px);
       }
       .tm-appbar-icon {
         width: 32px; height: 32px;
@@ -1482,15 +1996,35 @@ class TaskMatePanel extends HTMLElement {
         border-radius: 999px;
         border: 1px solid var(--tm-border);
       }
+      .tm-approval-pill {
+        background: var(--tm-warning-soft);
+        color: var(--tm-warning);
+        border: 1px solid color-mix(in srgb, var(--tm-warning), transparent 70%);
+        padding: 5px 12px 5px 10px;
+        border-radius: 999px;
+        font-size: 12px; font-weight: 600;
+        cursor: pointer;
+        font-family: inherit;
+        display: inline-flex; align-items: center; gap: 6px;
+        transition: all 0.12s var(--tm-easing);
+      }
+      .tm-approval-pill:hover { background: color-mix(in srgb, var(--tm-warning), transparent 80%); transform: translateY(-1px); }
+      .tm-approval-dot {
+        width: 8px; height: 8px; border-radius: 50%;
+        background: var(--tm-warning);
+        box-shadow: 0 0 8px var(--tm-warning);
+        animation: tm-pulse 2s ease-in-out infinite;
+      }
+      @keyframes tm-pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.45; } }
 
       /* Tabs */
       .tm-tabs {
         position: relative; z-index: 4;
         display: flex; padding: 0 16px;
         border-bottom: 1px solid var(--tm-border);
-        background: color-mix(in srgb, var(--tm-bg), transparent 20%);
-        backdrop-filter: blur(12px);
-        -webkit-backdrop-filter: blur(12px);
+        background: color-mix(in srgb, var(--tm-bg), transparent 14%);
+        backdrop-filter: blur(2px);
+        -webkit-backdrop-filter: blur(2px);
         overflow-x: auto; scrollbar-width: none;
         flex-shrink: 0;
       }
@@ -1524,6 +2058,24 @@ class TaskMatePanel extends HTMLElement {
         line-height: 1.4;
       }
       .tm-tab-active .tm-tab-pill { background: var(--tm-accent-soft); color: var(--tm-accent); }
+      .tm-tab-pill-urgent {
+        background: var(--tm-warning-soft) !important;
+        color: var(--tm-warning) !important;
+      }
+
+      /* Approval banner */
+      .tm-approval-banner {
+        position: relative; z-index: 3;
+        display: flex; align-items: center; gap: 12px;
+        padding: 10px 24px;
+        background: var(--tm-warning-soft);
+        border-bottom: 1px solid color-mix(in srgb, var(--tm-warning), transparent 70%);
+        color: color-mix(in srgb, var(--tm-warning), var(--tm-text) 50%);
+        font-size: 13px;
+      }
+      .tm-approval-banner ha-icon { --mdc-icon-size: 18px; color: var(--tm-warning); }
+      .tm-approval-banner span { flex: 1; }
+      .tm-approval-banner strong { color: var(--tm-text); font-weight: 600; }
 
       /* Body */
       .tm-body { flex: 1; overflow-y: auto; padding: 28px 32px 56px; position: relative; z-index: 1; }
@@ -1534,13 +2086,50 @@ class TaskMatePanel extends HTMLElement {
       .tm-toolbar-title {
         margin: 0; font-size: 22px; font-weight: 600;
         letter-spacing: -0.02em;
-        flex: 1;
       }
       .tm-toolbar-count {
         color: var(--tm-text-faint); font-weight: 400;
         margin-left: 6px;
         font-feature-settings: "tnum";
       }
+
+      /* Search input */
+      .tm-search-wrap {
+        position: relative;
+        flex: 1; min-width: 240px; max-width: 400px;
+      }
+      .tm-search-icon {
+        position: absolute; left: 10px; top: 50%; transform: translateY(-50%);
+        --mdc-icon-size: 16px; color: var(--tm-text-faint);
+        pointer-events: none;
+      }
+      .tm-search {
+        width: 100%;
+        background: var(--tm-surface-1);
+        border: 1px solid var(--tm-border);
+        border-radius: var(--tm-radius-sm);
+        padding: 8px 12px 8px 34px;
+        color: var(--tm-text);
+        font-size: 13px;
+        font-family: inherit;
+        transition: all 0.15s var(--tm-easing);
+      }
+      .tm-search:focus {
+        outline: 0;
+        border-color: var(--tm-accent);
+        box-shadow: 0 0 0 3px var(--tm-accent-soft);
+      }
+      .tm-search::placeholder { color: var(--tm-text-faint); }
+      .tm-search-clear {
+        position: absolute; right: 8px; top: 50%; transform: translateY(-50%);
+        background: var(--tm-surface-2);
+        color: var(--tm-text-muted);
+        border: 0;
+        width: 22px; height: 22px;
+        border-radius: 50%; cursor: pointer; font-size: 11px;
+        display: grid; place-items: center;
+      }
+      .tm-search-clear:hover { background: var(--tm-surface-3); color: var(--tm-text); }
 
       /* Buttons */
       .tm-btn {
@@ -1551,7 +2140,7 @@ class TaskMatePanel extends HTMLElement {
         letter-spacing: -0.005em;
         font-family: inherit;
         cursor: pointer;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.15), 0 0 0 1px rgba(255,255,255,0.06) inset;
+        box-shadow: 0 1px 2px rgba(0,0,0,0.10), 0 0 0 1px rgba(255,255,255,0.06) inset;
         transition: all 0.12s var(--tm-easing);
         display: inline-flex; align-items: center; gap: 6px;
       }
@@ -1559,11 +2148,11 @@ class TaskMatePanel extends HTMLElement {
       .tm-btn:active { transform: translateY(0); filter: brightness(0.95); }
       .tm-btn-sm     { padding: 5px 10px; font-size: 12px; }
       .tm-btn-ghost {
-        background: var(--tm-surface-2);
+        background: var(--tm-surface-1);
         color: var(--tm-text);
         box-shadow: 0 0 0 1px var(--tm-border) inset;
       }
-      .tm-btn-ghost:hover { background: var(--tm-surface-3); transform: translateY(-1px); }
+      .tm-btn-ghost:hover { background: var(--tm-surface-2); transform: translateY(-1px); }
       .tm-btn-danger {
         background: transparent;
         color: var(--tm-danger);
@@ -1587,25 +2176,28 @@ class TaskMatePanel extends HTMLElement {
       .tm-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(320px, 1fr)); gap: 16px; }
       .tm-card {
         position: relative; overflow: hidden;
-        background: linear-gradient(180deg, var(--tm-surface-1), var(--tm-surface-0));
+        background: var(--tm-surface-1);
         border: 1px solid var(--tm-border);
         border-radius: var(--tm-radius);
         padding: 20px;
         box-shadow: var(--tm-shadow-sm);
         transition: all 0.15s var(--tm-easing);
+        margin-bottom: 16px;
       }
-      .tm-card::before {
-        content: "";
-        position: absolute; top: 0; left: 1px; right: 1px;
-        height: 1px;
-        background: linear-gradient(90deg, transparent, color-mix(in srgb, var(--tm-text), transparent 88%), transparent);
-      }
-      .tm-card:hover { border-color: var(--tm-border-strong); transform: translateY(-1px); box-shadow: var(--tm-shadow); }
+      .tm-card:last-child { margin-bottom: 0; }
+      .tm-card:hover { border-color: var(--tm-border-strong); box-shadow: var(--tm-shadow); }
       .tm-card-error { border-left: 3px solid var(--tm-danger); color: var(--tm-danger); }
       .tm-loading { color: var(--tm-text-muted); }
 
+      .tm-section-title {
+        margin: 0 0 12px;
+        font-size: 14px; font-weight: 600;
+        letter-spacing: -0.005em;
+        display: flex; align-items: center; gap: 8px;
+      }
+
       /* Child / reward / group cards share head/avatar */
-      .tm-child-card { display: flex; flex-direction: column; gap: 16px; }
+      .tm-child-card { display: flex; flex-direction: column; gap: 16px; margin-bottom: 0; }
       .tm-child-head { display: flex; align-items: center; gap: 14px; }
       .tm-avatar {
         width: 48px; height: 48px;
@@ -1614,7 +2206,7 @@ class TaskMatePanel extends HTMLElement {
         display: grid; place-items: center;
         flex-shrink: 0;
         color: var(--tm-accent);
-        box-shadow: 0 0 0 1px var(--tm-border) inset, 0 1px 2px rgba(0,0,0,0.2);
+        box-shadow: 0 0 0 1px var(--tm-border) inset;
       }
       .tm-avatar ha-icon { --mdc-icon-size: 26px; }
       .tm-avatar-reward  { color: var(--tm-gold); }
@@ -1650,6 +2242,7 @@ class TaskMatePanel extends HTMLElement {
         margin-top: auto;
         padding-top: 16px;
         border-top: 1px solid var(--tm-border-soft);
+        flex-wrap: wrap;
       }
 
       .tm-add-tile {
@@ -1682,7 +2275,7 @@ class TaskMatePanel extends HTMLElement {
 
       /* Tables */
       .tm-table-wrap {
-        background: linear-gradient(180deg, var(--tm-surface-1), var(--tm-surface-0));
+        background: var(--tm-surface-1);
         border: 1px solid var(--tm-border);
         border-radius: var(--tm-radius);
         overflow: hidden;
@@ -1690,7 +2283,7 @@ class TaskMatePanel extends HTMLElement {
       }
       .tm-table { width: 100%; border-collapse: collapse; }
       .tm-table th, .tm-table td {
-        text-align: left; padding: 14px 18px;
+        text-align: left; padding: 12px 18px;
         border-bottom: 1px solid var(--tm-border-soft);
         font-size: 13px;
       }
@@ -1698,7 +2291,7 @@ class TaskMatePanel extends HTMLElement {
         color: var(--tm-text-faint);
         font-weight: 500; font-size: 10px;
         text-transform: uppercase; letter-spacing: 0.06em;
-        background: var(--tm-surface-0);
+        background: var(--tm-surface-2);
         border-bottom: 1px solid var(--tm-border);
       }
       .tm-table tr:last-child td { border-bottom: 0; }
@@ -1713,6 +2306,20 @@ class TaskMatePanel extends HTMLElement {
       .tm-neg { color: var(--tm-danger); }
       .tm-pos { color: var(--tm-positive); }
       .tm-cost { color: var(--tm-gold); }
+      .tm-table-hint { margin-top: 8px; font-size: 11px; }
+
+      .tm-inline-input {
+        background: var(--tm-surface-1);
+        border: 1px solid var(--tm-accent);
+        border-radius: 6px;
+        padding: 4px 8px;
+        color: var(--tm-text);
+        font-size: 13px; font-weight: 500;
+        font-family: inherit;
+        max-width: 240px;
+        outline: 0;
+        box-shadow: 0 0 0 3px var(--tm-accent-soft);
+      }
 
       /* Pills */
       .tm-pill {
@@ -1738,7 +2345,7 @@ class TaskMatePanel extends HTMLElement {
       }
 
       /* Reward extras */
-      .tm-reward-card { display: flex; flex-direction: column; gap: 14px; }
+      .tm-reward-card { display: flex; flex-direction: column; gap: 14px; margin-bottom: 0; }
       .tm-progress {
         height: 6px;
         background: var(--tm-surface-2);
@@ -1751,7 +2358,6 @@ class TaskMatePanel extends HTMLElement {
         display: block; height: 100%;
         background: linear-gradient(90deg, var(--tm-accent), color-mix(in srgb, var(--tm-accent), white 25%));
         border-radius: 999px;
-        box-shadow: 0 0 8px var(--tm-accent-glow);
       }
       .tm-progress-text {
         font-size: 12px; color: var(--tm-text-muted);
@@ -1785,21 +2391,58 @@ class TaskMatePanel extends HTMLElement {
       .tm-group-list { margin: 8px 0 0; padding-left: 20px; color: var(--tm-text-muted); font-size: 13px; }
       .tm-group-list li { margin-bottom: 2px; }
 
+      /* Activity tab */
+      .tm-approval-list { display: flex; flex-direction: column; gap: 8px; }
+      .tm-approval-item {
+        display: flex; align-items: center; gap: 14px;
+        padding: 12px;
+        background: var(--tm-surface-2);
+        border: 1px solid var(--tm-border);
+        border-radius: var(--tm-radius-sm);
+      }
+      .tm-approval-icon {
+        width: 36px; height: 36px;
+        border-radius: 50%;
+        background: var(--tm-warning-soft);
+        color: var(--tm-warning);
+        display: grid; place-items: center;
+        flex-shrink: 0;
+      }
+      .tm-approval-icon ha-icon { --mdc-icon-size: 20px; }
+      .tm-approval-body { flex: 1; min-width: 0; }
+      .tm-approval-line { font-size: 13px; }
+      .tm-approval-actions { display: flex; gap: 6px; flex-shrink: 0; }
+
+      .tm-timeline { display: flex; flex-direction: column; }
+      .tm-timeline-row {
+        display: grid; grid-template-columns: 80px 32px 1fr auto;
+        gap: 12px; align-items: center;
+        padding: 10px 0;
+        border-top: 1px solid var(--tm-border-soft);
+        font-size: 13px;
+      }
+      .tm-timeline-row:first-child { border-top: 0; }
+      .tm-timeline-time { color: var(--tm-text-faint); font-size: 12px; font-feature-settings: "tnum"; }
+      .tm-timeline-icon {
+        width: 28px; height: 28px;
+        border-radius: 8px;
+        display: grid; place-items: center;
+        background: var(--tm-surface-2);
+      }
+      .tm-timeline-icon ha-icon { --mdc-icon-size: 16px; }
+      .tm-timeline-completion ha-icon { color: var(--tm-positive); }
+      .tm-timeline-claim ha-icon      { color: var(--tm-gold); }
+      .tm-timeline-manual ha-icon     { color: var(--tm-accent); }
+      .tm-timeline-points { font-weight: 600; }
+
       /* Settings */
       .tm-settings { display: flex; flex-direction: column; gap: 16px; }
       .tm-section {
-        background: linear-gradient(180deg, var(--tm-surface-1), var(--tm-surface-0));
+        background: var(--tm-surface-1);
         border: 1px solid var(--tm-border);
         border-radius: var(--tm-radius);
         overflow: hidden;
         box-shadow: var(--tm-shadow-sm);
-        position: relative;
-      }
-      .tm-section::before {
-        content: "";
-        position: absolute; top: 0; left: 1px; right: 1px;
-        height: 1px;
-        background: linear-gradient(90deg, transparent, color-mix(in srgb, var(--tm-text), transparent 88%), transparent);
       }
       .tm-section-head {
         padding: 16px 20px;
@@ -1820,7 +2463,7 @@ class TaskMatePanel extends HTMLElement {
       .tm-setting-row input[type=text],
       .tm-setting-row input[type=number],
       .tm-setting-row select {
-        background: var(--tm-surface-2);
+        background: var(--tm-surface-1);
         border: 1px solid var(--tm-border);
         border-radius: var(--tm-radius-sm);
         padding: 8px 12px;
@@ -1860,20 +2503,20 @@ class TaskMatePanel extends HTMLElement {
         left: 3px; top: 3px;
         background: white; border-radius: 50%;
         transition: transform 0.2s var(--tm-easing);
-        box-shadow: 0 1px 3px rgba(0,0,0,0.3);
+        box-shadow: 0 1px 3px rgba(0,0,0,0.2);
       }
       .tm-switch input:checked + .tm-slider {
         background: var(--tm-accent);
-        box-shadow: 0 0 0 1px var(--tm-accent) inset, 0 0 12px var(--tm-accent-glow);
+        box-shadow: 0 0 0 1px var(--tm-accent) inset;
       }
       .tm-switch input:checked + .tm-slider::before { transform: translateX(18px); }
 
       /* Dialog */
       .tm-scrim {
         position: fixed; inset: 0;
-        background: color-mix(in srgb, var(--tm-bg), transparent 30%);
-        backdrop-filter: blur(8px);
-        -webkit-backdrop-filter: blur(8px);
+        background: color-mix(in srgb, var(--tm-bg), transparent 25%);
+        backdrop-filter: blur(2px);
+        -webkit-backdrop-filter: blur(2px);
         display: flex; align-items: flex-start; justify-content: center;
         padding: 60px 20px; z-index: 100;
         overflow-y: auto;
@@ -1881,7 +2524,7 @@ class TaskMatePanel extends HTMLElement {
       }
       @keyframes tm-scrim-in { from { opacity: 0; } to { opacity: 1; } }
       .tm-dialog {
-        background: linear-gradient(180deg, var(--tm-surface-2), var(--tm-surface-1));
+        background: var(--tm-surface-1);
         border: 1px solid var(--tm-border-strong);
         border-radius: var(--tm-radius-lg);
         width: 100%; max-width: 560px;
@@ -1890,13 +2533,6 @@ class TaskMatePanel extends HTMLElement {
         max-height: calc(100vh - 120px);
         overflow: hidden;
         animation: tm-dialog-in 0.25s var(--tm-easing);
-        position: relative;
-      }
-      .tm-dialog::before {
-        content: "";
-        position: absolute; top: 0; left: 1px; right: 1px;
-        height: 1px;
-        background: linear-gradient(90deg, transparent, color-mix(in srgb, var(--tm-text), transparent 86%), transparent);
       }
       @keyframes tm-dialog-in { from { opacity: 0; transform: translateY(8px) scale(0.985); } to { opacity: 1; transform: none; } }
 
@@ -1920,9 +2556,9 @@ class TaskMatePanel extends HTMLElement {
 
       .tm-field { display: block; margin-bottom: 18px; }
       .tm-field-label { display: block; color: var(--tm-text-muted); font-size: 12px; margin-bottom: 6px; font-weight: 500; }
-      .tm-field input[type=text], .tm-field input[type=number], .tm-field input[type=date], .tm-field select {
+      .tm-field input[type=text], .tm-field input[type=number], .tm-field input[type=date], .tm-field select, .tm-textarea {
         width: 100%;
-        background: var(--tm-surface-1);
+        background: var(--tm-surface-0);
         border: 1px solid var(--tm-border);
         border-radius: var(--tm-radius-sm);
         padding: 10px 12px;
@@ -1932,7 +2568,7 @@ class TaskMatePanel extends HTMLElement {
         box-sizing: border-box;
         transition: all 0.15s var(--tm-easing);
       }
-      .tm-field input:focus, .tm-field select:focus {
+      .tm-field input:focus, .tm-field select:focus, .tm-textarea:focus {
         outline: 0;
         border-color: var(--tm-accent);
         box-shadow: 0 0 0 3px var(--tm-accent-soft);
@@ -1947,8 +2583,8 @@ class TaskMatePanel extends HTMLElement {
         border-radius: 3px; font-size: 10px;
       }
       .tm-field-row { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+      .tm-textarea { resize: vertical; min-height: 100px; line-height: 1.5; }
 
-      /* HA pickers — make them blend with the dialog form */
       .tm-field ha-icon-picker, .tm-field ha-entity-picker,
       .tm-section-body ha-icon-picker {
         display: block; width: 100%;
@@ -1987,7 +2623,6 @@ class TaskMatePanel extends HTMLElement {
       .tm-day-on {
         background: var(--tm-accent); color: white;
         border-color: var(--tm-accent);
-        box-shadow: 0 1px 4px var(--tm-accent-glow);
       }
 
       .tm-check-row {
@@ -1999,7 +2634,6 @@ class TaskMatePanel extends HTMLElement {
       .tm-check-row > div { flex: 1; }
       .tm-check-title { font-size: 13px; color: var(--tm-text); font-weight: 500; }
 
-      /* Advanced */
       details.tm-advanced {
         background: var(--tm-surface-0);
         border: 1px solid var(--tm-border);
@@ -2026,6 +2660,23 @@ class TaskMatePanel extends HTMLElement {
         border-top: 1px solid var(--tm-border-soft);
       }
 
+      /* Reorder dialog */
+      .tm-reorder-list { display: flex; flex-direction: column; gap: 4px; margin-top: 12px; }
+      .tm-reorder-item {
+        display: flex; align-items: center; gap: 12px;
+        padding: 10px 12px;
+        background: var(--tm-surface-0);
+        border: 1px solid var(--tm-border);
+        border-radius: var(--tm-radius-sm);
+        cursor: grab;
+        transition: all 0.12s var(--tm-easing);
+      }
+      .tm-reorder-item:hover { border-color: var(--tm-accent); background: var(--tm-surface-2); }
+      .tm-reorder-item.tm-dragging { opacity: 0.4; }
+      .tm-reorder-handle { color: var(--tm-text-faint); cursor: grab; font-size: 18px; user-select: none; }
+      .tm-reorder-name { flex: 1; font-size: 13px; font-weight: 500; }
+      .tm-reorder-points { color: var(--tm-accent); font-weight: 600; font-size: 13px; }
+
       /* Toast */
       .tm-toast {
         position: fixed; bottom: 24px; left: 50%; transform: translateX(-50%);
@@ -2042,11 +2693,13 @@ class TaskMatePanel extends HTMLElement {
       @media (max-width: 700px) {
         .tm-body { padding: 16px; }
         .tm-toolbar { flex-direction: column; align-items: stretch; }
-        .tm-dialog { max-width: none; }
+        .tm-search-wrap { max-width: none; }
+        .tm-dialog { max-width: none; border-radius: 0; max-height: 100vh; height: 100vh; }
         .tm-scrim { padding: 0; }
-        .tm-dialog { border-radius: 0; max-height: 100vh; height: 100vh; }
         .tm-dialog-body .tm-field-row { grid-template-columns: 1fr; }
         .tm-setting-row { grid-template-columns: 1fr; gap: 6px; }
+        .tm-timeline-row { grid-template-columns: 1fr auto; }
+        .tm-timeline-time, .tm-timeline-icon { display: none; }
       }
     </style>`;
   }

--- a/custom_components/taskmate/www/taskmate-panel.js
+++ b/custom_components/taskmate/www/taskmate-panel.js
@@ -10,7 +10,7 @@
  * Lovelace view has been opened.
  */
 
-const PANEL_VERSION = "3.5.0-alpha.1";
+const PANEL_VERSION = "3.5.0-alpha.2";
 
 class TaskMatePanel extends HTMLElement {
   constructor() {

--- a/custom_components/taskmate/www/taskmate-panel.js
+++ b/custom_components/taskmate/www/taskmate-panel.js
@@ -1,17 +1,19 @@
 /**
  * TaskMate admin panel — sidebar entry at /taskmate-admin.
  *
- * All seven tabs (Children, Chores, Rewards, Penalties, Bonuses, Groups,
- * Settings) are wired to WebSocket commands. The classic options-flow menu
- * remains in place but is now redundant for everyday admin work.
- *
- * Vanilla HTMLElement — no LitElement dependency. The panel hits a single
- * read command (taskmate/get_state) on mount and after every mutation;
- * mutations call dedicated WS commands which in turn call coordinator
- * methods so existing business logic (refunds, cleanup, recompute) runs.
+ * v3.5.0-alpha.6 — polished visual treatment + UX fixes:
+ *   - Layered surfaces, frosted-glass app bar, refined typography
+ *   - Light/dark mode adapts via HA theme tokens (no hard-coded blacks)
+ *   - <ha-icon-picker> for icon fields (autocomplete with previews)
+ *   - <input type=date> for date fields (locale-aware display)
+ *   - Chip-multi-select for calendar entities (from hass.states)
+ *   - Schedule-mode selector dynamically reveals options on change
+ *   - Notify-service dropdown built from hass.services.notify
+ *   - Empty assignments render as "All children", not "(unassigned)"
+ *   - Adds Claim allowance, Start rotation with, "No filter" visibility
  */
 
-const PANEL_VERSION = "3.5.0-alpha.5";
+const PANEL_VERSION = "3.5.0-alpha.6";
 
 const TABS = [
   { id: "children",  label: "Children" },
@@ -59,7 +61,8 @@ const ASSIGNMENT_MODES = [
 ];
 
 const VISIBILITY_OPS = [
-  { v: "equals",     l: "Equals" },
+  { v: "none",       l: "No filter — always show chore" },
+  { v: "equals",     l: "Equals — state matches exactly" },
   { v: "not_equals", l: "Not equal" },
   { v: "gte",        l: "Greater than or equal (≥)" },
   { v: "lte",        l: "Less than or equal (≤)" },
@@ -102,20 +105,22 @@ class TaskMatePanel extends HTMLElement {
     this._error = null;
     this._loading = false;
     this._activeTab = "children";
-    this._dialog = null;        // { kind, mode: "add"|"edit", data }
+    this._dialog = null;
     this._rendered = false;
     this._onClick = this._onClick.bind(this);
     this._onInput = this._onInput.bind(this);
     this._onChange = this._onChange.bind(this);
+    this._onValueChanged = this._onValueChanged.bind(this);
     this._onKeyDown = this._onKeyDown.bind(this);
   }
 
-  // ---- HA injects these ------------------------------------------------
   set hass(value) {
     const first = this._hass === null;
     this._hass = value;
     if (first) this._fetchState();
     if (!this._rendered) this._render();
+    // Keep ha-picker components fed with the latest hass on every update
+    this._bindHaPickers();
   }
   get hass() { return this._hass; }
   set narrow(_v) {}
@@ -126,6 +131,7 @@ class TaskMatePanel extends HTMLElement {
     this.addEventListener("click", this._onClick);
     this.addEventListener("input", this._onInput);
     this.addEventListener("change", this._onChange);
+    this.addEventListener("value-changed", this._onValueChanged);
     this.addEventListener("keydown", this._onKeyDown);
     if (!this._rendered) this._render();
   }
@@ -133,6 +139,7 @@ class TaskMatePanel extends HTMLElement {
     this.removeEventListener("click", this._onClick);
     this.removeEventListener("input", this._onInput);
     this.removeEventListener("change", this._onChange);
+    this.removeEventListener("value-changed", this._onValueChanged);
     this.removeEventListener("keydown", this._onKeyDown);
   }
 
@@ -178,37 +185,33 @@ class TaskMatePanel extends HTMLElement {
     if (!t) return;
     const act = t.dataset.act;
 
-    if (act === "tab")           { this._activeTab = t.dataset.tab; this._render(); return; }
-    if (act === "close-dialog")  { this._dialog = null; this._render(); return; }
+    if (act === "tab")          { this._activeTab = t.dataset.tab; this._render(); return; }
+    if (act === "close-dialog") { this._dialog = null; this._render(); return; }
     if (act === "scrim") {
       if (e.target === this.querySelector(".tm-scrim")) { this._dialog = null; this._render(); }
       return;
     }
-    if (act === "retry")         { this._fetchState(); return; }
+    if (act === "retry")        { this._fetchState(); return; }
 
-    // -- Children --
-    if (act === "add-child")     { this._openChildDialog(null); return; }
-    if (act === "edit-child")    { this._openChildDialog(t.dataset.id); return; }
-    if (act === "delete-child")  { this._confirmDelete("child", t.dataset.id); return; }
-    if (act === "save-child")    { this._doSaveChild(); return; }
+    if (act === "add-child")    { this._openChildDialog(null); return; }
+    if (act === "edit-child")   { this._openChildDialog(t.dataset.id); return; }
+    if (act === "delete-child") { this._confirmDelete("child", t.dataset.id); return; }
+    if (act === "save-child")   { this._doSaveChild(); return; }
 
-    // -- Chores --
-    if (act === "add-chore")     { this._openChoreDialog(null); return; }
-    if (act === "edit-chore")    { this._openChoreDialog(t.dataset.id); return; }
-    if (act === "delete-chore")  { this._confirmDelete("chore", t.dataset.id); return; }
-    if (act === "save-chore")    { this._doSaveChore(); return; }
-    if (act === "toggle-day")    { this._toggleArrayField("due_days", t.dataset.day); return; }
-    if (act === "toggle-assigned") { this._toggleArrayField("assigned_to", t.dataset.id); return; }
-    if (act === "toggle-advanced") { const adv = this.querySelector(".tm-advanced"); if (adv) adv.toggleAttribute("open"); return; }
+    if (act === "add-chore")    { this._openChoreDialog(null); return; }
+    if (act === "edit-chore")   { this._openChoreDialog(t.dataset.id); return; }
+    if (act === "delete-chore") { this._confirmDelete("chore", t.dataset.id); return; }
+    if (act === "save-chore")   { this._doSaveChore(); return; }
+    if (act === "toggle-day")        { this._toggleArrayField("due_days", t.dataset.day); return; }
+    if (act === "toggle-assigned")   { this._toggleArrayField("assigned_to", t.dataset.id); return; }
+    if (act === "toggle-calendar")   { this._toggleArrayField("publish_calendar_entities", t.dataset.id); return; }
 
-    // -- Rewards --
     if (act === "add-reward")    { this._openRewardDialog(null); return; }
     if (act === "edit-reward")   { this._openRewardDialog(t.dataset.id); return; }
     if (act === "delete-reward") { this._confirmDelete("reward", t.dataset.id); return; }
     if (act === "save-reward")   { this._doSaveReward(); return; }
     if (act === "toggle-reward-assigned") { this._toggleArrayField("assigned_to", t.dataset.id); return; }
 
-    // -- Penalties --
     if (act === "add-penalty")    { this._openPenBonDialog("penalty", null); return; }
     if (act === "edit-penalty")   { this._openPenBonDialog("penalty", t.dataset.id); return; }
     if (act === "delete-penalty") { this._confirmDelete("penalty", t.dataset.id); return; }
@@ -216,7 +219,6 @@ class TaskMatePanel extends HTMLElement {
     if (act === "apply-penalty")  { this._openApplyDialog("penalty", t.dataset.id); return; }
     if (act === "do-apply-penalty") { this._doApplyPenBon("penalty", t.dataset.id, t.dataset.child); return; }
 
-    // -- Bonuses --
     if (act === "add-bonus")    { this._openPenBonDialog("bonus", null); return; }
     if (act === "edit-bonus")   { this._openPenBonDialog("bonus", t.dataset.id); return; }
     if (act === "delete-bonus") { this._confirmDelete("bonus", t.dataset.id); return; }
@@ -226,14 +228,12 @@ class TaskMatePanel extends HTMLElement {
 
     if (act === "toggle-penbon-assigned") { this._toggleArrayField("assigned_to", t.dataset.id); return; }
 
-    // -- Task groups --
     if (act === "add-group")    { this._openGroupDialog(null); return; }
     if (act === "edit-group")   { this._openGroupDialog(t.dataset.id); return; }
     if (act === "delete-group") { this._confirmDelete("group", t.dataset.id); return; }
     if (act === "save-group")   { this._doSaveGroup(); return; }
     if (act === "toggle-group-chore") { this._toggleArrayField("chore_ids", t.dataset.id); return; }
 
-    // -- Settings --
     if (act === "save-settings") { this._doSaveSettings(); return; }
   }
 
@@ -254,6 +254,16 @@ class TaskMatePanel extends HTMLElement {
     else if (t.type === "number") value = (t.value === "" ? null : Number(t.value));
     else value = t.value;
     this._dialog.data[t.dataset.field] = value;
+    if (t.dataset.rerender === "true") this._render();
+  }
+
+  // <ha-icon-picker> + <ha-entity-picker> fire value-changed instead of change.
+  _onValueChanged(e) {
+    if (!this._dialog) return;
+    const t = e.target;
+    if (!t.dataset || !t.dataset.field) return;
+    const v = e.detail && "value" in e.detail ? e.detail.value : t.value;
+    this._dialog.data[t.dataset.field] = v == null ? "" : v;
   }
 
   _onKeyDown(e) {
@@ -304,7 +314,7 @@ class TaskMatePanel extends HTMLElement {
     this._showToast("ok", "Deleted");
   }
 
-  // ---- Children: dialog open / save ------------------------------------
+  // ---- Children --------------------------------------------------------
   _openChildDialog(id) {
     if (id) {
       const c = (this._state.children || []).find(x => x.id === id);
@@ -335,20 +345,22 @@ class TaskMatePanel extends HTMLElement {
     this._showToast("ok", wasAdd ? "Child added" : "Child updated");
   }
 
-  // ---- Chores: dialog open / save --------------------------------------
+  // ---- Chores ----------------------------------------------------------
   _openChoreDialog(id) {
     const blank = {
       name: "", description: "", points: 10,
       assigned_to: [], requires_approval: true,
       time_category: "anytime", completion_sound: "coin", daily_limit: 1,
+      claim_allowance_minutes: 0,
       schedule_mode: "specific_days",
       due_days: [], recurrence: "weekly", recurrence_day: "", recurrence_start: "",
       first_occurrence_mode: "available_immediately",
       assignment_mode: "everyone", assignment_rotation_anchor: "",
+      manual_start_child_id: "",
       require_availability: false,
-      visibility_entity: "", visibility_state: "on", visibility_operator: "equals",
+      visibility_entity: "", visibility_state: "on", visibility_operator: "none",
       enabled: true,
-      publish_calendar_entities_csv: "",
+      publish_calendar_entities: [],
     };
     if (id) {
       const c = (this._state.chores || []).find(x => x.id === id);
@@ -358,7 +370,9 @@ class TaskMatePanel extends HTMLElement {
         ...c,
         assigned_to: [...(c.assigned_to || [])],
         due_days: [...(c.due_days || [])],
-        publish_calendar_entities_csv: (c.publish_calendar_entities || []).join(", "),
+        publish_calendar_entities: [...(c.publish_calendar_entities || [])],
+        visibility_operator: c.visibility_operator || "none",
+        manual_start_child_id: "",  // ephemeral — only set if user picks one
       } };
     } else {
       this._dialog = { kind: "chore", mode: "add", data: blank };
@@ -370,7 +384,6 @@ class TaskMatePanel extends HTMLElement {
     const d = this._dialog.data;
     if (!d.name || !d.name.trim()) { this._showToast("err", "Name is required"); return; }
     const wasAdd = this._dialog.mode === "add";
-    const calCsv = (d.publish_calendar_entities_csv || "").split(",").map(s => s.trim()).filter(Boolean);
     const base = {
       name: d.name.trim(),
       description: d.description || "",
@@ -378,6 +391,7 @@ class TaskMatePanel extends HTMLElement {
       assigned_to: d.assigned_to || [],
       requires_approval: !!d.requires_approval,
       time_category: d.time_category || "anytime",
+      claim_allowance_minutes: Math.max(0, Number(d.claim_allowance_minutes) || 0),
       completion_sound: d.completion_sound || "coin",
       daily_limit: Number(d.daily_limit) || 1,
       schedule_mode: d.schedule_mode || "specific_days",
@@ -391,9 +405,10 @@ class TaskMatePanel extends HTMLElement {
       require_availability: !!d.require_availability,
       visibility_entity: d.visibility_entity || "",
       visibility_state: d.visibility_state || "on",
-      visibility_operator: d.visibility_operator || "equals",
+      visibility_operator: d.visibility_operator || "none",
       enabled: d.enabled !== false,
-      publish_calendar_entities: calCsv,
+      publish_calendar_entities: d.publish_calendar_entities || [],
+      manual_start_child_id: d.manual_start_child_id || null,
     };
     const payload = wasAdd
       ? { type: "taskmate/add_chore", ...base }
@@ -449,7 +464,7 @@ class TaskMatePanel extends HTMLElement {
     this._showToast("ok", wasAdd ? "Reward added" : "Reward updated");
   }
 
-  // ---- Penalties / Bonuses (shared shape) ------------------------------
+  // ---- Penalties / Bonuses ---------------------------------------------
   _openPenBonDialog(kind, id) {
     const blank = { name: "", description: "", points: 10,
       icon: kind === "penalty" ? "mdi:alert-circle-outline" : "mdi:star-circle-outline",
@@ -532,7 +547,6 @@ class TaskMatePanel extends HTMLElement {
 
   // ---- Settings --------------------------------------------------------
   async _doSaveSettings() {
-    // Settings tab uses inline inputs; gather values directly from DOM.
     const root = this.querySelector(".tm-settings");
     if (!root) return;
     const fields = root.querySelectorAll("[data-setting]");
@@ -545,10 +559,33 @@ class TaskMatePanel extends HTMLElement {
       else v = el.value;
       if (v !== undefined) payload[name] = v;
     });
+    // ha-icon-picker: read .value
+    root.querySelectorAll("ha-icon-picker[data-setting]").forEach(el => {
+      payload[el.dataset.setting] = el.value || "";
+    });
     const { ok, err, res } = await this._callWS(payload);
     if (!ok) { this._showToast("err", `Save failed: ${err}`); return; }
     await this._fetchState();
     this._showToast("ok", `Saved (${(res && res.updated || []).length} field${(res && res.updated || []).length === 1 ? "" : "s"})`);
+  }
+
+  // ---- HA picker binding -----------------------------------------------
+  _bindHaPickers() {
+    if (!this._hass) return;
+    // <ha-icon-picker> needs hass + value via property
+    this.querySelectorAll("ha-icon-picker").forEach(el => {
+      el.hass = this._hass;
+      const v = el.getAttribute("data-current") || "";
+      if (el.value !== v) el.value = v;
+    });
+    // <ha-entity-picker> needs hass + includeDomains + value
+    this.querySelectorAll("ha-entity-picker").forEach(el => {
+      el.hass = this._hass;
+      const dom = el.getAttribute("data-domains");
+      if (dom && !el.includeDomains) el.includeDomains = dom.split(",");
+      const v = el.getAttribute("data-current") || "";
+      if (el.value !== v) el.value = v;
+    });
   }
 
   // ---- rendering -------------------------------------------------------
@@ -558,40 +595,61 @@ class TaskMatePanel extends HTMLElement {
     this.innerHTML = `
       ${this._styles()}
       <div class="tm-shell">
+        <div class="tm-bg-glow"></div>
         ${this._appbar()}
         ${this._tabstrip()}
         <div class="tm-body">
-          ${this._renderBody()}
+          <div class="tm-body-inner">
+            ${this._renderBody()}
+          </div>
         </div>
         ${this._dialog ? this._renderDialog() : ""}
       </div>
     `;
     if (existingToast) this.appendChild(existingToast);
+    // After DOM is in place, bind hass to ha-* pickers
+    this._bindHaPickers();
   }
 
   _appbar() {
+    const crumb = (TABS.find(t => t.id === this._activeTab) || {}).label || "";
+    const crumbLabel = (this._activeTab === "settings") ? "Settings" : crumb;
     return `
       <div class="tm-appbar">
-        <h1>TaskMate</h1>
-        <span class="tm-chip">v${PANEL_VERSION}</span>
+        <div class="tm-appbar-icon">
+          <ha-icon icon="mdi:checkbox-marked-circle-plus-outline"></ha-icon>
+        </div>
+        <h1 class="tm-appbar-title">TaskMate <span class="tm-sep">/</span> <span class="tm-crumb">${this._esc(crumbLabel)}</span></h1>
+        <span class="tm-version-chip">v${PANEL_VERSION}</span>
       </div>
     `;
   }
 
   _tabstrip() {
+    const counts = this._state ? {
+      children:  (this._state.children || []).length,
+      chores:    (this._state.chores || []).length,
+      rewards:   (this._state.rewards || []).length,
+      penalties: (this._state.penalties || []).length,
+      bonuses:   (this._state.bonuses || []).length,
+      groups:    (this._state.task_groups || []).length,
+    } : {};
     return `
       <nav class="tm-tabs">
-        ${TABS.map(t => `
-          <button class="tm-tab ${t.id === this._activeTab ? "tm-tab-active" : ""}" data-act="tab" data-tab="${t.id}" ${t.title ? `title="${t.title}"` : ""}>
-            ${this._esc(t.label)}
-          </button>
-        `).join("")}
+        ${TABS.map(t => {
+          const cnt = counts[t.id];
+          return `
+            <button class="tm-tab ${t.id === this._activeTab ? "tm-tab-active" : ""}" data-act="tab" data-tab="${t.id}" ${t.title ? `title="${t.title}"` : ""}>
+              ${this._esc(t.label)}${cnt != null ? `<span class="tm-tab-pill">${cnt}</span>` : ""}
+            </button>
+          `;
+        }).join("")}
       </nav>
     `;
   }
 
   _renderBody() {
-    if (this._loading && !this._state) return `<div class="tm-card">Loading…</div>`;
+    if (this._loading && !this._state) return `<div class="tm-card tm-loading">Loading…</div>`;
     if (this._error) return `
       <div class="tm-card tm-card-error">
         <h2>Failed to load state</h2>
@@ -618,19 +676,13 @@ class TaskMatePanel extends HTMLElement {
     const pointsName = this._state.settings.points_name || "points";
     return `
       <div class="tm-toolbar">
-        <div class="tm-title-sub">Manage the children in your family. Points balance and history stay intact when you edit.</div>
-        <button class="tm-btn" data-act="add-child">+ Add child</button>
+        <h2 class="tm-toolbar-title">Children <span class="tm-toolbar-count">${children.length}</span></h2>
+        <button class="tm-btn" data-act="add-child">＋ Add child</button>
       </div>
-      ${children.length === 0 ? `
-        <div class="tm-card tm-empty">
-          <h2>No children yet</h2>
-          <p>Add your first child to get started.</p>
-          <button class="tm-btn" data-act="add-child">+ Add child</button>
-        </div>
-      ` : `
+      ${children.length === 0 ? this._emptyState("👨‍👩‍👧‍👦", "No children yet", "Add your first child to get started.", "add-child", "+ Add child") : `
         <div class="tm-grid">
           ${children.map(c => this._renderChildCard(c, pointsName)).join("")}
-          <button class="tm-add-tile" data-act="add-child"><span class="tm-add-plus">+</span>Add child</button>
+          <button class="tm-add-tile" data-act="add-child"><span class="tm-add-plus">＋</span>Add child</button>
         </div>
       `}
     `;
@@ -639,22 +691,22 @@ class TaskMatePanel extends HTMLElement {
   _renderChildCard(child, pointsName) {
     return `
       <article class="tm-card tm-child-card">
-        <header class="tm-child-head">
+        <div class="tm-child-head">
           <div class="tm-avatar">${this._mdi(child.avatar)}</div>
           <div class="tm-child-name">
             <h3>${this._esc(child.name || "(unnamed)")}</h3>
-            <div class="tm-sub">${child.availability_entity ? `Availability: <code>${this._esc(child.availability_entity)}</code>` : `<em>No availability sensor</em>`}</div>
+            <div class="tm-meta">${child.availability_entity ? `<code>${this._esc(child.availability_entity)}</code>` : `No availability sensor`}</div>
           </div>
-        </header>
-        <div class="tm-stats">
-          <div class="tm-stat"><strong>${this._fmtNum(child.points || 0)}</strong><span>${this._esc(pointsName)}</span></div>
-          <div class="tm-stat"><strong>${this._fmtNum(child.total_points_earned || 0)}</strong><span>earned</span></div>
-          <div class="tm-stat"><strong>${this._fmtNum(child.total_chores_completed || 0)}</strong><span>chores done</span></div>
         </div>
-        <footer class="tm-card-foot">
-          <button class="tm-btn tm-btn-ghost" data-act="edit-child" data-id="${this._esc(child.id)}">Edit</button>
-          <button class="tm-btn tm-btn-danger" data-act="delete-child" data-id="${this._esc(child.id)}">Delete</button>
-        </footer>
+        <div class="tm-stats-row">
+          <div class="tm-stat tm-stat-highlight"><div class="tm-stat-value">${this._fmtNum(child.points || 0)}</div><div class="tm-stat-label">${this._esc(pointsName)}</div></div>
+          <div class="tm-stat"><div class="tm-stat-value">${this._fmtNum(child.total_points_earned || 0)}</div><div class="tm-stat-label">Earned</div></div>
+          <div class="tm-stat"><div class="tm-stat-value">${this._fmtNum(child.total_chores_completed || 0)}</div><div class="tm-stat-label">Done</div></div>
+        </div>
+        <div class="tm-card-foot">
+          <button class="tm-btn tm-btn-ghost tm-btn-sm" data-act="edit-child" data-id="${this._esc(child.id)}">Edit</button>
+          <button class="tm-btn tm-btn-danger tm-btn-sm" data-act="delete-child" data-id="${this._esc(child.id)}">Delete</button>
+        </div>
       </article>
     `;
   }
@@ -665,16 +717,10 @@ class TaskMatePanel extends HTMLElement {
     const childById = Object.fromEntries((this._state.children || []).map(c => [c.id, c]));
     return `
       <div class="tm-toolbar">
-        <div class="tm-title-sub">${chores.length} chore${chores.length === 1 ? "" : "s"} configured.</div>
-        <button class="tm-btn" data-act="add-chore">+ Add chore</button>
+        <h2 class="tm-toolbar-title">Chores <span class="tm-toolbar-count">${chores.length}</span></h2>
+        <button class="tm-btn" data-act="add-chore">＋ Add chore</button>
       </div>
-      ${chores.length === 0 ? `
-        <div class="tm-card tm-empty">
-          <h2>No chores yet</h2>
-          <p>Add a chore — it'll appear on the assigned children's cards.</p>
-          <button class="tm-btn" data-act="add-chore">+ Add chore</button>
-        </div>
-      ` : `
+      ${chores.length === 0 ? this._emptyState("📋", "No chores yet", "Add a chore — it'll show on the assigned children's cards.", "add-chore", "+ Add chore") : `
         <div class="tm-table-wrap">
           <table class="tm-table">
             <thead><tr>
@@ -690,20 +736,23 @@ class TaskMatePanel extends HTMLElement {
   }
 
   _renderChoreRow(c, childById) {
-    const assignedNames = (c.assigned_to || []).map(id => (childById[id] && childById[id].name) || "?").join(", ") || "(unassigned)";
+    const assignedNames = (c.assigned_to || []).length === 0
+      ? `<span class="tm-text-muted">All children</span>`
+      : this._esc((c.assigned_to || []).map(id => (childById[id] && childById[id].name) || "?").join(", "));
     const schedLabel = c.schedule_mode === "recurring"
       ? this._labelOf(RECURRENCES, c.recurrence) + (c.recurrence_day && c.recurrence_day !== "any_day" ? ` · ${c.recurrence_day}` : "")
       : c.schedule_mode === "one_shot"
       ? "One-shot"
-      : ((c.due_days || []).length === 0 ? "Daily" : (c.due_days || []).map(d => d.slice(0, 3)).join("/"));
+      : ((c.due_days || []).length === 0 ? "Daily" : (c.due_days || []).map(d => d.slice(0, 3)).join(" · "));
+    const schedClass = c.schedule_mode === "recurring" ? "tm-pill-accent" : c.schedule_mode === "one_shot" ? "tm-pill-warn" : "tm-pill-success";
     const modeBadge = c.assignment_mode && c.assignment_mode !== "everyone"
       ? `<span class="tm-pill tm-pill-${c.assignment_mode}">${c.assignment_mode}</span>` : "";
     return `
       <tr class="tm-row ${c.enabled === false ? "tm-row-disabled" : ""}">
         <td><strong>${this._esc(c.name)}</strong>${c.enabled === false ? ` <span class="tm-pill">disabled</span>` : ""}</td>
-        <td><strong>${c.points}</strong></td>
-        <td>${this._esc(assignedNames)} ${modeBadge}</td>
-        <td>${this._esc(schedLabel)}</td>
+        <td><strong class="tm-numeric">${c.points}</strong></td>
+        <td>${assignedNames} ${modeBadge}</td>
+        <td><span class="tm-pill ${schedClass} tm-pill-dot">${this._esc(schedLabel)}</span></td>
         <td>${c.requires_approval ? "<span class='tm-yes'>Yes</span>" : "<span class='tm-no'>No</span>"}</td>
         <td class="tm-row-actions">
           <button class="tm-icon-btn" data-act="edit-chore" data-id="${this._esc(c.id)}" title="Edit">✏</button>
@@ -719,19 +768,13 @@ class TaskMatePanel extends HTMLElement {
     const pointsName = this._state.settings.points_name || "points";
     return `
       <div class="tm-toolbar">
-        <div class="tm-title-sub">${rewards.length} reward${rewards.length === 1 ? "" : "s"} configured.</div>
-        <button class="tm-btn" data-act="add-reward">+ Add reward</button>
+        <h2 class="tm-toolbar-title">Rewards <span class="tm-toolbar-count">${rewards.length}</span></h2>
+        <button class="tm-btn" data-act="add-reward">＋ Add reward</button>
       </div>
-      ${rewards.length === 0 ? `
-        <div class="tm-card tm-empty">
-          <h2>No rewards yet</h2>
-          <p>Add a reward children can spend their ${this._esc(pointsName.toLowerCase())} on.</p>
-          <button class="tm-btn" data-act="add-reward">+ Add reward</button>
-        </div>
-      ` : `
+      ${rewards.length === 0 ? this._emptyState("🎁", "No rewards yet", `Add a reward children can spend their ${this._esc(pointsName.toLowerCase())} on.`, "add-reward", "+ Add reward") : `
         <div class="tm-grid">
           ${rewards.map(r => this._renderRewardCard(r, pointsName)).join("")}
-          <button class="tm-add-tile" data-act="add-reward"><span class="tm-add-plus">+</span>Add reward</button>
+          <button class="tm-add-tile" data-act="add-reward"><span class="tm-add-plus">＋</span>Add reward</button>
         </div>
       `}
     `;
@@ -739,29 +782,30 @@ class TaskMatePanel extends HTMLElement {
 
   _renderRewardCard(r, pointsName) {
     const totalPooled = (this._state.pool_allocations || []).filter(a => a.reward_id === r.id).reduce((s, a) => s + (a.allocated_points || 0), 0);
-    const progressBar = r.pool_enabled && r.cost > 0
-      ? `<div class="tm-progress"><span style="width:${Math.min(100, Math.round(totalPooled / r.cost * 100))}%"></span></div>
-         <div class="tm-sub">${this._fmtNum(totalPooled)} / ${this._fmtNum(r.cost)} ${this._esc(pointsName)}</div>`
-      : "";
+    const showProgress = r.pool_enabled && r.cost > 0;
+    const pct = showProgress ? Math.min(100, Math.round(totalPooled / r.cost * 100)) : 0;
     return `
       <article class="tm-card tm-reward-card">
-        <header class="tm-child-head">
-          <div class="tm-avatar tm-reward-avatar">${this._mdi(r.icon || "mdi:gift")}</div>
+        <div class="tm-child-head">
+          <div class="tm-avatar tm-avatar-reward">${this._mdi(r.icon || "mdi:gift")}</div>
           <div class="tm-child-name">
             <h3>${this._esc(r.name)} ${r.is_jackpot ? `<span class="tm-pill tm-pill-jackpot">🏆 Jackpot</span>` : ""} ${r.pool_enabled ? `<span class="tm-pill tm-pill-pool">Pool</span>` : ""}</h3>
-            <div class="tm-sub">${this._esc(r.description || "")}</div>
+            <div class="tm-meta">${this._esc(r.description || "")}</div>
           </div>
-        </header>
-        <div class="tm-stats">
-          <div class="tm-stat"><strong>${this._fmtNum(r.cost)}</strong><span>${this._esc(pointsName)} cost</span></div>
-          ${r.quantity != null ? `<div class="tm-stat"><strong>${r.quantity}</strong><span>remaining</span></div>` : ""}
-          ${r.expires_at ? `<div class="tm-stat"><strong>${this._esc(r.expires_at)}</strong><span>expires</span></div>` : ""}
         </div>
-        ${progressBar}
-        <footer class="tm-card-foot">
-          <button class="tm-btn tm-btn-ghost" data-act="edit-reward" data-id="${this._esc(r.id)}">Edit</button>
-          <button class="tm-btn tm-btn-danger" data-act="delete-reward" data-id="${this._esc(r.id)}">Delete</button>
-        </footer>
+        <div class="tm-stats-row" style="grid-template-columns: 1fr 1fr ${r.expires_at ? "1fr" : ""};">
+          <div class="tm-stat"><div class="tm-stat-value tm-numeric tm-cost">${this._fmtNum(r.cost)}</div><div class="tm-stat-label">${this._esc(pointsName)} cost</div></div>
+          ${r.quantity != null ? `<div class="tm-stat"><div class="tm-stat-value tm-numeric">${r.quantity}</div><div class="tm-stat-label">Remaining</div></div>` : `<div class="tm-stat"><div class="tm-stat-value">∞</div><div class="tm-stat-label">Unlimited</div></div>`}
+          ${r.expires_at ? `<div class="tm-stat"><div class="tm-stat-value" style="font-size: 14px;">${this._esc(r.expires_at)}</div><div class="tm-stat-label">Expires</div></div>` : ""}
+        </div>
+        ${showProgress ? `
+          <div class="tm-progress"><span style="width:${pct}%"></span></div>
+          <div class="tm-progress-text"><span><strong>${this._fmtNum(totalPooled)}</strong> / ${this._fmtNum(r.cost)}</span><span>${pct}%</span></div>
+        ` : ""}
+        <div class="tm-card-foot">
+          <button class="tm-btn tm-btn-ghost tm-btn-sm" data-act="edit-reward" data-id="${this._esc(r.id)}">Edit</button>
+          <button class="tm-btn tm-btn-danger tm-btn-sm" data-act="delete-reward" data-id="${this._esc(r.id)}">Delete</button>
+        </div>
       </article>
     `;
   }
@@ -770,34 +814,28 @@ class TaskMatePanel extends HTMLElement {
   _renderPenBonTab(kind) {
     const items = (kind === "penalty" ? this._state.penalties : this._state.bonuses) || [];
     const childById = Object.fromEntries((this._state.children || []).map(c => [c.id, c]));
-    const labels = kind === "penalty" ? { plural: "Penalties", add: "+ Add penalty" } : { plural: "Bonuses", add: "+ Add bonus" };
+    const labels = kind === "penalty" ? { plural: "Penalties", add: "+ Add penalty", icon: "⚠️" } : { plural: "Bonuses", add: "+ Add bonus", icon: "⭐" };
     return `
       <div class="tm-toolbar">
-        <div class="tm-title-sub">${items.length} ${labels.plural.toLowerCase()} configured.</div>
-        <button class="tm-btn" data-act="add-${kind}">${labels.add}</button>
+        <h2 class="tm-toolbar-title">${labels.plural} <span class="tm-toolbar-count">${items.length}</span></h2>
+        <button class="tm-btn" data-act="add-${kind}">＋ Add ${kind}</button>
       </div>
-      ${items.length === 0 ? `
-        <div class="tm-card tm-empty">
-          <h2>No ${labels.plural.toLowerCase()} yet</h2>
-          <p>${kind === "penalty" ? "Add a penalty to deduct points from a child for misbehaviour." : "Add a bonus to award points for going above and beyond."}</p>
-          <button class="tm-btn" data-act="add-${kind}">${labels.add}</button>
-        </div>
-      ` : `
+      ${items.length === 0 ? this._emptyState(labels.icon, `No ${labels.plural.toLowerCase()} yet`, kind === "penalty" ? "Add a penalty to deduct points for misbehaviour." : "Add a bonus to award points for going above and beyond.", `add-${kind}`, labels.add) : `
         <div class="tm-table-wrap">
           <table class="tm-table">
             <thead><tr><th>Name</th><th>Points</th><th>Assigned</th><th></th></tr></thead>
             <tbody>
               ${items.map(item => {
                 const assignedNames = (item.assigned_to || []).length === 0
-                  ? "Both / All"
-                  : (item.assigned_to || []).map(id => (childById[id] && childById[id].name) || "?").join(", ");
+                  ? `<span class="tm-text-muted">All children</span>`
+                  : this._esc((item.assigned_to || []).map(id => (childById[id] && childById[id].name) || "?").join(", "));
                 return `
                   <tr class="tm-row">
-                    <td><span class="tm-row-icon">${this._mdi(item.icon)}</span><strong>${this._esc(item.name)}</strong>${item.description ? `<div class="tm-sub">${this._esc(item.description)}</div>` : ""}</td>
-                    <td><strong class="${kind === "penalty" ? "tm-neg" : "tm-pos"}">${kind === "penalty" ? "−" : "+"}${item.points}</strong></td>
-                    <td>${this._esc(assignedNames)}</td>
+                    <td><span class="tm-row-icon">${this._mdi(item.icon)}</span><strong>${this._esc(item.name)}</strong>${item.description ? `<div class="tm-meta">${this._esc(item.description)}</div>` : ""}</td>
+                    <td><strong class="tm-numeric ${kind === "penalty" ? "tm-neg" : "tm-pos"}">${kind === "penalty" ? "−" : "+"}${item.points}</strong></td>
+                    <td>${assignedNames}</td>
                     <td class="tm-row-actions">
-                      <button class="tm-btn tm-btn-ghost" data-act="apply-${kind}" data-id="${this._esc(item.id)}">Apply…</button>
+                      <button class="tm-btn tm-btn-ghost tm-btn-sm" data-act="apply-${kind}" data-id="${this._esc(item.id)}">Apply…</button>
                       <button class="tm-icon-btn" data-act="edit-${kind}" data-id="${this._esc(item.id)}" title="Edit">✏</button>
                       <button class="tm-icon-btn" data-act="delete-${kind}" data-id="${this._esc(item.id)}" title="Delete">🗑</button>
                     </td>
@@ -817,31 +855,30 @@ class TaskMatePanel extends HTMLElement {
     const choreById = Object.fromEntries((this._state.chores || []).map(c => [c.id, c]));
     return `
       <div class="tm-toolbar">
-        <div class="tm-title-sub">Groups coordinate chore assignment across multiple chores. Sticky = same child for all; Spread = different children.</div>
-        <button class="tm-btn" data-act="add-group">+ Add group</button>
+        <h2 class="tm-toolbar-title">Task groups <span class="tm-toolbar-count">${groups.length}</span></h2>
+        <button class="tm-btn" data-act="add-group">＋ Add group</button>
       </div>
-      ${groups.length === 0 ? `
-        <div class="tm-card tm-empty">
-          <h2>No task groups yet</h2>
-          <p>Create a group to make chores rotate together (e.g. all the kitchen chores stay with one child each day).</p>
-          <button class="tm-btn" data-act="add-group">+ Add group</button>
-        </div>
-      ` : `
+      ${groups.length === 0 ? this._emptyState("🔗", "No task groups yet", "Create a group to make chores rotate together (e.g. all kitchen chores stay with one child each day).", "add-group", "+ Add group") : `
         <div class="tm-grid">
           ${groups.map(g => `
             <article class="tm-card">
-              <h3 style="margin: 0 0 6px;">${this._esc(g.name)} <span class="tm-pill tm-pill-${g.policy}">${g.policy}</span></h3>
-              <div class="tm-sub" style="margin-bottom: 12px;">${(g.chore_ids || []).length} member chore${(g.chore_ids || []).length === 1 ? "" : "s"}</div>
+              <div class="tm-child-head">
+                <div class="tm-avatar"><ha-icon icon="${g.policy === 'sticky' ? 'mdi:link-variant' : 'mdi:arrow-split-horizontal'}"></ha-icon></div>
+                <div class="tm-child-name">
+                  <h3>${this._esc(g.name)}</h3>
+                  <div class="tm-meta"><span class="tm-pill tm-pill-${g.policy}">${g.policy}</span> · ${(g.chore_ids || []).length} chore${(g.chore_ids || []).length === 1 ? "" : "s"}</div>
+                </div>
+              </div>
               <ul class="tm-group-list">
                 ${(g.chore_ids || []).map(id => `<li>${this._esc((choreById[id] && choreById[id].name) || `(missing chore ${id})`)}</li>`).join("")}
               </ul>
-              <footer class="tm-card-foot" style="margin-top: 12px;">
-                <button class="tm-btn tm-btn-ghost" data-act="edit-group" data-id="${this._esc(g.id)}">Edit</button>
-                <button class="tm-btn tm-btn-danger" data-act="delete-group" data-id="${this._esc(g.id)}">Delete</button>
-              </footer>
+              <div class="tm-card-foot">
+                <button class="tm-btn tm-btn-ghost tm-btn-sm" data-act="edit-group" data-id="${this._esc(g.id)}">Edit</button>
+                <button class="tm-btn tm-btn-danger tm-btn-sm" data-act="delete-group" data-id="${this._esc(g.id)}">Delete</button>
+              </div>
             </article>
           `).join("")}
-          <button class="tm-add-tile" data-act="add-group"><span class="tm-add-plus">+</span>Add group</button>
+          <button class="tm-add-tile" data-act="add-group"><span class="tm-add-plus">＋</span>Add group</button>
         </div>
       `}
     `;
@@ -850,64 +887,92 @@ class TaskMatePanel extends HTMLElement {
   // -- Settings tab ------------------------------------------------------
   _renderSettingsTab() {
     const s = this._state.settings || {};
+    const notifyServices = Object.keys((this._hass && this._hass.services && this._hass.services.notify) || {});
+    const notifyOptions = [
+      { v: "", l: "(none — use HA persistent notifications)" },
+      ...notifyServices.map(k => ({ v: `notify.${k}`, l: `notify.${k}` })),
+    ];
     return `
-      <div class="tm-card tm-settings">
-        <h2>Currency</h2>
-        <div class="tm-field-row">
-          <label class="tm-field-inline"><span>Points name</span>
-            <input type="text" data-setting="points_name" value="${this._esc(s.points_name || "Stars")}" placeholder="Stars">
-          </label>
-          <label class="tm-field-inline"><span>Points icon</span>
-            <input type="text" data-setting="points_icon" value="${this._esc(s.points_icon || "mdi:star")}" placeholder="mdi:star">
-          </label>
+      <div class="tm-toolbar">
+        <h2 class="tm-toolbar-title">Settings</h2>
+      </div>
+      <div class="tm-settings">
+        <div class="tm-section">
+          <div class="tm-section-head">
+            <div>
+              <h3>Currency</h3>
+              <p class="tm-meta">How points are named and shown across the app.</p>
+            </div>
+          </div>
+          <div class="tm-section-body">
+            <div class="tm-setting-row">
+              <div class="tm-setting-label">Points name<small>What you call them, e.g. Stars or Coins</small></div>
+              <input type="text" data-setting="points_name" value="${this._esc(s.points_name || "Stars")}" placeholder="Stars">
+            </div>
+            <div class="tm-setting-row">
+              <div class="tm-setting-label">Points icon<small>Pick any MDI icon</small></div>
+              <ha-icon-picker data-setting="points_icon" data-current="${this._esc(s.points_icon || 'mdi:star')}"></ha-icon-picker>
+            </div>
+          </div>
         </div>
 
-        <h2>History &amp; streaks</h2>
-        <div class="tm-field-row">
-          <label class="tm-field-inline"><span>History days to retain (30–365)</span>
-            <input type="number" min="30" max="365" data-setting="history_days" value="${s.history_days || 90}">
-          </label>
-          <label class="tm-field-inline"><span>Streak reset mode</span>
-            <select data-setting="streak_reset_mode">
-              ${STREAK_MODES.map(m => `<option value="${m.v}" ${m.v === (s.streak_reset_mode || "reset") ? "selected" : ""}>${this._esc(m.l)}</option>`).join("")}
-            </select>
-          </label>
-        </div>
-        <div class="tm-field-row">
-          <label class="tm-field-inline"><span>Weekend points multiplier (1.0 = off)</span>
-            <input type="number" step="0.1" min="1" max="5" data-setting="weekend_multiplier" value="${s.weekend_multiplier || 1.0}">
-          </label>
-          <label class="tm-field-inline"><span>Calendar planning horizon (days)</span>
-            <input type="number" min="1" max="90" data-setting="calendar_projection_days" value="${s.calendar_projection_days || 14}">
-          </label>
-        </div>
-
-        <h2>Bonuses</h2>
-        <div class="tm-check-row">
-          <label class="tm-switch"><input type="checkbox" data-setting="streak_milestones_enabled" ${s.streak_milestones_enabled ? "checked" : ""}><span class="tm-slider"></span></label>
-          Award bonus points at streak milestones (3, 7, 14, 30, 60, 100 days)
-        </div>
-        <div class="tm-check-row">
-          <label class="tm-switch"><input type="checkbox" data-setting="perfect_week_enabled" ${s.perfect_week_enabled ? "checked" : ""}><span class="tm-slider"></span></label>
-          Award bonus for completing chores every day of a week
-        </div>
-        <div class="tm-field-row">
-          <label class="tm-field-inline"><span>Perfect week bonus points</span>
-            <input type="number" min="0" data-setting="perfect_week_bonus" value="${s.perfect_week_bonus || 50}">
-          </label>
+        <div class="tm-section">
+          <div class="tm-section-head"><div><h3>History &amp; streaks</h3></div></div>
+          <div class="tm-section-body">
+            <div class="tm-setting-row">
+              <div class="tm-setting-label">Retention<small>How many days of completion history to keep</small></div>
+              <input type="number" min="30" max="365" data-setting="history_days" value="${s.history_days || 90}">
+            </div>
+            <div class="tm-setting-row">
+              <div class="tm-setting-label">Streak reset<small>What happens when a day is missed</small></div>
+              <select data-setting="streak_reset_mode">
+                ${STREAK_MODES.map(m => `<option value="${m.v}" ${m.v === (s.streak_reset_mode || "reset") ? "selected" : ""}>${this._esc(m.l)}</option>`).join("")}
+              </select>
+            </div>
+            <div class="tm-setting-row">
+              <div class="tm-setting-label">Weekend multiplier<small>Bonus on Sat/Sun (1.0 = off)</small></div>
+              <input type="number" step="0.1" min="1" max="5" data-setting="weekend_multiplier" value="${s.weekend_multiplier || 1.0}">
+            </div>
+            <div class="tm-setting-row">
+              <div class="tm-setting-label">Calendar projection<small>Days ahead each chore publishes to calendars</small></div>
+              <input type="number" min="1" max="90" data-setting="calendar_projection_days" value="${s.calendar_projection_days || 14}">
+            </div>
+          </div>
         </div>
 
-        <h2>Notifications</h2>
-        <div class="tm-field-row">
-          <label class="tm-field-inline"><span>Notify service for approval pings</span>
-            <input type="text" data-setting="notify_service" value="${this._esc(s.notify_service || "")}" placeholder="notify.mobile_app_your_phone">
-          </label>
+        <div class="tm-section">
+          <div class="tm-section-head"><div><h3>Bonuses</h3></div></div>
+          <div class="tm-section-body">
+            <div class="tm-setting-row">
+              <div class="tm-setting-label">Streak milestones<small>Bonus at 3, 7, 14, 30, 60, 100 days</small></div>
+              <label class="tm-switch"><input type="checkbox" data-setting="streak_milestones_enabled" ${s.streak_milestones_enabled ? "checked" : ""}><span class="tm-slider"></span></label>
+            </div>
+            <div class="tm-setting-row">
+              <div class="tm-setting-label">Perfect-week bonus<small>Bonus for completing every day of a week</small></div>
+              <label class="tm-switch"><input type="checkbox" data-setting="perfect_week_enabled" ${s.perfect_week_enabled ? "checked" : ""}><span class="tm-slider"></span></label>
+            </div>
+            <div class="tm-setting-row">
+              <div class="tm-setting-label">Perfect-week bonus points<small>How many points to award</small></div>
+              <input type="number" min="0" data-setting="perfect_week_bonus" value="${s.perfect_week_bonus || 50}">
+            </div>
+          </div>
         </div>
-        <div class="tm-sub" style="margin-bottom: 16px;">Leave blank to use HA's persistent notifications only.</div>
 
-        <footer class="tm-card-foot" style="border-top: 1px solid var(--divider-color); padding-top: 16px; justify-content: flex-end;">
+        <div class="tm-section">
+          <div class="tm-section-head"><div><h3>Notifications</h3></div></div>
+          <div class="tm-section-body">
+            <div class="tm-setting-row">
+              <div class="tm-setting-label">Notify service<small>Used for parent approval pings</small></div>
+              <select data-setting="notify_service">
+                ${notifyOptions.map(o => `<option value="${this._esc(o.v)}" ${o.v === (s.notify_service || "") ? "selected" : ""}>${this._esc(o.l)}</option>`).join("")}
+              </select>
+            </div>
+          </div>
+        </div>
+
+        <div class="tm-settings-foot">
           <button class="tm-btn" data-act="save-settings">Save settings</button>
-        </footer>
+        </div>
       </div>
     `;
   }
@@ -930,9 +995,9 @@ class TaskMatePanel extends HTMLElement {
     return this._dialogShell(this._dialog.mode === "add" ? "Add child" : "Edit child",
       [
         this._field("Name", "name", d.name, "text", "e.g. Malia"),
-        this._field("Avatar (MDI icon)", "avatar", d.avatar, "text", "Examples: mdi:face-woman, mdi:face-man, mdi:dog"),
-        this._field("Availability sensor (optional)", "availability_entity", d.availability_entity, "text",
-          "HA entity that says whether the child is available. States <code>on</code>, <code>home</code>, <code>available</code>, <code>present</code>, <code>true</code> mean available. Leave blank to treat as always available."),
+        this._iconPickerField("Avatar", "avatar", d.avatar),
+        this._entityPickerField("Availability sensor (optional)", "availability_entity", d.availability_entity, ["binary_sensor", "sensor", "input_boolean", "person"],
+          "States <code>on</code>, <code>home</code>, <code>available</code>, <code>present</code>, <code>true</code> mean available. Leave blank to treat as always available."),
       ].join(""),
       `<button class="tm-btn tm-btn-ghost" data-act="close-dialog">Cancel</button>
        <button class="tm-btn" data-act="save-child">Save</button>`
@@ -946,6 +1011,12 @@ class TaskMatePanel extends HTMLElement {
     const memberInGroup = (d.id && groups.find(g => (g.chore_ids || []).includes(d.id))) || null;
     const showSpecificDays = d.schedule_mode === "specific_days";
     const showRecurring    = d.schedule_mode === "recurring";
+    const showRotation     = ["alternating", "random", "balanced"].includes(d.assignment_mode);
+
+    // Calendar entities available in this HA
+    const calendarEntities = Object.keys((this._hass && this._hass.states) || {})
+      .filter(id => id.startsWith("calendar."))
+      .sort();
 
     return this._dialogShell(this._dialog.mode === "add" ? "Add chore" : "Edit chore",
       [
@@ -957,28 +1028,38 @@ class TaskMatePanel extends HTMLElement {
           ${this._field("Daily limit", "daily_limit", d.daily_limit, "number")}
         </div>`,
 
-        // Assigned to (multi-checkbox)
+        // Assigned to
         children.length > 0 ? `
           <div class="tm-field">
             <span class="tm-field-label">Assigned to</span>
-            <div class="tm-multi">
+            <div class="tm-chip-row">
               ${children.map(c => `
                 <button type="button" class="tm-chip-btn ${(d.assigned_to || []).includes(c.id) ? "tm-chip-on" : ""}" data-act="toggle-assigned" data-id="${this._esc(c.id)}">
                   ${this._esc(c.name)}
                 </button>
               `).join("")}
             </div>
-            <span class="tm-field-hint">Leave empty to assign to all children.</span>
+            <span class="tm-field-hint">Leave empty to assign to <strong>all children</strong>.</span>
           </div>
         ` : `<div class="tm-field"><span class="tm-field-hint">Add some children first to assign chores to them.</span></div>`,
 
         this._select("Assignment mode", "assignment_mode", d.assignment_mode, ASSIGNMENT_MODES,
-          "Everyone = all assigned children see it. Alternating = rotate one per day. Random = pick one daily. Balanced = split evenly across the day."),
+          "Everyone = all assigned children see it. Alternating = rotate one per day. Random = pick one daily. Balanced = split evenly across the day.",
+          true /* rerender on change so the rotation field appears */),
+
+        showRotation && children.length > 0 ? this._select(
+          "Start rotation with (optional)", "manual_start_child_id", d.manual_start_child_id,
+          [{ v: "", l: "(no override)" }, ...children.map(c => ({ v: c.id, l: c.name }))],
+          "Alternating mode: permanently reorders the pool. Random/Balanced: only overrides today; tomorrow resumes normally."
+        ) : "",
 
         this._select("Time category", "time_category", d.time_category, TIME_CATEGORIES),
 
-        // Schedule mode
-        this._select("Schedule mode", "schedule_mode", d.schedule_mode, SCHEDULE_MODES),
+        this._field("Claim allowance (minutes)", "claim_allowance_minutes", d.claim_allowance_minutes, "number",
+          "Extra minutes after the time-of-day window ends during which the chore stays claimable. 0 = no grace. Night chores still cap at midnight."),
+
+        // Schedule mode — re-renders to reveal options
+        this._select("Schedule mode", "schedule_mode", d.schedule_mode, SCHEDULE_MODES, "", true),
 
         showSpecificDays ? `
           <div class="tm-field">
@@ -997,14 +1078,13 @@ class TaskMatePanel extends HTMLElement {
             ${this._field("Day of week (weekly only)", "recurrence_day", d.recurrence_day, "text", "e.g. monday — leave blank for any day")}
           </div>
           <div class="tm-field-row">
-            ${this._field("Start date (every-2-days only)", "recurrence_start", d.recurrence_start, "text", "YYYY-MM-DD; blank = today")}
+            ${this._dateField("Start date (every-2-days only)", "recurrence_start", d.recurrence_start, "Anchor date — blank = today")}
             ${this._select("First occurrence", "first_occurrence_mode", d.first_occurrence_mode, FIRST_OCCURRENCE)}
           </div>
         ` : "",
 
         this._select("Completion sound", "completion_sound", d.completion_sound, COMPLETION_SOUNDS.map(s => ({ v: s, l: s }))),
 
-        // Switches
         this._switch("Requires parent approval", "requires_approval", d.requires_approval),
         this._switch("Skip unavailable children", "require_availability", d.require_availability,
           "Uses each child's availability sensor (set on their profile)."),
@@ -1015,16 +1095,31 @@ class TaskMatePanel extends HTMLElement {
           </div>
         ` : "",
 
-        // Advanced section
+        // Advanced
         `<details class="tm-advanced">
-          <summary>Advanced</summary>
-          <div style="padding-top: 12px;">
-            ${this._field("Visibility entity (optional)", "visibility_entity", d.visibility_entity, "text", "Entity ID; chore only shows when its state matches the rule below.")}
+          <summary>Advanced — visibility &amp; calendar publishing</summary>
+          <div>
+            ${this._entityPickerField("Visibility entity (optional)", "visibility_entity", d.visibility_entity, ["binary_sensor", "sensor", "switch", "input_boolean", "input_select"],
+              "Chore only shows when its state matches the rule below. Leave blank for always-show.")}
             <div class="tm-field-row">
               ${this._select("Visibility operator", "visibility_operator", d.visibility_operator, VISIBILITY_OPS)}
               ${this._field("Visibility value", "visibility_state", d.visibility_state, "text", 'e.g. "on", "home", "30"')}
             </div>
-            ${this._field("Calendar entities to publish to (comma-separated)", "publish_calendar_entities_csv", d.publish_calendar_entities_csv, "text", "e.g. calendar.family, calendar.kids — blank = no calendar publishing")}
+
+            <div class="tm-field">
+              <span class="tm-field-label">Publish to calendars (optional)</span>
+              ${calendarEntities.length === 0 ? `<span class="tm-field-hint">No calendar entities found in Home Assistant. Set one up first.</span>` : `
+                <div class="tm-chip-row">
+                  ${calendarEntities.map(cid => `
+                    <button type="button" class="tm-chip-btn ${(d.publish_calendar_entities || []).includes(cid) ? "tm-chip-on" : ""}" data-act="toggle-calendar" data-id="${this._esc(cid)}">
+                      ${this._esc(cid)}
+                    </button>
+                  `).join("")}
+                </div>
+                <span class="tm-field-hint">Today's assignment will be added as a calendar event on each selected calendar.</span>
+              `}
+            </div>
+
             ${this._switch("Enabled", "enabled", d.enabled !== false)}
           </div>
         </details>`,
@@ -1044,31 +1139,31 @@ class TaskMatePanel extends HTMLElement {
         this._field("Description (optional)", "description", d.description, "text"),
         `<div class="tm-field-row">
           ${this._field(`Cost (${pointsName})`, "cost", d.cost, "number")}
-          ${this._field("Icon (MDI)", "icon", d.icon, "text")}
+          ${this._iconPickerField("Icon", "icon", d.icon)}
         </div>`,
 
         children.length > 0 ? `
           <div class="tm-field">
             <span class="tm-field-label">Assigned to</span>
-            <div class="tm-multi">
+            <div class="tm-chip-row">
               ${children.map(c => `
                 <button type="button" class="tm-chip-btn ${(d.assigned_to || []).includes(c.id) ? "tm-chip-on" : ""}" data-act="toggle-reward-assigned" data-id="${this._esc(c.id)}">
                   ${this._esc(c.name)}
                 </button>
               `).join("")}
             </div>
-            <span class="tm-field-hint">Leave empty to make available to all children.</span>
+            <span class="tm-field-hint">Leave empty to make available to <strong>all children</strong>.</span>
           </div>
         ` : "",
 
         this._switch("Pool reward (savings jar)", "pool_enabled", d.pool_enabled,
-          "Children deposit points into this reward's dedicated pool rather than spending from their balance. Good for long-term savings goals."),
+          "Children deposit points into this reward's dedicated pool rather than spending from their balance. Good for long-term goals."),
         this._switch("Jackpot — pool from all assigned children", "is_jackpot", d.is_jackpot,
           "Combine all children's contributions toward one shared reward."),
 
         `<div class="tm-field-row">
           ${this._field("Limited quantity (blank = unlimited)", "quantity_str", d.quantity_str, "text", "Each approved claim reduces by 1.")}
-          ${this._field("Expires (YYYY-MM-DD, blank = never)", "expires_at", d.expires_at, "text", "Pooled points are refunded at midnight.")}
+          ${this._dateField("Expires (blank = never)", "expires_at", d.expires_at, "Pooled points are refunded at midnight.")}
         </div>`,
       ].join(""),
       `<button class="tm-btn tm-btn-ghost" data-act="close-dialog">Cancel</button>
@@ -1086,19 +1181,19 @@ class TaskMatePanel extends HTMLElement {
         this._field("Description (optional)", "description", d.description, "text"),
         `<div class="tm-field-row">
           ${this._field(`Points to ${isPenalty ? "deduct" : "award"}`, "points", d.points, "number")}
-          ${this._field("Icon (MDI)", "icon", d.icon, "text")}
+          ${this._iconPickerField("Icon", "icon", d.icon)}
         </div>`,
         children.length > 0 ? `
           <div class="tm-field">
             <span class="tm-field-label">Applies to</span>
-            <div class="tm-multi">
+            <div class="tm-chip-row">
               ${children.map(c => `
                 <button type="button" class="tm-chip-btn ${(d.assigned_to || []).includes(c.id) ? "tm-chip-on" : ""}" data-act="toggle-penbon-assigned" data-id="${this._esc(c.id)}">
                   ${this._esc(c.name)}
                 </button>
               `).join("")}
             </div>
-            <span class="tm-field-hint">Leave empty to apply to all children.</span>
+            <span class="tm-field-hint">Leave empty to apply to <strong>all children</strong>.</span>
           </div>
         ` : "",
       ].join(""),
@@ -1117,8 +1212,8 @@ class TaskMatePanel extends HTMLElement {
       : children.filter(c => (item.assigned_to || []).includes(c.id));
     return this._dialogShell(`Apply ${kind}: ${item.name}`,
       `<p>Choose which child to ${isPenalty ? "apply this penalty to (will deduct" : "award this bonus to (will add"} <strong>${item.points}</strong> points).</p>
-       ${eligible.length === 0 ? `<p class="tm-sub">No eligible children. Edit the ${kind} to set who it applies to.</p>` : `
-        <div class="tm-multi" style="margin-top: 12px;">
+       ${eligible.length === 0 ? `<p class="tm-meta">No eligible children. Edit the ${kind} to set who it applies to.</p>` : `
+        <div class="tm-chip-row" style="margin-top: 12px;">
           ${eligible.map(c => `
             <button type="button" class="tm-btn tm-btn-ghost" data-act="do-apply-${kind}" data-id="${this._esc(item.id)}" data-child="${this._esc(c.id)}">
               ${this._esc(c.name)}
@@ -1145,7 +1240,7 @@ class TaskMatePanel extends HTMLElement {
         ` : `
           <div class="tm-field">
             <span class="tm-field-label">Member chores (order matters for sticky — first is the leader)</span>
-            <div class="tm-multi">
+            <div class="tm-chip-row">
               ${chores.map(c => `
                 <button type="button" class="tm-chip-btn ${(d.chore_ids || []).includes(c.id) ? "tm-chip-on" : ""}" data-act="toggle-group-chore" data-id="${this._esc(c.id)}">
                   ${this._esc(c.name)}
@@ -1160,7 +1255,7 @@ class TaskMatePanel extends HTMLElement {
     );
   }
 
-  // ---- form-element helpers --------------------------------------------
+  // ---- form helpers ----------------------------------------------------
   _dialogShell(title, body, footer) {
     return `
       <div class="tm-scrim" data-act="scrim">
@@ -1184,11 +1279,23 @@ class TaskMatePanel extends HTMLElement {
       </label>`;
   }
 
-  _select(label, name, value, options, hint = "") {
+  _dateField(label, name, value, hint = "") {
+    // <input type=date> — the displayed format follows the user's browser
+    // locale (DD/MM/YYYY in en-GB) but the underlying value is YYYY-MM-DD,
+    // which is what TaskMate's storage expects.
     return `
       <label class="tm-field">
         <span class="tm-field-label">${this._esc(label)}</span>
-        <select data-field="${name}">
+        <input type="date" data-field="${name}" value="${this._esc(value || "")}">
+        ${hint ? `<span class="tm-field-hint">${hint}</span>` : ""}
+      </label>`;
+  }
+
+  _select(label, name, value, options, hint = "", rerender = false) {
+    return `
+      <label class="tm-field">
+        <span class="tm-field-label">${this._esc(label)}</span>
+        <select data-field="${name}" ${rerender ? `data-rerender="true"` : ""}>
           ${options.map(o => `<option value="${this._esc(o.v)}" ${o.v === value ? "selected" : ""}>${this._esc(o.l)}</option>`).join("")}
         </select>
         ${hint ? `<span class="tm-field-hint">${hint}</span>` : ""}
@@ -1203,10 +1310,39 @@ class TaskMatePanel extends HTMLElement {
           <span class="tm-slider"></span>
         </label>
         <div>
-          <div>${this._esc(label)}</div>
+          <div class="tm-check-title">${this._esc(label)}</div>
           ${hint ? `<span class="tm-field-hint">${hint}</span>` : ""}
         </div>
       </div>`;
+  }
+
+  _iconPickerField(label, name, value) {
+    return `
+      <label class="tm-field">
+        <span class="tm-field-label">${this._esc(label)}</span>
+        <ha-icon-picker data-field="${name}" data-current="${this._esc(value || "")}"></ha-icon-picker>
+      </label>`;
+  }
+
+  _entityPickerField(label, name, value, domains, hint = "") {
+    const dom = (domains || []).join(",");
+    return `
+      <label class="tm-field">
+        <span class="tm-field-label">${this._esc(label)}</span>
+        <ha-entity-picker data-field="${name}" data-current="${this._esc(value || "")}" ${dom ? `data-domains="${this._esc(dom)}"` : ""}></ha-entity-picker>
+        ${hint ? `<span class="tm-field-hint">${hint}</span>` : ""}
+      </label>`;
+  }
+
+  _emptyState(icon, title, copy, action, label) {
+    return `
+      <div class="tm-empty">
+        <div class="tm-empty-icon">${icon}</div>
+        <h3>${this._esc(title)}</h3>
+        <p>${this._esc(copy)}</p>
+        <button class="tm-btn" data-act="${action}">${this._esc(label)}</button>
+      </div>
+    `;
   }
 
   _labelOf(options, value) {
@@ -1229,140 +1365,679 @@ class TaskMatePanel extends HTMLElement {
     return `<ha-icon icon="${this._esc(name || "mdi:account-circle")}"></ha-icon>`;
   }
 
-  // ---- styles ----------------------------------------------------------
+  // ---- styles (HA-token-aware, light/dark adaptive) --------------------
   _styles() {
     return `<style>
-      :host, taskmate-panel { display: block; height: 100%; background: var(--primary-background-color, #111418); color: var(--primary-text-color, #e1e3e6); }
-      .tm-shell { display: flex; flex-direction: column; height: 100%; font-family: var(--paper-font-body1_-_font-family, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif); position: relative; }
+      taskmate-panel {
+        display: block; height: 100%;
 
-      .tm-appbar { height: 56px; background: var(--app-header-background-color, #1a1d22); color: var(--app-header-text-color, #fff); display: flex; align-items: center; gap: 12px; padding: 0 16px; flex-shrink: 0; border-bottom: 1px solid var(--divider-color, #2a2e36); }
-      .tm-appbar h1 { margin: 0; font-size: 20px; font-weight: 400; flex: 1; }
-      .tm-chip { background: rgba(255,255,255,0.1); padding: 4px 10px; border-radius: 999px; font-size: 12px; }
+        /* Source HA primaries with sensible dark fallbacks. Surfaces and
+           borders are derived from these via color-mix() so the panel
+           adapts to whatever HA theme is active. */
+        --tm-bg:           var(--primary-background-color, #08090b);
+        --tm-text:         var(--primary-text-color,        #f4f5f7);
+        --tm-text-muted:   var(--secondary-text-color,      #a8aeb8);
+        --tm-text-faint:   var(--disabled-text-color,       #6b7280);
+        --tm-text-vfaint:  color-mix(in srgb, var(--tm-text), transparent 70%);
 
-      .tm-tabs { display: flex; background: var(--app-header-background-color, #1a1d22); border-bottom: 1px solid var(--divider-color, #2a2e36); padding: 0 8px; overflow-x: auto; flex-shrink: 0; scrollbar-width: none; }
+        --tm-accent:       var(--primary-color,             #5eb1ff);
+        --tm-accent-press: color-mix(in srgb, var(--tm-accent), black 12%);
+        --tm-accent-soft:  color-mix(in srgb, var(--tm-accent), transparent 88%);
+        --tm-accent-glow:  color-mix(in srgb, var(--tm-accent), transparent 78%);
+
+        /* Layered surfaces — shift toward text colour so works in both themes */
+        --tm-surface-0: color-mix(in srgb, var(--tm-bg), var(--tm-text) 3%);
+        --tm-surface-1: color-mix(in srgb, var(--tm-bg), var(--tm-text) 5%);
+        --tm-surface-2: color-mix(in srgb, var(--tm-bg), var(--tm-text) 9%);
+        --tm-surface-3: color-mix(in srgb, var(--tm-bg), var(--tm-text) 13%);
+        --tm-surface-hover: color-mix(in srgb, var(--tm-bg), var(--tm-text) 7%);
+
+        --tm-border:        color-mix(in srgb, var(--tm-text), transparent 92%);
+        --tm-border-strong: color-mix(in srgb, var(--tm-text), transparent 86%);
+        --tm-border-soft:   color-mix(in srgb, var(--tm-text), transparent 95%);
+
+        --tm-positive:     var(--success-color,             #4ade80);
+        --tm-positive-soft: color-mix(in srgb, var(--tm-positive), transparent 90%);
+        --tm-warning:      var(--warning-color,             #fbbf24);
+        --tm-warning-soft: color-mix(in srgb, var(--tm-warning), transparent 90%);
+        --tm-danger:       var(--error-color,               #f87171);
+        --tm-danger-soft:  color-mix(in srgb, var(--tm-danger), transparent 90%);
+
+        --tm-gold:   #f5b300;
+        --tm-pool:   #fb923c;
+        --tm-sticky: #c084fc;
+
+        --tm-radius-sm: 8px;
+        --tm-radius:    12px;
+        --tm-radius-lg: 16px;
+
+        --tm-shadow-sm: 0 1px 2px rgba(0,0,0,0.18);
+        --tm-shadow:    0 4px 12px rgba(0,0,0,0.22);
+        --tm-shadow-lg: 0 24px 48px -12px rgba(0,0,0,0.40);
+        --tm-easing:    cubic-bezier(0.16, 1, 0.3, 1);
+
+        background: var(--tm-bg);
+        color: var(--tm-text);
+        font-family: var(--paper-font-body1_-_font-family,
+                     -apple-system, BlinkMacSystemFont, "Inter", "SF Pro Display",
+                     "Segoe UI", Roboto, sans-serif);
+        font-size: 14px;
+        line-height: 1.5;
+        letter-spacing: -0.005em;
+        -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
+      }
+
+      /* Lighten shadows in light themes */
+      @media (prefers-color-scheme: light) {
+        taskmate-panel {
+          --tm-shadow-sm: 0 1px 2px rgba(15,15,15,0.06);
+          --tm-shadow:    0 2px 8px rgba(15,15,15,0.08);
+          --tm-shadow-lg: 0 16px 40px rgba(15,15,15,0.12);
+        }
+      }
+
+      .tm-shell { display: flex; flex-direction: column; height: 100%; position: relative; overflow: hidden; }
+      .tm-bg-glow {
+        position: absolute; inset: 0;
+        background:
+          radial-gradient(900px 600px at 90% -10%, color-mix(in srgb, var(--tm-accent), transparent 92%), transparent 60%),
+          radial-gradient(700px 500px at -10% 110%, color-mix(in srgb, var(--tm-sticky), transparent 94%), transparent 60%);
+        pointer-events: none;
+      }
+
+      /* App bar */
+      .tm-appbar {
+        position: relative; z-index: 5;
+        height: 56px; padding: 0 24px;
+        display: flex; align-items: center; gap: 14px;
+        flex-shrink: 0;
+        border-bottom: 1px solid var(--tm-border);
+        background: color-mix(in srgb, var(--tm-bg), transparent 20%);
+        backdrop-filter: blur(16px) saturate(180%);
+        -webkit-backdrop-filter: blur(16px) saturate(180%);
+      }
+      .tm-appbar-icon {
+        width: 32px; height: 32px;
+        background: linear-gradient(135deg, var(--tm-accent), var(--tm-accent-press));
+        border-radius: 9px;
+        display: grid; place-items: center;
+        color: white;
+        box-shadow: 0 2px 8px var(--tm-accent-glow);
+      }
+      .tm-appbar-icon ha-icon { --mdc-icon-size: 18px; }
+      .tm-appbar-title {
+        margin: 0; font-size: 16px; font-weight: 600;
+        letter-spacing: -0.015em;
+        flex: 1;
+      }
+      .tm-sep   { color: var(--tm-text-vfaint); font-weight: 400; margin: 0 8px; }
+      .tm-crumb { color: var(--tm-text-muted); font-weight: 500; }
+      .tm-version-chip {
+        background: var(--tm-surface-2);
+        color: var(--tm-text-muted);
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 11px;
+        padding: 4px 10px;
+        border-radius: 999px;
+        border: 1px solid var(--tm-border);
+      }
+
+      /* Tabs */
+      .tm-tabs {
+        position: relative; z-index: 4;
+        display: flex; padding: 0 16px;
+        border-bottom: 1px solid var(--tm-border);
+        background: color-mix(in srgb, var(--tm-bg), transparent 20%);
+        backdrop-filter: blur(12px);
+        -webkit-backdrop-filter: blur(12px);
+        overflow-x: auto; scrollbar-width: none;
+        flex-shrink: 0;
+      }
       .tm-tabs::-webkit-scrollbar { display: none; }
-      .tm-tab { border: 0; background: transparent; color: var(--secondary-text-color, #9aa0a6); padding: 14px 18px; cursor: pointer; font-size: 14px; font-weight: 500; border-bottom: 2px solid transparent; margin-bottom: -1px; white-space: nowrap; font-family: inherit; }
-      .tm-tab:hover { color: var(--primary-text-color, #e1e3e6); }
-      .tm-tab-active { color: var(--primary-color, #03a9f4); border-bottom-color: var(--primary-color, #03a9f4); }
+      .tm-tab {
+        position: relative;
+        background: transparent; border: 0;
+        color: var(--tm-text-faint);
+        padding: 14px 16px;
+        cursor: pointer;
+        font-size: 13px; font-weight: 500;
+        letter-spacing: -0.005em;
+        white-space: nowrap;
+        display: flex; align-items: center; gap: 6px;
+        font-family: inherit;
+        transition: color 0.15s var(--tm-easing);
+      }
+      .tm-tab:hover       { color: var(--tm-text); }
+      .tm-tab-active      { color: var(--tm-text); }
+      .tm-tab-active::after {
+        content: "";
+        position: absolute;
+        left: 16px; right: 16px; bottom: -1px;
+        height: 2px; border-radius: 2px 2px 0 0;
+        background: var(--tm-accent);
+      }
+      .tm-tab-pill {
+        background: var(--tm-surface-2); color: var(--tm-text-muted);
+        font-size: 10px; font-weight: 600;
+        padding: 1px 7px; border-radius: 999px;
+        line-height: 1.4;
+      }
+      .tm-tab-active .tm-tab-pill { background: var(--tm-accent-soft); color: var(--tm-accent); }
 
-      .tm-body { flex: 1; overflow: auto; padding: 20px 24px 48px; }
-      .tm-toolbar { display: flex; align-items: center; gap: 16px; margin-bottom: 16px; flex-wrap: wrap; }
-      .tm-title-sub { flex: 1; color: var(--secondary-text-color, #9aa0a6); font-size: 13px; }
+      /* Body */
+      .tm-body { flex: 1; overflow-y: auto; padding: 28px 32px 56px; position: relative; z-index: 1; }
+      .tm-body-inner { max-width: 1200px; margin: 0 auto; }
 
-      .tm-card { background: var(--card-background-color, #1c1f24); border: 1px solid var(--divider-color, #2a2e36); border-radius: 12px; padding: 20px 24px; margin-bottom: 16px; }
-      .tm-card h2 { margin: 16px 0 12px; font-size: 14px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; color: var(--primary-text-color); }
-      .tm-card h2:first-child { margin-top: 0; }
-      .tm-card p { margin: 8px 0; color: var(--secondary-text-color, #9aa0a6); }
-      .tm-card code { background: var(--code-editor-background-color, #0e1115); padding: 2px 6px; border-radius: 4px; font-size: 12px; }
-      .tm-card-error { border-left: 3px solid var(--error-color, #ef5350); color: var(--error-color, #ef5350); }
-      .tm-empty { text-align: center; padding: 40px 24px; }
+      /* Toolbar */
+      .tm-toolbar { display: flex; align-items: center; gap: 12px; margin-bottom: 24px; flex-wrap: wrap; }
+      .tm-toolbar-title {
+        margin: 0; font-size: 22px; font-weight: 600;
+        letter-spacing: -0.02em;
+        flex: 1;
+      }
+      .tm-toolbar-count {
+        color: var(--tm-text-faint); font-weight: 400;
+        margin-left: 6px;
+        font-feature-settings: "tnum";
+      }
 
-      .tm-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); gap: 16px; }
-      .tm-child-card { margin-bottom: 0; display: flex; flex-direction: column; }
-      .tm-child-head { display: flex; align-items: center; gap: 12px; margin-bottom: 14px; }
-      .tm-avatar { width: 48px; height: 48px; border-radius: 50%; background: var(--secondary-background-color, #242830); display: grid; place-items: center; flex-shrink: 0; color: var(--primary-color, #03a9f4); }
-      .tm-avatar ha-icon { --mdc-icon-size: 28px; }
-      .tm-reward-avatar { color: var(--accent-color, #ffca28); }
+      /* Buttons */
+      .tm-btn {
+        background: linear-gradient(180deg, var(--tm-accent), var(--tm-accent-press));
+        color: white; border: 0;
+        padding: 8px 14px; border-radius: var(--tm-radius-sm);
+        font-size: 13px; font-weight: 500;
+        letter-spacing: -0.005em;
+        font-family: inherit;
+        cursor: pointer;
+        box-shadow: 0 1px 2px rgba(0,0,0,0.15), 0 0 0 1px rgba(255,255,255,0.06) inset;
+        transition: all 0.12s var(--tm-easing);
+        display: inline-flex; align-items: center; gap: 6px;
+      }
+      .tm-btn:hover  { filter: brightness(1.08); transform: translateY(-1px); box-shadow: 0 2px 8px var(--tm-accent-glow), 0 0 0 1px rgba(255,255,255,0.06) inset; }
+      .tm-btn:active { transform: translateY(0); filter: brightness(0.95); }
+      .tm-btn-sm     { padding: 5px 10px; font-size: 12px; }
+      .tm-btn-ghost {
+        background: var(--tm-surface-2);
+        color: var(--tm-text);
+        box-shadow: 0 0 0 1px var(--tm-border) inset;
+      }
+      .tm-btn-ghost:hover { background: var(--tm-surface-3); transform: translateY(-1px); }
+      .tm-btn-danger {
+        background: transparent;
+        color: var(--tm-danger);
+        box-shadow: 0 0 0 1px color-mix(in srgb, var(--tm-danger), transparent 75%) inset;
+      }
+      .tm-btn-danger:hover { background: var(--tm-danger-soft); transform: translateY(-1px); }
+      .tm-icon-btn {
+        width: 32px; height: 32px;
+        border: 0; background: transparent;
+        border-radius: 8px;
+        display: grid; place-items: center;
+        color: var(--tm-text-muted);
+        font-size: 14px;
+        cursor: pointer;
+        font-family: inherit;
+        transition: all 0.12s var(--tm-easing);
+      }
+      .tm-icon-btn:hover { background: var(--tm-surface-2); color: var(--tm-text); }
+
+      /* Cards */
+      .tm-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(320px, 1fr)); gap: 16px; }
+      .tm-card {
+        position: relative; overflow: hidden;
+        background: linear-gradient(180deg, var(--tm-surface-1), var(--tm-surface-0));
+        border: 1px solid var(--tm-border);
+        border-radius: var(--tm-radius);
+        padding: 20px;
+        box-shadow: var(--tm-shadow-sm);
+        transition: all 0.15s var(--tm-easing);
+      }
+      .tm-card::before {
+        content: "";
+        position: absolute; top: 0; left: 1px; right: 1px;
+        height: 1px;
+        background: linear-gradient(90deg, transparent, color-mix(in srgb, var(--tm-text), transparent 88%), transparent);
+      }
+      .tm-card:hover { border-color: var(--tm-border-strong); transform: translateY(-1px); box-shadow: var(--tm-shadow); }
+      .tm-card-error { border-left: 3px solid var(--tm-danger); color: var(--tm-danger); }
+      .tm-loading { color: var(--tm-text-muted); }
+
+      /* Child / reward / group cards share head/avatar */
+      .tm-child-card { display: flex; flex-direction: column; gap: 16px; }
+      .tm-child-head { display: flex; align-items: center; gap: 14px; }
+      .tm-avatar {
+        width: 48px; height: 48px;
+        border-radius: 14px;
+        background: linear-gradient(135deg, var(--tm-surface-3), var(--tm-surface-2));
+        display: grid; place-items: center;
+        flex-shrink: 0;
+        color: var(--tm-accent);
+        box-shadow: 0 0 0 1px var(--tm-border) inset, 0 1px 2px rgba(0,0,0,0.2);
+      }
+      .tm-avatar ha-icon { --mdc-icon-size: 26px; }
+      .tm-avatar-reward  { color: var(--tm-gold); }
       .tm-child-name { min-width: 0; flex: 1; }
-      .tm-child-name h3 { margin: 0; font-size: 17px; font-weight: 600; }
-      .tm-sub { color: var(--secondary-text-color, #9aa0a6); font-size: 12px; margin-top: 2px; word-break: break-all; }
-      .tm-sub code { background: var(--code-editor-background-color, #0e1115); padding: 1px 6px; border-radius: 4px; font-size: 11px; }
+      .tm-child-name h3 { margin: 0; font-size: 16px; font-weight: 600; letter-spacing: -0.01em; }
+      .tm-meta { color: var(--tm-text-faint); font-size: 12px; margin-top: 2px; word-break: break-word; }
+      .tm-meta code { font-family: ui-monospace, "SF Mono", Menlo, monospace; background: var(--tm-surface-2); padding: 1px 6px; border-radius: 4px; font-size: 11px; color: var(--tm-text-muted); }
+      .tm-text-muted { color: var(--tm-text-muted); }
 
-      .tm-stats { display: flex; gap: 14px; margin-bottom: 14px; flex-wrap: wrap; }
-      .tm-stat { background: var(--secondary-background-color, #242830); padding: 8px 12px; border-radius: 8px; flex: 1; min-width: 80px; }
-      .tm-stat strong { display: block; font-size: 20px; font-weight: 600; color: var(--primary-color, #03a9f4); }
-      .tm-stat span { font-size: 11px; color: var(--secondary-text-color, #9aa0a6); text-transform: uppercase; letter-spacing: 0.5px; }
+      .tm-stats-row { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 8px; }
+      .tm-stat {
+        background: var(--tm-surface-2);
+        border-radius: var(--tm-radius-sm);
+        padding: 10px 12px;
+        box-shadow: 0 0 0 1px var(--tm-border-soft) inset;
+      }
+      .tm-stat-value {
+        font-size: 20px; font-weight: 600;
+        letter-spacing: -0.02em;
+        font-feature-settings: "tnum";
+        color: var(--tm-text);
+        line-height: 1.1;
+      }
+      .tm-stat-label {
+        font-size: 10px; text-transform: uppercase; letter-spacing: 0.06em;
+        color: var(--tm-text-faint);
+        margin-top: 4px; font-weight: 500;
+      }
+      .tm-stat-highlight .tm-stat-value { color: var(--tm-accent); }
 
-      .tm-card-foot { display: flex; gap: 8px; margin-top: auto; padding-top: 12px; border-top: 1px solid var(--divider-color, #2a2e36); }
+      .tm-card-foot {
+        display: flex; gap: 8px;
+        margin-top: auto;
+        padding-top: 16px;
+        border-top: 1px solid var(--tm-border-soft);
+      }
 
-      .tm-add-tile { display: grid; place-items: center; gap: 6px; background: transparent; border: 2px dashed var(--divider-color, #2a2e36); border-radius: 12px; color: var(--secondary-text-color, #9aa0a6); cursor: pointer; min-height: 180px; font-size: 14px; font-family: inherit; transition: border-color .15s, color .15s, background .15s; }
-      .tm-add-tile:hover { border-color: var(--primary-color, #03a9f4); color: var(--primary-color, #03a9f4); background: rgba(3,169,244,0.06); }
-      .tm-add-plus { font-size: 32px; line-height: 1; }
-
-      .tm-btn { background: var(--primary-color, #03a9f4); color: var(--text-primary-color, #001a26); border: 0; padding: 8px 16px; border-radius: 8px; cursor: pointer; font-size: 14px; font-weight: 500; font-family: inherit; }
-      .tm-btn:hover { filter: brightness(1.1); }
-      .tm-btn-ghost { background: transparent; color: var(--primary-text-color, #e1e3e6); border: 1px solid var(--divider-color, #2a2e36); }
-      .tm-btn-ghost:hover { background: var(--secondary-background-color, #242830); filter: none; }
-      .tm-btn-danger { background: transparent; color: var(--error-color, #ef5350); border: 1px solid rgba(239,83,80,0.4); }
-      .tm-btn-danger:hover { background: rgba(239,83,80,0.1); filter: none; }
-      .tm-icon-btn { width: 36px; height: 36px; border: 0; background: transparent; border-radius: 50%; cursor: pointer; display: grid; place-items: center; color: var(--secondary-text-color, #9aa0a6); font-size: 18px; line-height: 1; font-family: inherit; }
-      .tm-icon-btn:hover { background: var(--secondary-background-color, #242830); color: var(--primary-text-color, #e1e3e6); }
-
-      /* Pills */
-      .tm-pill { display: inline-block; background: var(--secondary-background-color, #242830); color: var(--secondary-text-color, #9aa0a6); padding: 1px 8px; border-radius: 999px; font-size: 11px; margin-left: 4px; vertical-align: middle; }
-      .tm-pill-alternating, .tm-pill-random, .tm-pill-balanced { background: rgba(3,169,244,0.15); color: var(--primary-color, #03a9f4); }
-      .tm-pill-jackpot { background: rgba(255,202,40,0.15); color: var(--accent-color, #ffca28); }
-      .tm-pill-pool { background: rgba(255,167,38,0.15); color: #ffa726; }
-      .tm-pill-sticky { background: rgba(149,117,205,0.18); color: #b39ddb; }
-      .tm-pill-spread { background: rgba(102,187,106,0.15); color: var(--success-color, #66bb6a); }
+      .tm-add-tile {
+        background: transparent;
+        border: 1px dashed var(--tm-border-strong);
+        border-radius: var(--tm-radius);
+        padding: 36px 18px;
+        color: var(--tm-text-faint);
+        text-align: center;
+        font-size: 13px;
+        cursor: pointer;
+        font-family: inherit;
+        display: grid; place-items: center; gap: 8px;
+        transition: all 0.15s var(--tm-easing);
+      }
+      .tm-add-tile:hover {
+        border-color: var(--tm-accent);
+        color: var(--tm-accent);
+        background: var(--tm-accent-soft);
+      }
+      .tm-add-plus {
+        width: 32px; height: 32px;
+        border-radius: 50%;
+        background: var(--tm-surface-2);
+        display: grid; place-items: center;
+        font-size: 18px;
+        transition: all 0.15s var(--tm-easing);
+      }
+      .tm-add-tile:hover .tm-add-plus { background: var(--tm-accent); color: white; }
 
       /* Tables */
-      .tm-table-wrap { background: var(--card-background-color, #1c1f24); border: 1px solid var(--divider-color, #2a2e36); border-radius: 12px; overflow: hidden; }
-      .tm-table { width: 100%; border-collapse: collapse; font-size: 13px; }
-      .tm-table th, .tm-table td { padding: 12px 16px; text-align: left; border-bottom: 1px solid var(--divider-color, #2a2e36); }
-      .tm-table th { font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; color: var(--secondary-text-color, #9aa0a6); font-weight: 500; background: var(--app-header-background-color, #1a1d22); }
+      .tm-table-wrap {
+        background: linear-gradient(180deg, var(--tm-surface-1), var(--tm-surface-0));
+        border: 1px solid var(--tm-border);
+        border-radius: var(--tm-radius);
+        overflow: hidden;
+        box-shadow: var(--tm-shadow-sm);
+      }
+      .tm-table { width: 100%; border-collapse: collapse; }
+      .tm-table th, .tm-table td {
+        text-align: left; padding: 14px 18px;
+        border-bottom: 1px solid var(--tm-border-soft);
+        font-size: 13px;
+      }
+      .tm-table th {
+        color: var(--tm-text-faint);
+        font-weight: 500; font-size: 10px;
+        text-transform: uppercase; letter-spacing: 0.06em;
+        background: var(--tm-surface-0);
+        border-bottom: 1px solid var(--tm-border);
+      }
       .tm-table tr:last-child td { border-bottom: 0; }
-      .tm-row:hover { background: var(--secondary-background-color, #242830); }
+      .tm-row { transition: background 0.12s var(--tm-easing); }
+      .tm-row:hover { background: var(--tm-surface-hover); }
       .tm-row-disabled { opacity: 0.5; }
-      .tm-row-icon { display: inline-flex; vertical-align: middle; margin-right: 8px; --mdc-icon-size: 18px; color: var(--secondary-text-color); }
+      .tm-row-icon { display: inline-flex; vertical-align: middle; margin-right: 10px; opacity: 0.7; --mdc-icon-size: 18px; color: var(--tm-text-muted); }
       .tm-row-actions { text-align: right; white-space: nowrap; display: flex; gap: 4px; justify-content: flex-end; align-items: center; }
-      .tm-yes { color: var(--success-color, #66bb6a); }
-      .tm-no  { color: var(--secondary-text-color, #6a7079); }
-      .tm-neg { color: var(--error-color, #ef5350); }
-      .tm-pos { color: var(--success-color, #66bb6a); }
+      .tm-numeric { font-feature-settings: "tnum"; }
+      .tm-yes { color: var(--tm-positive); font-weight: 500; }
+      .tm-no  { color: var(--tm-text-faint); }
+      .tm-neg { color: var(--tm-danger); }
+      .tm-pos { color: var(--tm-positive); }
+      .tm-cost { color: var(--tm-gold); }
 
-      .tm-progress { height: 8px; background: var(--secondary-background-color, #242830); border-radius: 999px; overflow: hidden; margin: 8px 0 4px; }
-      .tm-progress > span { display: block; height: 100%; background: linear-gradient(90deg, var(--primary-color, #03a9f4), #4fc3f7); }
+      /* Pills */
+      .tm-pill {
+        display: inline-flex; align-items: center; gap: 4px;
+        padding: 2px 8px; border-radius: 999px;
+        font-size: 11px; font-weight: 500;
+        line-height: 1.5;
+        background: var(--tm-surface-2); color: var(--tm-text-muted);
+        margin-left: 4px; vertical-align: middle;
+      }
+      .tm-pill-accent  { background: var(--tm-accent-soft);   color: var(--tm-accent); }
+      .tm-pill-success { background: var(--tm-positive-soft); color: var(--tm-positive); }
+      .tm-pill-warn    { background: var(--tm-warning-soft);  color: var(--tm-warning); }
+      .tm-pill-danger  { background: var(--tm-danger-soft);   color: var(--tm-danger); }
+      .tm-pill-pool    { background: color-mix(in srgb, var(--tm-pool), transparent 90%); color: var(--tm-pool); }
+      .tm-pill-sticky  { background: color-mix(in srgb, var(--tm-sticky), transparent 90%); color: var(--tm-sticky); }
+      .tm-pill-spread  { background: var(--tm-positive-soft); color: var(--tm-positive); }
+      .tm-pill-jackpot { background: color-mix(in srgb, var(--tm-gold), transparent 88%); color: var(--tm-gold); }
+      .tm-pill-alternating, .tm-pill-random, .tm-pill-balanced { background: var(--tm-accent-soft); color: var(--tm-accent); }
+      .tm-pill-dot::before {
+        content: ""; width: 5px; height: 5px; border-radius: 50%;
+        background: currentColor;
+      }
 
-      .tm-group-list { margin: 0; padding-left: 20px; color: var(--secondary-text-color, #9aa0a6); font-size: 13px; }
+      /* Reward extras */
+      .tm-reward-card { display: flex; flex-direction: column; gap: 14px; }
+      .tm-progress {
+        height: 6px;
+        background: var(--tm-surface-2);
+        border-radius: 999px;
+        overflow: hidden;
+        margin-top: 4px;
+        box-shadow: 0 0 0 1px var(--tm-border-soft) inset;
+      }
+      .tm-progress > span {
+        display: block; height: 100%;
+        background: linear-gradient(90deg, var(--tm-accent), color-mix(in srgb, var(--tm-accent), white 25%));
+        border-radius: 999px;
+        box-shadow: 0 0 8px var(--tm-accent-glow);
+      }
+      .tm-progress-text {
+        font-size: 12px; color: var(--tm-text-muted);
+        display: flex; justify-content: space-between;
+        font-feature-settings: "tnum";
+        margin-top: 6px;
+      }
+      .tm-progress-text strong { color: var(--tm-text); font-weight: 600; }
+
+      /* Empty state */
+      .tm-empty {
+        text-align: center;
+        padding: 64px 24px;
+        background: var(--tm-surface-1);
+        border: 1px dashed var(--tm-border-strong);
+        border-radius: var(--tm-radius);
+      }
+      .tm-empty-icon {
+        width: 56px; height: 56px;
+        border-radius: 16px;
+        background: var(--tm-surface-2);
+        display: inline-grid; place-items: center;
+        font-size: 26px;
+        margin-bottom: 16px;
+        box-shadow: 0 0 0 1px var(--tm-border) inset;
+      }
+      .tm-empty h3 { margin: 0 0 6px; font-size: 16px; font-weight: 600; letter-spacing: -0.01em; }
+      .tm-empty p  { margin: 0 0 20px; color: var(--tm-text-muted); font-size: 13px; }
+
+      /* Group list */
+      .tm-group-list { margin: 8px 0 0; padding-left: 20px; color: var(--tm-text-muted); font-size: 13px; }
+      .tm-group-list li { margin-bottom: 2px; }
 
       /* Settings */
-      .tm-settings .tm-field-row { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; margin-bottom: 8px; }
-      .tm-field-inline { display: block; margin-bottom: 12px; }
-      .tm-field-inline span { display: block; color: var(--secondary-text-color, #9aa0a6); font-size: 12px; margin-bottom: 4px; }
-      .tm-field-inline input, .tm-field-inline select { width: 100%; background: var(--secondary-background-color, #242830); border: 1px solid var(--divider-color, #2a2e36); border-radius: 8px; padding: 8px 12px; color: var(--primary-text-color); font-size: 14px; box-sizing: border-box; font-family: inherit; }
+      .tm-settings { display: flex; flex-direction: column; gap: 16px; }
+      .tm-section {
+        background: linear-gradient(180deg, var(--tm-surface-1), var(--tm-surface-0));
+        border: 1px solid var(--tm-border);
+        border-radius: var(--tm-radius);
+        overflow: hidden;
+        box-shadow: var(--tm-shadow-sm);
+        position: relative;
+      }
+      .tm-section::before {
+        content: "";
+        position: absolute; top: 0; left: 1px; right: 1px;
+        height: 1px;
+        background: linear-gradient(90deg, transparent, color-mix(in srgb, var(--tm-text), transparent 88%), transparent);
+      }
+      .tm-section-head {
+        padding: 16px 20px;
+        border-bottom: 1px solid var(--tm-border-soft);
+      }
+      .tm-section-head h3 { margin: 0 0 2px; font-size: 14px; font-weight: 600; letter-spacing: -0.005em; }
+      .tm-section-head p  { margin: 0; color: var(--tm-text-faint); font-size: 12px; }
+      .tm-section-body { padding: 8px 20px 16px; }
+      .tm-setting-row {
+        display: grid; grid-template-columns: 240px 1fr;
+        gap: 24px; align-items: center;
+        padding: 12px 0;
+        border-bottom: 1px solid var(--tm-border-soft);
+      }
+      .tm-setting-row:last-child { border-bottom: 0; }
+      .tm-setting-label { color: var(--tm-text); font-size: 13px; font-weight: 500; }
+      .tm-setting-label small { display: block; color: var(--tm-text-faint); font-weight: 400; font-size: 12px; margin-top: 2px; }
+      .tm-setting-row input[type=text],
+      .tm-setting-row input[type=number],
+      .tm-setting-row select {
+        background: var(--tm-surface-2);
+        border: 1px solid var(--tm-border);
+        border-radius: var(--tm-radius-sm);
+        padding: 8px 12px;
+        color: var(--tm-text);
+        font-size: 13px;
+        font-family: inherit;
+        max-width: 360px;
+        transition: all 0.15s var(--tm-easing);
+      }
+      .tm-setting-row input:focus, .tm-setting-row select:focus {
+        outline: 0;
+        border-color: var(--tm-accent);
+        box-shadow: 0 0 0 3px var(--tm-accent-soft);
+      }
+      .tm-settings-foot {
+        display: flex; justify-content: flex-end;
+        padding-top: 8px;
+      }
+
+      /* iOS-style switch */
+      .tm-switch {
+        position: relative; display: inline-block;
+        width: 44px; height: 26px; flex-shrink: 0;
+      }
+      .tm-switch input { opacity: 0; width: 0; height: 0; }
+      .tm-slider {
+        position: absolute; inset: 0;
+        background: var(--tm-surface-3);
+        border-radius: 999px;
+        transition: background 0.2s var(--tm-easing);
+        cursor: pointer;
+        box-shadow: 0 0 0 1px var(--tm-border) inset;
+      }
+      .tm-slider::before {
+        content: ''; position: absolute;
+        height: 20px; width: 20px;
+        left: 3px; top: 3px;
+        background: white; border-radius: 50%;
+        transition: transform 0.2s var(--tm-easing);
+        box-shadow: 0 1px 3px rgba(0,0,0,0.3);
+      }
+      .tm-switch input:checked + .tm-slider {
+        background: var(--tm-accent);
+        box-shadow: 0 0 0 1px var(--tm-accent) inset, 0 0 12px var(--tm-accent-glow);
+      }
+      .tm-switch input:checked + .tm-slider::before { transform: translateX(18px); }
 
       /* Dialog */
-      .tm-scrim { position: fixed; inset: 0; background: rgba(0,0,0,0.55); display: flex; align-items: flex-start; justify-content: center; padding: 60px 20px; z-index: 100; overflow-y: auto; }
-      .tm-dialog { background: var(--card-background-color, #1c1f24); border: 1px solid var(--divider-color, #2a2e36); border-radius: 12px; width: 100%; max-width: 560px; box-shadow: 0 10px 40px rgba(0,0,0,0.5); display: flex; flex-direction: column; max-height: calc(100vh - 120px); }
-      .tm-dialog-head { padding: 16px 20px; border-bottom: 1px solid var(--divider-color, #2a2e36); display: flex; align-items: center; }
-      .tm-dialog-head h2 { margin: 0; font-size: 18px; font-weight: 500; flex: 1; }
-      .tm-dialog-body { padding: 16px 20px; overflow-y: auto; }
-      .tm-dialog-body .tm-field-row { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
-      .tm-dialog-foot { padding: 14px 20px; border-top: 1px solid var(--divider-color, #2a2e36); display: flex; justify-content: flex-end; gap: 10px; }
+      .tm-scrim {
+        position: fixed; inset: 0;
+        background: color-mix(in srgb, var(--tm-bg), transparent 30%);
+        backdrop-filter: blur(8px);
+        -webkit-backdrop-filter: blur(8px);
+        display: flex; align-items: flex-start; justify-content: center;
+        padding: 60px 20px; z-index: 100;
+        overflow-y: auto;
+        animation: tm-scrim-in 0.2s var(--tm-easing);
+      }
+      @keyframes tm-scrim-in { from { opacity: 0; } to { opacity: 1; } }
+      .tm-dialog {
+        background: linear-gradient(180deg, var(--tm-surface-2), var(--tm-surface-1));
+        border: 1px solid var(--tm-border-strong);
+        border-radius: var(--tm-radius-lg);
+        width: 100%; max-width: 560px;
+        box-shadow: var(--tm-shadow-lg);
+        display: flex; flex-direction: column;
+        max-height: calc(100vh - 120px);
+        overflow: hidden;
+        animation: tm-dialog-in 0.25s var(--tm-easing);
+        position: relative;
+      }
+      .tm-dialog::before {
+        content: "";
+        position: absolute; top: 0; left: 1px; right: 1px;
+        height: 1px;
+        background: linear-gradient(90deg, transparent, color-mix(in srgb, var(--tm-text), transparent 86%), transparent);
+      }
+      @keyframes tm-dialog-in { from { opacity: 0; transform: translateY(8px) scale(0.985); } to { opacity: 1; transform: none; } }
 
-      .tm-field { display: block; margin-bottom: 16px; }
-      .tm-field-label { display: block; color: var(--secondary-text-color, #9aa0a6); font-size: 12px; margin-bottom: 6px; font-weight: 500; }
-      .tm-field input, .tm-field select { width: 100%; background: var(--secondary-background-color, #242830); border: 1px solid var(--divider-color, #2a2e36); border-radius: 8px; padding: 9px 12px; color: var(--primary-text-color, #e1e3e6); font-size: 14px; box-sizing: border-box; font-family: inherit; }
-      .tm-field input:focus, .tm-field select:focus { outline: 2px solid var(--primary-color, #03a9f4); outline-offset: -1px; border-color: transparent; }
-      .tm-field-hint { display: block; color: var(--secondary-text-color, #6a7079); font-size: 12px; margin-top: 6px; line-height: 1.4; }
-      .tm-field-hint code { background: var(--code-editor-background-color, #0e1115); padding: 1px 5px; border-radius: 3px; font-size: 11px; }
+      .tm-dialog-head {
+        padding: 18px 22px;
+        border-bottom: 1px solid var(--tm-border-soft);
+        display: flex; align-items: center;
+      }
+      .tm-dialog-head h2 {
+        margin: 0; font-size: 16px; font-weight: 600;
+        letter-spacing: -0.01em;
+        flex: 1;
+      }
+      .tm-dialog-body { padding: 18px 22px; overflow-y: auto; }
+      .tm-dialog-foot {
+        padding: 14px 22px;
+        border-top: 1px solid var(--tm-border-soft);
+        background: var(--tm-surface-0);
+        display: flex; justify-content: flex-end; gap: 8px;
+      }
 
-      .tm-multi { display: flex; gap: 6px; flex-wrap: wrap; }
-      .tm-chip-btn { background: var(--secondary-background-color, #242830); color: var(--secondary-text-color, #9aa0a6); border: 1px solid var(--divider-color, #2a2e36); padding: 6px 12px; border-radius: 999px; cursor: pointer; font-size: 13px; font-family: inherit; }
-      .tm-chip-btn:hover { color: var(--primary-text-color, #e1e3e6); }
-      .tm-chip-on { background: var(--primary-color, #03a9f4); color: var(--text-primary-color, #001a26); border-color: var(--primary-color, #03a9f4); }
+      .tm-field { display: block; margin-bottom: 18px; }
+      .tm-field-label { display: block; color: var(--tm-text-muted); font-size: 12px; margin-bottom: 6px; font-weight: 500; }
+      .tm-field input[type=text], .tm-field input[type=number], .tm-field input[type=date], .tm-field select {
+        width: 100%;
+        background: var(--tm-surface-1);
+        border: 1px solid var(--tm-border);
+        border-radius: var(--tm-radius-sm);
+        padding: 10px 12px;
+        color: var(--tm-text);
+        font-size: 13px;
+        font-family: inherit;
+        box-sizing: border-box;
+        transition: all 0.15s var(--tm-easing);
+      }
+      .tm-field input:focus, .tm-field select:focus {
+        outline: 0;
+        border-color: var(--tm-accent);
+        box-shadow: 0 0 0 3px var(--tm-accent-soft);
+      }
+      .tm-field-hint {
+        display: block; color: var(--tm-text-faint);
+        font-size: 11px; margin-top: 6px; line-height: 1.5;
+      }
+      .tm-field-hint code {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        background: var(--tm-surface-2); padding: 1px 5px;
+        border-radius: 3px; font-size: 10px;
+      }
+      .tm-field-row { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+
+      /* HA pickers — make them blend with the dialog form */
+      .tm-field ha-icon-picker, .tm-field ha-entity-picker,
+      .tm-section-body ha-icon-picker {
+        display: block; width: 100%;
+      }
+
+      /* Chip multi-select */
+      .tm-chip-row { display: flex; gap: 6px; flex-wrap: wrap; }
+      .tm-chip-btn {
+        background: var(--tm-surface-1);
+        color: var(--tm-text-muted);
+        border: 1px solid var(--tm-border);
+        padding: 6px 12px; border-radius: 999px;
+        font-size: 12px; font-weight: 500;
+        font-family: inherit;
+        cursor: pointer;
+        transition: all 0.12s var(--tm-easing);
+      }
+      .tm-chip-btn:hover { color: var(--tm-text); border-color: var(--tm-border-strong); }
+      .tm-chip-on {
+        background: var(--tm-accent-soft);
+        color: var(--tm-accent);
+        border-color: var(--tm-accent);
+      }
 
       .tm-day-row { display: flex; gap: 6px; flex-wrap: wrap; }
-      .tm-day-btn { width: 44px; height: 36px; background: var(--secondary-background-color, #242830); color: var(--secondary-text-color, #9aa0a6); border: 1px solid var(--divider-color, #2a2e36); border-radius: 6px; cursor: pointer; font-size: 12px; font-family: inherit; }
-      .tm-day-on { background: var(--primary-color, #03a9f4); color: var(--text-primary-color, #001a26); border-color: var(--primary-color, #03a9f4); }
+      .tm-day-btn {
+        width: 42px; height: 36px;
+        background: var(--tm-surface-1);
+        color: var(--tm-text-muted);
+        border: 1px solid var(--tm-border);
+        border-radius: 8px;
+        font-size: 12px; font-weight: 500;
+        font-family: inherit; cursor: pointer;
+        transition: all 0.12s var(--tm-easing);
+      }
+      .tm-day-on {
+        background: var(--tm-accent); color: white;
+        border-color: var(--tm-accent);
+        box-shadow: 0 1px 4px var(--tm-accent-glow);
+      }
 
-      .tm-check-row { display: flex; align-items: flex-start; gap: 12px; padding: 8px 0; color: var(--primary-text-color, #e1e3e6); font-size: 14px; }
+      .tm-check-row {
+        display: flex; align-items: flex-start; gap: 14px;
+        padding: 12px 0;
+        border-top: 1px solid var(--tm-border-soft);
+      }
+      .tm-check-row:first-child { border-top: 0; padding-top: 0; }
       .tm-check-row > div { flex: 1; }
-      .tm-switch { position: relative; display: inline-block; width: 38px; height: 22px; flex-shrink: 0; }
-      .tm-switch input { opacity: 0; width: 0; height: 0; }
-      .tm-slider { position: absolute; inset: 0; background: var(--secondary-background-color, #242830); border: 1px solid var(--divider-color, #2a2e36); border-radius: 999px; transition: background .15s; cursor: pointer; }
-      .tm-slider::before { content: ''; position: absolute; height: 16px; width: 16px; left: 2px; top: 2px; background: white; border-radius: 50%; transition: transform .15s; }
-      .tm-switch input:checked + .tm-slider { background: var(--primary-color, #03a9f4); border-color: var(--primary-color, #03a9f4); }
-      .tm-switch input:checked + .tm-slider::before { transform: translateX(16px); }
+      .tm-check-title { font-size: 13px; color: var(--tm-text); font-weight: 500; }
 
-      .tm-advanced { border: 1px dashed var(--divider-color, #2a2e36); border-radius: 8px; padding: 10px 14px; margin-top: 8px; }
-      .tm-advanced summary { cursor: pointer; color: var(--secondary-text-color, #9aa0a6); font-size: 13px; user-select: none; }
+      /* Advanced */
+      details.tm-advanced {
+        background: var(--tm-surface-0);
+        border: 1px solid var(--tm-border);
+        border-radius: var(--tm-radius-sm);
+        margin-top: 16px;
+        overflow: hidden;
+      }
+      details.tm-advanced summary {
+        cursor: pointer; padding: 12px 14px;
+        color: var(--tm-text-muted); font-size: 12px; font-weight: 500;
+        user-select: none; list-style: none;
+        display: flex; align-items: center; gap: 8px;
+      }
+      details.tm-advanced summary::-webkit-details-marker { display: none; }
+      details.tm-advanced summary::before {
+        content: "▸";
+        transition: transform 0.15s var(--tm-easing);
+        color: var(--tm-text-faint);
+        font-size: 10px;
+      }
+      details.tm-advanced[open] summary::before { transform: rotate(90deg); }
+      details.tm-advanced > div {
+        padding: 14px;
+        border-top: 1px solid var(--tm-border-soft);
+      }
 
       /* Toast */
-      .tm-toast { position: fixed; bottom: 24px; left: 50%; transform: translateX(-50%); padding: 10px 18px; border-radius: 8px; font-size: 14px; box-shadow: 0 4px 16px rgba(0,0,0,0.4); z-index: 200; }
-      .tm-toast-ok { background: var(--primary-color, #03a9f4); color: var(--text-primary-color, #001a26); }
-      .tm-toast-err { background: var(--error-color, #ef5350); color: white; }
+      .tm-toast {
+        position: fixed; bottom: 24px; left: 50%; transform: translateX(-50%);
+        padding: 10px 18px; border-radius: var(--tm-radius-sm);
+        font-size: 13px; font-weight: 500;
+        box-shadow: var(--tm-shadow);
+        z-index: 200;
+        animation: tm-toast-in 0.25s var(--tm-easing);
+      }
+      @keyframes tm-toast-in { from { opacity: 0; transform: translate(-50%, 8px); } to { opacity: 1; transform: translateX(-50%); } }
+      .tm-toast-ok  { background: var(--tm-accent); color: white; box-shadow: 0 4px 16px var(--tm-accent-glow); }
+      .tm-toast-err { background: var(--tm-danger); color: white; }
 
       @media (max-width: 700px) {
         .tm-body { padding: 16px; }
@@ -1370,7 +2045,8 @@ class TaskMatePanel extends HTMLElement {
         .tm-dialog { max-width: none; }
         .tm-scrim { padding: 0; }
         .tm-dialog { border-radius: 0; max-height: 100vh; height: 100vh; }
-        .tm-dialog-body .tm-field-row, .tm-settings .tm-field-row { grid-template-columns: 1fr; }
+        .tm-dialog-body .tm-field-row { grid-template-columns: 1fr; }
+        .tm-setting-row { grid-template-columns: 1fr; gap: 6px; }
       }
     </style>`;
   }


### PR DESCRIPTION
The edit_child config flow form validated all fields (including avatar) before the handler could check if the action was delete. If a child had an avatar not in AVATAR_OPTIONS, the form rejected the entire submission — making delete impossible.

Split delete into a separate menu option with its own confirmation step that only has a boolean toggle, so avatar validation never blocks deletion. Also clamped the edit form avatar default to a valid option as a safety net.