### PR TITLE
fix(cards): dark mode support for HA theme selection

### DIFF
--- a/custom_components/taskmate/www/taskmate-child-card.js
+++ b/custom_components/taskmate/www/taskmate-child-card.js
@@ -830,7 +830,7 @@ class TaskMateChildCard extends LitElement {
         font-size: 0.72rem;
         font-weight: 600;
         color: var(--secondary-text-color);
-        background: rgba(0,0,0,0.06);
+        background: color-mix(in srgb, var(--primary-text-color, #212121) 8%, transparent);
         border-radius: 8px;
         padding: 1px 6px;
         margin-top: 3px;
@@ -853,7 +853,7 @@ class TaskMateChildCard extends LitElement {
         font-size: 0.72rem;
         font-weight: 600;
         color: var(--secondary-text-color);
-        background: rgba(0,0,0,0.06);
+        background: color-mix(in srgb, var(--primary-text-color, #212121) 8%, transparent);
         border-radius: 8px;
         padding: 1px 6px;
         margin-top: 3px;

--- a/custom_components/taskmate/www/taskmate-reward-progress-card.js
+++ b/custom_components/taskmate/www/taskmate-reward-progress-card.js
@@ -303,11 +303,11 @@ class TaskMateRewardProgressCard extends LitElement {
       }
       .availability-badge.badge-sold-out {
         background: rgba(189,195,199,0.3);
-        color: #7f8c8d;
+        color: var(--secondary-text-color, #757575);
       }
       .availability-badge.badge-expired {
-        background: rgba(52,73,94,0.2);
-        color: #34495e;
+        background: color-mix(in srgb, var(--secondary-text-color, #757575) 20%, transparent);
+        color: var(--secondary-text-color, #757575);
       }
       .availability-badge.badge-low-stock {
         background: rgba(231,76,60,0.18);

--- a/custom_components/taskmate/www/taskmate-rewards-card.js
+++ b/custom_components/taskmate/www/taskmate-rewards-card.js
@@ -215,7 +215,7 @@ class TaskMateRewardsCard extends LitElement {
       .progress-bar {
         flex: 1;
         height: 14px;
-        background: rgba(0, 0, 0, 0.08);
+        background: var(--divider-color, #e0e0e0);
         border-radius: 7px;
         overflow: hidden;
         position: relative;
@@ -322,7 +322,7 @@ class TaskMateRewardsCard extends LitElement {
       .jackpot-progress-bar {
         flex: 1;
         height: 18px;
-        background: rgba(0, 0, 0, 0.08);
+        background: var(--divider-color, #e0e0e0);
         border-radius: 9px;
         overflow: hidden;
         position: relative;
@@ -399,7 +399,7 @@ class TaskMateRewardsCard extends LitElement {
         align-items: center;
         gap: 3px;
         padding: 2px 8px;
-        background: rgba(0, 0, 0, 0.05);
+        background: color-mix(in srgb, var(--primary-text-color, #212121) 8%, transparent);
         border-radius: 10px;
         font-weight: 500;
       }
@@ -543,11 +543,11 @@ class TaskMateRewardsCard extends LitElement {
       }
       .availability-badge.badge-sold-out {
         background: rgba(189,195,199,0.25);
-        color: #7f8c8d;
+        color: var(--secondary-text-color, #757575);
       }
       .availability-badge.badge-expired {
-        background: rgba(52,73,94,0.18);
-        color: #34495e;
+        background: color-mix(in srgb, var(--secondary-text-color, #757575) 18%, transparent);
+        color: var(--secondary-text-color, #757575);
       }
       .availability-badge.badge-low-stock {
         background: rgba(231,76,60,0.15);


### PR DESCRIPTION
## Summary

Makes TaskMate Lovelace cards render correctly when HA's theme is set to Dark (Settings > General > Theme).

### What was broken
- Progress bar tracks in rewards card used `rgba(0,0,0,0.08)` — invisible on dark surfaces
- Availability badges (sold-out, expired) used hardcoded dark grey text (`#7f8c8d`, `#34495e`) — invisible on dark backgrounds
- Recurrence label pill backgrounds in child card used `rgba(0,0,0,0.06)` — invisible on dark surfaces

### What was already working
- 14 of 17 cards already use HA CSS variables (`--card-background-color`, `--primary-text-color`, `--divider-color`, etc.) correctly
- Accent/brand colours (pink, blue, green, gold badges, gradient circles) work on both light and dark

### Fix
- Replace progress bar track backgrounds with `var(--divider-color, #e0e0e0)`
- Replace hardcoded badge text colours with `var(--secondary-text-color, #757575)`
- Replace `rgba(0,0,0,...)` pill backgrounds with `color-mix()` using HA text colour variables

## Files changed
- `taskmate-rewards-card.js` — progress bars + availability badges
- `taskmate-reward-progress-card.js` — availability badges
- `taskmate-child-card.js` — recurrence label backgrounds

## Test plan
- [ ] Set HA theme to Light — verify cards render identically to before
- [ ] Set HA theme to Dark — verify text is readable, progress bar tracks visible, badges have contrast
- [ ] Set HA theme to Auto — verify it follows system preference