### PR TITLE
ci: restrict push triggers to main branch only

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,7 @@ name: Lint
 
 on:
   push:
+    branches: [main]
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,6 +2,7 @@ name: Validate & Test
 
 on:
   push:
+    branches: [main]
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
Prevents failed CI emails caused by branch deletion before the workflow completes. The `pull_request` trigger still validates branches before merge.

Changes `lint.yml` and `tests.yml` from bare `push:` (all branches) to `push: branches: [main]`.