### PR TITLE
style(child-card): replace hardcoded colors with HA theme variables

### DIFF
--- a/custom_components/taskmate/www/taskmate-calendar-card.js
+++ b/custom_components/taskmate/www/taskmate-calendar-card.js
@@ -64,10 +64,6 @@ class TaskMateCalendarCard extends LitElement {
     return css`
       :host {
         display: block;
-        --cal-green: #2ecc71;
-        --cal-amber: #f39c12;
-        --cal-grey: #bdc3c7;
-        --cal-blue: #3498db;
       }
 
       ha-card { overflow: hidden; }
@@ -77,8 +73,8 @@ class TaskMateCalendarCard extends LitElement {
         align-items: center;
         justify-content: space-between;
         padding: 14px 18px;
-        background: var(--taskmate-header-bg, #3498db);
-        color: white;
+        background: var(--taskmate-header-bg, var(--primary-color));
+        color: var(--text-primary-color, #fff);
       }
 
       .header-content { display: flex; align-items: center; gap: 10px; }
@@ -138,13 +134,13 @@ class TaskMateCalendarCard extends LitElement {
         width: 34px;
         height: 34px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #9b59b6, #a569bd);
+        background: var(--primary-color);
         display: flex;
         align-items: center;
         justify-content: center;
         flex-shrink: 0;
       }
-      .child-avatar ha-icon { --mdc-icon-size: 20px; color: white; }
+      .child-avatar ha-icon { --mdc-icon-size: 20px; color: var(--text-primary-color, #fff); }
 
       .child-name {
         font-weight: 700;
@@ -170,17 +166,17 @@ class TaskMateCalendarCard extends LitElement {
         align-items: center;
         gap: 8px;
         padding: 6px 10px;
-        background: var(--card-background-color, white);
+        background: var(--card-background-color);
         border-radius: 8px;
-        border-left: 4px solid var(--cal-grey);
+        border-left: 4px solid var(--disabled-text-color);
       }
-      .chore-row.approved { border-left-color: var(--cal-green); }
-      .chore-row.pending  { border-left-color: var(--cal-amber); }
+      .chore-row.approved { border-left-color: var(--success-color, #4caf50); }
+      .chore-row.pending  { border-left-color: var(--warning-color, #ff9800); }
       .chore-row.rotating { opacity: 0.6; font-style: italic; }
 
       .chore-icon { --mdc-icon-size: 18px; color: var(--secondary-text-color); }
-      .chore-icon.approved { color: var(--cal-green); }
-      .chore-icon.pending  { color: var(--cal-amber); }
+      .chore-icon.approved { color: var(--success-color, #4caf50); }
+      .chore-icon.pending  { color: var(--warning-color, #ff9800); }
 
       .chore-name {
         flex: 1;
@@ -196,7 +192,7 @@ class TaskMateCalendarCard extends LitElement {
         color: var(--secondary-text-color);
         font-weight: 600;
       }
-      .chore-points ha-icon { --mdc-icon-size: 14px; color: #f1c40f; }
+      .chore-points ha-icon { --mdc-icon-size: 14px; color: #ca8a04; }
 
       .no-chores {
         padding: 8px 10px;
@@ -215,9 +211,9 @@ class TaskMateCalendarCard extends LitElement {
       }
       .legend-item { display: flex; align-items: center; gap: 4px; }
       .dot { width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0; }
-      .dot.approved { background: var(--cal-green); }
-      .dot.pending  { background: var(--cal-amber); }
-      .dot.due      { background: var(--cal-grey); }
+      .dot.approved { background: var(--success-color, #4caf50); }
+      .dot.pending  { background: var(--warning-color, #ff9800); }
+      .dot.due      { background: var(--disabled-text-color); }
 
       .error-state, .empty-state {
         display: flex; flex-direction: column; align-items: center;
@@ -236,7 +232,7 @@ class TaskMateCalendarCard extends LitElement {
     this.config = {
       title: null,
       child_id: null,
-      header_color: "#3498db",
+      header_color: null,
       ...config,
     };
   }
@@ -416,7 +412,7 @@ class TaskMateCalendarCard extends LitElement {
 
     return html`
       <ha-card>
-        <style>:host { --taskmate-header-bg: ${this.config.header_color || "#3498db"}; }</style>
+        ${this.config.header_color ? html`<style>:host { --taskmate-header-bg: ${this.config.header_color}; }</style>` : ''}
         <div class="card-header">
           <div class="header-content">
             <ha-icon class="header-icon" icon="mdi:calendar-account"></ha-icon>

--- a/custom_components/taskmate/www/taskmate-child-card.js
+++ b/custom_components/taskmate/www/taskmate-child-card.js
@@ -405,14 +405,6 @@ class TaskMateChildCard extends LitElement {
     return css`
       :host {
         display: block;
-        --fun-pink: #ff6b9d;
-        --fun-purple: #9b59b6;
-        --fun-blue: #3498db;
-        --fun-green: #2ecc71;
-        --fun-yellow: #f1c40f;
-        --fun-orange: #e67e22;
-        --fun-red: #e74c3c;
-        --fun-cyan: #1abc9c;
       }
 
       ha-card { overflow: hidden; }
@@ -423,8 +415,8 @@ class TaskMateChildCard extends LitElement {
         align-items: center;
         justify-content: space-between;
         padding: 14px 18px;
-        background: var(--taskmate-header-bg, #9b59b6);
-        color: white;
+        background: var(--taskmate-header-bg, var(--primary-color));
+        color: var(--text-primary-color, #fff);
         gap: 12px;
         min-width: 0;
       }
@@ -452,7 +444,7 @@ class TaskMateChildCard extends LitElement {
 
       .avatar-container ha-icon {
         --mdc-icon-size: 30px;
-        color: white;
+        color: var(--text-primary-color, #fff);
       }
 
       .child-name-container {
@@ -464,7 +456,7 @@ class TaskMateChildCard extends LitElement {
       .child-name {
         font-size: 1.15rem;
         font-weight: 700;
-        color: white;
+        color: var(--text-primary-color, #fff);
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
@@ -505,10 +497,10 @@ class TaskMateChildCard extends LitElement {
         align-items: center;
         gap: 3px;
         white-space: nowrap;
-        color: white;
+        color: var(--text-primary-color, #fff);
       }
 
-      .stars-value.my-stars { color: white; }
+      .stars-value.my-stars { color: var(--text-primary-color, #fff); }
 
       .stars-value.waiting-stars {
         color: rgba(255,255,255,0.75);
@@ -517,8 +509,8 @@ class TaskMateChildCard extends LitElement {
 
       .stars-value ha-icon { --mdc-icon-size: 16px; flex-shrink: 0; }
 
-      .stars-value.my-stars ha-icon { color: var(--fun-yellow); }
-      .stars-value.waiting-stars ha-icon { color: var(--fun-orange); }
+      .stars-value.my-stars ha-icon { color: #ca8a04; }
+      .stars-value.waiting-stars ha-icon { color: var(--warning-color, #ff9800); }
 
       .stars-label {
         font-size: 0.6rem;
@@ -551,7 +543,7 @@ class TaskMateChildCard extends LitElement {
       .section-title {
         font-size: 1.4rem;
         font-weight: 700;
-        color: var(--fun-purple);
+        color: var(--primary-text-color);
         display: flex;
         align-items: center;
         gap: 10px;
@@ -565,8 +557,8 @@ class TaskMateChildCard extends LitElement {
 
       /* Individual chore card - optimized for tablet touch, ENTIRE ROW IS CLICKABLE */
       .chore-card {
-        background: var(--card-background-color, #fff);
-        border-radius: 20px;
+        background: var(--secondary-background-color, #f5f5f5);
+        border-radius: var(--ha-card-border-radius, 12px);
         padding: 16px 18px;
         display: flex;
         flex-direction: row;
@@ -574,9 +566,8 @@ class TaskMateChildCard extends LitElement {
         justify-content: space-between;
         flex-wrap: nowrap;
         gap: 12px;
-        box-shadow: 0 3px 10px rgba(0, 0, 0, 0.08);
-        border: 3px solid transparent;
-        transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
+        border: 1px solid var(--divider-color);
+        transition: transform 0.15s ease, background 0.15s ease;
         position: relative;
         overflow: hidden;
         min-height: 68px;
@@ -587,47 +578,21 @@ class TaskMateChildCard extends LitElement {
         box-sizing: border-box;
       }
 
-      .chore-card:nth-child(odd) {
-        border-color: var(--fun-blue);
-        background: var(--card-background-color, #fff);
-        background: color-mix(in srgb, var(--fun-blue) 10%, var(--card-background-color, #fff));
-      }
-
-      .chore-card:nth-child(even) {
-        border-color: var(--fun-pink);
-        background: var(--card-background-color, #fff);
-        background: color-mix(in srgb, var(--fun-pink) 10%, var(--card-background-color, #fff));
-      }
-
-      .chore-card:nth-child(3n) {
-        border-color: var(--fun-green);
-        background: var(--card-background-color, #fff);
-        background: color-mix(in srgb, var(--fun-green) 10%, var(--card-background-color, #fff));
-      }
-
-      .chore-card:nth-child(4n) {
-        border-color: var(--fun-orange);
-        background: var(--card-background-color, #fff);
-        background: color-mix(in srgb, var(--fun-orange) 10%, var(--card-background-color, #fff));
-      }
-
       /* Touch/hover feedback - works for both touch and mouse */
       .chore-card:active {
         transform: scale(0.98);
-        box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
       }
       .chore-card:focus {
         outline: none;
       }
       .chore-card:focus-visible {
-        outline: 2px solid var(--primary-color, #2196f3);
+        outline: 2px solid var(--primary-color);
         outline-offset: 2px;
       }
 
       @media (hover: hover) {
         .chore-card:hover {
-          transform: scale(1.02);
-          box-shadow: 0 6px 20px rgba(0, 0, 0, 0.15);
+          background: color-mix(in srgb, var(--primary-color) 8%, var(--secondary-background-color, #f5f5f5));
         }
       }
 
@@ -663,7 +628,7 @@ class TaskMateChildCard extends LitElement {
         position: relative;
       }
 
-      /* Fun chore number badge */
+      /* Chore number badge */
       .chore-number-badge {
         width: 38px;
         height: 38px;
@@ -674,28 +639,26 @@ class TaskMateChildCard extends LitElement {
         justify-content: center;
         font-size: 1.3rem;
         font-weight: 800;
-        color: white;
-        text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.2);
-        box-shadow: 0 3px 8px rgba(0, 0, 0, 0.2), inset 0 2px 4px rgba(255, 255, 255, 0.3);
-        transform: rotate(-5deg);
+        color: var(--text-primary-color, #fff);
+        background: var(--primary-color);
         transition: transform 0.2s ease;
-        font-family: 'Comic Sans MS', 'Chalkboard SE', 'Marker Felt', sans-serif;
+        font-family: inherit;
         flex-shrink: 0;
       }
 
       .chore-card:hover .chore-number-badge {
-        transform: rotate(5deg) scale(1.1);
+        transform: scale(1.05);
       }
 
-      /* Cycle through fun colors for number badges */
-      .chore-number-badge.color-0 { background: linear-gradient(135deg, #ff6b9d 0%, #ff4081 100%); } /* Pink */
-      .chore-number-badge.color-1 { background: linear-gradient(135deg, #3498db 0%, #2980b9 100%); } /* Blue */
-      .chore-number-badge.color-2 { background: linear-gradient(135deg, #2ecc71 0%, #27ae60 100%); } /* Green */
-      .chore-number-badge.color-3 { background: linear-gradient(135deg, #e67e22 0%, #d35400 100%); } /* Orange */
-      .chore-number-badge.color-4 { background: linear-gradient(135deg, #9b59b6 0%, #8e44ad 100%); } /* Purple */
-      .chore-number-badge.color-5 { background: linear-gradient(135deg, #1abc9c 0%, #16a085 100%); } /* Teal */
-      .chore-number-badge.color-6 { background: linear-gradient(135deg, #f1c40f 0%, #f39c12 100%); } /* Yellow */
-      .chore-number-badge.color-7 { background: linear-gradient(135deg, #e74c3c 0%, #c0392b 100%); } /* Red */
+      /* Cycle through colors for number badges — all use HA variables */
+      .chore-number-badge.color-0 { background: var(--primary-color); }
+      .chore-number-badge.color-1 { background: var(--primary-color); }
+      .chore-number-badge.color-2 { background: var(--success-color, #4caf50); }
+      .chore-number-badge.color-3 { background: var(--warning-color, #ff9800); }
+      .chore-number-badge.color-4 { background: var(--primary-color); }
+      .chore-number-badge.color-5 { background: var(--success-color, #4caf50); }
+      .chore-number-badge.color-6 { background: var(--warning-color, #ff9800); }
+      .chore-number-badge.color-7 { background: var(--error-color, #f44336); }
 
       /* Completed state for number badge */
       .chore-card.completed .chore-number-badge {
@@ -709,12 +672,11 @@ class TaskMateChildCard extends LitElement {
         height: 40px;
         min-width: 40px;
         border-radius: 10px;
-        border: 3px solid var(--divider-color, #bdc3c7);
+        border: 2px solid var(--divider-color);
         background: var(--card-background-color, #fff);
         display: flex;
         align-items: center;
         justify-content: center;
-        box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
         transition: all 0.2s ease;
         flex-shrink: 0;
         align-self: center;
@@ -728,19 +690,18 @@ class TaskMateChildCard extends LitElement {
 
       /* Unchecked state - hover effect */
       .chore-card:not(.completed):hover .chore-checkbox {
-        border-color: var(--fun-green);
-        background: rgba(46, 204, 113, 0.1);
+        border-color: var(--success-color, #4caf50);
+        background: color-mix(in srgb, var(--success-color, #4caf50) 10%, var(--card-background-color, #fff));
       }
 
       /* Checked state */
       .chore-card.completed .chore-checkbox {
-        border-color: var(--fun-green);
-        background: linear-gradient(135deg, #2ecc71 0%, #27ae60 100%);
-        box-shadow: 0 3px 10px rgba(46, 204, 113, 0.4);
+        border-color: var(--success-color, #4caf50);
+        background: var(--success-color, #4caf50);
       }
 
       .chore-card.completed .chore-checkbox ha-icon {
-        color: white;
+        color: var(--text-primary-color, #fff);
       }
 
       .chore-details {
@@ -776,14 +737,14 @@ class TaskMateChildCard extends LitElement {
         align-items: center;
         gap: 6px;
         font-size: 1rem;
-        color: var(--fun-orange);
+        color: #ca8a04;
         font-weight: 600;
         margin-top: 2px;
       }
 
       .chore-points ha-icon {
         --mdc-icon-size: 18px;
-        color: var(--fun-yellow);
+        color: #ca8a04;
       }
 
       @keyframes spin {
@@ -863,19 +824,16 @@ class TaskMateChildCard extends LitElement {
         --mdc-icon-size: 12px;
       }
 
-      /* Chore card in completed state - faded green styling */
+      /* Chore card in completed state */
       .chore-card.completed {
         opacity: 0.75;
         border-style: dashed;
-        border-color: var(--fun-green) !important;
-        background: linear-gradient(135deg,
-          rgba(46, 204, 113, 0.25) 0%,
-          rgba(39, 174, 96, 0.35) 100%) !important;
-        filter: saturate(0.7);
+        border-color: var(--success-color, #4caf50) !important;
+        background: color-mix(in srgb, var(--success-color, #4caf50) 12%, var(--secondary-background-color, #f5f5f5)) !important;
       }
 
       .chore-card.completed .chore-icon-container {
-        background: rgba(255, 255, 255, 0.8);
+        background: var(--card-background-color, #fff);
       }
 
       .chore-card.completed .chore-name {
@@ -909,8 +867,8 @@ class TaskMateChildCard extends LitElement {
       }
 
       .reset-countdown.soon {
-        color: var(--fun-orange);
-        background: rgba(230,126,34,0.12);
+        color: var(--warning-color, #ff9800);
+        background: color-mix(in srgb, var(--warning-color, #ff9800) 12%, transparent);
         font-weight: 700;
       }
 
@@ -926,7 +884,7 @@ class TaskMateChildCard extends LitElement {
 
       .empty-state ha-icon {
         --mdc-icon-size: 80px;
-        color: var(--fun-green);
+        color: var(--success-color, #4caf50);
         margin-bottom: 16px;
         animation: bounce 1s ease infinite;
       }
@@ -939,7 +897,7 @@ class TaskMateChildCard extends LitElement {
       .empty-state .message {
         font-size: 1.6rem;
         font-weight: bold;
-        color: var(--fun-purple);
+        color: var(--primary-text-color);
         margin-bottom: 8px;
       }
 
@@ -970,7 +928,7 @@ class TaskMateChildCard extends LitElement {
 
       .celebration-content {
         background: var(--card-background-color, #fff);
-        border-radius: 30px;
+        border-radius: var(--ha-card-border-radius, 12px);
         padding: 40px 50px;
         text-align: center;
         animation: pop-in 0.5s cubic-bezier(0.68, -0.55, 0.265, 1.55);
@@ -1003,7 +961,7 @@ class TaskMateChildCard extends LitElement {
       .celebration-title {
         font-size: 2.5rem;
         font-weight: bold;
-        color: var(--fun-purple);
+        color: var(--primary-text-color);
         margin-bottom: 8px;
       }
 
@@ -1016,7 +974,7 @@ class TaskMateChildCard extends LitElement {
       .celebration-points {
         font-size: 1.8rem;
         font-weight: bold;
-        color: var(--fun-orange);
+        color: #ca8a04;
         display: flex;
         align-items: center;
         justify-content: center;
@@ -1025,7 +983,7 @@ class TaskMateChildCard extends LitElement {
 
       .celebration-points ha-icon {
         --mdc-icon-size: 28px;
-        color: var(--fun-yellow);
+        color: #ca8a04;
       }
 
       /* Confetti */
@@ -1151,7 +1109,7 @@ class TaskMateChildCard extends LitElement {
       elapsed_time_mode: "dim",      // "dim" | "hide" | "show" — chores whose time period has passed without completion
       show_countdown: true,          // Show midnight reset countdown below section title
       show_due_days_only: true,      // Whether to apply due_days filtering at all
-            header_color: '#9b59b6',
+            header_color: '',
     ...config,
     };
   }
@@ -1256,7 +1214,7 @@ class TaskMateChildCard extends LitElement {
 
     return html`
       <ha-card>
-        <style>:host { --taskmate-header-bg: ${this.config.header_color || '#9b59b6'}; }</style>
+        ${this.config.header_color ? html`<style>:host { --taskmate-header-bg: ${this.config.header_color}; }</style>` : ''}
         <div class="card-header">
           <div class="header-left">
             <div class="avatar-container">
@@ -1863,7 +1821,7 @@ class TaskMateChildCard extends LitElement {
         </div>
         <div class="chore-checkbox">
           ${isLoading
-            ? html`<ha-icon icon="mdi:loading" style="animation: spin 1s linear infinite; color: var(--fun-purple);"></ha-icon>`
+            ? html`<ha-icon icon="mdi:loading" style="animation: spin 1s linear infinite; color: var(--primary-color);"></ha-icon>`
             : isLockedPreview
               ? html`<ha-icon icon="mdi:lock-clock" class="chore-lock-icon"></ha-icon>`
               : html`<ha-icon icon="mdi:check-bold"></ha-icon>`}
@@ -1896,7 +1854,15 @@ class TaskMateChildCard extends LitElement {
   }
 
   _renderConfetti() {
-    const colors = ["#ff6b9d", "#9b59b6", "#3498db", "#2ecc71", "#f1c40f", "#e67e22"];
+    const cs = getComputedStyle(this);
+    const colors = [
+      cs.getPropertyValue('--primary-color').trim() || '#03a9f4',
+      cs.getPropertyValue('--success-color').trim() || '#4caf50',
+      cs.getPropertyValue('--warning-color').trim() || '#ff9800',
+      cs.getPropertyValue('--error-color').trim() || '#f44336',
+      '#ca8a04',
+      cs.getPropertyValue('--primary-color').trim() || '#03a9f4',
+    ];
 
     return html`
       <div class="confetti-container">
@@ -2360,13 +2326,13 @@ class TaskMateChildCardEditor extends LitElement {
         .computeHelper=${this._computeHelper}
         @value-changed=${this._formChanged}
       ></ha-form>
-      ${this._renderColourPicker('header_color', '#9b59b6')}
+      ${this._renderColourPicker('header_color', '#4183c4')}
     `;
   }
 
   _renderColourPicker(key, defaultValue) {
     const current = this.config[key] || defaultValue;
-    const presets = ['#9b59b6', '#e67e22', '#27ae60', '#3498db', '#f1c40f', '#e74c3c', '#34495e'];
+    const presets = ['#4183c4', '#4caf50', '#ff9800', '#f44336', '#9c27b0', '#607d8b', '#795548'];
     const isActive = (c) => c.toLowerCase() === current.toLowerCase();
     return html`
       <div class="colour-field">
@@ -2449,6 +2415,6 @@ const _tmVersion = new URLSearchParams(
 ).get("v") || "?";
 console.info(
   "%c TASKMATE CHILD CARD %c v" + _tmVersion + " ",
-  "background:#9b59b6;color:white;font-weight:bold;padding:2px 4px;border-radius:4px 0 0 4px;",
-  "background:#2c3e50;color:white;font-weight:bold;padding:2px 4px;border-radius:0 4px 4px 0;"
+  "background:#4183c4;color:white;font-weight:bold;padding:2px 4px;border-radius:4px 0 0 4px;",
+  "background:#37474f;color:white;font-weight:bold;padding:2px 4px;border-radius:0 4px 4px 0;"
 );

--- a/custom_components/taskmate/www/taskmate-rewards-card.js
+++ b/custom_components/taskmate/www/taskmate-rewards-card.js
@@ -40,14 +40,6 @@ class TaskMateRewardsCard extends LitElement {
     return css`
       :host {
         display: block;
-        --reward-purple: #9b59b6;
-        --reward-purple-light: #a569bd;
-        --reward-gold: #f1c40f;
-        --reward-gold-dark: #d4a80a;
-        --text-primary: var(--primary-text-color, #212121);
-        --text-secondary: var(--secondary-text-color, #757575);
-        --card-bg: var(--card-background-color, #fff);
-        --divider: var(--divider-color, #e0e0e0);
       }
 
       ha-card {
@@ -59,8 +51,8 @@ class TaskMateRewardsCard extends LitElement {
         align-items: center;
         justify-content: space-between;
         padding: 14px 18px;
-        background: var(--taskmate-header-bg, #e67e22);
-        color: white;
+        background: var(--taskmate-header-bg, var(--primary-color));
+        color: var(--text-primary-color, #fff);
       }
 
       .header-content {
@@ -80,7 +72,7 @@ class TaskMateRewardsCard extends LitElement {
       }
 
       .reward-count {
-        background: rgba(255, 255, 255, 0.2);
+        background: rgba(255, 255, 255, 0.25);
         padding: 4px 12px;
         border-radius: 16px;
         font-size: 0.9rem;
@@ -100,14 +92,14 @@ class TaskMateRewardsCard extends LitElement {
         align-items: flex-start;
         gap: 16px;
         padding: 16px;
-        background: var(--card-bg);
-        border: 1px solid var(--divider);
-        border-radius: 12px;
+        background: var(--card-background-color, #fff);
+        border: 1px solid var(--divider-color, #e0e0e0);
+        border-radius: var(--ha-card-border-radius, 12px);
         transition: box-shadow 0.2s ease, transform 0.15s ease;
       }
 
       .reward-row:hover {
-        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+        box-shadow: var(--ha-card-box-shadow, none);
         transform: translateY(-1px);
       }
 
@@ -119,31 +111,29 @@ class TaskMateRewardsCard extends LitElement {
         justify-content: center;
         min-width: 70px;
         padding: 12px 8px;
-        background: linear-gradient(135deg, var(--reward-gold) 0%, var(--reward-gold-dark) 100%);
-        border-radius: 12px;
-        box-shadow: 0 2px 8px rgba(241, 196, 15, 0.3);
+        background: #ca8a04;
+        border-radius: var(--ha-card-border-radius, 12px);
         flex-shrink: 0;
       }
 
       .cost-badge ha-icon {
         --mdc-icon-size: 24px;
-        color: white;
-        filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.2));
+        color: var(--text-primary-color, #fff);
         margin-bottom: 4px;
       }
 
       .cost-value {
         font-size: 1.4rem;
         font-weight: 700;
-        color: white;
-        text-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+        color: var(--text-primary-color, #fff);
         line-height: 1;
       }
 
       .cost-label {
         font-size: 0.65rem;
         font-weight: 600;
-        color: rgba(255, 255, 255, 0.9);
+        color: var(--text-primary-color, #fff);
+        opacity: 0.9;
         text-transform: uppercase;
         letter-spacing: 0.5px;
         margin-top: 2px;
@@ -162,13 +152,13 @@ class TaskMateRewardsCard extends LitElement {
       .reward-name {
         font-size: 1.15rem;
         font-weight: 600;
-        color: var(--text-primary);
+        color: var(--primary-text-color, #212121);
         line-height: 1.3;
       }
 
       .reward-description {
         font-size: 0.9rem;
-        color: var(--text-secondary);
+        color: var(--secondary-text-color, #757575);
         line-height: 1.4;
       }
 
@@ -184,16 +174,16 @@ class TaskMateRewardsCard extends LitElement {
         display: inline-flex;
         align-items: center;
         padding: 2px 8px;
-        background: rgba(155, 89, 182, 0.15);
+        background: color-mix(in srgb, var(--primary-color) 15%, transparent);
         border-radius: 12px;
         font-size: 0.75rem;
-        color: var(--reward-purple);
+        color: var(--primary-color);
         font-weight: 500;
       }
 
       .child-badge.all-children {
-        background: rgba(46, 204, 113, 0.15);
-        color: #27ae60;
+        background: color-mix(in srgb, var(--success-color, #4caf50) 15%, transparent);
+        color: var(--success-color, #4caf50);
       }
 
       /* Progress bar styles */
@@ -215,48 +205,26 @@ class TaskMateRewardsCard extends LitElement {
       .progress-bar {
         flex: 1;
         height: 14px;
-        background: var(--divider-color, #e0e0e0);
+        background: var(--secondary-background-color, #e0e0e0);
         border-radius: 7px;
         overflow: hidden;
         position: relative;
-        border: 2px solid rgba(52, 152, 219, 0.4);
-        box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.1);
+        border: 1px solid var(--divider-color, #e0e0e0);
       }
 
       .progress-fill {
         height: 100%;
         border-radius: 7px;
-        background: linear-gradient(90deg, #3498db 0%, #2ecc71 100%);
+        background: var(--primary-color);
         transition: width 0.4s ease;
         position: relative;
         overflow: hidden;
       }
 
-      .progress-fill::after {
-        content: '';
-        position: absolute;
-        top: 0;
-        left: -100%;
-        width: 50%;
-        height: 100%;
-        background: linear-gradient(
-          90deg,
-          transparent,
-          rgba(255, 255, 255, 0.4),
-          transparent
-        );
-        animation: shimmer 2s infinite;
-      }
-
-      @keyframes shimmer {
-        0% { left: -100%; }
-        100% { left: 200%; }
-      }
-
       .progress-text {
         font-size: 0.85rem;
         font-weight: 600;
-        color: var(--text-secondary);
+        color: var(--secondary-text-color, #757575);
         white-space: nowrap;
         min-width: 70px;
         text-align: right;
@@ -264,38 +232,10 @@ class TaskMateRewardsCard extends LitElement {
 
       /* Jackpot reward styles */
       .reward-row.jackpot {
-        border: 2px solid var(--reward-gold);
-        background: linear-gradient(135deg, rgba(241, 196, 15, 0.08) 0%, rgba(255, 255, 255, 0) 100%);
+        border: 2px solid #ca8a04;
+        background: color-mix(in srgb, #ca8a04 6%, var(--card-background-color, #fff));
         position: relative;
         overflow: hidden;
-      }
-
-      .reward-row.jackpot::before {
-        content: '';
-        position: absolute;
-        top: 0;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        background: linear-gradient(
-          45deg,
-          transparent 40%,
-          rgba(241, 196, 15, 0.1) 50%,
-          transparent 60%
-        );
-        animation: jackpot-shine 40s ease-in-out infinite;
-        pointer-events: none;
-      }
-
-      /* Shine 3 times (each ~2.5s = 7.5s total), then wait ~32.5s before repeating */
-      @keyframes jackpot-shine {
-        0% { transform: translateX(-100%); }
-        2.5% { transform: translateX(100%); }
-        5% { transform: translateX(-100%); }
-        7.5% { transform: translateX(100%); }
-        10% { transform: translateX(-100%); }
-        12.5% { transform: translateX(100%); }
-        15%, 100% { transform: translateX(-100%); opacity: 0; }
       }
 
       .jackpot-label {
@@ -303,15 +243,14 @@ class TaskMateRewardsCard extends LitElement {
         align-items: center;
         gap: 4px;
         padding: 3px 10px;
-        background: linear-gradient(135deg, var(--reward-gold) 0%, #e67e22 100%);
+        background: #ca8a04;
         border-radius: 12px;
         font-size: 0.7rem;
         font-weight: 700;
-        color: white;
+        color: var(--text-primary-color, #fff);
         text-transform: uppercase;
         letter-spacing: 0.5px;
         margin-bottom: 4px;
-        box-shadow: 0 2px 6px rgba(241, 196, 15, 0.4);
       }
 
       .jackpot-label span {
@@ -322,13 +261,12 @@ class TaskMateRewardsCard extends LitElement {
       .jackpot-progress-bar {
         flex: 1;
         height: 18px;
-        background: var(--divider-color, #e0e0e0);
+        background: var(--secondary-background-color, #e0e0e0);
         border-radius: 9px;
         overflow: hidden;
         position: relative;
         display: flex;
-        border: 2px solid rgba(241, 196, 15, 0.5);
-        box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.1);
+        border: 1px solid var(--divider-color, #e0e0e0);
       }
 
       .jackpot-segment {
@@ -336,33 +274,6 @@ class TaskMateRewardsCard extends LitElement {
         transition: width 0.4s ease;
         position: relative;
         overflow: hidden;
-      }
-
-      .jackpot-segment::after {
-        content: '';
-        position: absolute;
-        top: 0;
-        left: -100%;
-        width: 100%;
-        height: 100%;
-        background: linear-gradient(
-          90deg,
-          transparent,
-          rgba(255, 255, 255, 0.4),
-          transparent
-        );
-        animation: jackpot-segment-shimmer 40s infinite;
-      }
-
-      /* Shimmer 3 times then wait ~30s before repeating */
-      @keyframes jackpot-segment-shimmer {
-        0% { left: -100%; }
-        2.5% { left: 200%; }
-        5% { left: -100%; }
-        7.5% { left: 200%; }
-        10% { left: -100%; }
-        12.5% { left: 200%; }
-        15%, 100% { left: -100%; opacity: 0; }
       }
 
       .jackpot-segment:first-child {
@@ -377,13 +288,13 @@ class TaskMateRewardsCard extends LitElement {
         border-radius: 9px;
       }
 
-      /* Fun kid-friendly colors for segments */
-      .jackpot-segment.color-0 { background: linear-gradient(180deg, #ff6b9d 0%, #e91e63 100%); }
-      .jackpot-segment.color-1 { background: linear-gradient(180deg, #64b5f6 0%, #2196f3 100%); }
-      .jackpot-segment.color-2 { background: linear-gradient(180deg, #81c784 0%, #4caf50 100%); }
-      .jackpot-segment.color-3 { background: linear-gradient(180deg, #ffb74d 0%, #ff9800 100%); }
-      .jackpot-segment.color-4 { background: linear-gradient(180deg, #ba68c8 0%, #9c27b0 100%); }
-      .jackpot-segment.color-5 { background: linear-gradient(180deg, #4dd0e1 0%, #00bcd4 100%); }
+      /* Distinct colors for segments */
+      .jackpot-segment.color-0 { background: #e91e63; }
+      .jackpot-segment.color-1 { background: #2196f3; }
+      .jackpot-segment.color-2 { background: var(--success-color, #4caf50); }
+      .jackpot-segment.color-3 { background: var(--warning-color, #ff9800); }
+      .jackpot-segment.color-4 { background: #9c27b0; }
+      .jackpot-segment.color-5 { background: #00bcd4; }
 
       .jackpot-breakdown {
         display: flex;
@@ -391,7 +302,7 @@ class TaskMateRewardsCard extends LitElement {
         gap: 6px;
         margin-top: 4px;
         font-size: 0.8rem;
-        color: var(--text-secondary);
+        color: var(--secondary-text-color, #757575);
       }
 
       .jackpot-child-contribution {
@@ -427,33 +338,30 @@ class TaskMateRewardsCard extends LitElement {
 
       .jackpot-total {
         font-weight: 700;
-        color: var(--reward-gold-dark);
+        color: #ca8a04;
         padding: 2px 8px;
-        background: rgba(241, 196, 15, 0.15);
+        background: color-mix(in srgb, #ca8a04 15%, transparent);
         border-radius: 10px;
       }
 
       /* Cost badge for jackpot - special styling */
       .reward-row.jackpot .cost-badge {
-        background: linear-gradient(135deg, var(--reward-gold) 0%, #e67e22 100%);
-        box-shadow: 0 3px 10px rgba(241, 196, 15, 0.4);
+        background: #ca8a04;
       }
 
       /* Dynamic reward styles */
       .reward-row.dynamic {
-        border: 1px dashed rgba(52, 152, 219, 0.5);
+        border: 1px dashed color-mix(in srgb, var(--primary-color) 50%, transparent);
       }
 
       .cost-badge.dynamic-cost {
-        background: linear-gradient(135deg, #3498db 0%, #2980b9 100%);
-        box-shadow: 0 2px 8px rgba(52, 152, 219, 0.3);
+        background: var(--primary-color);
         position: relative;
       }
 
       .dynamic-indicator {
         font-size: 0.9rem;
         margin-top: 2px;
-        filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.3));
       }
 
       /* Reward icon + claim button wrapper */
@@ -497,7 +405,7 @@ class TaskMateRewardsCard extends LitElement {
         width: 44px;
         height: 44px;
         border-radius: 50%;
-        background: linear-gradient(135deg, var(--reward-purple) 0%, var(--reward-purple-light) 100%);
+        background: var(--primary-color);
         display: flex;
         align-items: center;
         justify-content: center;
@@ -506,21 +414,21 @@ class TaskMateRewardsCard extends LitElement {
 
       .reward-icon-container ha-icon {
         --mdc-icon-size: 24px;
-        color: white;
+        color: var(--text-primary-color, #fff);
       }
 
       /* Pending approval state */
       .reward-row.pending-approval {
         opacity: 0.6;
-        border-left: 3px solid #e67e22;
+        border-left: 3px solid var(--warning-color, #ff9800);
       }
 
       .pending-label {
         display: inline-flex;
         align-items: center;
         gap: 4px;
-        background: rgba(230,126,34,0.12);
-        color: #e67e22;
+        background: color-mix(in srgb, var(--warning-color, #ff9800) 12%, transparent);
+        color: var(--warning-color, #ff9800);
         border-radius: 8px;
         padding: 3px 8px;
         font-size: 0.75rem;
@@ -542,7 +450,7 @@ class TaskMateRewardsCard extends LitElement {
         letter-spacing: 0.02em;
       }
       .availability-badge.badge-sold-out {
-        background: rgba(189,195,199,0.25);
+        background: color-mix(in srgb, var(--disabled-text-color, #bdbdbd) 25%, transparent);
         color: var(--secondary-text-color, #757575);
       }
       .availability-badge.badge-expired {
@@ -550,12 +458,12 @@ class TaskMateRewardsCard extends LitElement {
         color: var(--secondary-text-color, #757575);
       }
       .availability-badge.badge-low-stock {
-        background: rgba(231,76,60,0.15);
-        color: #c0392b;
+        background: color-mix(in srgb, var(--error-color, #f44336) 15%, transparent);
+        color: var(--error-color, #f44336);
       }
       .availability-badge.badge-expiring-soon {
-        background: rgba(243,156,18,0.18);
-        color: #d35400;
+        background: color-mix(in srgb, var(--warning-color, #ff9800) 18%, transparent);
+        color: var(--warning-color, #ff9800);
       }
       .reward-row.unavailable { opacity: 0.55; }
 
@@ -563,22 +471,20 @@ class TaskMateRewardsCard extends LitElement {
       .claim-btn {
         width: 42px; height: 42px;
         border-radius: 50%; border: none; cursor: pointer;
-        background: linear-gradient(135deg, #9b59b6, #8e44ad);
-        color: white;
+        background: var(--primary-color);
+        color: var(--text-primary-color, #fff);
         display: flex; align-items: center; justify-content: center;
-        box-shadow: 0 3px 10px rgba(155,89,182,0.35);
-        transition: transform 0.15s, box-shadow 0.15s;
+        transition: transform 0.15s, opacity 0.15s;
         flex-shrink: 0;
       }
 
-      .claim-btn:hover { transform: scale(1.08); box-shadow: 0 4px 14px rgba(155,89,182,0.45); }
+      .claim-btn:hover { transform: scale(1.08); }
       .claim-btn:active { transform: scale(0.96); }
       .claim-btn:disabled { opacity: 0.4; cursor: not-allowed; transform: none; }
       .claim-btn ha-icon { --mdc-icon-size: 22px; }
 
       .claim-btn.cant-afford {
-        background: linear-gradient(135deg, #bdc3c7, #95a5a6);
-        box-shadow: none;
+        background: var(--disabled-text-color, #bdbdbd);
         cursor: not-allowed;
       }
 
@@ -589,7 +495,7 @@ class TaskMateRewardsCard extends LitElement {
         align-items: center;
         justify-content: center;
         padding: 48px 24px;
-        color: var(--text-secondary);
+        color: var(--secondary-text-color, #757575);
         text-align: center;
       }
 
@@ -597,14 +503,14 @@ class TaskMateRewardsCard extends LitElement {
         --mdc-icon-size: 56px;
         margin-bottom: 16px;
         opacity: 0.5;
-        color: var(--reward-purple);
+        color: var(--primary-color);
       }
 
       .empty-state .message {
         font-size: 1.1rem;
         font-weight: 500;
         margin-bottom: 4px;
-        color: var(--text-primary);
+        color: var(--primary-text-color, #212121);
       }
 
       .empty-state .submessage {
@@ -686,18 +592,18 @@ class TaskMateRewardsCard extends LitElement {
         gap: 10px;
         padding: 10px 14px;
         margin: 8px 14px 0 14px;
-        background: linear-gradient(135deg, rgba(52, 152, 219, 0.15), rgba(46, 204, 113, 0.12));
+        background: var(--secondary-background-color, #f5f5f5);
         border-radius: 10px;
-        border: 1px solid rgba(52, 152, 219, 0.25);
+        border: 1px solid var(--divider-color, #e0e0e0);
       }
 
       .spendable-banner ha-icon {
-        color: var(--reward-purple);
+        color: var(--primary-color);
         --mdc-icon-size: 22px;
       }
 
       .spendable-banner .spendable-label {
-        color: var(--text-secondary);
+        color: var(--secondary-text-color, #757575);
         font-size: 0.82rem;
         text-transform: uppercase;
         letter-spacing: 0.04em;
@@ -706,13 +612,13 @@ class TaskMateRewardsCard extends LitElement {
       .spendable-banner .spendable-value {
         font-weight: 700;
         font-size: 1.15rem;
-        color: var(--text-primary);
+        color: var(--primary-text-color, #212121);
         margin-left: auto;
       }
 
       .spendable-banner .spendable-of {
         font-weight: 400;
-        color: var(--text-secondary);
+        color: var(--secondary-text-color, #757575);
         font-size: 0.82rem;
         margin-left: 4px;
       }
@@ -737,17 +643,16 @@ class TaskMateRewardsCard extends LitElement {
         border-radius: 8px;
         border: none;
         cursor: pointer;
-        background: linear-gradient(135deg, #3498db, #2980b9);
-        color: white;
+        background: var(--primary-color);
+        color: var(--text-primary-color, #fff);
         font-weight: 700;
         font-size: 0.9rem;
-        transition: transform 0.1s, opacity 0.1s, box-shadow 0.15s;
-        box-shadow: 0 1px 3px rgba(52, 152, 219, 0.3);
+        transition: transform 0.1s, opacity 0.1s;
       }
 
       .alloc-btn:hover:not(:disabled) {
         transform: scale(1.04);
-        box-shadow: 0 2px 6px rgba(52, 152, 219, 0.5);
+        opacity: 0.9;
       }
 
       .alloc-btn:disabled {
@@ -765,26 +670,19 @@ class TaskMateRewardsCard extends LitElement {
         border-radius: 20px;
         border: none;
         cursor: pointer;
-        background: linear-gradient(135deg, #2ecc71, #27ae60);
-        color: white;
+        background: var(--success-color, #4caf50);
+        color: var(--text-primary-color, #fff);
         font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 3px 10px rgba(46, 204, 113, 0.35);
-        animation: pulse-green 1.6s ease-in-out infinite;
       }
 
       .redeem-btn ha-icon {
         --mdc-icon-size: 18px;
       }
 
-      @keyframes pulse-green {
-        0%, 100% { box-shadow: 0 3px 10px rgba(46, 204, 113, 0.35); transform: scale(1); }
-        50% { box-shadow: 0 3px 18px rgba(46, 204, 113, 0.65); transform: scale(1.02); }
-      }
-
       .pool-locked-note {
         font-size: 0.72rem;
-        color: var(--text-secondary);
+        color: var(--secondary-text-color, #757575);
         font-style: italic;
         margin-top: 4px;
       }
@@ -800,7 +698,7 @@ class TaskMateRewardsCard extends LitElement {
       child_id: null, // Optional: filter rewards for a specific child
       show_child_badges: true, // Show which children can claim each reward
       enable_pool_mode: false, // v3.0: "savings jar" allocation mode (opt-in per card)
-      header_color: '#e67e22',
+      header_color: '',
       ...config,
     };
   }
@@ -886,7 +784,7 @@ class TaskMateRewardsCard extends LitElement {
 
     return html`
       <ha-card>
-        <style>:host { --taskmate-header-bg: ${this.config.header_color || '#e67e22'}; }</style>
+        <style>:host { --taskmate-header-bg: ${this.config.header_color || ''}; }</style>
         <div class="card-header">
           <div class="header-content">
             <ha-icon class="header-icon" icon="mdi:gift-outline"></ha-icon>
@@ -1510,13 +1408,13 @@ class TaskMateRewardsCardEditor extends LitElement {
         .computeHelper=${this._computeHelper}
         @value-changed=${this._formChanged}
       ></ha-form>
-      ${this._renderColourPicker('header_color', '#e67e22')}
+      ${this._renderColourPicker('header_color', '#03a9f4')}
     `;
   }
 
   _renderColourPicker(key, defaultValue) {
     const current = this.config[key] || defaultValue;
-    const presets = ['#e67e22', '#27ae60', '#3498db', '#9b59b6', '#f1c40f', '#e74c3c', '#34495e'];
+    const presets = ['#03a9f4', '#4caf50', '#ff9800', '#e91e63', '#9c27b0', '#f44336', '#607d8b'];
     const isActive = (c) => c.toLowerCase() === current.toLowerCase();
     return html`
       <div class="colour-field">
@@ -1607,6 +1505,6 @@ const _tmVersion = new URLSearchParams(
 ).get("v") || "?";
 console.info(
   "%c TASKMATE REWARDS CARD %c v" + _tmVersion + " ",
-  "background:#e67e22;color:white;font-weight:bold;padding:2px 4px;border-radius:4px 0 0 4px;",
-  "background:#2c3e50;color:white;font-weight:bold;padding:2px 4px;border-radius:0 4px 4px 0;"
+  "background:#4183c4;color:white;font-weight:bold;padding:2px 4px;border-radius:4px 0 0 4px;",
+  "background:#333;color:white;font-weight:bold;padding:2px 4px;border-radius:0 4px 4px 0;"
 );

--- a/custom_components/taskmate/www/taskmate-streak-card.js
+++ b/custom_components/taskmate/www/taskmate-streak-card.js
@@ -31,12 +31,6 @@ class TaskMateStreakCard extends LitElement {
     return css`
       :host {
         display: block;
-        --str-purple: #9b59b6;
-        --str-gold: #f1c40f;
-        --str-orange: #e67e22;
-        --str-green: #2ecc71;
-        --str-red: #e74c3c;
-        --str-fire: #ff6b35;
       }
 
       ha-card { overflow: hidden; }
@@ -46,8 +40,8 @@ class TaskMateStreakCard extends LitElement {
         align-items: center;
         justify-content: space-between;
         padding: 14px 18px;
-        background: var(--taskmate-header-bg, #e74c3c);
-        color: white;
+        background: var(--taskmate-header-bg, var(--primary-color));
+        color: var(--text-primary-color, #fff);
       }
 
       .header-content { display: flex; align-items: center; gap: 10px; }
@@ -80,14 +74,14 @@ class TaskMateStreakCard extends LitElement {
         width: 42px;
         height: 42px;
         border-radius: 50%;
-        background: linear-gradient(135deg, var(--str-purple) 0%, #a569bd 100%);
+        background: var(--primary-color);
         display: flex;
         align-items: center;
         justify-content: center;
         flex-shrink: 0;
       }
 
-      .child-avatar ha-icon { --mdc-icon-size: 26px; color: white; }
+      .child-avatar ha-icon { --mdc-icon-size: 26px; color: var(--text-primary-color, #fff); }
 
       .streak-info { flex: 1; }
       .child-name {
@@ -109,8 +103,8 @@ class TaskMateStreakCard extends LitElement {
         line-height: 1;
       }
 
-      .streak-number.hot { color: var(--str-fire); }
-      .streak-number.warm { color: var(--str-orange); }
+      .streak-number.hot { color: var(--error-color, #db4437); }
+      .streak-number.warm { color: var(--warning-color, #ff9800); }
       .streak-number.cold { color: var(--secondary-text-color); }
 
       .streak-label {
@@ -136,9 +130,9 @@ class TaskMateStreakCard extends LitElement {
         transition: transform 0.2s ease;
       }
 
-      .day-dot.active { background: var(--str-fire); }
-      .day-dot.today-active { background: var(--str-green); transform: scale(1.3); }
-      .day-dot.inactive { background: var(--divider-color, #e0e0e0); }
+      .day-dot.active { background: var(--warning-color, #ff9800); }
+      .day-dot.today-active { background: var(--success-color, #4caf50); transform: scale(1.3); }
+      .day-dot.inactive { background: var(--divider-color); }
 
       /* Achievements */
       .achievements-section {
@@ -177,8 +171,8 @@ class TaskMateStreakCard extends LitElement {
       .badge:hover { transform: scale(1.05); }
 
       .badge.earned {
-        background: linear-gradient(135deg, rgba(241,196,15,0.2), rgba(230,126,34,0.2));
-        border: 1px solid rgba(241,196,15,0.4);
+        background: var(--secondary-background-color);
+        border: 1px solid var(--divider-color);
       }
 
       .badge.locked { opacity: 0.35; filter: grayscale(1); }
@@ -192,7 +186,7 @@ class TaskMateStreakCard extends LitElement {
         line-height: 1.2;
       }
 
-      .badge.earned .badge-name { color: var(--str-orange); }
+      .badge.earned .badge-name { color: #ca8a04; }
 
       /* Empty / error */
       .error-state, .empty-state {
@@ -212,8 +206,8 @@ class TaskMateStreakCard extends LitElement {
       title: null,
       child_id: null,
       streak_days_shown: 14,
-            header_color: '#e74c3c',
-    ...config,
+      header_color: null,
+      ...config,
     };
   }
 
@@ -251,7 +245,7 @@ class TaskMateStreakCard extends LitElement {
 
     return html`
       <ha-card>
-        <style>:host { --taskmate-header-bg: ${this.config.header_color || '#e74c3c'}; }</style>
+        ${this.config.header_color ? html`<style>:host { --taskmate-header-bg: ${this.config.header_color}; }</style>` : ''}
         <div class="card-header">
           <div class="header-content">
             <ha-icon class="header-icon" icon="mdi:fire"></ha-icon>

--- a/custom_components/taskmate/www/taskmate-weekly-card.js
+++ b/custom_components/taskmate/www/taskmate-weekly-card.js
@@ -31,12 +31,6 @@ class TaskMateWeeklyCard extends LitElement {
     return css`
       :host {
         display: block;
-        --wk-purple: #9b59b6;
-        --wk-green: #2ecc71;
-        --wk-orange: #e67e22;
-        --wk-blue: #3498db;
-        --wk-gold: #f1c40f;
-        --wk-red: #e74c3c;
       }
 
       ha-card { overflow: hidden; }
@@ -46,8 +40,8 @@ class TaskMateWeeklyCard extends LitElement {
         align-items: center;
         justify-content: space-between;
         padding: 14px 18px;
-        background: var(--taskmate-header-bg, #27ae60);
-        color: white;
+        background: var(--taskmate-header-bg, var(--primary-color));
+        color: var(--text-primary-color, #fff);
       }
 
       .header-content { display: flex; align-items: center; gap: 10px; }
@@ -92,9 +86,9 @@ class TaskMateWeeklyCard extends LitElement {
         line-height: 1;
       }
 
-      .stat-value.green { color: var(--wk-green); }
-      .stat-value.orange { color: var(--wk-orange); }
-      .stat-value.purple { color: var(--wk-purple); }
+      .stat-value.green { color: var(--success-color, #4caf50); }
+      .stat-value.orange { color: var(--warning-color, #ff9800); }
+      .stat-value.purple { color: var(--primary-color); }
 
       .stat-label {
         font-size: 0.68rem;
@@ -149,19 +143,19 @@ class TaskMateWeeklyCard extends LitElement {
       }
 
       .bar-fill.today {
-        background: linear-gradient(180deg, var(--wk-green) 0%, #27ae60 100%);
+        background: var(--success-color, #4caf50);
       }
 
       .bar-fill.past {
-        background: linear-gradient(180deg, var(--wk-blue) 0%, #2980b9 100%);
+        background: var(--primary-color);
       }
 
       .bar-fill.future {
-        background: var(--divider-color, #e8e8e8);
+        background: var(--divider-color);
       }
 
       .bar-fill.zero {
-        background: var(--divider-color, #e8e8e8);
+        background: var(--divider-color);
         min-height: 3px !important;
         height: 3px !important;
       }
@@ -173,7 +167,7 @@ class TaskMateWeeklyCard extends LitElement {
       }
 
       .bar-day.today {
-        color: var(--wk-green);
+        color: var(--success-color, #4caf50);
         font-weight: 800;
       }
 
@@ -194,14 +188,14 @@ class TaskMateWeeklyCard extends LitElement {
         width: 34px;
         height: 34px;
         border-radius: 50%;
-        background: linear-gradient(135deg, var(--wk-purple), #a569bd);
+        background: var(--primary-color);
         display: flex;
         align-items: center;
         justify-content: center;
         flex-shrink: 0;
       }
 
-      .child-avatar ha-icon { --mdc-icon-size: 20px; color: white; }
+      .child-avatar ha-icon { --mdc-icon-size: 20px; color: var(--text-primary-color, #fff); }
 
       .child-info { flex: 1; min-width: 0; }
 
@@ -236,7 +230,7 @@ class TaskMateWeeklyCard extends LitElement {
       .week-progress-fill {
         height: 100%;
         border-radius: 3px;
-        background: linear-gradient(90deg, var(--wk-green), #27ae60);
+        background: var(--success-color, #4caf50);
       }
 
       /* Error / empty */
@@ -256,8 +250,8 @@ class TaskMateWeeklyCard extends LitElement {
     this.config = {
       title: null,
       child_id: null,
-            header_color: '#27ae60',
-    ...config,
+      header_color: null,
+      ...config,
     };
   }
 
@@ -347,7 +341,7 @@ class TaskMateWeeklyCard extends LitElement {
 
     return html`
       <ha-card>
-        <style>:host { --taskmate-header-bg: ${this.config.header_color || '#27ae60'}; }</style>
+        ${this.config.header_color ? html`<style>:host { --taskmate-header-bg: ${this.config.header_color}; }</style>` : ''}
         <div class="card-header">
           <div class="header-content">
             <ha-icon class="header-icon" icon="mdi:calendar-week"></ha-icon>
@@ -419,9 +413,9 @@ class TaskMateWeeklyCard extends LitElement {
                     <div class="child-info">
                       <div class="child-name">${child.name}</div>
                       <div class="child-week-stats">
-                        <span><ha-icon icon="mdi:checkbox-marked-circle" style="color:var(--wk-green)"></ha-icon>${this._t('weekly.child_chores', { count: childChoreCount })}</span>
-                        <span><ha-icon icon="${pointsIcon}" style="color:var(--wk-gold)"></ha-icon>${childPoints} ${pointsName}</span>
-                        <span><ha-icon icon="mdi:calendar-check" style="color:var(--wk-blue)"></ha-icon>${this._t('weekly.child_days', { count: childDaysActive })}</span>
+                        <span><ha-icon icon="mdi:checkbox-marked-circle" style="color:var(--success-color, #4caf50)"></ha-icon>${this._t('weekly.child_chores', { count: childChoreCount })}</span>
+                        <span><ha-icon icon="${pointsIcon}" style="color:#ca8a04"></ha-icon>${childPoints} ${pointsName}</span>
+                        <span><ha-icon icon="mdi:calendar-check" style="color:var(--primary-color)"></ha-icon>${this._t('weekly.child_days', { count: childDaysActive })}</span>
                       </div>
                     </div>
                     <div class="week-progress-bar" title="${this._t('weekly.child_days_active_title', { count: childDaysActive })}">


### PR DESCRIPTION
Replace all custom --fun-* CSS variables, hardcoded hex colors, gradients, Comic Sans font, and custom shadows in taskmate-child-card.js with Home Assistant theme variables.

- Removed custom --fun-pink/purple/blue/green/yellow/orange/red/cyan CSS vars
- Replaced hardcoded colors with var(--primary-color), var(--success-color), var(--warning-color), var(--error-color), var(--primary-text-color), var(--secondary-text-color), var(--divider-color), etc.
- Replaced gradients with flat HA variable colors
- Replaced Comic Sans font-family with inherit
- Replaced custom shadows with simple borders
- Kept gold #ca8a04 for points display (no HA equivalent)
- Kept functional layout unchanged