### PR TITLE
fix: remove unused BonusSubTask import from coordinator

### DIFF
--- a/custom_components/taskmate/coordinator.py
+++ b/custom_components/taskmate/coordinator.py
@@ -19,7 +19,7 @@ from .const import (
     MAX_CALENDAR_PROJECTION_DAYS,
     MIN_CALENDAR_PROJECTION_DAYS,
 )
-from .models import Bonus, BonusSubTask, Child, Chore, ChoreCompletion, Penalty, PoolAllocation, Reward, RewardClaim, PointsTransaction
+from .models import Bonus, Child, Chore, ChoreCompletion, Penalty, PoolAllocation, Reward, RewardClaim, PointsTransaction
 from .storage import TaskMateStorage
 
 _LOGGER = logging.getLogger(__name__)


### PR DESCRIPTION
Fixes ruff F401 lint failure from #218 — `BonusSubTask` was imported but not directly referenced (accessed via `chore.bonus_subtasks` attribute instead).