### PR TITLE
style(cards): use HA theme variables in overview, activity, leaderboard

### DIFF
--- a/custom_components/taskmate/www/taskmate-activity-card.js
+++ b/custom_components/taskmate/www/taskmate-activity-card.js
@@ -62,12 +62,6 @@ class TaskMateActivityCard extends LitElement {
     return css`
       :host {
         display: block;
-        --act-purple: #9b59b6;
-        --act-green: #2ecc71;
-        --act-orange: #e67e22;
-        --act-blue: #3498db;
-        --act-red: #e74c3c;
-        --act-gold: #f1c40f;
       }
 
       ha-card { overflow: hidden; }
@@ -77,8 +71,8 @@ class TaskMateActivityCard extends LitElement {
         align-items: center;
         justify-content: space-between;
         padding: 14px 18px;
-        background: var(--taskmate-header-bg, #2471a3);
-        color: white;
+        background: var(--taskmate-header-bg, var(--primary-color));
+        color: var(--text-primary-color, #fff);
       }
 
       .header-content { display: flex; align-items: center; gap: 10px; }
@@ -135,17 +129,17 @@ class TaskMateActivityCard extends LitElement {
         margin-top: 2px;
       }
 
-      .activity-icon ha-icon { --mdc-icon-size: 18px; color: white; }
+      .activity-icon ha-icon { --mdc-icon-size: 18px; color: var(--text-primary-color, #fff); }
 
-      .activity-icon.chore { background: var(--act-blue); }
-      .activity-icon.approved { background: var(--act-green); }
-      .activity-icon.rejected { background: var(--act-red); }
-      .activity-icon.points_added { background: var(--act-green); }
-      .activity-icon.points_removed { background: var(--act-red); }
-      .activity-icon.reward { background: var(--act-purple); }
-      .activity-icon.reward_claimed { background: var(--act-orange); }
-      .activity-icon.reward_approved { background: var(--act-purple); }
-      .activity-icon.pending { background: var(--act-orange); }
+      .activity-icon.chore { background: var(--primary-color); }
+      .activity-icon.approved { background: var(--success-color, #4caf50); }
+      .activity-icon.rejected { background: var(--error-color, #db4437); }
+      .activity-icon.points_added { background: var(--success-color, #4caf50); }
+      .activity-icon.points_removed { background: var(--error-color, #db4437); }
+      .activity-icon.reward { background: var(--primary-color); }
+      .activity-icon.reward_claimed { background: var(--warning-color, #ff9800); }
+      .activity-icon.reward_approved { background: var(--primary-color); }
+      .activity-icon.pending { background: var(--warning-color, #ff9800); }
 
       .activity-reason {
         font-size: 0.78rem;
@@ -163,7 +157,7 @@ class TaskMateActivityCard extends LitElement {
         line-height: 1.3;
       }
 
-      .activity-title strong { color: var(--act-purple); }
+      .activity-title strong { color: var(--primary-color); }
 
       .activity-meta {
         display: flex;
@@ -184,10 +178,10 @@ class TaskMateActivityCard extends LitElement {
         gap: 3px;
         font-size: 0.75rem;
         font-weight: 600;
-        color: var(--act-orange);
+        color: var(--warning-color, #ff9800);
       }
 
-      .activity-points ha-icon { --mdc-icon-size: 12px; color: var(--act-gold); }
+      .activity-points ha-icon { --mdc-icon-size: 12px; color: var(--warning-color, #ff9800); }
 
       .activity-status {
         display: inline-flex;
@@ -200,18 +194,18 @@ class TaskMateActivityCard extends LitElement {
       }
 
       .activity-status.pending {
-        background: rgba(230,126,34,0.15);
-        color: var(--act-orange);
+        background: rgba(var(--rgb-warning-color, 255,152,0),0.15);
+        color: var(--warning-color, #ff9800);
       }
 
       .activity-status.approved {
-        background: rgba(46,204,113,0.15);
-        color: var(--act-green);
+        background: rgba(var(--rgb-success-color, 76,175,80),0.15);
+        color: var(--success-color, #4caf50);
       }
 
       .activity-status.rejected {
-        background: rgba(231,76,60,0.15);
-        color: var(--act-red);
+        background: rgba(var(--rgb-error-color, 219,68,55),0.15);
+        color: var(--error-color, #db4437);
       }
 
       /* Empty / error */
@@ -238,7 +232,7 @@ class TaskMateActivityCard extends LitElement {
       title: "",
       max_items: 30,
       child_id: null,
-            header_color: '#2471a3',
+            header_color: null,
     ...config,
     };
   }
@@ -328,7 +322,7 @@ class TaskMateActivityCard extends LitElement {
 
     return html`
       <ha-card>
-        <style>:host { --taskmate-header-bg: ${this.config.header_color || '#2471a3'}; }</style>
+        ${this.config.header_color ? html`<style>:host { --taskmate-header-bg: ${this.config.header_color}; }</style>` : ''}
         <div class="card-header">
           <div class="header-content">
             <ha-icon class="header-icon" icon="mdi:timeline-clock"></ha-icon>
@@ -370,10 +364,10 @@ class TaskMateActivityCard extends LitElement {
         pointsColour = '';
       } else if (isSpend) {
         verb = this._t('activity.spent');
-        pointsColour = 'color: var(--act-orange);';
+        pointsColour = 'color: var(--warning-color, #ff9800);';
       } else {
         verb = this._t('activity.lost');
-        pointsColour = 'color: var(--act-red);';
+        pointsColour = 'color: var(--error-color, #db4437);';
       }
       const displayReason = this._translateReason(item.reason);
       return html`
@@ -419,7 +413,7 @@ class TaskMateActivityCard extends LitElement {
             <div class="activity-meta">
               <span class="activity-time">${time}</span>
               ${pts ? html`
-                <span class="activity-points" style="color: var(--act-orange);">
+                <span class="activity-points" style="color: var(--warning-color, #ff9800);">
                   <ha-icon icon="${pointsIcon}"></ha-icon>
                   -${pts}
                 </span>

--- a/custom_components/taskmate/www/taskmate-leaderboard-card.js
+++ b/custom_components/taskmate/www/taskmate-leaderboard-card.js
@@ -12,7 +12,7 @@ const LitElement = customElements.get("hui-masonry-view")
 const html = LitElement.prototype.html;
 const css = LitElement.prototype.css;
 
-const RANK_COLOURS = ["#f1c40f", "#bdc3c7", "#cd7f32", "#9b59b6", "#3498db"];
+const RANK_COLOURS = ["#ca8a04", null, "#cd7f32", null, null];
 const RANK_LABELS = ["🥇", "🥈", "🥉", "4th", "5th"];
 
 class TaskMateLeaderboardCard extends LitElement {
@@ -33,8 +33,8 @@ class TaskMateLeaderboardCard extends LitElement {
       .card-header {
         display: flex; align-items: center; justify-content: space-between;
         padding: 14px 18px;
-        background: var(--taskmate-header-bg, #b7950b);
-        color: white; gap: 12px;
+        background: var(--taskmate-header-bg, var(--primary-color));
+        color: var(--text-primary-color, #fff); gap: 12px;
       }
 
       .header-content { display: flex; align-items: center; gap: 10px; min-width: 0; }
@@ -66,21 +66,21 @@ class TaskMateLeaderboardCard extends LitElement {
         overflow: hidden;
       }
 
-      .rank-row:hover { box-shadow: 0 3px 12px rgba(0,0,0,0.08); }
+      .rank-row:hover { box-shadow: var(--ha-card-box-shadow, 0 2px 6px rgba(0,0,0,0.08)); }
 
       .rank-row.first {
-        border-color: #f1c40f;
-        background: linear-gradient(135deg, rgba(241,196,15,0.06) 0%, var(--card-background-color, #fff) 100%);
+        border-color: #ca8a04;
+        background: var(--card-background-color, #fff);
       }
 
       .rank-row.second {
-        border-color: #bdc3c7;
-        background: linear-gradient(135deg, rgba(189,195,199,0.06) 0%, var(--card-background-color, #fff) 100%);
+        border-color: var(--disabled-text-color, #bdbdbd);
+        background: var(--card-background-color, #fff);
       }
 
       .rank-row.third {
         border-color: #cd7f32;
-        background: linear-gradient(135deg, rgba(205,127,50,0.06) 0%, var(--card-background-color, #fff) 100%);
+        background: var(--card-background-color, #fff);
       }
 
       .rank-badge {
@@ -107,7 +107,7 @@ class TaskMateLeaderboardCard extends LitElement {
         flex-shrink: 0;
       }
 
-      .child-avatar ha-icon { --mdc-icon-size: 26px; color: white; }
+      .child-avatar ha-icon { --mdc-icon-size: 26px; color: var(--text-primary-color, #fff); }
 
       .rank-info { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 3px; }
 
@@ -148,7 +148,7 @@ class TaskMateLeaderboardCard extends LitElement {
       /* Tie indicator */
       .tie-line {
         height: 1px;
-        background: linear-gradient(90deg, transparent, var(--divider-color, #e0e0e0), transparent);
+        background: var(--divider-color, #e0e0e0);
         margin: -4px 0;
         position: relative;
       }
@@ -222,7 +222,7 @@ class TaskMateLeaderboardCard extends LitElement {
       sort_by: "points",      // "points" | "streak" | "weekly"
       show_streak: true,
       show_weekly: true,
-            header_color: '#b7950b',
+            header_color: null,
     ...config,
     };
   }
@@ -269,7 +269,7 @@ class TaskMateLeaderboardCard extends LitElement {
 
     return html`
       <ha-card>
-        <style>:host { --taskmate-header-bg: ${this.config.header_color || '#b7950b'}; }</style>
+        ${this.config.header_color ? html`<style>:host { --taskmate-header-bg: ${this.config.header_color}; }</style>` : ''}
         <div class="card-header">
           <div class="header-content">
             <ha-icon class="header-icon" icon="mdi:trophy"></ha-icon>
@@ -300,9 +300,16 @@ class TaskMateLeaderboardCard extends LitElement {
     return (a.points || 0) === (b.points || 0);
   }
 
+  _getRankColour(idx) {
+    const c = RANK_COLOURS[idx];
+    if (c) return c;
+    if (idx === 1) return getComputedStyle(this).getPropertyValue('--disabled-text-color').trim() || '#9e9e9e';
+    return getComputedStyle(this).getPropertyValue('--primary-color').trim() || '#03a9f4';
+  }
+
   _renderRankRow(child, idx, sortBy, weeklyPoints, pointsIcon, pointsName) {
     const rankClass = idx === 0 ? "first" : idx === 1 ? "second" : idx === 2 ? "third" : "";
-    const avatarColour = RANK_COLOURS[idx % RANK_COLOURS.length];
+    const avatarColour = this._getRankColour(idx);
     const rankEmoji = idx < 3 ? RANK_LABELS[idx] : null;
     const rankNum = idx + 1;
 
@@ -324,7 +331,7 @@ class TaskMateLeaderboardCard extends LitElement {
           ? html`<div class="rank-badge">${rankEmoji}</div>`
           : html`<div class="rank-number">${rankNum}</div>`}
 
-        <div class="child-avatar" style="background: linear-gradient(135deg, ${avatarColour} 0%, ${avatarColour}cc 100%);">
+        <div class="child-avatar" style="background: ${avatarColour};">
           <ha-icon icon="${child.avatar || 'mdi:account-circle'}"></ha-icon>
         </div>
 
@@ -333,19 +340,19 @@ class TaskMateLeaderboardCard extends LitElement {
           <div class="rank-stats">
             ${this.config.show_streak !== false && sortBy !== "streak" ? html`
               <span class="stat-chip">
-                <ha-icon icon="mdi:fire" style="color: #e67e22;"></ha-icon>
+                <ha-icon icon="mdi:fire" style="color: var(--warning-color, #ff9800);"></ha-icon>
                 ${this._t('common.d_streak', { count: child.current_streak || 0 })}
               </span>
             ` : ''}
             ${this.config.show_weekly !== false && sortBy !== "weekly" ? html`
               <span class="stat-chip">
-                <ha-icon icon="mdi:calendar-week" style="color: #3498db;"></ha-icon>
+                <ha-icon icon="mdi:calendar-week" style="color: var(--primary-color);"></ha-icon>
                 ${weeklyPoints[child.id] || 0} ${this._t('common.this_week')}
               </span>
             ` : ''}
             ${sortBy !== "points" ? html`
               <span class="stat-chip">
-                <ha-icon icon="${pointsIcon}" style="color: #f1c40f;"></ha-icon>
+                <ha-icon icon="${pointsIcon}" style="color: var(--warning-color, #ff9800);"></ha-icon>
                 ${child.points || 0} ${this._t('common.total')}
               </span>
             ` : ''}
@@ -368,7 +375,7 @@ class TaskMateLeaderboardCard extends LitElement {
 
     return html`
       <ha-card>
-        <style>:host { --taskmate-header-bg: ${this.config.header_color || '#b7950b'}; }</style>
+        ${this.config.header_color ? html`<style>:host { --taskmate-header-bg: ${this.config.header_color}; }</style>` : ''}
         <div class="card-header">
           <div class="header-content">
             <ha-icon class="header-icon" icon="mdi:trophy"></ha-icon>
@@ -378,19 +385,19 @@ class TaskMateLeaderboardCard extends LitElement {
         <div class="card-content">
           <div class="rank-row first">
             <div class="rank-badge">🥇</div>
-            <div class="child-avatar" style="background: linear-gradient(135deg, #f1c40f 0%, #e67e22 100%);">
+            <div class="child-avatar" style="background: #ca8a04;">
               <ha-icon icon="${child.avatar || 'mdi:account-circle'}"></ha-icon>
             </div>
             <div class="rank-info">
               <div class="rank-name">${child.name}</div>
               <div class="rank-stats">
                 <span class="stat-chip">
-                  <ha-icon icon="mdi:fire" style="color:#e67e22;"></ha-icon>
+                  <ha-icon icon="mdi:fire" style="color: var(--warning-color, #ff9800);"></ha-icon>
                   ${this._t('common.d_streak', { count: child.current_streak || 0 })}
                 </span>
               </div>
             </div>
-            <div class="rank-score" style="color:#f1c40f;">
+            <div class="rank-score" style="color: #ca8a04;">
               <div class="score-value">${child.points || 0}</div>
               <div class="score-label">${pointsName}</div>
             </div>
@@ -398,22 +405,22 @@ class TaskMateLeaderboardCard extends LitElement {
 
           <div class="solo-header">${this._t('leaderboard.personal_bests')}</div>
           <div class="personal-best-row">
-            <ha-icon class="pb-icon" icon="mdi:fire" style="color:#e67e22;"></ha-icon>
+            <ha-icon class="pb-icon" icon="mdi:fire" style="color: var(--warning-color, #ff9800);"></ha-icon>
             <span class="pb-label">${this._t('leaderboard.best_streak')}</span>
             <span class="pb-value">${this._t('leaderboard.best_streak_value', { count: bestStreak })}</span>
           </div>
           <div class="personal-best-row">
-            <ha-icon class="pb-icon" icon="mdi:checkbox-multiple-marked" style="color:#3498db;"></ha-icon>
+            <ha-icon class="pb-icon" icon="mdi:checkbox-multiple-marked" style="color: var(--primary-color);"></ha-icon>
             <span class="pb-label">${this._t('leaderboard.total_chores_completed')}</span>
             <span class="pb-value">${totalChores}</span>
           </div>
           <div class="personal-best-row">
-            <ha-icon class="pb-icon" icon="mdi:calendar-week" style="color:#9b59b6;"></ha-icon>
+            <ha-icon class="pb-icon" icon="mdi:calendar-week" style="color: var(--primary-color);"></ha-icon>
             <span class="pb-label">${this._t('leaderboard.points_this_week')}</span>
             <span class="pb-value">${weekly}</span>
           </div>
           <div class="personal-best-row">
-            <ha-icon class="pb-icon" icon="${pointsIcon}" style="color:#f1c40f;"></ha-icon>
+            <ha-icon class="pb-icon" icon="${pointsIcon}" style="color: var(--warning-color, #ff9800);"></ha-icon>
             <span class="pb-label">${this._t('leaderboard.total_points_earned')}</span>
             <span class="pb-value">${child.total_points_earned || child.points || 0}</span>
           </div>

--- a/custom_components/taskmate/www/taskmate-overview-card.js
+++ b/custom_components/taskmate/www/taskmate-overview-card.js
@@ -31,13 +31,6 @@ class TaskMateOverviewCard extends LitElement {
     return css`
       :host {
         display: block;
-        --ov-purple: #9b59b6;
-        --ov-purple-light: #a569bd;
-        --ov-gold: #f1c40f;
-        --ov-green: #2ecc71;
-        --ov-orange: #e67e22;
-        --ov-red: #e74c3c;
-        --ov-blue: #3498db;
       }
 
       ha-card { overflow: hidden; }
@@ -47,8 +40,8 @@ class TaskMateOverviewCard extends LitElement {
         align-items: center;
         justify-content: space-between;
         padding: 14px 18px;
-        background: var(--taskmate-header-bg, #8e44ad);
-        color: white;
+        background: var(--taskmate-header-bg, var(--primary-color));
+        color: var(--text-primary-color, #fff);
       }
 
       .header-content { display: flex; align-items: center; gap: 10px; }
@@ -56,8 +49,8 @@ class TaskMateOverviewCard extends LitElement {
       .header-title { font-size: 1.2rem; font-weight: 600; }
 
       .pending-badge {
-        background: var(--ov-red);
-        color: white;
+        background: var(--error-color, #db4437);
+        color: var(--text-primary-color, #fff);
         border-radius: 12px;
         padding: 3px 10px;
         font-size: 0.85rem;
@@ -69,8 +62,8 @@ class TaskMateOverviewCard extends LitElement {
       }
 
       @keyframes badge-pulse {
-        0%, 100% { box-shadow: 0 0 0 0 rgba(231,76,60,0.4); }
-        50% { box-shadow: 0 0 0 5px rgba(231,76,60,0); }
+        0%, 100% { box-shadow: 0 0 0 0 rgba(var(--rgb-error-color, 219,68,55),0.4); }
+        50% { box-shadow: 0 0 0 5px rgba(var(--rgb-error-color, 219,68,55),0); }
       }
 
       .pending-badge ha-icon { --mdc-icon-size: 14px; }
@@ -95,21 +88,21 @@ class TaskMateOverviewCard extends LitElement {
       }
 
       .child-tile:hover {
-        box-shadow: 0 3px 10px rgba(0,0,0,0.08);
+        box-shadow: var(--ha-card-box-shadow, 0 2px 6px rgba(0,0,0,0.08));
       }
 
       .child-avatar {
         width: 46px;
         height: 46px;
         border-radius: 50%;
-        background: linear-gradient(135deg, var(--ov-purple) 0%, var(--ov-purple-light) 100%);
+        background: var(--primary-color);
         display: flex;
         align-items: center;
         justify-content: center;
         flex-shrink: 0;
       }
 
-      .child-avatar ha-icon { --mdc-icon-size: 28px; color: white; }
+      .child-avatar ha-icon { --mdc-icon-size: 28px; color: var(--text-primary-color, #fff); }
 
       .child-main { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 6px; }
 
@@ -133,8 +126,8 @@ class TaskMateOverviewCard extends LitElement {
         display: flex;
         align-items: center;
         gap: 4px;
-        background: rgba(241,196,15,0.15);
-        color: var(--ov-orange);
+        background: rgba(var(--rgb-warning-color, 255,152,0),0.15);
+        color: var(--warning-color, #ff9800);
         border-radius: 10px;
         padding: 3px 8px;
         font-size: 0.85rem;
@@ -142,14 +135,14 @@ class TaskMateOverviewCard extends LitElement {
         flex-shrink: 0;
       }
 
-      .points-pill ha-icon { --mdc-icon-size: 14px; color: var(--ov-gold); }
+      .points-pill ha-icon { --mdc-icon-size: 14px; color: var(--warning-color, #ff9800); }
 
       .pending-points-pill {
         display: flex;
         align-items: center;
         gap: 3px;
-        background: rgba(230,126,34,0.12);
-        color: var(--ov-orange);
+        background: rgba(var(--rgb-warning-color, 255,152,0),0.12);
+        color: var(--warning-color, #ff9800);
         border-radius: 10px;
         padding: 2px 7px;
         font-size: 0.78rem;
@@ -182,11 +175,11 @@ class TaskMateOverviewCard extends LitElement {
       }
 
       .progress-bar-fill.complete {
-        background: linear-gradient(90deg, var(--ov-green), #27ae60);
+        background: var(--success-color, #4caf50);
       }
 
       .progress-bar-fill.partial {
-        background: linear-gradient(90deg, var(--ov-blue), #2980b9);
+        background: var(--primary-color);
       }
 
       .progress-bar-fill.none {
@@ -203,15 +196,15 @@ class TaskMateOverviewCard extends LitElement {
         text-align: right;
       }
 
-      .progress-label.complete { color: var(--ov-green); }
+      .progress-label.complete { color: var(--success-color, #4caf50); }
 
       /* Approval item in tile */
       .approvals-chip {
         display: inline-flex;
         align-items: center;
         gap: 4px;
-        background: rgba(231,76,60,0.12);
-        color: var(--ov-red);
+        background: rgba(var(--rgb-error-color, 219,68,55),0.12);
+        color: var(--error-color, #db4437);
         border-radius: 10px;
         padding: 2px 8px;
         font-size: 0.78rem;
@@ -278,7 +271,7 @@ class TaskMateOverviewCard extends LitElement {
     this.config = {
       title: "TaskMate",
       approvals_entity: null,
-            header_color: '#8e44ad',
+            header_color: null,
     ...config,
     };
   }
@@ -329,7 +322,7 @@ class TaskMateOverviewCard extends LitElement {
 
     return html`
       <ha-card>
-        <style>:host { --taskmate-header-bg: ${this.config.header_color || '#8e44ad'}; }</style>
+        ${this.config.header_color ? html`<style>:host { --taskmate-header-bg: ${this.config.header_color}; }</style>` : ''}
         <div class="card-header">
           <div class="header-content">
             <ha-icon class="header-icon" icon="mdi:home-heart"></ha-icon>
@@ -365,7 +358,7 @@ class TaskMateOverviewCard extends LitElement {
           ${pendingApprovals > 0 ? html`
             <div class="summary-divider"></div>
             <div class="summary-stat">
-              <span class="summary-stat-value" style="color: var(--ov-red);">${pendingApprovals}</span>
+              <span class="summary-stat-value" style="color: var(--error-color, #db4437);">${pendingApprovals}</span>
               <span class="summary-stat-label">${this._t('common.pending')}</span>
             </div>
           ` : ''}


### PR DESCRIPTION
Replace custom CSS variables (--ov-*, --act-*) and hardcoded hex colors with HA theme variables in overview, activity, and leaderboard cards.

- Gradients replaced with flat colors
- Headers fall back to var(--primary-color) when no custom color set
- Leaderboard ranks: #ca8a04 gold, --disabled-text-color silver, #cd7f32 bronze, --primary-color for others