### PR TITLE
chore: bump version to v3.5.0-beta.3

### DIFF
--- a/custom_components/taskmate/manifest.json
+++ b/custom_components/taskmate/manifest.json
@@ -17,5 +17,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/tempus2016/taskmate/issues",
   "requirements": [],
-  "version": "3.5.0-beta.2"
+  "version": "3.5.0-beta.3"
 }


### PR DESCRIPTION
Bump for HACS pre-release install with dark mode CSS variable fix.