### PR TITLE
fix(points-display): render avatar as ha-icon instead of broken img tag

### DIFF
--- a/custom_components/taskmate/www/taskmate-points-display-card.js
+++ b/custom_components/taskmate/www/taskmate-points-display-card.js
@@ -56,6 +56,8 @@ function weeklyPoints(child) {
 }
 
 function childAvatar(child, colour) {
+  const av = child.avatar || "mdi:account-circle";
+  const isIcon = av.startsWith("mdi:");
   const initials = (child.name || "?")
     .split(" ")
     .map(w => w[0])
@@ -64,9 +66,11 @@ function childAvatar(child, colour) {
     .toUpperCase();
   return html`
     <div class="avatar" style="background:${colour}">
-      ${child.avatar
-        ? html`<img src="${child.avatar}" alt="${child.name}">`
-        : initials}
+      ${isIcon
+        ? html`<ha-icon icon="${av}"></ha-icon>`
+        : av
+          ? html`<img src="${av}" alt="${child.name}">`
+          : initials}
     </div>`;
 }
 
@@ -149,6 +153,10 @@ class TaskMatePointsDisplayCard extends LitElement {
         flex-shrink: 0;
         overflow: hidden;
       }
+      .avatar ha-icon {
+        --mdc-icon-size: 32px;
+        color: white;
+      }
       .avatar img {
         width: 100%;
         height: 100%;
@@ -177,6 +185,9 @@ class TaskMatePointsDisplayCard extends LitElement {
         height: 80px;
         font-size: 1.8rem;
         box-shadow: 0 4px 16px rgba(0,0,0,0.15);
+      }
+      .single-wrap .avatar ha-icon {
+        --mdc-icon-size: 48px;
       }
       .child-name {
         font-size: 1.25rem;


### PR DESCRIPTION
## Summary

- The `childAvatar()` helper was rendering `<img src="mdi:account-circle">` which is not a valid URL — the avatar field stores MDI icon strings, not image paths
- This caused a broken image icon and layout disruption (name overlapping the avatar circle)
- Now renders `<ha-icon>` for MDI values, matching how `taskmate-child-card.js` handles avatars
- Properly sized icons: 32px for standard avatars, 48px for the larger single-mode avatar

## Test plan

- [ ] Open a dashboard with `taskmate-points-display-card` in single mode — avatar should show the MDI icon in a coloured circle with the name properly centered below
- [ ] Check multi mode — each child tile should show the correct icon
- [ ] Check cumulative mode — row avatars should render correctly