### PR TITLE
style: HA-native styling across all cards and admin panel

### DIFF
--- a/custom_components/taskmate/manifest.json
+++ b/custom_components/taskmate/manifest.json
@@ -17,5 +17,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/tempus2016/taskmate/issues",
   "requirements": [],
-  "version": "3.5.0-beta.4"
+  "version": "3.5.0-beta.5"
 }

--- a/custom_components/taskmate/www/taskmate-approvals-card.js
+++ b/custom_components/taskmate/www/taskmate-approvals-card.js
@@ -42,8 +42,8 @@ class TaskMateApprovalsCard extends LitElement {
         align-items: center;
         justify-content: space-between;
         padding: 14px 18px;
-        background: var(--taskmate-header-bg, #27ae60);
-        color: white;
+        background: var(--taskmate-header-bg, var(--primary-color));
+        color: var(--text-primary-color, #fff);
       }
 
       .header-left {
@@ -56,7 +56,7 @@ class TaskMateApprovalsCard extends LitElement {
 
       .header-icon {
         --mdc-icon-size: 22px;
-        color: white;
+        color: var(--text-primary-color, #fff);
         opacity: 0.9;
         flex-shrink: 0;
       }
@@ -64,15 +64,15 @@ class TaskMateApprovalsCard extends LitElement {
       .card-title {
         font-size: 1.05rem;
         font-weight: 600;
-        color: white;
+        color: var(--text-primary-color, #fff);
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
       }
 
       .pending-count {
-        background: #e74c3c;
-        color: white;
+        background: var(--error-color, #db4437);
+        color: var(--text-primary-color, #fff);
         border-radius: 12px;
         padding: 3px 10px;
         font-size: 0.82rem;
@@ -128,7 +128,7 @@ class TaskMateApprovalsCard extends LitElement {
       }
 
       .approval-item:hover {
-        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        box-shadow: var(--ha-card-box-shadow, none);
       }
 
       .approval-item.loading {
@@ -208,7 +208,7 @@ class TaskMateApprovalsCard extends LitElement {
 
       .action-button:hover {
         transform: scale(1.1);
-        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+        box-shadow: var(--ha-card-box-shadow, none);
       }
 
       .action-button:active {
@@ -216,13 +216,13 @@ class TaskMateApprovalsCard extends LitElement {
       }
 
       .action-button.approve {
-        background: #4caf50;
-        color: white;
+        background: var(--success-color, #4caf50);
+        color: var(--text-primary-color, #fff);
       }
 
       .action-button.reject {
-        background: #f44336;
-        color: white;
+        background: var(--error-color, #db4437);
+        color: var(--text-primary-color, #fff);
       }
 
       .action-button ha-icon {
@@ -304,7 +304,7 @@ class TaskMateApprovalsCard extends LitElement {
     }
     this.config = {
       title: "",
-      header_color: '#27ae60',
+      header_color: '',
       ...config,
     };
   }
@@ -367,7 +367,7 @@ class TaskMateApprovalsCard extends LitElement {
 
     return html`
       <ha-card>
-        <style>:host { --taskmate-header-bg: ${this.config.header_color || '#27ae60'}; }</style>
+        <style>:host { --taskmate-header-bg: ${this.config.header_color || 'var(--primary-color)'}; }</style>
         <div class="card-header">
           <div class="header-left">
             <ha-icon class="header-icon" icon="mdi:check-circle-outline"></ha-icon>
@@ -842,13 +842,13 @@ class TaskMateApprovalsCardEditor extends LitElement {
         .computeHelper=${this._computeHelper}
         @value-changed=${this._formChanged}
       ></ha-form>
-      ${this._renderColourPicker('header_color', '#27ae60')}
+      ${this._renderColourPicker('header_color', '#03a9f4')}
     `;
   }
 
   _renderColourPicker(key, defaultValue) {
     const current = this.config[key] || defaultValue;
-    const presets = [defaultValue, '#e67e22', '#3498db', '#9b59b6', '#f1c40f', '#e74c3c', '#34495e'];
+    const presets = [defaultValue, '#4caf50', '#e67e22', '#3498db', '#9b59b6', '#f1c40f', '#34495e'];
     const isActive = (c) => c.toLowerCase() === current.toLowerCase();
     return html`
       <div class="colour-field">

--- a/custom_components/taskmate/www/taskmate-bonuses-card.js
+++ b/custom_components/taskmate/www/taskmate-bonuses-card.js
@@ -60,9 +60,8 @@ class TaskMateBonusesCard extends LitElement {
     return css`
       :host {
         display: block;
-        --bonus-green: #2e7d32;
-        --bonus-green-dark: #1b5e20;
-        --bonus-green-light: rgba(46, 125, 50, 0.12);
+        --bonus-accent: var(--success-color, #4caf50);
+        --bonus-accent-light: color-mix(in srgb, var(--success-color, #4caf50) 12%, transparent);
         --text-primary: var(--primary-text-color, #212121);
         --text-secondary: var(--secondary-text-color, #757575);
         --card-bg: var(--card-background-color, #fff);
@@ -77,8 +76,8 @@ class TaskMateBonusesCard extends LitElement {
         align-items: center;
         justify-content: space-between;
         padding: 14px 18px;
-        background: var(--taskmate-header-bg, var(--bonus-green));
-        color: white;
+        background: var(--taskmate-header-bg, var(--bonus-accent));
+        color: var(--text-primary-color, #fff);
       }
       .header-left { display: flex; align-items: center; gap: 12px; }
       .header-icon { --mdc-icon-size: 32px; opacity: 0.95; }
@@ -134,9 +133,9 @@ class TaskMateBonusesCard extends LitElement {
       }
       .child-tab ha-icon { --mdc-icon-size: 18px; }
       .child-tab.selected {
-        background: var(--bonus-green-light);
-        border-color: var(--bonus-green);
-        color: var(--bonus-green);
+        background: var(--bonus-accent-light);
+        border-color: var(--bonus-accent);
+        color: var(--bonus-accent);
       }
 
       /* ── Card body ── */
@@ -158,12 +157,12 @@ class TaskMateBonusesCard extends LitElement {
         border-radius: 12px;
         transition: box-shadow 0.2s, transform 0.15s;
       }
-      .bonus-row:hover { box-shadow: 0 3px 10px rgba(0,0,0,0.09); transform: translateY(-1px); }
+      .bonus-row:hover { box-shadow: var(--ha-card-box-shadow, none); transform: translateY(-1px); }
 
       /* Flash animation when bonus is applied */
       @keyframes flash-green {
-        0%   { background: var(--bonus-green-light); }
-        40%  { background: rgba(46,125,50,0.25); }
+        0%   { background: var(--bonus-accent-light); }
+        40%  { background: color-mix(in srgb, var(--success-color, #4caf50) 25%, transparent); }
         100% { background: var(--card-bg); }
       }
       .bonus-row.flashing { animation: flash-green 0.6s ease forwards; }
@@ -176,14 +175,13 @@ class TaskMateBonusesCard extends LitElement {
         justify-content: center;
         min-width: 64px;
         padding: 10px 8px;
-        background: linear-gradient(135deg, var(--bonus-green) 0%, var(--bonus-green-dark) 100%);
+        background: var(--bonus-accent);
         border-radius: 10px;
         flex-shrink: 0;
-        box-shadow: 0 2px 6px rgba(46,125,50,0.3);
       }
-      .points-badge ha-icon { --mdc-icon-size: 20px; color: white; margin-bottom: 2px; }
-      .points-value { font-size: 1.3rem; font-weight: 700; color: white; line-height: 1; }
-      .points-label { font-size: 0.62rem; font-weight: 600; color: rgba(255,255,255,0.88); text-transform: uppercase; letter-spacing: 0.4px; margin-top: 2px; }
+      .points-badge ha-icon { --mdc-icon-size: 20px; color: var(--text-primary-color, #fff); margin-bottom: 2px; }
+      .points-value { font-size: 1.3rem; font-weight: 700; color: var(--text-primary-color, #fff); line-height: 1; }
+      .points-label { font-size: 0.62rem; font-weight: 600; color: var(--text-primary-color, #fff); opacity: 0.88; text-transform: uppercase; letter-spacing: 0.4px; margin-top: 2px; }
 
       /* Bonus info */
       .bonus-info { flex: 1; min-width: 0; }
@@ -197,19 +195,19 @@ class TaskMateBonusesCard extends LitElement {
         justify-content: center;
         gap: 6px;
         padding: 8px 16px;
-        background: var(--bonus-green);
-        color: white;
+        background: var(--bonus-accent);
+        color: var(--text-primary-color, #fff);
         border: none;
         border-radius: 8px;
         font-size: 0.9rem;
         font-weight: 600;
         cursor: pointer;
-        transition: background 0.15s, transform 0.1s;
+        transition: opacity 0.15s, transform 0.1s;
         white-space: nowrap;
         flex-shrink: 0;
         --mdc-icon-size: 16px;
       }
-      .apply-btn:hover { background: var(--bonus-green-dark); }
+      .apply-btn:hover { opacity: 0.85; }
       .apply-btn:active { transform: scale(0.97); }
       .apply-btn:disabled { opacity: 0.55; cursor: default; }
 
@@ -230,11 +228,11 @@ class TaskMateBonusesCard extends LitElement {
         transition: all 0.15s;
       }
       .edit-btn:hover { background: var(--divider); color: var(--text-primary); }
-      .edit-btn.delete:hover { background: var(--bonus-green-light); color: var(--bonus-green); border-color: var(--bonus-green); }
+      .edit-btn.delete:hover { background: color-mix(in srgb, var(--error-color, #db4437) 12%, transparent); color: var(--error-color, #db4437); border-color: var(--error-color, #db4437); }
 
       /* Inline edit form */
       .edit-form {
-        background: var(--ha-card-background, #f5f5f5);
+        background: var(--secondary-background-color, #f5f5f5);
         border: 1px solid var(--divider);
         border-radius: 12px;
         padding: 14px;
@@ -262,19 +260,19 @@ class TaskMateBonusesCard extends LitElement {
         width: 100%;
         box-sizing: border-box;
       }
-      .form-field input:focus { outline: 2px solid var(--bonus-green); border-color: transparent; }
+      .form-field input:focus { outline: 2px solid var(--primary-color); border-color: transparent; }
       .form-actions { display: flex; gap: 8px; justify-content: flex-end; margin-top: 4px; }
       .btn-save {
         padding: 8px 18px;
-        background: var(--bonus-green);
-        color: white;
+        background: var(--primary-color);
+        color: var(--text-primary-color, #fff);
         border: none;
         border-radius: 8px;
         font-size: 0.9rem;
         font-weight: 600;
         cursor: pointer;
       }
-      .btn-save:hover { background: var(--bonus-green-dark); }
+      .btn-save:hover { opacity: 0.85; }
       .btn-cancel {
         padding: 8px 14px;
         background: none;
@@ -303,7 +301,7 @@ class TaskMateBonusesCard extends LitElement {
         transition: all 0.15s;
         --mdc-icon-size: 20px;
       }
-      .add-bonus-btn:hover { border-color: var(--bonus-green); color: var(--bonus-green); background: var(--bonus-green-light); }
+      .add-bonus-btn:hover { border-color: var(--bonus-accent); color: var(--bonus-accent); background: var(--bonus-accent-light); }
 
       /* Empty state */
       .empty-state {
@@ -321,8 +319,8 @@ class TaskMateBonusesCard extends LitElement {
         bottom: 24px;
         left: 50%;
         transform: translateX(-50%) translateY(0);
-        background: #333;
-        color: white;
+        background: var(--primary-text-color, #333);
+        color: var(--card-background-color, #fff);
         padding: 10px 20px;
         border-radius: 24px;
         font-size: 0.92rem;
@@ -624,7 +622,7 @@ class TaskMateBonusesCard extends LitElement {
 
     return html`
       <ha-card>
-        <style>:host { --taskmate-header-bg: ${this.config.header_color || '#2e7d32'}; }</style>
+        <style>:host { --taskmate-header-bg: ${this.config.header_color || 'var(--success-color, #4caf50)'}; }</style>
         <div class="card-header">
           <div class="header-left">
             <ha-icon class="header-icon" icon="mdi:star-circle"></ha-icon>
@@ -753,13 +751,13 @@ class TaskMateBonusesCardEditor extends LitElement {
         .computeHelper=${this._computeHelper}
         @value-changed=${this._formChanged}
       ></ha-form>
-      ${this._renderColourPicker('header_color', '#2e7d32')}
+      ${this._renderColourPicker('header_color', '#4caf50')}
     `;
   }
 
   _renderColourPicker(key, defaultValue) {
     const current = this.config[key] || defaultValue;
-    const presets = [defaultValue, '#e67e22', '#27ae60', '#3498db', '#9b59b6', '#f1c40f', '#34495e'];
+    const presets = [defaultValue, '#e67e22', '#2e7d32', '#3498db', '#9b59b6', '#f1c40f', '#34495e'];
     const isActive = (c) => c.toLowerCase() === current.toLowerCase();
     return html`
       <div class="colour-field">

--- a/custom_components/taskmate/www/taskmate-graph-card.js
+++ b/custom_components/taskmate/www/taskmate-graph-card.js
@@ -47,11 +47,6 @@ class TaskMateGraphCard extends LitElement {
     return css`
       :host {
         display: block;
-        --gr-purple: #9b59b6;
-        --gr-purple-light: #a569bd;
-        --gr-gold: #f1c40f;
-        --gr-green: #2ecc71;
-        --gr-blue: #3498db;
       }
 
       ha-card { overflow: hidden; }
@@ -61,8 +56,8 @@ class TaskMateGraphCard extends LitElement {
         align-items: center;
         justify-content: space-between;
         padding: 14px 18px;
-        background: var(--taskmate-header-bg, #d35400);
-        color: white;
+        background: var(--taskmate-header-bg, var(--primary-color, #03a9f4));
+        color: var(--text-primary-color, #fff);
         gap: 12px;
       }
 
@@ -94,11 +89,11 @@ class TaskMateGraphCard extends LitElement {
 
       .mode-btn.active {
         background: rgba(255,255,255,0.2);
-        color: white;
+        color: var(--text-primary-color, #fff);
       }
 
       .mode-btn:hover:not(.active) {
-        color: rgba(255,255,255,0.85);
+        color: var(--text-primary-color, rgba(255,255,255,0.85));
       }
 
       .card-content {
@@ -148,7 +143,7 @@ class TaskMateGraphCard extends LitElement {
         padding: 8px 12px;
         font-size: 0.8rem;
         color: var(--primary-text-color);
-        box-shadow: 0 4px 16px rgba(0,0,0,0.15);
+        box-shadow: var(--ha-card-box-shadow, 0 2px 6px rgba(0,0,0,0.15));
         pointer-events: none;
         z-index: 10;
         white-space: nowrap;

--- a/custom_components/taskmate/www/taskmate-panel.js
+++ b/custom_components/taskmate/www/taskmate-panel.js
@@ -1,20 +1,15 @@
 /**
  * TaskMate admin panel — sidebar entry at /taskmate-admin.
  *
- * v3.5.0-alpha.9 — sidebar layout + connection recovery:
- *   - Left-rail navigation replaces horizontal tabs (grouped by section).
- *     Horizontal tab row falls back automatically on narrow screens.
- *   - Slim topbar: breadcrumbs, approval pill, version chip.
- *   - Refined token system: light is the primary aesthetic (cleaner
- *     #fafafa/#fff palette, sharper #2563eb accent, less roundness,
- *     border-first instead of shadow-heavy). Dark inverted to match.
- *   - Connection recovery: refetch state when WS reconnects after a
- *     drop and when the tab becomes visible again. Fixes blank-panel
- *     after the tab has been idle for a while.
- *   - _fetchState retries once on transient failure.
+ * v3.5.0-beta.5 — HA-native styling:
+ *   - All custom --tm-* tokens now map to HA theme variables
+ *     (--primary-color, --card-background-color, etc.).
+ *   - Dark mode handled automatically via HA vars (no .dark override).
+ *   - Shadows, radii, fonts follow HA defaults.
+ *   - Entity picker dropdown uses theme-aware colors.
  */
 
-const PANEL_VERSION = "3.5.0-alpha.9";
+const PANEL_VERSION = "3.5.0-beta.5";
 
 const TABS = [
   { id: "children",  label: "Children" },
@@ -411,7 +406,7 @@ class TaskMatePanel extends HTMLElement {
     const t = e.target;
     if (!t.dataset || !t.dataset.field) return;
     let value;
-    if (t.type === "checkbox") value = t.checked;
+    if (t.type === "checkbox" || t.tagName === "HA-SWITCH") value = t.checked;
     else if (t.type === "number") value = (t.value === "" ? null : Number(t.value));
     else value = t.value;
     this._dialog.data[t.dataset.field] = value;
@@ -890,6 +885,14 @@ class TaskMatePanel extends HTMLElement {
     this.querySelectorAll("ha-icon-picker").forEach(el => {
       el.hass = this._hass;
       const v = el.getAttribute("data-current") || "";
+      if (el.value !== v) el.value = v;
+    });
+    this.querySelectorAll("ha-textfield[data-field]").forEach(el => {
+      const v = el.getAttribute("data-value") || "";
+      if (el.value !== v) el.value = v;
+    });
+    this.querySelectorAll("ha-select[data-field]").forEach(el => {
+      const v = el.getAttribute("data-value") || "";
       if (el.value !== v) el.value = v;
     });
   }
@@ -1560,7 +1563,7 @@ class TaskMatePanel extends HTMLElement {
         </div>
 
         <div class="tm-settings-foot">
-          <button class="tm-btn" data-act="save-settings">Save settings</button>
+          <mwc-button raised data-act="save-settings">Save settings</mwc-button>
         </div>
       </div>
     `;
@@ -1595,8 +1598,8 @@ class TaskMatePanel extends HTMLElement {
         this._entityPickerField("Unavailability sensor (optional)", "unavailability_entity", d.unavailability_entity, ["binary_sensor", "sensor", "input_boolean", "person", "calendar"],
           "A second sensor where <code>on</code>/<code>active</code> means the child is busy. Useful for school calendars. The child is available only when the availability sensor says available AND this sensor does not say busy."),
       ].join(""),
-      `<button class="tm-btn tm-btn-ghost" data-act="close-dialog">Cancel</button>
-       <button class="tm-btn" data-act="save-child">Save</button>`
+      `<mwc-button slot="secondaryAction" data-act="close-dialog">Cancel</mwc-button>
+       <mwc-button slot="primaryAction" raised data-act="save-child">Save</mwc-button>`
     );
   }
 
@@ -1699,8 +1702,8 @@ class TaskMatePanel extends HTMLElement {
           </div>
         </details>`,
       ].join(""),
-      `<button class="tm-btn tm-btn-ghost" data-act="close-dialog">Cancel</button>
-       <button class="tm-btn" data-act="save-chore">Save</button>`
+      `<mwc-button slot="secondaryAction" data-act="close-dialog">Cancel</mwc-button>
+       <mwc-button slot="primaryAction" raised data-act="save-chore">Save</mwc-button>`
     );
   }
 
@@ -1738,8 +1741,8 @@ class TaskMatePanel extends HTMLElement {
           ${this._dateField("Expires (blank = never)", "expires_at", d.expires_at, "Pooled points are refunded at midnight.")}
         </div>`,
       ].join(""),
-      `<button class="tm-btn tm-btn-ghost" data-act="close-dialog">Cancel</button>
-       <button class="tm-btn" data-act="save-reward">Save</button>`
+      `<mwc-button slot="secondaryAction" data-act="close-dialog">Cancel</mwc-button>
+       <mwc-button slot="primaryAction" raised data-act="save-reward">Save</mwc-button>`
     );
   }
 
@@ -1769,8 +1772,8 @@ class TaskMatePanel extends HTMLElement {
           </div>
         ` : "",
       ].join(""),
-      `<button class="tm-btn tm-btn-ghost" data-act="close-dialog">Cancel</button>
-       <button class="tm-btn" data-act="save-${kind}">Save</button>`
+      `<mwc-button slot="secondaryAction" data-act="close-dialog">Cancel</mwc-button>
+       <mwc-button slot="primaryAction" raised data-act="save-${kind}">Save</mwc-button>`
     );
   }
 
@@ -1793,7 +1796,7 @@ class TaskMatePanel extends HTMLElement {
           `).join("")}
         </div>
        `}`,
-      `<button class="tm-btn tm-btn-ghost" data-act="close-dialog">Close</button>`
+      `<mwc-button slot="secondaryAction" data-act="close-dialog">Close</mwc-button>`
     );
   }
 
@@ -1822,8 +1825,8 @@ class TaskMatePanel extends HTMLElement {
           </div>
         `,
       ].join(""),
-      `<button class="tm-btn tm-btn-ghost" data-act="close-dialog">Cancel</button>
-       <button class="tm-btn" data-act="save-group">Save</button>`
+      `<mwc-button slot="secondaryAction" data-act="close-dialog">Cancel</mwc-button>
+       <mwc-button slot="primaryAction" raised data-act="save-group">Save</mwc-button>`
     );
   }
 
@@ -1869,8 +1872,8 @@ class TaskMatePanel extends HTMLElement {
         this._select("Completion sound", "completion_sound", d.completion_sound, COMPLETION_SOUNDS.map(s => ({ v: s, l: s }))),
         this._switch("Requires parent approval", "requires_approval", d.requires_approval),
       ].join(""),
-      `<button class="tm-btn tm-btn-ghost" data-act="close-dialog">Cancel</button>
-       <button class="tm-btn" data-act="save-bulk-chores">Create chores</button>`
+      `<mwc-button slot="secondaryAction" data-act="close-dialog">Cancel</mwc-button>
+       <mwc-button slot="primaryAction" raised data-act="save-bulk-chores">Create chores</mwc-button>`
     );
   }
 
@@ -1892,8 +1895,8 @@ class TaskMatePanel extends HTMLElement {
            `;
          }).join("")}
        </div>`,
-      `<button class="tm-btn tm-btn-ghost" data-act="close-dialog">Cancel</button>
-       <button class="tm-btn" data-act="save-chore-order">Save order</button>`
+      `<mwc-button slot="secondaryAction" data-act="close-dialog">Cancel</mwc-button>
+       <mwc-button slot="primaryAction" raised data-act="save-chore-order">Save order</mwc-button>`
     );
   }
 
@@ -1914,40 +1917,51 @@ class TaskMatePanel extends HTMLElement {
 
   _field(label, name, value, type = "text", hint = "") {
     return `
-      <label class="tm-field">
-        <span class="tm-field-label">${this._esc(label)}</span>
-        <input type="${type}" data-field="${name}" value="${this._esc(value == null ? "" : value)}">
+      <div class="tm-field">
+        <ha-textfield
+          label="${this._esc(label)}"
+          data-field="${name}"
+          data-value="${this._esc(value == null ? "" : value)}"
+          ${type === "number" ? 'type="number"' : ''}
+        ></ha-textfield>
         ${hint ? `<span class="tm-field-hint">${hint}</span>` : ""}
-      </label>`;
+      </div>`;
   }
 
   _dateField(label, name, value, hint = "") {
     return `
-      <label class="tm-field">
-        <span class="tm-field-label">${this._esc(label)}</span>
-        <input type="date" data-field="${name}" value="${this._esc(value || "")}">
+      <div class="tm-field">
+        <ha-textfield
+          label="${this._esc(label)}"
+          data-field="${name}"
+          data-value="${this._esc(value || "")}"
+          type="date"
+        ></ha-textfield>
         ${hint ? `<span class="tm-field-hint">${hint}</span>` : ""}
-      </label>`;
+      </div>`;
   }
 
   _select(label, name, value, options, hint = "", rerender = false) {
     return `
-      <label class="tm-field">
-        <span class="tm-field-label">${this._esc(label)}</span>
-        <select data-field="${name}" ${rerender ? `data-rerender="true"` : ""}>
-          ${options.map(o => `<option value="${this._esc(o.v)}" ${o.v === value ? "selected" : ""}>${this._esc(o.l)}</option>`).join("")}
-        </select>
+      <div class="tm-field">
+        <ha-select
+          label="${this._esc(label)}"
+          data-field="${name}"
+          data-value="${this._esc(value || "")}"
+          ${rerender ? 'data-rerender="true"' : ""}
+          fixedMenuPosition
+          naturalMenuWidth
+        >
+          ${options.map(o => `<mwc-list-item value="${this._esc(o.v)}" ${String(o.v) === String(value) ? "selected activated" : ""}>${this._esc(o.l)}</mwc-list-item>`).join("")}
+        </ha-select>
         ${hint ? `<span class="tm-field-hint">${hint}</span>` : ""}
-      </label>`;
+      </div>`;
   }
 
   _switch(label, name, checked, hint = "") {
     return `
       <div class="tm-check-row">
-        <label class="tm-switch">
-          <input type="checkbox" data-field="${name}" ${checked ? "checked" : ""}>
-          <span class="tm-slider"></span>
-        </label>
+        <ha-switch data-field="${name}" ${checked ? "checked" : ""}></ha-switch>
         <div>
           <div class="tm-check-title">${this._esc(label)}</div>
           ${hint ? `<span class="tm-field-hint">${hint}</span>` : ""}
@@ -1957,10 +1971,10 @@ class TaskMatePanel extends HTMLElement {
 
   _iconPickerField(label, name, value) {
     return `
-      <label class="tm-field">
+      <div class="tm-field">
         <span class="tm-field-label">${this._esc(label)}</span>
         <ha-icon-picker data-field="${name}" data-current="${this._esc(value || "")}"></ha-icon-picker>
-      </label>`;
+      </div>`;
   }
 
   _entityPickerField(label, name, value, domains, hint = "") {
@@ -1995,34 +2009,22 @@ class TaskMatePanel extends HTMLElement {
       .slice(0, 50);
     if (!entities.length) return;
     const dd = document.createElement("div");
-    Object.assign(dd.style, {
-      position: "absolute", top: "100%", left: "0", right: "0",
-      maxHeight: "260px", overflowY: "auto",
-      background: "#1c1c1e", border: "1px solid #3a3a3c",
-      borderRadius: "10px", zIndex: "200",
-      marginTop: "4px", padding: "4px 0",
-      boxShadow: "0 8px 32px rgba(0,0,0,0.45)"
-    });
+    dd.className = "tm-ep-dropdown";
     entities.forEach(([id, st]) => {
       const fn = st.attributes?.friendly_name || "";
       const opt = document.createElement("div");
+      opt.className = "tm-ep-option";
       opt.dataset.act = "pick-entity";
       opt.dataset.field = field;
       opt.dataset.value = id;
-      Object.assign(opt.style, {
-        padding: "8px 12px", cursor: "pointer",
-        borderBottom: "1px solid rgba(255,255,255,0.06)"
-      });
-      opt.addEventListener("mouseenter", () => opt.style.background = "rgba(255,255,255,0.1)");
-      opt.addEventListener("mouseleave", () => opt.style.background = "transparent");
       const idDiv = document.createElement("div");
+      idDiv.className = "tm-ep-id";
       idDiv.textContent = id;
-      Object.assign(idDiv.style, { fontSize: "13px", color: "#f5f5f5", fontFamily: "ui-monospace, monospace" });
       opt.appendChild(idDiv);
       if (fn) {
         const nameDiv = document.createElement("div");
+        nameDiv.className = "tm-ep-name";
         nameDiv.textContent = fn;
-        Object.assign(nameDiv.style, { fontSize: "11px", color: "#8e8e93", marginTop: "2px" });
         opt.appendChild(nameDiv);
       }
       dd.appendChild(opt);
@@ -2066,127 +2068,71 @@ class TaskMatePanel extends HTMLElement {
     return `<ha-icon icon="${this._esc(name || "mdi:account-circle")}"></ha-icon>`;
   }
 
-  // ---- styles (Shopify-grade light + polished dark, blur 2px) ----------
   _styles() {
     return `<style>
       taskmate-panel {
         display: block; height: 100%;
 
-        /* ===== Light is the default ===== */
-        --tm-bg:            #fafafa;
-        --tm-surface-0:     #ffffff;
-        --tm-surface-1:     #ffffff;
-        --tm-surface-2:     #f5f5f5;
-        --tm-surface-3:     #ebebeb;
-        --tm-surface-hover: #f5f5f5;
+        --tm-bg:            var(--primary-background-color, #fafafa);
+        --tm-surface-0:     var(--card-background-color, #fff);
+        --tm-surface-1:     var(--card-background-color, #fff);
+        --tm-surface-2:     var(--secondary-background-color, #f5f5f5);
+        --tm-surface-3:     var(--secondary-background-color, #e8e8e8);
+        --tm-surface-hover: var(--secondary-background-color, #f5f5f5);
 
-        --tm-border:        #e5e5e5;
-        --tm-border-strong: #d4d4d4;
-        --tm-border-soft:   #ededed;
+        --tm-border:        var(--divider-color, #e0e0e0);
+        --tm-border-strong: var(--divider-color, #d4d4d4);
+        --tm-border-soft:   var(--divider-color, #e8e8e8);
 
-        --tm-text:          #0a0a0a;
-        --tm-text-muted:    #525252;
-        --tm-text-faint:    #737373;
-        --tm-text-vfaint:   #a3a3a3;
+        --tm-text:          var(--primary-text-color, #212121);
+        --tm-text-muted:    var(--secondary-text-color, #727272);
+        --tm-text-faint:    var(--secondary-text-color, #727272);
+        --tm-text-vfaint:   var(--disabled-text-color, #bdbdbd);
 
-        --tm-accent:        #2563eb;
-        --tm-accent-hover:  #1d4ed8;
-        --tm-accent-press:  #1e40af;
-        --tm-accent-soft:   #eff6ff;
-        --tm-accent-border: #bfdbfe;
-        --tm-accent-text:   #1e40af;
-        --tm-accent-glow:   rgba(37,99,235,0.15);
+        --tm-accent:        var(--primary-color, #03a9f4);
+        --tm-accent-hover:  var(--primary-color, #03a9f4);
+        --tm-accent-press:  var(--primary-color, #03a9f4);
+        --tm-accent-soft:   color-mix(in srgb, var(--primary-color, #03a9f4), transparent 90%);
+        --tm-accent-border: color-mix(in srgb, var(--primary-color, #03a9f4), transparent 70%);
+        --tm-accent-text:   var(--primary-color, #03a9f4);
+        --tm-accent-glow:   color-mix(in srgb, var(--primary-color, #03a9f4), transparent 85%);
 
-        --tm-positive:      #16a34a;
-        --tm-positive-soft: #f0fdf4;
-        --tm-positive-border:#bbf7d0;
-        --tm-warning:       #d97706;
-        --tm-warning-soft:  #fffbeb;
-        --tm-warning-border:#fde68a;
-        --tm-danger:        #dc2626;
-        --tm-danger-soft:   #fef2f2;
-        --tm-danger-border: #fecaca;
+        --tm-positive:      var(--success-color, #4caf50);
+        --tm-positive-soft: color-mix(in srgb, var(--success-color, #4caf50), transparent 90%);
+        --tm-positive-border:color-mix(in srgb, var(--success-color, #4caf50), transparent 70%);
+        --tm-warning:       var(--warning-color, #ff9800);
+        --tm-warning-soft:  color-mix(in srgb, var(--warning-color, #ff9800), transparent 90%);
+        --tm-warning-border:color-mix(in srgb, var(--warning-color, #ff9800), transparent 70%);
+        --tm-danger:        var(--error-color, #db4437);
+        --tm-danger-soft:   color-mix(in srgb, var(--error-color, #db4437), transparent 90%);
+        --tm-danger-border: color-mix(in srgb, var(--error-color, #db4437), transparent 70%);
 
-        --tm-gold:          #ca8a04;
-        --tm-gold-soft:     #fefce8;
-        --tm-pool:          #c2410c;
-        --tm-pool-soft:     #fff7ed;
-        --tm-sticky:        #7c3aed;
-        --tm-sticky-soft:   #f5f3ff;
+        --tm-gold:          var(--warning-color, #ff9800);
+        --tm-gold-soft:     color-mix(in srgb, var(--warning-color, #ff9800), transparent 90%);
+        --tm-pool:          var(--accent-color, #ff9800);
+        --tm-pool-soft:     color-mix(in srgb, var(--accent-color, #ff9800), transparent 90%);
+        --tm-sticky:        var(--info-color, #039be5);
+        --tm-sticky-soft:   color-mix(in srgb, var(--info-color, #039be5), transparent 90%);
 
-        --tm-radius-sm:     6px;
-        --tm-radius:        8px;
-        --tm-radius-lg:     12px;
+        --tm-radius-sm:     8px;
+        --tm-radius:        var(--ha-card-border-radius, 12px);
+        --tm-radius-lg:     var(--ha-card-border-radius, 12px);
 
-        --tm-shadow-xs:     0 1px 2px rgba(0,0,0,0.04);
-        --tm-shadow-sm:     0 1px 3px rgba(0,0,0,0.06), 0 1px 2px rgba(0,0,0,0.04);
-        --tm-shadow:        0 4px 12px rgba(0,0,0,0.06), 0 1px 3px rgba(0,0,0,0.04);
-        --tm-shadow-lg:     0 24px 48px -12px rgba(0,0,0,0.18), 0 8px 16px -4px rgba(0,0,0,0.06);
-        --tm-shadow-focus:  0 0 0 3px var(--tm-accent-glow);
-        --tm-easing:        cubic-bezier(0.16, 1, 0.3, 1);
+        --tm-shadow-xs:     none;
+        --tm-shadow-sm:     none;
+        --tm-shadow:        var(--ha-card-box-shadow, none);
+        --tm-shadow-lg:     var(--ha-card-box-shadow, 0 2px 6px rgba(0,0,0,0.15));
+        --tm-shadow-focus:  0 0 0 2px var(--tm-accent-glow);
+        --tm-easing:        ease;
 
         --tm-sidebar-w:     240px;
 
         background: var(--tm-bg);
         color: var(--tm-text);
-        font-family: "Inter", var(--paper-font-body1_-_font-family,
-                     -apple-system, BlinkMacSystemFont, "SF Pro Text",
-                     "Segoe UI", Roboto, sans-serif);
-        font-size: 13px;
+        font-family: var(--paper-font-body1_-_font-family, Roboto, "Noto Sans", sans-serif);
+        font-size: 14px;
         line-height: 1.5;
-        letter-spacing: -0.003em;
         -webkit-font-smoothing: antialiased;
-        -moz-osx-font-smoothing: grayscale;
-        font-feature-settings: "cv11", "ss01";
-      }
-
-      /* ===== Dark theme — follows HA's theme selector ===== */
-      taskmate-panel.dark {
-          --tm-bg:            #0a0a0a;
-          --tm-surface-0:     #111111;
-          --tm-surface-1:     #161616;
-          --tm-surface-2:     #1c1c1c;
-          --tm-surface-3:     #242424;
-          --tm-surface-hover: #1c1c1c;
-
-          --tm-border:        #262626;
-          --tm-border-strong: #333333;
-          --tm-border-soft:   #1f1f1f;
-
-          --tm-text:          #fafafa;
-          --tm-text-muted:    #a3a3a3;
-          --tm-text-faint:    #737373;
-          --tm-text-vfaint:   #525252;
-
-          --tm-accent:        #60a5fa;
-          --tm-accent-hover:  #93c5fd;
-          --tm-accent-press:  #3b82f6;
-          --tm-accent-soft:   rgba(96,165,250,0.10);
-          --tm-accent-border: rgba(96,165,250,0.25);
-          --tm-accent-text:   #93c5fd;
-          --tm-accent-glow:   rgba(96,165,250,0.20);
-
-          --tm-positive:      #4ade80;
-          --tm-positive-soft: rgba(74,222,128,0.10);
-          --tm-positive-border:rgba(74,222,128,0.25);
-          --tm-warning:       #fbbf24;
-          --tm-warning-soft:  rgba(251,191,36,0.10);
-          --tm-warning-border:rgba(251,191,36,0.25);
-          --tm-danger:        #f87171;
-          --tm-danger-soft:   rgba(248,113,113,0.10);
-          --tm-danger-border: rgba(248,113,113,0.25);
-
-          --tm-gold:          #f5b300;
-          --tm-gold-soft:     rgba(245,179,0,0.10);
-          --tm-pool:          #fb923c;
-          --tm-pool-soft:     rgba(251,146,60,0.10);
-          --tm-sticky:        #c084fc;
-          --tm-sticky-soft:   rgba(192,132,252,0.10);
-
-          --tm-shadow-xs:     0 1px 2px rgba(0,0,0,0.4);
-          --tm-shadow-sm:     0 1px 3px rgba(0,0,0,0.4), 0 1px 2px rgba(0,0,0,0.3);
-          --tm-shadow:        0 4px 12px rgba(0,0,0,0.5), 0 1px 3px rgba(0,0,0,0.3);
-          --tm-shadow-lg:     0 24px 48px -12px rgba(0,0,0,0.7), 0 8px 16px -4px rgba(0,0,0,0.3);
       }
 
       /* ===== Shell ===== */
@@ -2214,11 +2160,10 @@ class TaskMatePanel extends HTMLElement {
       .tm-brand-mark {
         width: 28px; height: 28px;
         border-radius: 7px;
-        background: linear-gradient(135deg, var(--tm-accent), var(--tm-accent-press));
-        color: #fff;
+        background: var(--tm-accent);
+        color: var(--text-primary-color, #fff);
         display: grid; place-items: center;
         flex-shrink: 0;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.15), inset 0 1px 0 rgba(255,255,255,0.18);
       }
       .tm-brand-mark ha-icon { --mdc-icon-size: 16px; }
       .tm-brand-text {
@@ -2420,44 +2365,39 @@ class TaskMatePanel extends HTMLElement {
       /* Buttons */
       .tm-btn {
         background: var(--tm-accent);
-        color: white;
-        border: 1px solid var(--tm-accent);
-        padding: 6px 12px;
+        color: var(--text-primary-color, #fff);
+        border: none;
+        padding: 8px 16px;
         border-radius: var(--tm-radius-sm);
-        font-size: 13px; font-weight: 500;
-        letter-spacing: -0.005em;
+        font-size: 14px; font-weight: 500;
         font-family: inherit;
         cursor: pointer;
-        box-shadow: var(--tm-shadow-xs), inset 0 1px 0 rgba(255,255,255,0.15);
-        transition: all 0.1s var(--tm-easing);
+        transition: opacity 0.1s ease;
         display: inline-flex; align-items: center; gap: 6px;
         white-space: nowrap;
       }
-      .tm-btn:hover  { background: var(--tm-accent-hover); border-color: var(--tm-accent-hover); }
+      .tm-btn:hover  { opacity: 0.85; }
       .tm-btn:focus-visible { outline: 0; box-shadow: var(--tm-shadow-focus); }
-      .tm-btn:active { filter: brightness(0.95); }
+      .tm-btn:active { opacity: 0.75; }
       .tm-btn-sm     { padding: 4px 9px; font-size: 12px; }
       .tm-btn-ghost {
-        background: var(--tm-surface-0);
+        background: transparent;
         color: var(--tm-text);
         border: 1px solid var(--tm-border);
-        box-shadow: var(--tm-shadow-xs);
       }
       .tm-btn-ghost:hover {
         background: var(--tm-surface-2);
-        border-color: var(--tm-border-strong);
-        color: var(--tm-text);
+        opacity: 1;
       }
       .tm-btn-danger {
-        background: var(--tm-surface-0);
+        background: transparent;
         color: var(--tm-danger);
         border: 1px solid var(--tm-danger-border);
-        box-shadow: var(--tm-shadow-xs);
       }
       .tm-btn-danger:hover {
         background: var(--tm-danger);
-        color: #fff;
-        border-color: var(--tm-danger);
+        color: var(--text-primary-color, #fff);
+        opacity: 1;
       }
       .tm-icon-btn {
         width: 28px; height: 28px;
@@ -2502,7 +2442,7 @@ class TaskMatePanel extends HTMLElement {
       .tm-avatar {
         width: 44px; height: 44px;
         border-radius: 10px;
-        background: linear-gradient(135deg, var(--tm-accent-soft), var(--tm-surface-0));
+        background: var(--tm-accent-soft);
         border: 1px solid var(--tm-border);
         display: grid; place-items: center;
         flex-shrink: 0;
@@ -2580,7 +2520,7 @@ class TaskMatePanel extends HTMLElement {
         font-size: 18px;
         transition: all 0.15s var(--tm-easing);
       }
-      .tm-add-tile:hover .tm-add-plus { background: var(--tm-accent); color: white; }
+      .tm-add-tile:hover .tm-add-plus { background: var(--tm-accent); color: var(--text-primary-color, #fff); }
 
       /* Tables */
       .tm-table-wrap {
@@ -2667,7 +2607,7 @@ class TaskMatePanel extends HTMLElement {
       }
       .tm-progress > span {
         display: block; height: 100%;
-        background: linear-gradient(90deg, var(--tm-accent), var(--tm-sticky));
+        background: var(--tm-accent);
         border-radius: 999px;
       }
       .tm-progress-text {
@@ -2811,9 +2751,9 @@ class TaskMatePanel extends HTMLElement {
         content: ''; position: absolute;
         height: 16px; width: 16px;
         left: 2px; top: 2px;
-        background: white; border-radius: 50%;
+        background: var(--card-background-color, #fff); border-radius: 50%;
         transition: transform 0.15s var(--tm-easing);
-        box-shadow: 0 1px 2px rgba(0,0,0,0.2);
+        box-shadow: 0 1px 2px rgba(0,0,0,0.15);
       }
       .tm-switch input:checked + .tm-slider {
         background: var(--tm-accent);
@@ -2823,15 +2763,12 @@ class TaskMatePanel extends HTMLElement {
       /* Dialog */
       .tm-scrim {
         position: fixed; inset: 0;
-        background: rgba(10,10,10,0.4);
-        backdrop-filter: blur(4px);
-        -webkit-backdrop-filter: blur(4px);
+        background: rgba(0,0,0,0.5);
         display: flex; align-items: flex-start; justify-content: center;
         padding: 60px 20px; z-index: 100;
         overflow-y: auto;
         animation: tm-scrim-in 0.18s var(--tm-easing);
       }
-      taskmate-panel.dark .tm-scrim { background: rgba(0,0,0,0.6); }
       @keyframes tm-scrim-in { from { opacity: 0; } to { opacity: 1; } }
       .tm-dialog {
         background: var(--tm-surface-0);
@@ -2903,18 +2840,18 @@ class TaskMatePanel extends HTMLElement {
       .tm-ep-dropdown {
         position: absolute; top: 100%; left: 0; right: 0;
         max-height: 260px; overflow-y: auto;
-        background: #1c1c1e; border: 1px solid #3a3a3c;
-        border-radius: 10px; z-index: 200;
+        background: var(--tm-surface-0); border: 1px solid var(--tm-border);
+        border-radius: var(--tm-radius); z-index: 200;
         margin-top: 4px; padding: 4px 0;
-        box-shadow: 0 8px 32px rgba(0,0,0,0.45);
+        box-shadow: var(--tm-shadow-lg);
       }
       .tm-ep-option {
         padding: 7px 12px; cursor: pointer;
         transition: background 0.08s;
       }
-      .tm-ep-option:hover { background: rgba(255,255,255,0.08); }
-      .tm-ep-id { font-size: 12px; color: #f5f5f5; font-family: ui-monospace, monospace; }
-      .tm-ep-name { font-size: 11px; color: #8e8e93; margin-top: 1px; }
+      .tm-ep-option:hover { background: var(--tm-surface-hover); }
+      .tm-ep-id { font-size: 12px; color: var(--tm-text); font-family: ui-monospace, monospace; }
+      .tm-ep-name { font-size: 11px; color: var(--tm-text-muted); margin-top: 1px; }
       .tm-field-hint {
         display: block; color: var(--tm-text-faint);
         font-size: 11.5px; margin-top: 4px; line-height: 1.5;
@@ -2966,7 +2903,7 @@ class TaskMatePanel extends HTMLElement {
       }
       .tm-day-btn:hover { color: var(--tm-text); border-color: var(--tm-border-strong); }
       .tm-day-on {
-        background: var(--tm-accent); color: white;
+        background: var(--tm-accent); color: var(--text-primary-color, #fff);
         border-color: var(--tm-accent);
       }
 
@@ -3032,8 +2969,8 @@ class TaskMatePanel extends HTMLElement {
         animation: tm-toast-in 0.2s var(--tm-easing);
       }
       @keyframes tm-toast-in { from { opacity: 0; transform: translate(-50%, 8px); } to { opacity: 1; transform: translateX(-50%); } }
-      .tm-toast-ok  { background: var(--tm-positive); color: white; }
-      .tm-toast-err { background: var(--tm-danger); color: white; }
+      .tm-toast-ok  { background: var(--tm-positive); color: var(--text-primary-color, #fff); }
+      .tm-toast-err { background: var(--tm-danger); color: var(--text-primary-color, #fff); }
 
       /* ===== Mobile / narrow ===== */
       @media (max-width: 900px) {

--- a/custom_components/taskmate/www/taskmate-penalties-card.js
+++ b/custom_components/taskmate/www/taskmate-penalties-card.js
@@ -60,9 +60,8 @@ class TaskMatePenaltiesCard extends LitElement {
     return css`
       :host {
         display: block;
-        --penalty-red: #e74c3c;
-        --penalty-red-dark: #c0392b;
-        --penalty-red-light: rgba(231, 76, 60, 0.12);
+        --penalty-accent: var(--error-color, #db4437);
+        --penalty-accent-light: color-mix(in srgb, var(--error-color, #db4437) 12%, transparent);
         --text-primary: var(--primary-text-color, #212121);
         --text-secondary: var(--secondary-text-color, #757575);
         --card-bg: var(--card-background-color, #fff);
@@ -77,8 +76,8 @@ class TaskMatePenaltiesCard extends LitElement {
         align-items: center;
         justify-content: space-between;
         padding: 14px 18px;
-        background: var(--taskmate-header-bg, var(--penalty-red));
-        color: white;
+        background: var(--taskmate-header-bg, var(--penalty-accent));
+        color: var(--text-primary-color, #fff);
       }
       .header-left { display: flex; align-items: center; gap: 12px; }
       .header-icon { --mdc-icon-size: 32px; opacity: 0.95; }
@@ -134,9 +133,9 @@ class TaskMatePenaltiesCard extends LitElement {
       }
       .child-tab ha-icon { --mdc-icon-size: 18px; }
       .child-tab.selected {
-        background: var(--penalty-red-light);
-        border-color: var(--penalty-red);
-        color: var(--penalty-red);
+        background: var(--penalty-accent-light);
+        border-color: var(--penalty-accent);
+        color: var(--penalty-accent);
       }
 
       /* ── Card body ── */
@@ -158,12 +157,12 @@ class TaskMatePenaltiesCard extends LitElement {
         border-radius: 12px;
         transition: box-shadow 0.2s, transform 0.15s;
       }
-      .penalty-row:hover { box-shadow: 0 3px 10px rgba(0,0,0,0.09); transform: translateY(-1px); }
+      .penalty-row:hover { box-shadow: var(--ha-card-box-shadow, none); transform: translateY(-1px); }
 
       /* Flash animation when penalty is applied */
       @keyframes flash-red {
-        0%   { background: var(--penalty-red-light); }
-        40%  { background: rgba(231,76,60,0.25); }
+        0%   { background: var(--penalty-accent-light); }
+        40%  { background: color-mix(in srgb, var(--error-color, #db4437) 25%, transparent); }
         100% { background: var(--card-bg); }
       }
       .penalty-row.flashing { animation: flash-red 0.6s ease forwards; }
@@ -176,14 +175,13 @@ class TaskMatePenaltiesCard extends LitElement {
         justify-content: center;
         min-width: 64px;
         padding: 10px 8px;
-        background: linear-gradient(135deg, var(--penalty-red) 0%, var(--penalty-red-dark) 100%);
+        background: var(--penalty-accent);
         border-radius: 10px;
         flex-shrink: 0;
-        box-shadow: 0 2px 6px rgba(231,76,60,0.3);
       }
-      .points-badge ha-icon { --mdc-icon-size: 20px; color: white; margin-bottom: 2px; }
-      .points-value { font-size: 1.3rem; font-weight: 700; color: white; line-height: 1; }
-      .points-label { font-size: 0.62rem; font-weight: 600; color: rgba(255,255,255,0.88); text-transform: uppercase; letter-spacing: 0.4px; margin-top: 2px; }
+      .points-badge ha-icon { --mdc-icon-size: 20px; color: var(--text-primary-color, #fff); margin-bottom: 2px; }
+      .points-value { font-size: 1.3rem; font-weight: 700; color: var(--text-primary-color, #fff); line-height: 1; }
+      .points-label { font-size: 0.62rem; font-weight: 600; color: var(--text-primary-color, #fff); opacity: 0.88; text-transform: uppercase; letter-spacing: 0.4px; margin-top: 2px; }
 
       /* Penalty info */
       .penalty-info { flex: 1; min-width: 0; }
@@ -197,19 +195,19 @@ class TaskMatePenaltiesCard extends LitElement {
         justify-content: center;
         gap: 6px;
         padding: 8px 16px;
-        background: var(--penalty-red);
-        color: white;
+        background: var(--penalty-accent);
+        color: var(--text-primary-color, #fff);
         border: none;
         border-radius: 8px;
         font-size: 0.9rem;
         font-weight: 600;
         cursor: pointer;
-        transition: background 0.15s, transform 0.1s;
+        transition: opacity 0.15s, transform 0.1s;
         white-space: nowrap;
         flex-shrink: 0;
         --mdc-icon-size: 16px;
       }
-      .apply-btn:hover { background: var(--penalty-red-dark); }
+      .apply-btn:hover { opacity: 0.85; }
       .apply-btn:active { transform: scale(0.97); }
       .apply-btn:disabled { opacity: 0.55; cursor: default; }
 
@@ -230,11 +228,11 @@ class TaskMatePenaltiesCard extends LitElement {
         transition: all 0.15s;
       }
       .edit-btn:hover { background: var(--divider); color: var(--text-primary); }
-      .edit-btn.delete:hover { background: var(--penalty-red-light); color: var(--penalty-red); border-color: var(--penalty-red); }
+      .edit-btn.delete:hover { background: var(--penalty-accent-light); color: var(--penalty-accent); border-color: var(--penalty-accent); }
 
       /* Inline edit form */
       .edit-form {
-        background: var(--ha-card-background, #f5f5f5);
+        background: var(--secondary-background-color, #f5f5f5);
         border: 1px solid var(--divider);
         border-radius: 12px;
         padding: 14px;
@@ -262,19 +260,19 @@ class TaskMatePenaltiesCard extends LitElement {
         width: 100%;
         box-sizing: border-box;
       }
-      .form-field input:focus { outline: 2px solid var(--penalty-red); border-color: transparent; }
+      .form-field input:focus { outline: 2px solid var(--primary-color); border-color: transparent; }
       .form-actions { display: flex; gap: 8px; justify-content: flex-end; margin-top: 4px; }
       .btn-save {
         padding: 8px 18px;
-        background: var(--penalty-red);
-        color: white;
+        background: var(--primary-color);
+        color: var(--text-primary-color, #fff);
         border: none;
         border-radius: 8px;
         font-size: 0.9rem;
         font-weight: 600;
         cursor: pointer;
       }
-      .btn-save:hover { background: var(--penalty-red-dark); }
+      .btn-save:hover { opacity: 0.85; }
       .btn-cancel {
         padding: 8px 14px;
         background: none;
@@ -303,7 +301,7 @@ class TaskMatePenaltiesCard extends LitElement {
         transition: all 0.15s;
         --mdc-icon-size: 20px;
       }
-      .add-penalty-btn:hover { border-color: var(--penalty-red); color: var(--penalty-red); background: var(--penalty-red-light); }
+      .add-penalty-btn:hover { border-color: var(--penalty-accent); color: var(--penalty-accent); background: var(--penalty-accent-light); }
 
       /* Empty state */
       .empty-state {
@@ -321,8 +319,8 @@ class TaskMatePenaltiesCard extends LitElement {
         bottom: 24px;
         left: 50%;
         transform: translateX(-50%) translateY(0);
-        background: #333;
-        color: white;
+        background: var(--primary-text-color, #333);
+        color: var(--card-background-color, #fff);
         padding: 10px 20px;
         border-radius: 24px;
         font-size: 0.92rem;
@@ -622,7 +620,7 @@ class TaskMatePenaltiesCard extends LitElement {
 
     return html`
       <ha-card>
-        <style>:host { --taskmate-header-bg: ${this.config.header_color || '#e74c3c'}; }</style>
+        <style>:host { --taskmate-header-bg: ${this.config.header_color || 'var(--error-color, #db4437)'}; }</style>
         <div class="card-header">
           <div class="header-left">
             <ha-icon class="header-icon" icon="mdi:alert-circle-outline"></ha-icon>
@@ -751,13 +749,13 @@ class TaskMatePenaltiesCardEditor extends LitElement {
         .computeHelper=${this._computeHelper}
         @value-changed=${this._formChanged}
       ></ha-form>
-      ${this._renderColourPicker('header_color', '#e74c3c')}
+      ${this._renderColourPicker('header_color', '#db4437')}
     `;
   }
 
   _renderColourPicker(key, defaultValue) {
     const current = this.config[key] || defaultValue;
-    const presets = [defaultValue, '#e67e22', '#27ae60', '#3498db', '#9b59b6', '#f1c40f', '#34495e'];
+    const presets = [defaultValue, '#e74c3c', '#e67e22', '#3498db', '#9b59b6', '#f1c40f', '#34495e'];
     const isActive = (c) => c.toLowerCase() === current.toLowerCase();
     return html`
       <div class="colour-field">

--- a/custom_components/taskmate/www/taskmate-points-card.js
+++ b/custom_components/taskmate/www/taskmate-points-card.js
@@ -38,12 +38,13 @@ class TaskMatePointsCard extends LitElement {
     return css`
       :host {
         display: block;
-        --card-primary-color: var(--primary-color, #5c6bc0);
+        --card-primary-color: var(--primary-color);
         --card-success-color: var(--success-color, #4caf50);
-        --card-error-color: var(--error-color, #f44336);
+        --card-error-color: var(--error-color, #db4437);
         --card-warning-color: var(--warning-color, #ff9800);
-        --text-primary: var(--primary-text-color, #212121);
-        --text-secondary: var(--secondary-text-color, #757575);
+        --card-gold-color: #ca8a04;
+        --text-primary: var(--primary-text-color);
+        --text-secondary: var(--secondary-text-color);
       }
 
       ha-card {
@@ -55,8 +56,8 @@ class TaskMatePointsCard extends LitElement {
         justify-content: space-between;
         align-items: center;
         padding: 14px 18px;
-        background: var(--taskmate-header-bg, #2980b9);
-        color: white;
+        background: var(--taskmate-header-bg, var(--primary-color));
+        color: var(--text-primary-color, #fff);
       }
 
       .header-content {
@@ -95,7 +96,7 @@ class TaskMatePointsCard extends LitElement {
       }
 
       .child-row:hover {
-        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        box-shadow: var(--ha-card-box-shadow, none);
       }
 
       .child-row.loading {
@@ -115,7 +116,7 @@ class TaskMatePointsCard extends LitElement {
         width: 48px;
         height: 48px;
         border-radius: 50%;
-        background: linear-gradient(135deg, var(--card-primary-color) 0%, #7986cb 100%);
+        background: var(--card-primary-color);
         display: flex;
         align-items: center;
         justify-content: center;
@@ -124,7 +125,7 @@ class TaskMatePointsCard extends LitElement {
 
       .child-avatar ha-icon {
         --mdc-icon-size: 28px;
-        color: white;
+        color: var(--text-primary-color, #fff);
       }
 
       .child-details {
@@ -154,7 +155,7 @@ class TaskMatePointsCard extends LitElement {
 
       .child-points ha-icon {
         --mdc-icon-size: 18px;
-        color: #ffd700;
+        color: var(--card-gold-color);
       }
 
       /* Action buttons */
@@ -180,7 +181,7 @@ class TaskMatePointsCard extends LitElement {
 
       .action-button:hover {
         transform: scale(1.1);
-        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+        box-shadow: var(--ha-card-box-shadow, none);
       }
 
       .action-button:active {
@@ -188,13 +189,13 @@ class TaskMatePointsCard extends LitElement {
       }
 
       .action-button.remove {
-        background: linear-gradient(135deg, #ef5350 0%, #e53935 100%);
-        color: white;
+        background: var(--card-error-color);
+        color: var(--text-primary-color, #fff);
       }
 
       .action-button.add {
-        background: linear-gradient(135deg, #66bb6a 0%, #43a047 100%);
-        color: white;
+        background: var(--card-success-color);
+        color: var(--text-primary-color, #fff);
       }
 
       .action-button ha-icon {
@@ -237,19 +238,19 @@ class TaskMatePointsCard extends LitElement {
 
       .quick-btn:hover {
         transform: scale(1.08);
-        box-shadow: 0 2px 8px rgba(0,0,0,0.18);
+        box-shadow: var(--ha-card-box-shadow, none);
       }
 
       .quick-btn:active { transform: scale(0.95); }
 
       .quick-btn.add {
-        background: linear-gradient(135deg, #66bb6a 0%, #43a047 100%);
-        color: white;
+        background: var(--card-success-color);
+        color: var(--text-primary-color, #fff);
       }
 
       .quick-btn.remove {
-        background: linear-gradient(135deg, #ef5350 0%, #e53935 100%);
-        color: white;
+        background: var(--card-error-color);
+        color: var(--text-primary-color, #fff);
       }
 
       .quick-btn.custom {
@@ -299,7 +300,7 @@ class TaskMatePointsCard extends LitElement {
         padding: 24px;
         min-width: 300px;
         max-width: 400px;
-        box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+        box-shadow: var(--ha-card-box-shadow, 0 2px 6px rgba(0, 0, 0, 0.15));
         animation: slide-up 0.3s ease;
       }
 
@@ -331,16 +332,16 @@ class TaskMatePointsCard extends LitElement {
       }
 
       .dialog-header .icon-container.add {
-        background: linear-gradient(135deg, #66bb6a 0%, #43a047 100%);
+        background: var(--card-success-color);
       }
 
       .dialog-header .icon-container.remove {
-        background: linear-gradient(135deg, #ef5350 0%, #e53935 100%);
+        background: var(--card-error-color);
       }
 
       .dialog-header .icon-container ha-icon {
         --mdc-icon-size: 28px;
-        color: white;
+        color: var(--text-primary-color, #fff);
       }
 
       .dialog-header-text {
@@ -431,7 +432,7 @@ class TaskMatePointsCard extends LitElement {
 
       .dialog-button:hover {
         transform: translateY(-1px);
-        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+        box-shadow: var(--ha-card-box-shadow, none);
       }
 
       .dialog-button:active {
@@ -444,15 +445,15 @@ class TaskMatePointsCard extends LitElement {
       }
 
       .dialog-button.confirm {
-        color: white;
+        color: var(--text-primary-color, #fff);
       }
 
       .dialog-button.confirm.add {
-        background: linear-gradient(135deg, #66bb6a 0%, #43a047 100%);
+        background: var(--card-success-color);
       }
 
       .dialog-button.confirm.remove {
-        background: linear-gradient(135deg, #ef5350 0%, #e53935 100%);
+        background: var(--card-error-color);
       }
 
       .dialog-button.loading {
@@ -468,12 +469,12 @@ class TaskMatePointsCard extends LitElement {
         transform: translateX(-50%);
         padding: 12px 24px;
         border-radius: 8px;
-        color: white;
+        color: var(--text-primary-color, #fff);
         font-weight: 500;
         display: flex;
         align-items: center;
         gap: 8px;
-        box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
+        box-shadow: var(--ha-card-box-shadow, 0 2px 6px rgba(0, 0, 0, 0.15));
         z-index: 10000;
         animation: slide-up-notification 0.3s ease;
       }
@@ -490,11 +491,11 @@ class TaskMatePointsCard extends LitElement {
       }
 
       .notification.success {
-        background: linear-gradient(135deg, #66bb6a 0%, #43a047 100%);
+        background: var(--card-success-color);
       }
 
       .notification.error {
-        background: linear-gradient(135deg, #ef5350 0%, #e53935 100%);
+        background: var(--card-error-color);
       }
 
       .notification ha-icon {
@@ -586,7 +587,6 @@ class TaskMatePointsCard extends LitElement {
     }
     this.config = {
       title: "Manage Points",
-            header_color: '#2980b9',
     ...config,
     };
   }
@@ -642,7 +642,7 @@ class TaskMatePointsCard extends LitElement {
 
     return html`
       <ha-card>
-        <style>:host { --taskmate-header-bg: ${this.config.header_color || '#2980b9'}; }</style>
+        ${this.config.header_color ? html`<style>:host { --taskmate-header-bg: ${this.config.header_color}; }</style>` : ''}
         <div class="card-header">
           <div class="header-content">
             <ha-icon class="header-icon" icon="${pointsIcon}"></ha-icon>
@@ -967,8 +967,8 @@ class TaskMatePointsCardEditor extends LitElement {
       ha-form { display: block; margin-bottom: 16px; }
       .amounts-preview { display: flex; flex-wrap: wrap; gap: 5px; margin: 4px 0 16px; }
       .preview-btn { padding: 3px 9px; border-radius: 6px; font-size: 0.8rem; font-weight: 700; border: none; }
-      .preview-btn.add { background: #43a047; color: white; }
-      .preview-btn.remove { background: #e53935; color: white; }
+      .preview-btn.add { background: var(--success-color, #4caf50); color: var(--text-primary-color, #fff); }
+      .preview-btn.remove { background: var(--error-color, #db4437); color: var(--text-primary-color, #fff); }
       .colour-field { display: flex; flex-direction: column; gap: 8px; padding: 12px 16px; border: 1px solid var(--outline-color, var(--divider-color, #e0e0e0)); border-radius: 4px; background: var(--mdc-text-field-fill-color, var(--card-background-color)); }
       .colour-field-label { font-size: 0.82rem; color: var(--primary-color); font-weight: 500; }
       .colour-field-body { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }
@@ -1053,7 +1053,7 @@ class TaskMatePointsCardEditor extends LitElement {
         ${addAmounts.map(a => html`<span class="preview-btn add">+${a}</span>`)}
         ${removeAmounts.map(a => html`<span class="preview-btn remove">−${a}</span>`)}
       </div>
-      ${this._renderColourPicker('header_color', '#2980b9')}
+      ${this._renderColourPicker('header_color', '')}
     `;
   }
 
@@ -1147,6 +1147,6 @@ const _tmVersion = new URLSearchParams(
 ).get("v") || "?";
 console.info(
   "%c TASKMATE POINTS CARD %c v" + _tmVersion + " ",
-  "background:#2980b9;color:white;font-weight:bold;padding:2px 4px;border-radius:4px 0 0 4px;",
+  "background:#03a9f4;color:white;font-weight:bold;padding:2px 4px;border-radius:4px 0 0 4px;",
   "background:#2c3e50;color:white;font-weight:bold;padding:2px 4px;border-radius:0 4px 4px 0;"
 );

--- a/custom_components/taskmate/www/taskmate-points-display-card.js
+++ b/custom_components/taskmate/www/taskmate-points-display-card.js
@@ -28,7 +28,7 @@ const LitElement = customElements.get("hui-masonry-view")
 const html = LitElement.prototype.html;
 const css  = LitElement.prototype.css;
 
-const DEFAULT_HEADER = "#9b59b6";
+const DEFAULT_HEADER = "";
 
 const CHILD_COLOURS = [
   "#e74c3c", "#3498db", "#27ae60", "#f39c12",
@@ -107,7 +107,7 @@ class TaskMatePointsDisplayCard extends LitElement {
         align-items: center;
         justify-content: space-between;
         padding: 14px 18px;
-        color: white;
+        color: var(--text-primary-color, #fff);
         gap: 10px;
       }
       .header-left {
@@ -149,13 +149,13 @@ class TaskMatePointsDisplayCard extends LitElement {
         justify-content: center;
         font-size: 1.3rem;
         font-weight: 800;
-        color: white;
+        color: var(--text-primary-color, #fff);
         flex-shrink: 0;
         overflow: hidden;
       }
       .avatar ha-icon {
         --mdc-icon-size: 32px;
-        color: white;
+        color: var(--text-primary-color, #fff);
       }
       .avatar img {
         width: 100%;
@@ -184,7 +184,7 @@ class TaskMatePointsDisplayCard extends LitElement {
         width: 80px;
         height: 80px;
         font-size: 1.8rem;
-        box-shadow: 0 4px 16px rgba(0,0,0,0.15);
+        box-shadow: var(--ha-card-box-shadow, none);
       }
       .single-wrap .avatar ha-icon {
         --mdc-icon-size: 48px;
@@ -206,7 +206,7 @@ class TaskMatePointsDisplayCard extends LitElement {
         padding: 22px 40px;
         width: 100%;
         box-sizing: border-box;
-        box-shadow: 0 2px 12px rgba(0,0,0,0.06);
+        box-shadow: var(--ha-card-box-shadow, none);
         position: relative;
         overflow: hidden;
       }
@@ -299,7 +299,7 @@ class TaskMatePointsDisplayCard extends LitElement {
         transition: box-shadow 0.2s;
         overflow: hidden;
       }
-      .child-tile:hover { box-shadow: 0 4px 16px rgba(0,0,0,0.1); }
+      .child-tile:hover { box-shadow: var(--ha-card-box-shadow, 0 2px 6px rgba(0,0,0,0.1)); }
       .child-tile .rank-badge {
         position: absolute;
         top: 8px;
@@ -380,7 +380,7 @@ class TaskMatePointsDisplayCard extends LitElement {
         background: var(--card-background-color, #fff);
         border: 2px solid var(--divider-color, #e0e0e0);
         border-radius: 20px;
-        box-shadow: 0 2px 12px rgba(0,0,0,0.06);
+        box-shadow: var(--ha-card-box-shadow, none);
         position: relative;
         overflow: hidden;
       }
@@ -521,7 +521,8 @@ class TaskMatePointsDisplayCard extends LitElement {
   /* ── Render helpers ─────────────────────────────────────────────────── */
 
   _headerStyle() {
-    return `background: ${this.config.header_color || DEFAULT_HEADER};`;
+    const c = this.config.header_color;
+    return c ? `background: ${c};` : `background: var(--primary-color, #03a9f4);`;
   }
 
   _defaultTitle() {
@@ -655,7 +656,7 @@ class TaskMatePointsDisplayCard extends LitElement {
       <div class="cumulative-wrap">
         <div class="cumulative-total">
           <div class="points-label">${this._t("points_display.combined_family_total")}</div>
-          <div class="points-number" style="color:${this.config.header_color || DEFAULT_HEADER}">
+          <div class="points-number" style="color:${this.config.header_color || 'var(--primary-color, #03a9f4)'}">
             <span class="points-star">\u{1F31F}</span>${total.toLocaleString()}
           </div>
           <div class="family-label">${this._t("points_display.family_subtitle", { count: ranked.length })}</div>

--- a/custom_components/taskmate/www/taskmate-reorder-card.js
+++ b/custom_components/taskmate/www/taskmate-reorder-card.js
@@ -50,8 +50,8 @@ class TaskMateReorderCard extends LitElement {
         align-items: center;
         justify-content: space-between;
         padding: 14px 18px;
-        background: var(--taskmate-header-bg, #16a085);
-        color: white;
+        background: var(--taskmate-header-bg, var(--primary-color));
+        color: var(--text-primary-color, #fff);
         gap: 12px;
       }
 
@@ -73,7 +73,7 @@ class TaskMateReorderCard extends LitElement {
       .card-title {
         font-size: 1.05rem;
         font-weight: 600;
-        color: white;
+        color: var(--text-primary-color, #fff);
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;

--- a/custom_components/taskmate/www/taskmate-reorder-card.js
+++ b/custom_components/taskmate/www/taskmate-reorder-card.js
@@ -67,7 +67,7 @@ class TaskMateReorderCard extends LitElement {
         --mdc-icon-size: 22px;
         opacity: 0.9;
         flex-shrink: 0;
-        color: white;
+        color: var(--text-primary-color, #fff);
       }
 
       .card-title {
@@ -92,7 +92,7 @@ class TaskMateReorderCard extends LitElement {
 
       .save-button {
         background: rgba(255,255,255,0.15);
-        color: white;
+        color: var(--text-primary-color, #fff);
         border: 1px solid rgba(255,255,255,0.3);
         border-radius: 8px;
         padding: 7px 14px;
@@ -196,7 +196,7 @@ class TaskMateReorderCard extends LitElement {
       }
 
       .chore-item:hover {
-        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+        box-shadow: var(--ha-card-box-shadow, none);
         border-color: var(--primary-color);
       }
 

--- a/custom_components/taskmate/www/taskmate-reward-progress-card.js
+++ b/custom_components/taskmate/www/taskmate-reward-progress-card.js
@@ -33,8 +33,8 @@ class TaskMateRewardProgressCard extends LitElement {
         align-items: center;
         justify-content: space-between;
         padding: 14px 18px;
-        background: var(--taskmate-header-bg, #7d3c98);
-        color: white;
+        background: var(--taskmate-header-bg, var(--primary-color));
+        color: var(--text-primary-color, #fff);
         gap: 12px;
       }
 
@@ -61,11 +61,11 @@ class TaskMateRewardProgressCard extends LitElement {
         width: 90px;
         height: 90px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #9b59b6 0%, #8e44ad 100%);
+        background: var(--primary-color);
         display: flex;
         align-items: center;
         justify-content: center;
-        box-shadow: 0 6px 24px rgba(155,89,182,0.35);
+        box-shadow: var(--ha-card-box-shadow, none);
         animation: hero-float 3s ease-in-out infinite;
       }
 
@@ -74,7 +74,7 @@ class TaskMateRewardProgressCard extends LitElement {
         50% { transform: translateY(-6px); }
       }
 
-      .reward-icon-wrap ha-icon { --mdc-icon-size: 52px; color: white; }
+      .reward-icon-wrap ha-icon { --mdc-icon-size: 52px; color: var(--text-primary-color, #fff); }
 
       .reward-name {
         font-size: 1.6rem;
@@ -124,13 +124,13 @@ class TaskMateRewardProgressCard extends LitElement {
         height: 40px;
         min-width: 40px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #9b59b6 0%, #8e44ad 100%);
+        background: var(--primary-color);
         display: flex;
         align-items: center;
         justify-content: center;
       }
 
-      .child-avatar ha-icon { --mdc-icon-size: 24px; color: white; }
+      .child-avatar ha-icon { --mdc-icon-size: 24px; color: var(--text-primary-color, #fff); }
 
       .child-progress-name {
         font-size: 1rem;
@@ -161,14 +161,14 @@ class TaskMateRewardProgressCard extends LitElement {
       .cost-value {
         font-size: 1.2rem;
         font-weight: 700;
-        color: #9b59b6;
+        color: var(--primary-color);
         display: flex;
         align-items: center;
         gap: 3px;
         justify-content: flex-end;
       }
 
-      .cost-value ha-icon { --mdc-icon-size: 16px; color: #f1c40f; }
+      .cost-value ha-icon { --mdc-icon-size: 16px; color: #ca8a04; }
 
       /* Big animated progress bar */
       .big-progress-wrap {
@@ -209,19 +209,19 @@ class TaskMateRewardProgressCard extends LitElement {
       }
 
       .big-progress-fill.affordable {
-        background: linear-gradient(90deg, #27ae60, #2ecc71);
+        background: var(--success-color, #4caf50);
       }
 
       .big-progress-fill.close {
-        background: linear-gradient(90deg, #e67e22, #f39c12);
+        background: var(--warning-color, #ff9800);
       }
 
       .big-progress-fill.far {
-        background: linear-gradient(90deg, #9b59b6, #a569bd);
+        background: var(--primary-color);
       }
 
       .big-progress-fill.complete {
-        background: linear-gradient(90deg, #27ae60, #1abc9c);
+        background: var(--success-color, #4caf50);
       }
 
       .progress-stat-row {
@@ -245,17 +245,17 @@ class TaskMateRewardProgressCard extends LitElement {
         font-size: 0.95rem;
       }
 
-      .progress-pct.affordable { color: #27ae60; }
-      .progress-pct.close { color: #e67e22; }
-      .progress-pct.far { color: #9b59b6; }
+      .progress-pct.affordable { color: var(--success-color, #4caf50); }
+      .progress-pct.close { color: var(--warning-color, #ff9800); }
+      .progress-pct.far { color: var(--primary-color); }
 
       /* Can afford badge */
       .can-afford-badge {
         display: inline-flex;
         align-items: center;
         gap: 5px;
-        background: rgba(46,204,113,0.15);
-        color: #27ae60;
+        background: color-mix(in srgb, var(--success-color, #4caf50) 15%, transparent);
+        color: var(--success-color, #4caf50);
         border-radius: 20px;
         padding: 5px 12px;
         font-size: 0.85rem;
@@ -267,8 +267,8 @@ class TaskMateRewardProgressCard extends LitElement {
       .can-afford-badge ha-icon { --mdc-icon-size: 16px; }
 
       @keyframes pulse-green {
-        0%, 100% { box-shadow: 0 0 0 0 rgba(46,204,113,0.3); }
-        50% { box-shadow: 0 0 0 6px rgba(46,204,113,0); }
+        0%, 100% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--success-color, #4caf50) 30%, transparent); }
+        50% { box-shadow: 0 0 0 6px transparent; }
       }
 
       /* Jackpot section */
@@ -276,8 +276,8 @@ class TaskMateRewardProgressCard extends LitElement {
         display: inline-flex;
         align-items: center;
         gap: 5px;
-        background: linear-gradient(135deg, #f39c12, #f1c40f);
-        color: white;
+        background: #ca8a04;
+        color: var(--text-primary-color, #fff);
         border-radius: 20px;
         padding: 4px 12px;
         font-size: 0.8rem;
@@ -310,20 +310,20 @@ class TaskMateRewardProgressCard extends LitElement {
         color: var(--secondary-text-color, #757575);
       }
       .availability-badge.badge-low-stock {
-        background: rgba(231,76,60,0.18);
-        color: #c0392b;
+        background: color-mix(in srgb, var(--error-color, #db4437) 18%, transparent);
+        color: var(--error-color, #db4437);
       }
       .availability-badge.badge-expiring-soon {
-        background: rgba(243,156,18,0.2);
-        color: #d35400;
+        background: color-mix(in srgb, var(--warning-color, #ff9800) 20%, transparent);
+        color: var(--warning-color, #ff9800);
       }
 
       .jackpot-pool {
         display: flex;
         flex-direction: column;
         gap: 8px;
-        background: rgba(241,196,15,0.08);
-        border: 1px solid rgba(241,196,15,0.25);
+        background: color-mix(in srgb, #ca8a04 8%, transparent);
+        border: 1px solid color-mix(in srgb, #ca8a04 25%, transparent);
         border-radius: 12px;
         padding: 12px;
       }
@@ -357,11 +357,11 @@ class TaskMateRewardProgressCard extends LitElement {
       .jackpot-contributor .mini-avatar {
         width: 22px; height: 22px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #f39c12, #f1c40f);
+        background: #ca8a04;
         display: flex; align-items: center; justify-content: center;
       }
 
-      .jackpot-contributor .mini-avatar ha-icon { --mdc-icon-size: 13px; color: white; }
+      .jackpot-contributor .mini-avatar ha-icon { --mdc-icon-size: 13px; color: var(--text-primary-color, #fff); }
 
       /* Error / empty */
       .error-state, .empty-state {
@@ -369,7 +369,7 @@ class TaskMateRewardProgressCard extends LitElement {
         justify-content: center; padding: 40px 20px;
         color: var(--secondary-text-color); text-align: center;
       }
-      .error-state { color: var(--error-color, #f44336); }
+      .error-state { color: var(--error-color, #db4437); }
       .error-state ha-icon, .empty-state ha-icon { --mdc-icon-size: 48px; margin-bottom: 12px; opacity: 0.5; }
 
       /* Responsive */
@@ -390,7 +390,6 @@ class TaskMateRewardProgressCard extends LitElement {
       title: null,
       reward_id: null,
       child_id: null,
-            header_color: '#7d3c98',
     ...config,
     };
   }
@@ -455,7 +454,7 @@ class TaskMateRewardProgressCard extends LitElement {
 
     return html`
       <ha-card>
-        <style>:host { --taskmate-header-bg: ${this.config.header_color || '#7d3c98'}; }</style>
+        ${this.config.header_color ? html`<style>:host { --taskmate-header-bg: ${this.config.header_color}; }</style>` : ''}
         <div class="card-header">
           <div class="header-content">
             <ha-icon class="header-icon" icon="mdi:trophy-outline"></ha-icon>
@@ -715,7 +714,7 @@ class TaskMateRewardProgressCardEditor extends LitElement {
         .computeHelper=${this._computeHelper}
         @value-changed=${this._formChanged}
       ></ha-form>
-      ${this._renderColourPicker('header_color', '#7d3c98')}
+      ${this._renderColourPicker('header_color', '')}
     `;
   }
 
@@ -788,6 +787,6 @@ const _tmVersion = new URLSearchParams(
 ).get("v") || "?";
 console.info(
   "%c TASKMATE REWARD PROGRESS CARD %c v" + _tmVersion + " ",
-  "background:#7d3c98;color:white;font-weight:bold;padding:2px 4px;border-radius:4px 0 0 4px;",
+  "background:#03a9f4;color:white;font-weight:bold;padding:2px 4px;border-radius:4px 0 0 4px;",
   "background:#2c3e50;color:white;font-weight:bold;padding:2px 4px;border-radius:0 4px 4px 0;"
 );


### PR DESCRIPTION
Replace all custom color systems with HA theme variables across the entire integration.

- Admin panel: remap --tm-* tokens to HA vars, remove dark theme block, use HA fonts/shadows/radii, fix entity picker hardcoded colors
- All card files: replace custom palettes with HA theme vars
- Header defaults use --primary-color instead of hardcoded hex
- Gradients replaced with flat HA colors
- Gold kept as #ca8a04 where no HA variable exists
- Version bump to 3.5.0-beta.5