### PR TITLE
fix(config_flow): allow adding child without availability sensor

### DIFF
--- a/custom_components/taskmate/config_flow.py
+++ b/custom_components/taskmate/config_flow.py
@@ -281,11 +281,11 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
                             mode=selector.SelectSelectorMode.DROPDOWN,
                         )
                     ),
-                    vol.Optional("availability_entity", default=""): selector.EntitySelector(
+                    vol.Optional("availability_entity"): selector.EntitySelector(
                         selector.EntitySelectorConfig()
                     ),
                     vol.Optional("availability_inverted", default=False): selector.BooleanSelector(),
-                    vol.Optional("unavailability_entity", default=""): selector.EntitySelector(
+                    vol.Optional("unavailability_entity"): selector.EntitySelector(
                         selector.EntitySelectorConfig()
                     ),
                 }


### PR DESCRIPTION
Remove `default=""` from EntitySelector fields in the add_child form schema.

HA validates the empty string as an entity ID and rejects it with "Entity is neither a valid entity ID nor a valid UUID", blocking child creation when the optional availability sensor fields are left blank.

The edit_child form already handled this correctly by omitting the default when the value is empty.