### PR TITLE
feat: add conditional bonus sub-tasks for chores

### DIFF
--- a/custom_components/taskmate/__init__.py
+++ b/custom_components/taskmate/__init__.py
@@ -16,6 +16,7 @@ from .const import (
     ATTR_BONUS_ID,
     ATTR_BONUS_NAME,
     ATTR_BONUS_POINTS,
+    ATTR_BONUS_SUBTASK_ID,
     ATTR_CHILD_ID,
     ATTR_CHORE_ASSIGNED_TO,
     ATTR_CHORE_DESCRIPTION,
@@ -49,6 +50,7 @@ from .const import (
     SERVICE_APPROVE_REWARD,
     SERVICE_CLAIM_REWARD,
     SERVICE_REJECT_REWARD,
+    SERVICE_COMPLETE_BONUS_SUBTASK,
     SERVICE_COMPLETE_CHORE,
     SERVICE_PREVIEW_SOUND,
     SERVICE_REJECT_CHORE,
@@ -165,6 +167,17 @@ async def _async_register_services(hass: HomeAssistant) -> None:
         chore_id = call.data[ATTR_CHORE_ID]
         child_id = call.data[ATTR_CHILD_ID]
         await coordinator.async_complete_chore(chore_id, child_id)
+
+    async def handle_complete_bonus_subtask(call: ServiceCall) -> None:
+        """Handle the complete_bonus_subtask service call."""
+        coordinator = _get_coordinator(hass)
+        if not coordinator:
+            _LOGGER.error("No TaskMate coordinator available")
+            return
+        chore_id = call.data[ATTR_CHORE_ID]
+        bonus_subtask_id = call.data[ATTR_BONUS_SUBTASK_ID]
+        child_id = call.data[ATTR_CHILD_ID]
+        await coordinator.async_complete_bonus_subtask(chore_id, bonus_subtask_id, child_id)
 
     async def handle_approve_chore(call: ServiceCall) -> None:
         """Handle the approve_chore service call."""
@@ -461,6 +474,19 @@ async def _async_register_services(hass: HomeAssistant) -> None:
 
     hass.services.async_register(
         DOMAIN,
+        SERVICE_COMPLETE_BONUS_SUBTASK,
+        handle_complete_bonus_subtask,
+        schema=vol.Schema(
+            {
+                vol.Required(ATTR_CHORE_ID): cv.string,
+                vol.Required(ATTR_BONUS_SUBTASK_ID): cv.string,
+                vol.Required(ATTR_CHILD_ID): cv.string,
+            }
+        ),
+    )
+
+    hass.services.async_register(
+        DOMAIN,
         SERVICE_APPROVE_CHORE,
         handle_approve_chore,
         schema=vol.Schema(
@@ -733,6 +759,7 @@ def _async_unregister_services(hass: HomeAssistant) -> None:
     """Unregister TaskMate services."""
     services = [
         SERVICE_COMPLETE_CHORE,
+        SERVICE_COMPLETE_BONUS_SUBTASK,
         SERVICE_APPROVE_CHORE,
         SERVICE_REJECT_CHORE,
         SERVICE_CLAIM_REWARD,

--- a/custom_components/taskmate/const.py
+++ b/custom_components/taskmate/const.py
@@ -249,6 +249,7 @@ SERVICE_SET_CHORE_MANUAL_START: Final = "set_chore_manual_start"
 SERVICE_ADD_TASK_GROUP: Final = "add_task_group"
 SERVICE_UPDATE_TASK_GROUP: Final = "update_task_group"
 SERVICE_REMOVE_TASK_GROUP: Final = "remove_task_group"
+SERVICE_COMPLETE_BONUS_SUBTASK: Final = "complete_bonus_subtask"
 
 # Events
 EVENT_PREVIEW_SOUND: Final = "taskmate_preview_sound"
@@ -280,6 +281,7 @@ ATTR_CHORE_ASSIGNED_TO: Final = "assigned_to"
 ATTR_CHORE_TIME_CATEGORY: Final = "time_category"
 ATTR_CHORE_ONE_SHOT: Final = "one_shot"
 ATTR_CHORE_REQUIRES_APPROVAL: Final = "requires_approval"
+ATTR_BONUS_SUBTASK_ID: Final = "bonus_subtask_id"
 
 # States
 STATE_PENDING: Final = "pending"

--- a/custom_components/taskmate/coordinator.py
+++ b/custom_components/taskmate/coordinator.py
@@ -19,7 +19,7 @@ from .const import (
     MAX_CALENDAR_PROJECTION_DAYS,
     MIN_CALENDAR_PROJECTION_DAYS,
 )
-from .models import Bonus, Child, Chore, ChoreCompletion, Penalty, PoolAllocation, Reward, RewardClaim, PointsTransaction
+from .models import Bonus, BonusSubTask, Child, Chore, ChoreCompletion, Penalty, PoolAllocation, Reward, RewardClaim, PointsTransaction
 from .storage import TaskMateStorage
 
 _LOGGER = logging.getLogger(__name__)
@@ -1616,11 +1616,11 @@ class TaskMateCoordinator(DataUpdateCoordinator):
                     f"Chore '{chore.name}' is not available (one-shot chore already completed or expired)."
                 )
 
-        # Check daily limit
+        # Check daily limit (only count parent completions, not bonus sub-tasks)
         all_completions = self.storage.get_completions()
         todays_completions_count = 0
         for comp in all_completions:
-            if comp.chore_id == chore_id and comp.child_id == child_id:
+            if comp.chore_id == chore_id and comp.child_id == child_id and not comp.bonus_subtask_id:
                 comp_dt = comp.completed_at
                 if isinstance(comp_dt, str):
                     try:
@@ -1674,6 +1674,79 @@ class TaskMateCoordinator(DataUpdateCoordinator):
         await self.async_refresh()
         return completion
 
+    async def async_complete_bonus_subtask(
+        self, chore_id: str, bonus_subtask_id: str, child_id: str
+    ) -> ChoreCompletion:
+        """Complete a bonus sub-task (only available after parent chore is completed today)."""
+        chore = self.get_chore(chore_id)
+        if not chore:
+            raise ValueError(f"Chore {chore_id} not found")
+
+        subtask = next((b for b in chore.bonus_subtasks if b.id == bonus_subtask_id), None)
+        if not subtask:
+            raise ValueError(f"Bonus sub-task {bonus_subtask_id} not found on chore '{chore.name}'")
+
+        child = self.get_child(child_id)
+        if not child:
+            raise ValueError(f"Child {child_id} not found")
+
+        now = dt_util.now()
+        today = dt_util.as_local(now).date()
+
+        # Gate check: parent chore must be completed today
+        all_completions = self.storage.get_completions()
+        parent_done_today = any(
+            c.chore_id == chore_id
+            and c.child_id == child_id
+            and not c.bonus_subtask_id
+            and dt_util.as_local(c.completed_at).date() == today
+            for c in all_completions
+        )
+        if not parent_done_today:
+            raise ValueError(
+                f"Cannot complete bonus sub-task '{subtask.name}' — "
+                f"parent chore '{chore.name}' must be completed first today."
+            )
+
+        # Duplicate check: bonus sub-task not already completed today
+        already_done = any(
+            c.chore_id == chore_id
+            and c.child_id == child_id
+            and c.bonus_subtask_id == bonus_subtask_id
+            and dt_util.as_local(c.completed_at).date() == today
+            for c in all_completions
+        )
+        if already_done:
+            raise ValueError(
+                f"Bonus sub-task '{subtask.name}' already completed today."
+            )
+
+        completion = ChoreCompletion(
+            chore_id=chore_id,
+            child_id=child_id,
+            completed_at=now,
+            approved=not chore.requires_approval,
+            points_awarded=subtask.points if not chore.requires_approval else 0,
+            bonus_subtask_id=bonus_subtask_id,
+        )
+
+        if not chore.requires_approval:
+            total_awarded = await self._award_points(child, subtask.points, skip_streak=True)
+            completion.approved = True
+            completion.approved_at = dt_util.now()
+            completion.points_awarded = total_awarded
+
+        self.storage.add_completion(completion)
+        await self.storage.async_save()
+
+        if chore.requires_approval:
+            await self._async_notify_pending_approval(
+                child.name, f"{chore.name} › {subtask.name}", subtask.points
+            )
+
+        await self.async_refresh()
+        return completion
+
     async def async_approve_chore(self, completion_id: str) -> None:
         """Approve a chore completion."""
         completions = self.storage.get_completions()
@@ -1684,14 +1757,24 @@ class TaskMateCoordinator(DataUpdateCoordinator):
 
                 if chore and child:
                     comp_date = dt_util.as_local(completion.completed_at).date()
-                    total_awarded = await self._award_points(child, chore.points, completion_date=comp_date)
+                    is_bonus = bool(completion.bonus_subtask_id)
+                    if is_bonus:
+                        subtask = next(
+                            (b for b in chore.bonus_subtasks if b.id == completion.bonus_subtask_id), None
+                        )
+                        pts = subtask.points if subtask else 0
+                    else:
+                        pts = chore.points
+                    total_awarded = await self._award_points(
+                        child, pts, completion_date=comp_date, skip_streak=is_bonus
+                    )
                     completion.approved = True
                     completion.approved_at = dt_util.now()
                     completion.points_awarded = total_awarded
                     self.storage.update_completion(completion)
 
-                    # One-shot: disable for this child on approval
-                    if getattr(chore, 'schedule_mode', 'specific_days') == 'one_shot':
+                    # One-shot: disable for this child on approval (parent completions only)
+                    if not is_bonus and getattr(chore, 'schedule_mode', 'specific_days') == 'one_shot':
                         if completion.child_id not in chore.disabled_for:
                             chore.disabled_for.append(completion.child_id)
                         self._check_one_shot_fully_disabled(chore)
@@ -1717,30 +1800,56 @@ class TaskMateCoordinator(DataUpdateCoordinator):
                 if completion.points_awarded > 0:
                     child = self.get_child(completion.child_id)
                     if child:
-                        # Reverse base + weekend bonus points
                         child.points = max(0, child.points - completion.points_awarded)
                         child.total_points_earned = max(0, child.total_points_earned - completion.points_awarded)
                         child.total_chores_completed = max(0, child.total_chores_completed - 1)
 
-                        # Reverse streak: decrement (but don't go below 0)
-                        child.current_streak = max(0, child.current_streak - 1)
+                        # Only reverse streak for parent completions
+                        if not completion.bonus_subtask_id:
+                            child.current_streak = max(0, child.current_streak - 1)
 
                         self.storage.update_child(child)
                 break
 
-        # Undo last_completed store so recurrence window resets correctly
         if target_completion:
-            self.storage.undo_last_completed(
-                target_completion.chore_id, target_completion.child_id
-            )
+            is_parent = not target_completion.bonus_subtask_id
 
-            # One-shot: re-enable for this child on rejection
-            chore = self.get_chore(target_completion.chore_id)
-            if chore and getattr(chore, 'schedule_mode', 'specific_days') == 'one_shot':
-                if target_completion.child_id in chore.disabled_for:
-                    chore.disabled_for.remove(target_completion.child_id)
-                chore.enabled = True
-                self.storage.update_chore(chore)
+            # Cascade: if rejecting a parent completion, also reverse any bonus sub-task
+            # completions for the same chore/child on the same day
+            if is_parent:
+                comp_date = dt_util.as_local(target_completion.completed_at).date()
+                bonus_completions = [
+                    c for c in completions
+                    if c.chore_id == target_completion.chore_id
+                    and c.child_id == target_completion.child_id
+                    and c.bonus_subtask_id
+                    and c.id != completion_id
+                    and dt_util.as_local(c.completed_at).date() == comp_date
+                ]
+                if bonus_completions:
+                    child = self.get_child(target_completion.child_id)
+                    for bc in bonus_completions:
+                        if bc.points_awarded > 0 and child:
+                            child.points = max(0, child.points - bc.points_awarded)
+                            child.total_points_earned = max(0, child.total_points_earned - bc.points_awarded)
+                            child.total_chores_completed = max(0, child.total_chores_completed - 1)
+                        self.storage.remove_completion(bc.id)
+                    if child:
+                        self.storage.update_child(child)
+
+            # Undo last_completed store so recurrence window resets correctly (parent only)
+            if is_parent:
+                self.storage.undo_last_completed(
+                    target_completion.chore_id, target_completion.child_id
+                )
+
+                # One-shot: re-enable for this child on rejection
+                chore = self.get_chore(target_completion.chore_id)
+                if chore and getattr(chore, 'schedule_mode', 'specific_days') == 'one_shot':
+                    if target_completion.child_id in chore.disabled_for:
+                        chore.disabled_for.remove(target_completion.child_id)
+                    chore.enabled = True
+                    self.storage.update_chore(chore)
 
         self.storage.remove_completion(completion_id)
         await self.storage.async_save()
@@ -2449,11 +2558,15 @@ class TaskMateCoordinator(DataUpdateCoordinator):
         child: Child,
         points: int,
         completion_date: date | None = None,
+        skip_streak: bool = False,
     ) -> int:
         """Award points to a child, update streak, and apply bonus systems.
 
         Returns the total points awarded (base + weekend bonus), excluding
         milestone bonuses (which are logged as separate transactions).
+
+        If skip_streak is True, streak tracking is skipped (used for bonus
+        sub-task completions where the parent already counted).
         """
         now = dt_util.now()
         today = now.date()
@@ -2492,43 +2605,44 @@ class TaskMateCoordinator(DataUpdateCoordinator):
             self.storage.add_points_transaction(transaction)
 
         # ── Streak tracking ─────────────────────────────────────────────────
-        streak_mode = self.storage.get_setting("streak_reset_mode", "reset")
-        streak_paused = getattr(child, "streak_paused", False)
-        streak_before = child.current_streak or 0
         streak_reset_occurred = False
+        if not skip_streak:
+            streak_mode = self.storage.get_setting("streak_reset_mode", "reset")
+            streak_paused = getattr(child, "streak_paused", False)
+            streak_before = child.current_streak or 0
 
-        if last_date_str is None:
-            child.current_streak = 1
-            child.streak_paused = False
-        elif last_date_str == effective_date_str:
-            pass  # Already completed on this date — streak unchanged
-        else:
-            try:
-                last_date = date.fromisoformat(last_date_str)
-                yesterday = effective_date - timedelta(days=1)
-                if last_date == yesterday:
-                    child.current_streak = streak_before + 1
-                    child.streak_paused = False
-                elif streak_mode == "pause" or streak_paused:
-                    child.streak_paused = False
-                    _LOGGER.debug("Streak resumed for %s at %d", child.name, child.current_streak)
-                else:
+            if last_date_str is None:
+                child.current_streak = 1
+                child.streak_paused = False
+            elif last_date_str == effective_date_str:
+                pass  # Already completed on this date — streak unchanged
+            else:
+                try:
+                    last_date = date.fromisoformat(last_date_str)
+                    yesterday = effective_date - timedelta(days=1)
+                    if last_date == yesterday:
+                        child.current_streak = streak_before + 1
+                        child.streak_paused = False
+                    elif streak_mode == "pause" or streak_paused:
+                        child.streak_paused = False
+                        _LOGGER.debug("Streak resumed for %s at %d", child.name, child.current_streak)
+                    else:
+                        child.current_streak = 1
+                        child.streak_paused = False
+                        streak_reset_occurred = True
+                except (ValueError, TypeError):
                     child.current_streak = 1
                     child.streak_paused = False
                     streak_reset_occurred = True
-            except (ValueError, TypeError):
-                child.current_streak = 1
-                child.streak_paused = False
-                streak_reset_occurred = True
 
-        child.last_completion_date = effective_date_str
+            child.last_completion_date = effective_date_str
 
-        if child.current_streak > (child.best_streak or 0):
-            child.best_streak = child.current_streak
+            if child.current_streak > (child.best_streak or 0):
+                child.best_streak = child.current_streak
 
         # ── Streak milestone bonus ──────────────────────────────────────────
         milestones_enabled = self.storage.get_setting("streak_milestones_enabled", "true") == "true"
-        if milestones_enabled and child.current_streak > 0:
+        if not skip_streak and milestones_enabled and child.current_streak > 0:
             # Parse custom milestone config
             milestone_setting = self.storage.get_setting(
                 "streak_milestones", self.DEFAULT_STREAK_MILESTONES

--- a/custom_components/taskmate/models.py
+++ b/custom_components/taskmate/models.py
@@ -59,6 +59,33 @@ def format_datetime(dt: datetime | None) -> str | None:
 
 
 @dataclass
+class BonusSubTask:
+    """An optional bonus sub-task embedded within a parent chore."""
+
+    name: str
+    points: int = 5
+    description: str = ""
+    id: str = field(default_factory=generate_id)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> BonusSubTask:
+        return cls(
+            name=data.get("name", ""),
+            points=data.get("points", 5),
+            description=data.get("description", ""),
+            id=data.get("id", generate_id()),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "points": self.points,
+            "description": self.description,
+            "id": self.id,
+        }
+
+
+@dataclass
 class Child:
     """Represents a child."""
 
@@ -171,6 +198,8 @@ class Chore:
     # idempotence (don't re-publish the same day) and projection cleanup
     # (entries < today are pruned before each publish pass).
     publish_calendar_published_dates: list[str] = field(default_factory=list)
+    # Bonus sub-tasks: optional extra-credit tasks that unlock after the parent chore is completed
+    bonus_subtasks: list[BonusSubTask] = field(default_factory=list)
     id: str = field(default_factory=generate_id)
 
     @classmethod
@@ -219,6 +248,7 @@ class Chore:
                 list(data.get("publish_calendar_published_dates", []))
                 or ([data["publish_calendar_last_date"]] if data.get("publish_calendar_last_date") else [])
             ),
+            bonus_subtasks=[BonusSubTask.from_dict(b) for b in data.get("bonus_subtasks", [])],
             id=data.get("id", generate_id()),
         )
 
@@ -254,6 +284,7 @@ class Chore:
             "skip_count": self.skip_count,
             "publish_calendar_entities": self.publish_calendar_entities,
             "publish_calendar_published_dates": self.publish_calendar_published_dates,
+            "bonus_subtasks": [b.to_dict() for b in self.bonus_subtasks],
             "id": self.id,
         }
 
@@ -319,6 +350,7 @@ class ChoreCompletion:
     approved: bool = False
     approved_at: datetime | None = None
     points_awarded: int = 0
+    bonus_subtask_id: str = ""  # Non-empty = this completion is for a bonus sub-task
     id: str = field(default_factory=generate_id)
 
     @classmethod
@@ -334,6 +366,7 @@ class ChoreCompletion:
             approved=data.get("approved", False),
             approved_at=approved_at,
             points_awarded=data.get("points_awarded", 0),
+            bonus_subtask_id=data.get("bonus_subtask_id", ""),
             id=data.get("id", generate_id()),
         )
 
@@ -346,6 +379,7 @@ class ChoreCompletion:
             "approved": self.approved,
             "approved_at": format_datetime(self.approved_at),
             "points_awarded": self.points_awarded,
+            "bonus_subtask_id": self.bonus_subtask_id,
             "id": self.id,
         }
 

--- a/custom_components/taskmate/sensor.py
+++ b/custom_components/taskmate/sensor.py
@@ -270,15 +270,24 @@ def _build_todays_completions(common: dict) -> list[dict]:
         if comp_date != today:
             continue
         matched_chore = chore_lookup.get(comp.chore_id)
+        bonus_subtask_id = getattr(comp, "bonus_subtask_id", "") or ""
+        if bonus_subtask_id and matched_chore:
+            subtask = next((b for b in matched_chore.bonus_subtasks if b.id == bonus_subtask_id), None)
+            display_name = f"{matched_chore.name} › {subtask.name}" if subtask else matched_chore.name
+            display_points = subtask.points if subtask else 0
+        else:
+            display_name = matched_chore.name if matched_chore else ""
+            display_points = matched_chore.points if matched_chore else 0
         out.append({
             "completion_id": comp.id,
             "chore_id": comp.chore_id,
             "child_id": comp.child_id,
             "child_name": child_lookup[comp.child_id].name if comp.child_id in child_lookup else "",
-            "chore_name": matched_chore.name if matched_chore else "",
-            "points": matched_chore.points if matched_chore else 0,
+            "chore_name": display_name,
+            "points": display_points,
             "approved": comp.approved,
             "completed_at": comp.completed_at.isoformat() if hasattr(comp.completed_at, 'isoformat') else str(comp.completed_at),
+            "bonus_subtask_id": bonus_subtask_id,
         })
     return out
 

--- a/custom_components/taskmate/services.yaml
+++ b/custom_components/taskmate/services.yaml
@@ -15,6 +15,29 @@ complete_chore:
       selector:
         text:
 
+complete_bonus_subtask:
+  name: Complete Bonus Sub-task
+  description: Complete a bonus sub-task after the parent chore is done
+  fields:
+    chore_id:
+      name: Chore ID
+      description: The ID of the parent chore
+      required: true
+      selector:
+        text:
+    bonus_subtask_id:
+      name: Bonus Sub-task ID
+      description: The ID of the bonus sub-task to complete
+      required: true
+      selector:
+        text:
+    child_id:
+      name: Child ID
+      description: The ID of the child completing the bonus sub-task
+      required: true
+      selector:
+        text:
+
 approve_chore:
   name: Approve Chore
   description: Approve a completed chore and award points

--- a/custom_components/taskmate/websocket.py
+++ b/custom_components/taskmate/websocket.py
@@ -52,7 +52,7 @@ from homeassistant.core import HomeAssistant
 
 from .const import DOMAIN
 from .coordinator import TaskMateCoordinator
-from .models import Reward
+from .models import BonusSubTask, Reward
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -90,6 +90,7 @@ WS_REMOVE_TASK_GROUP: Final   = "taskmate/remove_task_group"
 WS_UPDATE_SETTINGS: Final     = "taskmate/update_settings"
 
 # Operational
+WS_COMPLETE_BONUS_SUBTASK: Final = "taskmate/complete_bonus_subtask"
 WS_APPROVE_CHORE: Final       = "taskmate/approve_chore"
 WS_REJECT_CHORE: Final        = "taskmate/reject_chore"
 WS_APPROVE_REWARD: Final      = "taskmate/approve_reward"
@@ -270,7 +271,7 @@ _CHORE_EDITABLE_FIELDS = {
     "recurrence_start", "first_occurrence_mode", "visibility_entity",
     "visibility_state", "visibility_operator", "enabled",
     "assignment_mode", "assignment_rotation_anchor", "require_availability",
-    "publish_calendar_entities",
+    "publish_calendar_entities", "bonus_subtasks",
 }
 
 
@@ -301,6 +302,12 @@ def _chore_payload_schema(*, require_name: bool):
         vol.Optional("assignment_rotation_anchor"): str,
         vol.Optional("require_availability"): bool,
         vol.Optional("publish_calendar_entities"): [str],
+        vol.Optional("bonus_subtasks"): [{
+            vol.Required("name"): vol.All(str, vol.Length(min=1, max=200)),
+            vol.Optional("points"): vol.All(int, vol.Range(min=0)),
+            vol.Optional("description"): str,
+            vol.Optional("id"): str,
+        }],
     }
 
 
@@ -346,7 +353,10 @@ async def _ws_add_chore(hass, connection, msg, coordinator):
     }
     if extra_fields:
         for f in extra_fields:
-            setattr(chore, f, msg[f] if not isinstance(msg[f], list) else list(msg[f]))
+            if f == "bonus_subtasks":
+                setattr(chore, f, [BonusSubTask.from_dict(b) for b in (msg[f] or [])])
+            else:
+                setattr(chore, f, msg[f] if not isinstance(msg[f], list) else list(msg[f]))
         await coordinator.async_update_chore(chore)
     await _maybe_apply_manual_start(coordinator, chore.id, msg.get("manual_start_child_id"))
     connection.send_result(msg["id"], {"id": chore.id})
@@ -368,7 +378,9 @@ async def _ws_update_chore(hass, connection, msg, coordinator):
     for field in _CHORE_EDITABLE_FIELDS:
         if field in msg:
             value = msg[field]
-            if isinstance(value, list):
+            if field == "bonus_subtasks":
+                value = [BonusSubTask.from_dict(b) for b in (value or [])]
+            elif isinstance(value, list):
                 value = list(value)
             elif field == "name":
                 value = value.strip()
@@ -752,6 +764,21 @@ async def _ws_update_settings(hass, connection, msg, coordinator):
 # ---------------------------------------------------------------------------
 
 @websocket_api.websocket_command({
+    vol.Required("type"): WS_COMPLETE_BONUS_SUBTASK,
+    vol.Required("chore_id"): str,
+    vol.Required("bonus_subtask_id"): str,
+    vol.Required("child_id"): str,
+})
+@websocket_api.async_response
+@_admin_only
+async def _ws_complete_bonus_subtask(hass, connection, msg, coordinator):
+    completion = await coordinator.async_complete_bonus_subtask(
+        msg["chore_id"], msg["bonus_subtask_id"], msg["child_id"]
+    )
+    connection.send_result(msg["id"], {"id": completion.id})
+
+
+@websocket_api.websocket_command({
     vol.Required("type"): WS_APPROVE_CHORE,
     vol.Required("completion_id"): str,
 })
@@ -853,6 +880,7 @@ _COMMANDS = (
     _ws_add_bonus, _ws_update_bonus, _ws_remove_bonus, _ws_apply_bonus,
     _ws_add_task_group, _ws_update_task_group, _ws_remove_task_group,
     _ws_update_settings,
+    _ws_complete_bonus_subtask,
     _ws_approve_chore, _ws_reject_chore, _ws_approve_reward, _ws_reject_reward,
     _ws_set_chore_order, _ws_add_chores_bulk,
 )

--- a/custom_components/taskmate/www/taskmate-child-card.js
+++ b/custom_components/taskmate/www/taskmate-child-card.js
@@ -888,6 +888,51 @@ class TaskMateChildCard extends LitElement {
         opacity: 0.6;
       }
 
+      /* Bonus sub-task cards */
+      .chore-card.bonus-subtask {
+        margin-left: 24px;
+        border-left: 3px solid var(--fun-amber, #f39c12);
+        background: linear-gradient(135deg,
+          rgba(243, 156, 18, 0.08) 0%,
+          rgba(241, 196, 15, 0.12) 100%);
+        padding: 8px 12px;
+        min-height: unset;
+      }
+
+      .chore-card.bonus-subtask .bonus-badge {
+        background: linear-gradient(135deg, #f39c12, #f1c40f) !important;
+        width: 22px;
+        height: 22px;
+        min-width: 22px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+
+      .chore-card.bonus-subtask .bonus-badge ha-icon {
+        color: #fff;
+      }
+
+      .bonus-name {
+        font-size: 0.88em;
+      }
+
+      .bonus-label {
+        font-size: 0.65em;
+        font-weight: 700;
+        letter-spacing: 0.5px;
+        color: #f39c12;
+        background: rgba(243, 156, 18, 0.15);
+        padding: 1px 5px;
+        border-radius: 3px;
+        margin-left: 6px;
+      }
+
+      .chore-card.bonus-subtask.completed {
+        border-color: var(--fun-green) !important;
+        border-left: 3px solid var(--fun-green);
+      }
+
       /* Reset countdown — inline beside section title */
       .reset-countdown {
         display: inline-flex;
@@ -1306,7 +1351,10 @@ class TaskMateChildCard extends LitElement {
                     ` : '';
                   })() : ''}
                 </div>
-                ${childChores.map((chore, index) => this._renderChoreCard(chore, child, pointsIcon, todaysCompletions, index))}
+                ${childChores.map((chore, index) => html`
+                  ${this._renderChoreCard(chore, child, pointsIcon, todaysCompletions, index)}
+                  ${this._renderBonusSubtasks(chore, child, pointsIcon, todaysCompletions)}
+                `)}
               `}
         </div>
 
@@ -1735,7 +1783,7 @@ class TaskMateChildCard extends LitElement {
     // Check how many times this chore was completed today by this child
     // Both pending (awaiting approval) AND approved completions count toward the daily limit
     const childCompletionsToday = todaysCompletions.filter(
-      (comp) => comp.chore_id === chore.id && comp.child_id === child.id
+      (comp) => comp.chore_id === chore.id && comp.child_id === child.id && !comp.bonus_subtask_id
     );
     let completionsToday = childCompletionsToday.length;
     const dailyLimit = chore.daily_limit || 1;
@@ -1870,6 +1918,98 @@ class TaskMateChildCard extends LitElement {
         </div>
       </div>
     `;
+  }
+
+  _renderBonusSubtasks(chore, child, pointsIcon, todaysCompletions) {
+    const subtasks = chore.bonus_subtasks;
+    if (!subtasks || subtasks.length === 0) return '';
+
+    // Check if parent chore is completed today (including optimistic)
+    const parentCompletions = todaysCompletions.filter(
+      c => c.chore_id === chore.id && c.child_id === child.id && !c.bonus_subtask_id
+    );
+    const optimisticKey = `${chore.id}_${child.id}`;
+    const hasOptimistic = this._optimisticCompletions && this._optimisticCompletions[optimisticKey];
+    const parentDone = parentCompletions.length > 0 || hasOptimistic;
+
+    if (!parentDone) return '';
+
+    return html`${subtasks.map(subtask => {
+      const bonusKey = `${chore.id}_bonus_${subtask.id}_${child.id}`;
+      const bonusOptimistic = this._optimisticCompletions && this._optimisticCompletions[bonusKey];
+      const bonusDone = todaysCompletions.some(
+        c => c.chore_id === chore.id && c.child_id === child.id && c.bonus_subtask_id === subtask.id
+      ) || bonusOptimistic;
+      const isLoading = this._loading[bonusKey];
+
+      const handleClick = () => {
+        if (isLoading || bonusDone) return;
+        this._handleCompleteBonusSubtask(chore, subtask, child);
+      };
+
+      return html`
+        <div
+          class="chore-card bonus-subtask ${bonusDone ? 'completed' : ''} ${isLoading ? 'loading' : ''}"
+          role="button"
+          tabindex="${bonusDone ? '-1' : '0'}"
+          @click="${handleClick}"
+          title="${bonusDone ? this._t('child.click_to_undo') : 'Bonus: ' + subtask.name}"
+        >
+          <div class="chore-info">
+            <div class="chore-number-wrapper">
+              <div class="chore-number-badge bonus-badge">
+                <ha-icon icon="mdi:star-plus" style="--mdc-icon-size:14px"></ha-icon>
+              </div>
+            </div>
+            <div class="chore-details">
+              <div class="chore-name bonus-name">${subtask.name}</div>
+              <div class="chore-points">
+                <ha-icon icon="${pointsIcon}"></ha-icon>
+                +${subtask.points}
+                <span class="bonus-label">BONUS</span>
+              </div>
+            </div>
+          </div>
+          <div class="chore-checkbox">
+            ${isLoading
+              ? html`<ha-icon icon="mdi:loading" style="animation: spin 1s linear infinite; color: var(--fun-purple);"></ha-icon>`
+              : html`<ha-icon icon="mdi:check-bold"></ha-icon>`}
+          </div>
+        </div>
+      `;
+    })}`;
+  }
+
+  async _handleCompleteBonusSubtask(chore, subtask, child) {
+    const bonusKey = `${chore.id}_bonus_${subtask.id}_${child.id}`;
+    this._loading = { ...this._loading, [bonusKey]: true };
+    this.requestUpdate();
+
+    // Optimistic completion
+    if (!this._optimisticCompletions) this._optimisticCompletions = {};
+    this._optimisticCompletions[bonusKey] = { timestamp: Date.now(), count: 1 };
+
+    try {
+      await this.hass.callService("taskmate", "complete_bonus_subtask", {
+        chore_id: chore.id,
+        bonus_subtask_id: subtask.id,
+        child_id: child.id,
+      });
+      this._playSound(chore.completion_sound || this.config.default_sound || "chime");
+    } catch (err) {
+      delete this._optimisticCompletions[bonusKey];
+    }
+
+    this._loading = { ...this._loading, [bonusKey]: false };
+    this.requestUpdate();
+
+    // Clear optimistic after 30s
+    setTimeout(() => {
+      if (this._optimisticCompletions && this._optimisticCompletions[bonusKey]) {
+        delete this._optimisticCompletions[bonusKey];
+        this.requestUpdate();
+      }
+    }, 30000);
   }
 
   _renderCelebration() {
@@ -2079,10 +2219,16 @@ class TaskMateChildCard extends LitElement {
       const undoSoundToPlay = this.config.undo_sound || 'undo';
       this._playSound(undoSoundToPlay);
 
-      // Clear any optimistic completion data for this chore/child
+      // Clear any optimistic completion data for this chore/child (including bonus sub-tasks)
       const key = `${chore.id}_${child.id}`;
       const newOptimistic = { ...this._optimisticCompletions };
       delete newOptimistic[key];
+      // Also clear bonus sub-task optimistic completions
+      const bonusPrefix = `${chore.id}_bonus_`;
+      const bonusSuffix = `_${child.id}`;
+      for (const k of Object.keys(newOptimistic)) {
+        if (k.startsWith(bonusPrefix) && k.endsWith(bonusSuffix)) delete newOptimistic[k];
+      }
       this._optimisticCompletions = newOptimistic;
 
     } catch (error) {

--- a/custom_components/taskmate/www/taskmate-panel.js
+++ b/custom_components/taskmate/www/taskmate-panel.js
@@ -326,6 +326,8 @@ class TaskMatePanel extends HTMLElement {
     if (act === "toggle-bulk-day")   { this._toggleArrayField("due_days", t.dataset.day); return; }
     if (act === "toggle-assigned")   { this._toggleArrayField("assigned_to", t.dataset.id); return; }
     if (act === "toggle-calendar")   { this._toggleArrayField("publish_calendar_entities", t.dataset.id); return; }
+    if (act === "add-bonus-subtask") { this._addBonusSubtask(); return; }
+    if (act === "remove-bonus-subtask") { this._removeBonusSubtask(Number(t.dataset.idx)); return; }
 
     // Rewards
     if (act === "add-reward")    { this._openRewardDialog(null); return; }
@@ -409,8 +411,17 @@ class TaskMatePanel extends HTMLElement {
     }
     // Dialog field
     if (this._dialog && t.dataset.field) {
+      const field = t.dataset.field;
       const value = (t.type === "number") ? (t.value === "" ? null : Number(t.value)) : t.value;
-      this._dialog.data[t.dataset.field] = value;
+      const arrMatch = field.match(/^(\w+)\[(\d+)\]\.(\w+)$/);
+      if (arrMatch) {
+        const [, arr, idx, prop] = arrMatch;
+        if (this._dialog.data[arr] && this._dialog.data[arr][Number(idx)] !== undefined) {
+          this._dialog.data[arr][Number(idx)][prop] = value;
+        }
+      } else {
+        this._dialog.data[field] = value;
+      }
       return;
     }
   }
@@ -692,6 +703,7 @@ class TaskMatePanel extends HTMLElement {
       visibility_entity: "", visibility_state: "on", visibility_operator: "none",
       enabled: true,
       publish_calendar_entities: [],
+      bonus_subtasks: [],
     };
     if (id) {
       const c = (this._state.chores || []).find(x => x.id === id);
@@ -701,6 +713,7 @@ class TaskMatePanel extends HTMLElement {
         assigned_to: [...(c.assigned_to || [])],
         due_days: [...(c.due_days || [])],
         publish_calendar_entities: [...(c.publish_calendar_entities || [])],
+        bonus_subtasks: (c.bonus_subtasks || []).map(b => ({...b})),
         visibility_operator: c.visibility_operator || "none",
         manual_start_child_id: "",
       } });
@@ -737,6 +750,10 @@ class TaskMatePanel extends HTMLElement {
       visibility_operator: d.visibility_operator || "none",
       enabled: d.enabled !== false,
       publish_calendar_entities: d.publish_calendar_entities || [],
+      bonus_subtasks: (d.bonus_subtasks || []).filter(b => b.name && b.name.trim()).map(b => ({
+        name: b.name.trim(), points: Number(b.points) || 5,
+        description: b.description || "", ...(b.id ? {id: b.id} : {}),
+      })),
       manual_start_child_id: d.manual_start_child_id || null,
     };
     const payload = wasAdd
@@ -747,6 +764,23 @@ class TaskMatePanel extends HTMLElement {
     this._closeDialog(true);
     await this._fetchState();
     this._showToast("ok", wasAdd ? "Chore added" : "Chore updated");
+  }
+
+  _addBonusSubtask() {
+    if (!this._dialog) return;
+    const d = this._dialog.data;
+    d.bonus_subtasks = d.bonus_subtasks || [];
+    d.bonus_subtasks.push({ name: "", points: 5, description: "" });
+    this._render();
+  }
+
+  _removeBonusSubtask(idx) {
+    if (!this._dialog) return;
+    const d = this._dialog.data;
+    if (d.bonus_subtasks && d.bonus_subtasks[idx] !== undefined) {
+      d.bonus_subtasks.splice(idx, 1);
+      this._render();
+    }
   }
 
   // ---- Rewards ---------------------------------------------------------
@@ -1214,12 +1248,18 @@ class TaskMatePanel extends HTMLElement {
             ${pendingCompletions.map(c => {
               const chore = choreById[c.chore_id];
               const child = childById[c.child_id];
+              let choreName = (chore && chore.name) || "(deleted chore)";
+              let chorePoints = chore ? chore.points : 0;
+              if (c.bonus_subtask_id && chore) {
+                const sub = (chore.bonus_subtasks || []).find(b => b.id === c.bonus_subtask_id);
+                if (sub) { choreName = `${chore.name} › ${sub.name}`; chorePoints = sub.points; }
+              }
               return `
                 <div class="tm-approval-item">
-                  <div class="tm-approval-icon"><ha-icon icon="mdi:checkbox-marked-circle-outline"></ha-icon></div>
+                  <div class="tm-approval-icon"><ha-icon icon="${c.bonus_subtask_id ? 'mdi:star-plus' : 'mdi:checkbox-marked-circle-outline'}"></ha-icon></div>
                   <div class="tm-approval-body">
-                    <div class="tm-approval-line"><strong>${this._esc((child && child.name) || "?")}</strong> completed <strong>${this._esc((chore && chore.name) || "(deleted chore)")}</strong></div>
-                    <div class="tm-meta">${this._timeAgo(c.completed_at)}${chore ? ` · ${chore.points} points` : ""}</div>
+                    <div class="tm-approval-line"><strong>${this._esc((child && child.name) || "?")}</strong> completed <strong>${this._esc(choreName)}</strong></div>
+                    <div class="tm-meta">${this._timeAgo(c.completed_at)} · ${chorePoints} points</div>
                   </div>
                   <div class="tm-approval-actions">
                     <button class="tm-btn tm-btn-sm" data-act="reject-chore" data-id="${this._esc(c.id)}">Reject</button>
@@ -1690,6 +1730,20 @@ class TaskMatePanel extends HTMLElement {
             <span class="tm-field-hint">Member of task group: <strong>${this._esc(memberInGroup.name)}</strong> (${memberInGroup.policy}). Manage membership on the Groups tab.</span>
           </div>
         ` : "",
+        `<details class="tm-advanced">
+          <summary>Bonus sub-tasks (optional)</summary>
+          <div>
+            <span class="tm-field-hint" style="margin-bottom:8px;display:block">Optional extra-credit tasks that unlock after the main chore is completed.</span>
+            ${(d.bonus_subtasks || []).map((b, idx) => `
+              <div class="tm-field-row" style="align-items:flex-end;gap:6px;margin-bottom:6px">
+                <div class="tm-field" style="flex:2;margin:0"><input class="tm-input" placeholder="Sub-task name" value="${this._esc(b.name)}" data-field="bonus_subtasks[${idx}].name"></div>
+                <div class="tm-field" style="flex:0 0 70px;margin:0"><input class="tm-input" type="number" min="0" placeholder="Pts" value="${b.points}" data-field="bonus_subtasks[${idx}].points"></div>
+                <button type="button" class="tm-btn tm-btn-icon" data-act="remove-bonus-subtask" data-idx="${idx}" title="Remove" style="padding:6px 10px">✕</button>
+              </div>
+            `).join("")}
+            <button type="button" class="tm-btn" data-act="add-bonus-subtask" style="margin-top:4px">+ Add bonus sub-task</button>
+          </div>
+        </details>`,
         `<details class="tm-advanced">
           <summary>Advanced — visibility &amp; calendar publishing</summary>
           <div>


### PR DESCRIPTION
## Summary

- Adds optional bonus sub-tasks to chores that unlock after the parent chore is completed
- Each bonus sub-task has its own name and point value, inheriting parent's schedule/assignment/approval settings
- Rejecting a parent chore cascades to reverse any bonus sub-task completions from that day
- Admin panel gets a collapsible editor section for managing bonus sub-tasks per chore
- Child card shows indented amber-styled bonus rows that appear after the parent is marked complete

## Test plan

- [ ] Add a chore with 1-2 bonus sub-tasks in the admin panel
- [ ] Verify bonus sub-tasks are hidden on the child card before parent completion
- [ ] Complete the parent chore → bonus sub-tasks should appear below it
- [ ] Complete a bonus sub-task → points awarded correctly
- [ ] Undo the parent chore → bonus sub-task completions also reversed
- [ ] Test with `requires_approval: true` → bonus completions appear as pending
- [ ] Verify existing chores without bonus sub-tasks still work unchanged

Fixes #65