### PR TITLE
feat(children): availability sensor inversion and dual-sensor support

### DIFF
--- a/custom_components/taskmate/config_flow.py
+++ b/custom_components/taskmate/config_flow.py
@@ -262,6 +262,8 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
                     name=name,
                     avatar=user_input.get("avatar", "mdi:account-circle"),
                     availability_entity=user_input.get("availability_entity", "") or "",
+                    availability_inverted=user_input.get("availability_inverted", False),
+                    unavailability_entity=user_input.get("unavailability_entity", "") or "",
                 )
                 return await self.async_step_manage_children()
 
@@ -280,6 +282,10 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
                         )
                     ),
                     vol.Optional("availability_entity", default=""): selector.EntitySelector(
+                        selector.EntitySelectorConfig()
+                    ),
+                    vol.Optional("availability_inverted", default=False): selector.BooleanSelector(),
+                    vol.Optional("unavailability_entity", default=""): selector.EntitySelector(
                         selector.EntitySelectorConfig()
                     ),
                 }
@@ -303,6 +309,10 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
             child.availability_entity = (
                 user_input.get("availability_entity", "") or ""
             )
+            child.availability_inverted = user_input.get("availability_inverted", False)
+            child.unavailability_entity = (
+                user_input.get("unavailability_entity", "") or ""
+            )
             await self.coordinator.async_update_child(child)
             return await self.async_step_manage_children()
 
@@ -312,6 +322,13 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
             vol.Optional("availability_entity", default=availability_default)
             if availability_default
             else vol.Optional("availability_entity")
+        )
+        inverted_default = getattr(child, "availability_inverted", False)
+        unavailability_default = getattr(child, "unavailability_entity", "") or ""
+        unavailability_key = (
+            vol.Optional("unavailability_entity", default=unavailability_default)
+            if unavailability_default
+            else vol.Optional("unavailability_entity")
         )
 
         return self.async_show_form(
@@ -329,6 +346,10 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
                         )
                     ),
                     availability_key: selector.EntitySelector(
+                        selector.EntitySelectorConfig()
+                    ),
+                    vol.Optional("availability_inverted", default=inverted_default): selector.BooleanSelector(),
+                    unavailability_key: selector.EntitySelector(
                         selector.EntitySelectorConfig()
                     ),
                 }

--- a/custom_components/taskmate/coordinator.py
+++ b/custom_components/taskmate/coordinator.py
@@ -296,9 +296,17 @@ class TaskMateCoordinator(DataUpdateCoordinator):
         name: str,
         avatar: str = "mdi:account-circle",
         availability_entity: str = "",
+        availability_inverted: bool = False,
+        unavailability_entity: str = "",
     ) -> Child:
         """Add a new child."""
-        child = Child(name=name, avatar=avatar, availability_entity=availability_entity)
+        child = Child(
+            name=name,
+            avatar=avatar,
+            availability_entity=availability_entity,
+            availability_inverted=availability_inverted,
+            unavailability_entity=unavailability_entity,
+        )
         self.storage.add_child(child)
         await self.storage.async_save()
         await self.async_refresh()

--- a/custom_components/taskmate/coordinator.py
+++ b/custom_components/taskmate/coordinator.py
@@ -98,11 +98,12 @@ class TaskMateCoordinator(DataUpdateCoordinator):
         entity_id = data.get("entity_id")
         if not entity_id:
             return
-        tracked = {
-            c.availability_entity
-            for c in self.storage.get_children()
-            if getattr(c, "availability_entity", "")
-        }
+        tracked: set[str] = set()
+        for c in self.storage.get_children():
+            if getattr(c, "availability_entity", ""):
+                tracked.add(c.availability_entity)
+            if getattr(c, "unavailability_entity", ""):
+                tracked.add(c.unavailability_entity)
         if entity_id not in tracked:
             return
         self.hass.async_create_task(self._async_reevaluate_availability())
@@ -826,31 +827,53 @@ class TaskMateCoordinator(DataUpdateCoordinator):
     })
 
     def _is_child_available(self, child_id: str) -> bool:
-        """Return True if the child's availability entity reports them as available.
+        """Return True when the child should receive chores today.
 
-        Rules:
-          - Empty/missing availability_entity on the child → True (no opinion).
-          - Entity not registered, or state is unavailable/unknown/None → True
-            (fail-open; don't block on a broken sensor).
-          - State (case-insensitive) in {"on", "home", "available", "present",
-            "true"} → True. Everything else (e.g. "off", "not_home", "away")
-            → False.
+        Two-step evaluation:
+          1. availability_entity  — fail-open; if inverted, _AVAILABLE_STATES means BUSY.
+             Inversion only applies to real states, not broken/missing sensors.
+          2. unavailability_entity — neutral when missing; _AVAILABLE_STATES means BUSY.
+        Final = step1 AND NOT step2.
         """
         child = self.storage.get_child(child_id)
         if not child:
             return True
+
+        # Step 1: availability sensor (fail-open when broken/missing)
+        avail_ok = True
         entity_id = getattr(child, "availability_entity", "") or ""
-        if not entity_id:
-            return True
+        if entity_id:
+            raw = self._read_entity_active(entity_id)
+            if raw is not None:
+                avail_ok = raw
+                if getattr(child, "availability_inverted", False):
+                    avail_ok = not avail_ok
+
+        # Step 2: unavailability sensor (neutral when broken/missing)
+        busy = False
+        unav_id = getattr(child, "unavailability_entity", "") or ""
+        if unav_id:
+            raw = self._read_entity_active(unav_id)
+            if raw is not None:
+                busy = raw
+
+        return avail_ok and not busy
+
+    def _read_entity_active(self, entity_id: str) -> bool | None:
+        """Read an entity's state and return True if it's in _AVAILABLE_STATES,
+        False if it's a real state not in the set, or None if the entity is
+        missing/broken (unavailable/unknown/None) so callers can apply their
+        own default.
+        """
         state_obj = self.hass.states.get(entity_id)
         if state_obj is None:
-            return True
+            return None
         raw = getattr(state_obj, "state", None)
         if raw is None:
-            return True
+            return None
         value = str(raw).strip().lower()
         if value in ("unavailable", "unknown", "none", ""):
-            return True
+            return None
         return value in self._AVAILABLE_STATES
 
     def _chore_assignment_pool(self, chore: Chore) -> list[str]:

--- a/custom_components/taskmate/models.py
+++ b/custom_components/taskmate/models.py
@@ -76,6 +76,8 @@ class Child:
     streak_milestones_achieved: list[int] = field(default_factory=list)
     awarded_perfect_weeks: list[str] = field(default_factory=list)
     availability_entity: str = ""  # HA entity id; empty = always available
+    availability_inverted: bool = False  # When True, _AVAILABLE_STATES means UNAVAILABLE
+    unavailability_entity: str = ""  # Second HA entity; _AVAILABLE_STATES = child is busy
     id: str = field(default_factory=generate_id)
 
     @classmethod
@@ -96,6 +98,8 @@ class Child:
             streak_milestones_achieved=list(data.get("streak_milestones_achieved", [])),
             awarded_perfect_weeks=list(data.get("awarded_perfect_weeks", [])),
             availability_entity=data.get("availability_entity", ""),
+            availability_inverted=data.get("availability_inverted", False),
+            unavailability_entity=data.get("unavailability_entity", ""),
             id=data.get("id", generate_id()),
         )
 
@@ -116,6 +120,8 @@ class Child:
             "streak_milestones_achieved": self.streak_milestones_achieved,
             "awarded_perfect_weeks": self.awarded_perfect_weeks,
             "availability_entity": self.availability_entity,
+            "availability_inverted": self.availability_inverted,
+            "unavailability_entity": self.unavailability_entity,
             "id": self.id,
         }
 

--- a/custom_components/taskmate/strings.json
+++ b/custom_components/taskmate/strings.json
@@ -44,10 +44,14 @@
         "data": {
           "name": "Child's Name",
           "avatar": "Avatar",
-          "availability_entity": "Availability Sensor (optional)"
+          "availability_entity": "Availability Sensor (optional)",
+          "availability_inverted": "Invert availability logic",
+          "unavailability_entity": "Unavailability Sensor (optional)"
         },
         "data_description": {
-          "availability_entity": "Optional Home Assistant entity whose state tells TaskMate whether this child is available. States 'on', 'home', 'available', 'present', or 'true' mean available; anything else (e.g. 'off', 'not_home', 'away') means unavailable. Leave blank to treat the child as always available. For calendars, wire up a template binary sensor since a calendar event usually means 'busy / unavailable'."
+          "availability_entity": "Optional Home Assistant entity whose state tells TaskMate whether this child is available. States 'on', 'home', 'available', 'present', or 'true' mean available; anything else (e.g. 'off', 'not_home', 'away') means unavailable. Leave blank to treat the child as always available. For calendars, wire up a template binary sensor since a calendar event usually means 'busy / unavailable'.",
+          "availability_inverted": "When on, an active state (on/home/available) on the Availability Sensor means the child is unavailable. Use this for calendar or schedule sensors where an event means the child is busy.",
+          "unavailability_entity": "A second sensor that indicates when the child is busy. An active state (on/home/available) on this sensor means unavailable. Useful for school calendars or schedule sensors. The child is only available when the Availability Sensor says available AND this sensor does not say busy."
         }
       },
       "edit_child": {
@@ -56,10 +60,14 @@
         "data": {
           "name": "Child's Name",
           "avatar": "Avatar",
-          "availability_entity": "Availability Sensor (optional)"
+          "availability_entity": "Availability Sensor (optional)",
+          "availability_inverted": "Invert availability logic",
+          "unavailability_entity": "Unavailability Sensor (optional)"
         },
         "data_description": {
-          "availability_entity": "Optional Home Assistant entity whose state tells TaskMate whether this child is available. States 'on', 'home', 'available', 'present', or 'true' mean available; anything else (e.g. 'off', 'not_home', 'away') means unavailable. Leave blank to treat the child as always available."
+          "availability_entity": "Optional Home Assistant entity whose state tells TaskMate whether this child is available. States 'on', 'home', 'available', 'present', or 'true' mean available; anything else (e.g. 'off', 'not_home', 'away') means unavailable. Leave blank to treat the child as always available.",
+          "availability_inverted": "When on, an active state (on/home/available) on the Availability Sensor means the child is unavailable. Use this for calendar or schedule sensors where an event means the child is busy.",
+          "unavailability_entity": "A second sensor that indicates when the child is busy. An active state (on/home/available) on this sensor means unavailable. Useful for school calendars or schedule sensors. The child is only available when the Availability Sensor says available AND this sensor does not say busy."
         }
       },
       "confirm_delete_child": {

--- a/custom_components/taskmate/translations/en-GB.json
+++ b/custom_components/taskmate/translations/en-GB.json
@@ -43,10 +43,14 @@
         "data": {
           "name": "Child's Name",
           "avatar": "Avatar",
-          "availability_entity": "Availability Sensor (optional)"
+          "availability_entity": "Availability Sensor (optional)",
+          "availability_inverted": "Invert availability logic",
+          "unavailability_entity": "Unavailability Sensor (optional)"
         },
         "data_description": {
-          "availability_entity": "Optional Home Assistant entity whose state tells TaskMate whether this child is available. States 'on', 'home', 'available', 'present', or 'true' mean available; anything else (e.g. 'off', 'not_home', 'away') means unavailable. Leave blank to treat the child as always available. For calendars, wire up a template binary sensor since a calendar event usually means 'busy / unavailable'."
+          "availability_entity": "Optional Home Assistant entity whose state tells TaskMate whether this child is available. States 'on', 'home', 'available', 'present', or 'true' mean available; anything else (e.g. 'off', 'not_home', 'away') means unavailable. Leave blank to treat the child as always available. For calendars, wire up a template binary sensor since a calendar event usually means 'busy / unavailable'.",
+          "availability_inverted": "When on, an active state (on/home/available) on the Availability Sensor means the child is unavailable. Use this for calendar or schedule sensors where an event means the child is busy.",
+          "unavailability_entity": "A second sensor that indicates when the child is busy. An active state (on/home/available) on this sensor means unavailable. Useful for school calendars or schedule sensors. The child is only available when the Availability Sensor says available AND this sensor does not say busy."
         }
       },
       "edit_child": {
@@ -55,10 +59,14 @@
         "data": {
           "name": "Child's Name",
           "avatar": "Avatar",
-          "availability_entity": "Availability Sensor (optional)"
+          "availability_entity": "Availability Sensor (optional)",
+          "availability_inverted": "Invert availability logic",
+          "unavailability_entity": "Unavailability Sensor (optional)"
         },
         "data_description": {
-          "availability_entity": "Optional Home Assistant entity whose state tells TaskMate whether this child is available. States 'on', 'home', 'available', 'present', or 'true' mean available; anything else (e.g. 'off', 'not_home', 'away') means unavailable. Leave blank to treat the child as always available."
+          "availability_entity": "Optional Home Assistant entity whose state tells TaskMate whether this child is available. States 'on', 'home', 'available', 'present', or 'true' mean available; anything else (e.g. 'off', 'not_home', 'away') means unavailable. Leave blank to treat the child as always available.",
+          "availability_inverted": "When on, an active state (on/home/available) on the Availability Sensor means the child is unavailable. Use this for calendar or schedule sensors where an event means the child is busy.",
+          "unavailability_entity": "A second sensor that indicates when the child is busy. An active state (on/home/available) on this sensor means unavailable. Useful for school calendars or schedule sensors. The child is only available when the Availability Sensor says available AND this sensor does not say busy."
         }
       },
       "confirm_delete_child": {

--- a/custom_components/taskmate/translations/en.json
+++ b/custom_components/taskmate/translations/en.json
@@ -43,10 +43,14 @@
         "data": {
           "name": "Child's Name",
           "avatar": "Avatar",
-          "availability_entity": "Availability Sensor (optional)"
+          "availability_entity": "Availability Sensor (optional)",
+          "availability_inverted": "Invert availability logic",
+          "unavailability_entity": "Unavailability Sensor (optional)"
         },
         "data_description": {
-          "availability_entity": "Optional Home Assistant entity whose state tells TaskMate whether this child is available. States 'on', 'home', 'available', 'present', or 'true' mean available; anything else (e.g. 'off', 'not_home', 'away') means unavailable. Leave blank to treat the child as always available. For calendars, wire up a template binary sensor since a calendar event usually means 'busy / unavailable'."
+          "availability_entity": "Optional Home Assistant entity whose state tells TaskMate whether this child is available. States 'on', 'home', 'available', 'present', or 'true' mean available; anything else (e.g. 'off', 'not_home', 'away') means unavailable. Leave blank to treat the child as always available. For calendars, wire up a template binary sensor since a calendar event usually means 'busy / unavailable'.",
+          "availability_inverted": "When on, an active state (on/home/available) on the Availability Sensor means the child is unavailable. Use this for calendar or schedule sensors where an event means the child is busy.",
+          "unavailability_entity": "A second sensor that indicates when the child is busy. An active state (on/home/available) on this sensor means unavailable. Useful for school calendars or schedule sensors. The child is only available when the Availability Sensor says available AND this sensor does not say busy."
         }
       },
       "edit_child": {
@@ -55,10 +59,14 @@
         "data": {
           "name": "Child's Name",
           "avatar": "Avatar",
-          "availability_entity": "Availability Sensor (optional)"
+          "availability_entity": "Availability Sensor (optional)",
+          "availability_inverted": "Invert availability logic",
+          "unavailability_entity": "Unavailability Sensor (optional)"
         },
         "data_description": {
-          "availability_entity": "Optional Home Assistant entity whose state tells TaskMate whether this child is available. States 'on', 'home', 'available', 'present', or 'true' mean available; anything else (e.g. 'off', 'not_home', 'away') means unavailable. Leave blank to treat the child as always available."
+          "availability_entity": "Optional Home Assistant entity whose state tells TaskMate whether this child is available. States 'on', 'home', 'available', 'present', or 'true' mean available; anything else (e.g. 'off', 'not_home', 'away') means unavailable. Leave blank to treat the child as always available.",
+          "availability_inverted": "When on, an active state (on/home/available) on the Availability Sensor means the child is unavailable. Use this for calendar or schedule sensors where an event means the child is busy.",
+          "unavailability_entity": "A second sensor that indicates when the child is busy. An active state (on/home/available) on this sensor means unavailable. Useful for school calendars or schedule sensors. The child is only available when the Availability Sensor says available AND this sensor does not say busy."
         }
       },
       "confirm_delete_child": {

--- a/custom_components/taskmate/translations/fr.json
+++ b/custom_components/taskmate/translations/fr.json
@@ -43,10 +43,14 @@
         "data": {
           "name": "Nom de l'enfant",
           "avatar": "Avatar",
-          "availability_entity": "Capteur de disponibilité (optionnel)"
+          "availability_entity": "Capteur de disponibilité (optionnel)",
+          "availability_inverted": "Invert availability logic",
+          "unavailability_entity": "Unavailability Sensor (optional)"
         },
         "data_description": {
-          "availability_entity": "Entité Home Assistant optionnelle dont l'état indique à TaskMate si cet enfant est disponible. Les états 'on', 'home', 'available', 'present' ou 'true' signifient disponible ; tout autre état (ex. 'off', 'not_home', 'away') signifie indisponible. Laissez vide pour considérer l'enfant comme toujours disponible. Pour les calendriers, utilisez un capteur binaire modèle puisqu'un événement de calendrier signifie généralement 'occupé / indisponible'."
+          "availability_entity": "Entité Home Assistant optionnelle dont l'état indique à TaskMate si cet enfant est disponible. Les états 'on', 'home', 'available', 'present' ou 'true' signifient disponible ; tout autre état (ex. 'off', 'not_home', 'away') signifie indisponible. Laissez vide pour considérer l'enfant comme toujours disponible. Pour les calendriers, utilisez un capteur binaire modèle puisqu'un événement de calendrier signifie généralement 'occupé / indisponible'.",
+          "availability_inverted": "When on, an active state (on/home/available) on the Availability Sensor means the child is unavailable. Use this for calendar or schedule sensors where an event means the child is busy.",
+          "unavailability_entity": "A second sensor that indicates when the child is busy. An active state (on/home/available) on this sensor means unavailable. Useful for school calendars or schedule sensors. The child is only available when the Availability Sensor says available AND this sensor does not say busy."
         }
       },
       "edit_child": {
@@ -55,10 +59,14 @@
         "data": {
           "name": "Nom de l'enfant",
           "avatar": "Avatar",
-          "availability_entity": "Capteur de disponibilité (optionnel)"
+          "availability_entity": "Capteur de disponibilité (optionnel)",
+          "availability_inverted": "Invert availability logic",
+          "unavailability_entity": "Unavailability Sensor (optional)"
         },
         "data_description": {
-          "availability_entity": "Entité Home Assistant optionnelle dont l'état indique à TaskMate si cet enfant est disponible. Les états 'on', 'home', 'available', 'present' ou 'true' signifient disponible ; tout autre état (ex. 'off', 'not_home', 'away') signifie indisponible. Laissez vide pour considérer l'enfant comme toujours disponible."
+          "availability_entity": "Entité Home Assistant optionnelle dont l'état indique à TaskMate si cet enfant est disponible. Les états 'on', 'home', 'available', 'present' ou 'true' signifient disponible ; tout autre état (ex. 'off', 'not_home', 'away') signifie indisponible. Laissez vide pour considérer l'enfant comme toujours disponible.",
+          "availability_inverted": "When on, an active state (on/home/available) on the Availability Sensor means the child is unavailable. Use this for calendar or schedule sensors where an event means the child is busy.",
+          "unavailability_entity": "A second sensor that indicates when the child is busy. An active state (on/home/available) on this sensor means unavailable. Useful for school calendars or schedule sensors. The child is only available when the Availability Sensor says available AND this sensor does not say busy."
         }
       },
       "confirm_delete_child": {

--- a/custom_components/taskmate/translations/nb.json
+++ b/custom_components/taskmate/translations/nb.json
@@ -43,10 +43,14 @@
         "data": {
           "name": "Barnets navn",
           "avatar": "Avatar",
-          "availability_entity": "Tilgjengelighetssensor (valgfritt)"
+          "availability_entity": "Tilgjengelighetssensor (valgfritt)",
+          "availability_inverted": "Invert availability logic",
+          "unavailability_entity": "Unavailability Sensor (optional)"
         },
         "data_description": {
-          "availability_entity": "Valgfri Home Assistant-entitet hvis tilstand forteller TaskMate om dette barnet er tilgjengelig. Tilstandene 'on', 'home', 'available', 'present' eller 'true' betyr tilgjengelig; alt annet (f.eks. 'off', 'not_home', 'away') betyr utilgjengelig. La stå tom for å behandle barnet som alltid tilgjengelig. For kalendere, bruk en template binary sensor siden en kalenderhendelse vanligvis betyr 'opptatt / utilgjengelig'."
+          "availability_entity": "Valgfri Home Assistant-entitet hvis tilstand forteller TaskMate om dette barnet er tilgjengelig. Tilstandene 'on', 'home', 'available', 'present' eller 'true' betyr tilgjengelig; alt annet (f.eks. 'off', 'not_home', 'away') betyr utilgjengelig. La stå tom for å behandle barnet som alltid tilgjengelig. For kalendere, bruk en template binary sensor siden en kalenderhendelse vanligvis betyr 'opptatt / utilgjengelig'.",
+          "availability_inverted": "When on, an active state (on/home/available) on the Availability Sensor means the child is unavailable. Use this for calendar or schedule sensors where an event means the child is busy.",
+          "unavailability_entity": "A second sensor that indicates when the child is busy. An active state (on/home/available) on this sensor means unavailable. Useful for school calendars or schedule sensors. The child is only available when the Availability Sensor says available AND this sensor does not say busy."
         }
       },
       "edit_child": {
@@ -55,10 +59,14 @@
         "data": {
           "name": "Barnets navn",
           "avatar": "Avatar",
-          "availability_entity": "Tilgjengelighetssensor (valgfritt)"
+          "availability_entity": "Tilgjengelighetssensor (valgfritt)",
+          "availability_inverted": "Invert availability logic",
+          "unavailability_entity": "Unavailability Sensor (optional)"
         },
         "data_description": {
-          "availability_entity": "Valgfri Home Assistant-entitet hvis tilstand forteller TaskMate om dette barnet er tilgjengelig. Tilstandene 'on', 'home', 'available', 'present' eller 'true' betyr tilgjengelig; alt annet (f.eks. 'off', 'not_home', 'away') betyr utilgjengelig. La stå tom for å behandle barnet som alltid tilgjengelig."
+          "availability_entity": "Valgfri Home Assistant-entitet hvis tilstand forteller TaskMate om dette barnet er tilgjengelig. Tilstandene 'on', 'home', 'available', 'present' eller 'true' betyr tilgjengelig; alt annet (f.eks. 'off', 'not_home', 'away') betyr utilgjengelig. La stå tom for å behandle barnet som alltid tilgjengelig.",
+          "availability_inverted": "When on, an active state (on/home/available) on the Availability Sensor means the child is unavailable. Use this for calendar or schedule sensors where an event means the child is busy.",
+          "unavailability_entity": "A second sensor that indicates when the child is busy. An active state (on/home/available) on this sensor means unavailable. Useful for school calendars or schedule sensors. The child is only available when the Availability Sensor says available AND this sensor does not say busy."
         }
       },
       "confirm_delete_child": {

--- a/custom_components/taskmate/translations/nn.json
+++ b/custom_components/taskmate/translations/nn.json
@@ -43,10 +43,14 @@
         "data": {
           "name": "Namnet til bornet",
           "avatar": "Avatar",
-          "availability_entity": "Tilgjengesensor (valfritt)"
+          "availability_entity": "Tilgjengesensor (valfritt)",
+          "availability_inverted": "Invert availability logic",
+          "unavailability_entity": "Unavailability Sensor (optional)"
         },
         "data_description": {
-          "availability_entity": "Valfri Home Assistant-entitet som med tilstanden si fortel TaskMate om dette bornet er tilgjengeleg. Tilstandane 'on', 'home', 'available', 'present' eller 'true' tyder tilgjengeleg; alt anna (t.d. 'off', 'not_home', 'away') tyder utilgjengeleg. Lat stå tom for å handsame bornet som alltid tilgjengeleg. For kalenderar, bruk ein template binary sensor sidan ei kalenderhending oftast tyder 'oppteken / utilgjengeleg'."
+          "availability_entity": "Valfri Home Assistant-entitet som med tilstanden si fortel TaskMate om dette bornet er tilgjengeleg. Tilstandane 'on', 'home', 'available', 'present' eller 'true' tyder tilgjengeleg; alt anna (t.d. 'off', 'not_home', 'away') tyder utilgjengeleg. Lat stå tom for å handsame bornet som alltid tilgjengeleg. For kalenderar, bruk ein template binary sensor sidan ei kalenderhending oftast tyder 'oppteken / utilgjengeleg'.",
+          "availability_inverted": "When on, an active state (on/home/available) on the Availability Sensor means the child is unavailable. Use this for calendar or schedule sensors where an event means the child is busy.",
+          "unavailability_entity": "A second sensor that indicates when the child is busy. An active state (on/home/available) on this sensor means unavailable. Useful for school calendars or schedule sensors. The child is only available when the Availability Sensor says available AND this sensor does not say busy."
         }
       },
       "edit_child": {
@@ -55,10 +59,14 @@
         "data": {
           "name": "Namnet til bornet",
           "avatar": "Avatar",
-          "availability_entity": "Tilgjengesensor (valfritt)"
+          "availability_entity": "Tilgjengesensor (valfritt)",
+          "availability_inverted": "Invert availability logic",
+          "unavailability_entity": "Unavailability Sensor (optional)"
         },
         "data_description": {
-          "availability_entity": "Valfri Home Assistant-entitet som med tilstanden si fortel TaskMate om dette bornet er tilgjengeleg. Tilstandane 'on', 'home', 'available', 'present' eller 'true' tyder tilgjengeleg; alt anna (t.d. 'off', 'not_home', 'away') tyder utilgjengeleg. Lat stå tom for å handsame bornet som alltid tilgjengeleg."
+          "availability_entity": "Valfri Home Assistant-entitet som med tilstanden si fortel TaskMate om dette bornet er tilgjengeleg. Tilstandane 'on', 'home', 'available', 'present' eller 'true' tyder tilgjengeleg; alt anna (t.d. 'off', 'not_home', 'away') tyder utilgjengeleg. Lat stå tom for å handsame bornet som alltid tilgjengeleg.",
+          "availability_inverted": "When on, an active state (on/home/available) on the Availability Sensor means the child is unavailable. Use this for calendar or schedule sensors where an event means the child is busy.",
+          "unavailability_entity": "A second sensor that indicates when the child is busy. An active state (on/home/available) on this sensor means unavailable. Useful for school calendars or schedule sensors. The child is only available when the Availability Sensor says available AND this sensor does not say busy."
         }
       },
       "confirm_delete_child": {

--- a/custom_components/taskmate/translations/pt-BR.json
+++ b/custom_components/taskmate/translations/pt-BR.json
@@ -43,10 +43,14 @@
         "data": {
           "name": "Nome da criança",
           "avatar": "Avatar",
-          "availability_entity": "Sensor de disponibilidade (opcional)"
+          "availability_entity": "Sensor de disponibilidade (opcional)",
+          "availability_inverted": "Invert availability logic",
+          "unavailability_entity": "Unavailability Sensor (optional)"
         },
         "data_description": {
-          "availability_entity": "Entidade opcional do Home Assistant cujo estado informa ao TaskMate se esta criança está disponível. Os estados 'on', 'home', 'available', 'present' ou 'true' significam disponível; qualquer outro (ex.: 'off', 'not_home', 'away') significa indisponível. Deixe em branco para tratar a criança como sempre disponível. Para calendários, configure um binary sensor por template, já que um evento de calendário normalmente significa 'ocupado / indisponível'."
+          "availability_entity": "Entidade opcional do Home Assistant cujo estado informa ao TaskMate se esta criança está disponível. Os estados 'on', 'home', 'available', 'present' ou 'true' significam disponível; qualquer outro (ex.: 'off', 'not_home', 'away') significa indisponível. Deixe em branco para tratar a criança como sempre disponível. Para calendários, configure um binary sensor por template, já que um evento de calendário normalmente significa 'ocupado / indisponível'.",
+          "availability_inverted": "When on, an active state (on/home/available) on the Availability Sensor means the child is unavailable. Use this for calendar or schedule sensors where an event means the child is busy.",
+          "unavailability_entity": "A second sensor that indicates when the child is busy. An active state (on/home/available) on this sensor means unavailable. Useful for school calendars or schedule sensors. The child is only available when the Availability Sensor says available AND this sensor does not say busy."
         }
       },
       "edit_child": {
@@ -55,10 +59,14 @@
         "data": {
           "name": "Nome da criança",
           "avatar": "Avatar",
-          "availability_entity": "Sensor de disponibilidade (opcional)"
+          "availability_entity": "Sensor de disponibilidade (opcional)",
+          "availability_inverted": "Invert availability logic",
+          "unavailability_entity": "Unavailability Sensor (optional)"
         },
         "data_description": {
-          "availability_entity": "Entidade opcional do Home Assistant cujo estado informa ao TaskMate se esta criança está disponível. Os estados 'on', 'home', 'available', 'present' ou 'true' significam disponível; qualquer outro (ex.: 'off', 'not_home', 'away') significa indisponível. Deixe em branco para tratar a criança como sempre disponível."
+          "availability_entity": "Entidade opcional do Home Assistant cujo estado informa ao TaskMate se esta criança está disponível. Os estados 'on', 'home', 'available', 'present' ou 'true' significam disponível; qualquer outro (ex.: 'off', 'not_home', 'away') significa indisponível. Deixe em branco para tratar a criança como sempre disponível.",
+          "availability_inverted": "When on, an active state (on/home/available) on the Availability Sensor means the child is unavailable. Use this for calendar or schedule sensors where an event means the child is busy.",
+          "unavailability_entity": "A second sensor that indicates when the child is busy. An active state (on/home/available) on this sensor means unavailable. Useful for school calendars or schedule sensors. The child is only available when the Availability Sensor says available AND this sensor does not say busy."
         }
       },
       "confirm_delete_child": {

--- a/custom_components/taskmate/translations/pt.json
+++ b/custom_components/taskmate/translations/pt.json
@@ -43,10 +43,14 @@
         "data": {
           "name": "Nome da criança",
           "avatar": "Avatar",
-          "availability_entity": "Sensor de disponibilidade (opcional)"
+          "availability_entity": "Sensor de disponibilidade (opcional)",
+          "availability_inverted": "Invert availability logic",
+          "unavailability_entity": "Unavailability Sensor (optional)"
         },
         "data_description": {
-          "availability_entity": "Entidade opcional do Home Assistant cujo estado indica ao TaskMate se esta criança está disponível. Os estados 'on', 'home', 'available', 'present' ou 'true' significam disponível; qualquer outro (ex.: 'off', 'not_home', 'away') significa indisponível. Deixe vazio para tratar a criança como sempre disponível. Para calendários, configure um binary sensor por template, pois um evento de calendário normalmente significa 'ocupado / indisponível'."
+          "availability_entity": "Entidade opcional do Home Assistant cujo estado indica ao TaskMate se esta criança está disponível. Os estados 'on', 'home', 'available', 'present' ou 'true' significam disponível; qualquer outro (ex.: 'off', 'not_home', 'away') significa indisponível. Deixe vazio para tratar a criança como sempre disponível. Para calendários, configure um binary sensor por template, pois um evento de calendário normalmente significa 'ocupado / indisponível'.",
+          "availability_inverted": "When on, an active state (on/home/available) on the Availability Sensor means the child is unavailable. Use this for calendar or schedule sensors where an event means the child is busy.",
+          "unavailability_entity": "A second sensor that indicates when the child is busy. An active state (on/home/available) on this sensor means unavailable. Useful for school calendars or schedule sensors. The child is only available when the Availability Sensor says available AND this sensor does not say busy."
         }
       },
       "edit_child": {
@@ -55,10 +59,14 @@
         "data": {
           "name": "Nome da criança",
           "avatar": "Avatar",
-          "availability_entity": "Sensor de disponibilidade (opcional)"
+          "availability_entity": "Sensor de disponibilidade (opcional)",
+          "availability_inverted": "Invert availability logic",
+          "unavailability_entity": "Unavailability Sensor (optional)"
         },
         "data_description": {
-          "availability_entity": "Entidade opcional do Home Assistant cujo estado indica ao TaskMate se esta criança está disponível. Os estados 'on', 'home', 'available', 'present' ou 'true' significam disponível; qualquer outro (ex.: 'off', 'not_home', 'away') significa indisponível. Deixe vazio para tratar a criança como sempre disponível."
+          "availability_entity": "Entidade opcional do Home Assistant cujo estado indica ao TaskMate se esta criança está disponível. Os estados 'on', 'home', 'available', 'present' ou 'true' significam disponível; qualquer outro (ex.: 'off', 'not_home', 'away') significa indisponível. Deixe vazio para tratar a criança como sempre disponível.",
+          "availability_inverted": "When on, an active state (on/home/available) on the Availability Sensor means the child is unavailable. Use this for calendar or schedule sensors where an event means the child is busy.",
+          "unavailability_entity": "A second sensor that indicates when the child is busy. An active state (on/home/available) on this sensor means unavailable. Useful for school calendars or schedule sensors. The child is only available when the Availability Sensor says available AND this sensor does not say busy."
         }
       },
       "confirm_delete_child": {

--- a/custom_components/taskmate/websocket.py
+++ b/custom_components/taskmate/websocket.py
@@ -196,6 +196,8 @@ async def _ws_get_state(hass, connection, msg, coordinator):
     vol.Required("name"): vol.All(str, vol.Length(min=1, max=120)),
     vol.Optional("avatar", default="mdi:account-circle"): str,
     vol.Optional("availability_entity", default=""): str,
+    vol.Optional("availability_inverted", default=False): bool,
+    vol.Optional("unavailability_entity", default=""): str,
 })
 @websocket_api.async_response
 @_admin_only
@@ -204,6 +206,8 @@ async def _ws_add_child(hass, connection, msg, coordinator):
         name=msg["name"].strip(),
         avatar=msg.get("avatar") or "mdi:account-circle",
         availability_entity=_opt_str(msg.get("availability_entity")),
+        availability_inverted=bool(msg.get("availability_inverted", False)),
+        unavailability_entity=_opt_str(msg.get("unavailability_entity")),
     )
     connection.send_result(msg["id"], {"id": child.id})
 
@@ -214,6 +218,8 @@ async def _ws_add_child(hass, connection, msg, coordinator):
     vol.Optional("name"): vol.All(str, vol.Length(min=1, max=120)),
     vol.Optional("avatar"): str,
     vol.Optional("availability_entity"): str,
+    vol.Optional("availability_inverted"): bool,
+    vol.Optional("unavailability_entity"): str,
 })
 @websocket_api.async_response
 @_admin_only
@@ -228,6 +234,10 @@ async def _ws_update_child(hass, connection, msg, coordinator):
         existing.avatar = msg["avatar"] or "mdi:account-circle"
     if "availability_entity" in msg:
         existing.availability_entity = _opt_str(msg["availability_entity"])
+    if "availability_inverted" in msg:
+        existing.availability_inverted = bool(msg["availability_inverted"])
+    if "unavailability_entity" in msg:
+        existing.unavailability_entity = _opt_str(msg["unavailability_entity"])
     await coordinator.async_update_child(existing)
     connection.send_result(msg["id"], {"id": existing.id})
 

--- a/custom_components/taskmate/www/taskmate-panel.js
+++ b/custom_components/taskmate/www/taskmate-panel.js
@@ -498,10 +498,13 @@ class TaskMatePanel extends HTMLElement {
       this._openDialog({ kind: "child", mode: "edit", data: {
         id: c.id, name: c.name || "", avatar: c.avatar || "mdi:account-circle",
         availability_entity: c.availability_entity || "",
+        availability_inverted: !!c.availability_inverted,
+        unavailability_entity: c.unavailability_entity || "",
       } });
     } else {
       this._openDialog({ kind: "child", mode: "add", data: {
         name: "", avatar: "mdi:account-circle", availability_entity: "",
+        availability_inverted: false, unavailability_entity: "",
       } });
     }
   }
@@ -511,8 +514,12 @@ class TaskMatePanel extends HTMLElement {
     if (!d.name || !d.name.trim()) { this._showToast("err", "Name is required"); return; }
     const wasAdd = this._dialog.mode === "add";
     const payload = wasAdd
-      ? { type: "taskmate/add_child", name: d.name.trim(), avatar: d.avatar || "mdi:account-circle", availability_entity: d.availability_entity || "" }
-      : { type: "taskmate/update_child", child_id: d.id, name: d.name.trim(), avatar: d.avatar || "mdi:account-circle", availability_entity: d.availability_entity || "" };
+      ? { type: "taskmate/add_child", name: d.name.trim(), avatar: d.avatar || "mdi:account-circle",
+          availability_entity: d.availability_entity || "", availability_inverted: !!d.availability_inverted,
+          unavailability_entity: d.unavailability_entity || "" }
+      : { type: "taskmate/update_child", child_id: d.id, name: d.name.trim(), avatar: d.avatar || "mdi:account-circle",
+          availability_entity: d.availability_entity || "", availability_inverted: !!d.availability_inverted,
+          unavailability_entity: d.unavailability_entity || "" };
     const { ok, err } = await this._callWS(payload);
     if (!ok) { this._showToast("err", `Save failed: ${err}`); return; }
     this._closeDialog(true);
@@ -1077,7 +1084,7 @@ class TaskMatePanel extends HTMLElement {
           <div class="tm-avatar">${this._mdi(child.avatar)}</div>
           <div class="tm-child-name">
             <h3>${this._esc(child.name || "(unnamed)")}</h3>
-            <div class="tm-meta">${child.availability_entity ? `<code>${this._esc(child.availability_entity)}</code>` : `No availability sensor`}</div>
+            <div class="tm-meta">${child.availability_entity ? `<code>${this._esc(child.availability_entity)}</code>${child.availability_inverted ? ` <em>(inverted)</em>` : ""}` : `No availability sensor`}${child.unavailability_entity ? ` · Busy: <code>${this._esc(child.unavailability_entity)}</code>` : ""}</div>
           </div>
         </div>
         <div class="tm-stats-row">
@@ -1534,12 +1541,17 @@ class TaskMatePanel extends HTMLElement {
 
   _renderChildDialog() {
     const d = this._dialog.data;
+    const hasAvail = !!(d.availability_entity && d.availability_entity.trim());
     return this._dialogShell(this._dialog.mode === "add" ? "Add child" : "Edit child",
       [
         this._field("Name", "name", d.name, "text", "e.g. Malia"),
         this._iconPickerField("Avatar", "avatar", d.avatar),
         this._entityPickerField("Availability sensor (optional)", "availability_entity", d.availability_entity, ["binary_sensor", "sensor", "input_boolean", "person"],
           "States <code>on</code>, <code>home</code>, <code>available</code>, <code>present</code>, <code>true</code> mean available. Leave blank to treat as always available."),
+        hasAvail ? this._switch("Invert logic (ON = unavailable)", "availability_inverted", d.availability_inverted,
+          "Turn on for calendar or schedule sensors where an active state means the child is busy.") : "",
+        this._entityPickerField("Unavailability sensor (optional)", "unavailability_entity", d.unavailability_entity, ["binary_sensor", "sensor", "input_boolean", "person", "calendar"],
+          "A second sensor where <code>on</code>/<code>active</code> means the child is busy. Useful for school calendars. The child is available only when the availability sensor says available AND this sensor does not say busy."),
       ].join(""),
       `<button class="tm-btn tm-btn-ghost" data-act="close-dialog">Cancel</button>
        <button class="tm-btn" data-act="save-child">Save</button>`


### PR DESCRIPTION
## Summary

- Add `availability_inverted` toggle to flip availability sensor logic (ON = unavailable) for calendar/schedule sensors
- Add `unavailability_entity` as a second sensor where active state means the child is busy
- Final availability = availability check AND NOT unavailability check
- Fully backward-compatible — defaults preserve existing behaviour
- Broken/missing sensors fail safely: availability fails open, unavailability stays neutral
- State change listener now tracks both sensor types for real-time re-evaluation

## Files changed

- `models.py` — Two new fields on Child dataclass
- `coordinator.py` — Rewritten `_is_child_available()` with two-step evaluation, expanded state listener
- `config_flow.py` — New fields in add/edit child forms
- `websocket.py` — New fields in add/update child WS handlers
- `taskmate-panel.js` — Invert toggle + unavailability picker in child editor
- `strings.json` + 7 translation files — New labels and descriptions

## Test plan

- [ ] Add a child with only availability_entity set — behaviour unchanged
- [ ] Toggle invert on: ON state now means unavailable
- [ ] Add unavailability_entity (e.g. school calendar): child hidden when calendar is active
- [ ] Both sensors configured: child available only when presence=home AND calendar=inactive
- [ ] Remove/break a sensor: verify fail-open (availability) and neutral (unavailability) defaults
- [ ] Edit child via config flow and admin panel — both paths save/load correctly