### PR TITLE
feat: timed tasks with points-per-minute calculation

### DIFF
--- a/custom_components/taskmate/__init__.py
+++ b/custom_components/taskmate/__init__.py
@@ -52,6 +52,9 @@ from .const import (
     SERVICE_REJECT_REWARD,
     SERVICE_COMPLETE_BONUS_SUBTASK,
     SERVICE_COMPLETE_CHORE,
+    SERVICE_START_TIMED_TASK,
+    SERVICE_PAUSE_TIMED_TASK,
+    SERVICE_STOP_TIMED_TASK,
     SERVICE_PREVIEW_SOUND,
     SERVICE_REJECT_CHORE,
     SERVICE_REMOVE_BONUS,
@@ -178,6 +181,36 @@ async def _async_register_services(hass: HomeAssistant) -> None:
         bonus_subtask_id = call.data[ATTR_BONUS_SUBTASK_ID]
         child_id = call.data[ATTR_CHILD_ID]
         await coordinator.async_complete_bonus_subtask(chore_id, bonus_subtask_id, child_id)
+
+    async def handle_start_timed_task(call: ServiceCall) -> None:
+        """Handle the start_timed_task service call."""
+        coordinator = _get_coordinator(hass)
+        if not coordinator:
+            _LOGGER.error("No TaskMate coordinator available")
+            return
+        await coordinator.async_start_timed_task(
+            call.data[ATTR_CHORE_ID], call.data[ATTR_CHILD_ID]
+        )
+
+    async def handle_pause_timed_task(call: ServiceCall) -> None:
+        """Handle the pause_timed_task service call."""
+        coordinator = _get_coordinator(hass)
+        if not coordinator:
+            _LOGGER.error("No TaskMate coordinator available")
+            return
+        await coordinator.async_pause_timed_task(
+            call.data[ATTR_CHORE_ID], call.data[ATTR_CHILD_ID]
+        )
+
+    async def handle_stop_timed_task(call: ServiceCall) -> None:
+        """Handle the stop_timed_task service call."""
+        coordinator = _get_coordinator(hass)
+        if not coordinator:
+            _LOGGER.error("No TaskMate coordinator available")
+            return
+        await coordinator.async_stop_timed_task(
+            call.data[ATTR_CHORE_ID], call.data[ATTR_CHILD_ID]
+        )
 
     async def handle_approve_chore(call: ServiceCall) -> None:
         """Handle the approve_chore service call."""
@@ -487,6 +520,42 @@ async def _async_register_services(hass: HomeAssistant) -> None:
 
     hass.services.async_register(
         DOMAIN,
+        SERVICE_START_TIMED_TASK,
+        handle_start_timed_task,
+        schema=vol.Schema(
+            {
+                vol.Required(ATTR_CHORE_ID): cv.string,
+                vol.Required(ATTR_CHILD_ID): cv.string,
+            }
+        ),
+    )
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_PAUSE_TIMED_TASK,
+        handle_pause_timed_task,
+        schema=vol.Schema(
+            {
+                vol.Required(ATTR_CHORE_ID): cv.string,
+                vol.Required(ATTR_CHILD_ID): cv.string,
+            }
+        ),
+    )
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_STOP_TIMED_TASK,
+        handle_stop_timed_task,
+        schema=vol.Schema(
+            {
+                vol.Required(ATTR_CHORE_ID): cv.string,
+                vol.Required(ATTR_CHILD_ID): cv.string,
+            }
+        ),
+    )
+
+    hass.services.async_register(
+        DOMAIN,
         SERVICE_APPROVE_CHORE,
         handle_approve_chore,
         schema=vol.Schema(
@@ -784,6 +853,9 @@ def _async_unregister_services(hass: HomeAssistant) -> None:
         SERVICE_ADD_TASK_GROUP,
         SERVICE_UPDATE_TASK_GROUP,
         SERVICE_REMOVE_TASK_GROUP,
+        SERVICE_START_TIMED_TASK,
+        SERVICE_PAUSE_TIMED_TASK,
+        SERVICE_STOP_TIMED_TASK,
     ]
     for service in services:
         hass.services.async_remove(DOMAIN, service)

--- a/custom_components/taskmate/const.py
+++ b/custom_components/taskmate/const.py
@@ -250,6 +250,9 @@ SERVICE_ADD_TASK_GROUP: Final = "add_task_group"
 SERVICE_UPDATE_TASK_GROUP: Final = "update_task_group"
 SERVICE_REMOVE_TASK_GROUP: Final = "remove_task_group"
 SERVICE_COMPLETE_BONUS_SUBTASK: Final = "complete_bonus_subtask"
+SERVICE_START_TIMED_TASK: Final = "start_timed_task"
+SERVICE_PAUSE_TIMED_TASK: Final = "pause_timed_task"
+SERVICE_STOP_TIMED_TASK: Final = "stop_timed_task"
 
 # Events
 EVENT_PREVIEW_SOUND: Final = "taskmate_preview_sound"

--- a/custom_components/taskmate/coordinator.py
+++ b/custom_components/taskmate/coordinator.py
@@ -19,7 +19,7 @@ from .const import (
     MAX_CALENDAR_PROJECTION_DAYS,
     MIN_CALENDAR_PROJECTION_DAYS,
 )
-from .models import Bonus, Child, Chore, ChoreCompletion, Penalty, PoolAllocation, Reward, RewardClaim, PointsTransaction
+from .models import Bonus, Child, Chore, ChoreCompletion, Penalty, PoolAllocation, Reward, RewardClaim, PointsTransaction, TimedSession
 from .storage import TaskMateStorage
 
 _LOGGER = logging.getLogger(__name__)
@@ -79,6 +79,7 @@ class TaskMateCoordinator(DataUpdateCoordinator):
         self.hass.async_create_task(self._async_check_streaks())
         self.hass.async_create_task(self._async_expire_one_shot_chores())
         self.hass.async_create_task(self._async_expire_rewards())
+        self.hass.async_create_task(self._async_stop_stale_timed_sessions())
         # Rotate assignment_current_child_id and publish today's events to every configured calendar
         self.hass.async_create_task(self._async_refresh_assignments_and_publish())
         # Check for perfect week bonus every Monday at midnight
@@ -273,6 +274,7 @@ class TaskMateCoordinator(DataUpdateCoordinator):
 
     async def _async_update_data(self) -> dict[str, Any]:
         """Fetch data from storage."""
+        await self._async_auto_stop_capped_sessions()
         return {
             "children": self.storage.get_children(),
             "chores": self.storage.get_chores(),
@@ -288,6 +290,7 @@ class TaskMateCoordinator(DataUpdateCoordinator):
             "penalties": self.storage.get_penalties(),
             "bonuses": self.storage.get_bonuses(),
             "pool_allocations": self.storage.get_pool_allocations(),
+            "timed_sessions": self.storage.get_timed_sessions(),
         }
 
     # Child operations
@@ -1763,6 +1766,9 @@ class TaskMateCoordinator(DataUpdateCoordinator):
                             (b for b in chore.bonus_subtasks if b.id == completion.bonus_subtask_id), None
                         )
                         pts = subtask.points if subtask else 0
+                    elif completion.timed_duration_seconds > 0 and chore.task_type == "timed":
+                        rate_seconds = chore.timed_rate_minutes * 60
+                        pts = (completion.timed_duration_seconds // rate_seconds) * chore.timed_rate_points
                     else:
                         pts = chore.points
                     total_awarded = await self._award_points(
@@ -1865,6 +1871,212 @@ class TaskMateCoordinator(DataUpdateCoordinator):
 
         if target_children and target_children.issubset(set(chore.disabled_for)):
             chore.enabled = False
+
+    # ── Timed task methods ──────────────────────────────────────────────────
+
+    async def async_start_timed_task(self, chore_id: str, child_id: str) -> None:
+        """Start or resume a timed task session."""
+        chore = self.get_chore(chore_id)
+        if not chore:
+            raise ValueError(f"Chore {chore_id} not found")
+        if chore.task_type != "timed":
+            raise ValueError(f"Chore '{chore.name}' is not a timed task")
+
+        child = self.get_child(child_id)
+        if not child:
+            raise ValueError(f"Child {child_id} not found")
+
+        now = dt_util.now()
+        today = dt_util.as_local(now).date().isoformat()
+
+        existing = self.storage.get_active_timed_session(chore_id, child_id)
+        if existing and existing.state == "running":
+            raise ValueError("Timer is already running")
+
+        if existing and existing.state == "paused":
+            # Check daily cap before resuming
+            if chore.timed_max_daily_minutes > 0:
+                if existing.total_seconds_today >= chore.timed_max_daily_minutes * 60:
+                    raise ValueError(
+                        f"Daily cap reached ({chore.timed_max_daily_minutes} min)"
+                    )
+            existing.state = "running"
+            existing.segments.append({"start": now.isoformat(), "end": None})
+            self.storage.save_timed_session(existing)
+        else:
+            # Check daily cap before starting fresh
+            if chore.timed_max_daily_minutes > 0:
+                old_session = self.storage.get_timed_session(chore_id, child_id, today)
+                if old_session and old_session.total_seconds_today >= chore.timed_max_daily_minutes * 60:
+                    raise ValueError(
+                        f"Daily cap reached ({chore.timed_max_daily_minutes} min)"
+                    )
+            session = TimedSession(
+                chore_id=chore_id,
+                child_id=child_id,
+                state="running",
+                segments=[{"start": now.isoformat(), "end": None}],
+                total_seconds_today=0,
+                session_date=today,
+            )
+            self.storage.save_timed_session(session)
+
+        await self.storage.async_save()
+        await self.async_refresh()
+
+    async def async_pause_timed_task(self, chore_id: str, child_id: str) -> None:
+        """Pause a running timed task session."""
+        session = self.storage.get_active_timed_session(chore_id, child_id)
+        if not session or session.state != "running":
+            raise ValueError("No running timer to pause")
+
+        now = dt_util.now()
+        if session.segments and session.segments[-1].get("end") is None:
+            session.segments[-1]["end"] = now.isoformat()
+
+        session.total_seconds_today = self._calc_session_seconds(session)
+        session.state = "paused"
+        self.storage.save_timed_session(session)
+        await self.storage.async_save()
+        await self.async_refresh()
+
+    async def async_stop_timed_task(self, chore_id: str, child_id: str) -> None:
+        """Stop a timed task session and create a completion."""
+        session = self.storage.get_active_timed_session(chore_id, child_id)
+        if not session:
+            raise ValueError("No active timer to stop")
+
+        chore = self.get_chore(chore_id)
+        if not chore:
+            raise ValueError(f"Chore {chore_id} not found")
+
+        child = self.get_child(child_id)
+        if not child:
+            raise ValueError(f"Child {child_id} not found")
+
+        now = dt_util.now()
+
+        # Close running segment
+        if session.state == "running" and session.segments and session.segments[-1].get("end") is None:
+            session.segments[-1]["end"] = now.isoformat()
+
+        total_seconds = self._calc_session_seconds(session)
+
+        # Clamp to daily cap
+        if chore.timed_max_daily_minutes > 0:
+            max_seconds = chore.timed_max_daily_minutes * 60
+            total_seconds = min(total_seconds, max_seconds)
+
+        # Calculate points
+        rate_seconds = chore.timed_rate_minutes * 60
+        pts = (total_seconds // rate_seconds) * chore.timed_rate_points
+
+        completion = ChoreCompletion(
+            chore_id=chore_id,
+            child_id=child_id,
+            completed_at=now,
+            approved=not chore.requires_approval,
+            points_awarded=pts if not chore.requires_approval else 0,
+            timed_duration_seconds=total_seconds,
+        )
+
+        if not chore.requires_approval:
+            total_awarded = await self._award_points(child, pts)
+            completion.approved = True
+            completion.approved_at = dt_util.now()
+            completion.points_awarded = total_awarded
+
+        self.storage.add_completion(completion)
+        self.storage.set_last_completed(chore_id, child_id, now.isoformat())
+        self.storage.remove_timed_session(session.id)
+
+        await self.storage.async_save()
+
+        if chore.requires_approval:
+            duration_min = total_seconds // 60
+            await self._async_notify_pending_approval(
+                child.name, chore.name, pts,
+            )
+
+        await self.async_refresh()
+
+    def _calc_session_seconds(self, session: TimedSession) -> int:
+        """Calculate total elapsed seconds from session segments."""
+        total = 0
+        for seg in session.segments:
+            start_str = seg.get("start")
+            end_str = seg.get("end")
+            if not start_str:
+                continue
+            try:
+                start_dt = datetime.fromisoformat(start_str)
+                end_dt = datetime.fromisoformat(end_str) if end_str else dt_util.now()
+                diff = (end_dt - start_dt).total_seconds()
+                if diff > 0:
+                    total += int(diff)
+            except (ValueError, TypeError):
+                continue
+        return total
+
+    async def _async_stop_stale_timed_sessions(self) -> None:
+        """Auto-stop any timed sessions from a previous day (midnight cleanup)."""
+        today = dt_util.as_local(dt_util.now()).date().isoformat()
+        sessions = self.storage.get_timed_sessions()
+        stale = [s for s in sessions if s.session_date != today and s.state in ("running", "paused")]
+
+        for session in stale:
+            chore = self.get_chore(session.chore_id)
+            child = self.get_child(session.child_id)
+            if not chore or not child:
+                self.storage.remove_timed_session(session.id)
+                continue
+
+            # Close any open segment at midnight
+            if session.segments and session.segments[-1].get("end") is None:
+                midnight_str = f"{today}T00:00:00"
+                session.segments[-1]["end"] = midnight_str
+
+            total_seconds = self._calc_session_seconds(session)
+            if chore.timed_max_daily_minutes > 0:
+                total_seconds = min(total_seconds, chore.timed_max_daily_minutes * 60)
+
+            rate_seconds = chore.timed_rate_minutes * 60
+            pts = (total_seconds // rate_seconds) * chore.timed_rate_points
+
+            if total_seconds > 0:
+                completion = ChoreCompletion(
+                    chore_id=session.chore_id,
+                    child_id=session.child_id,
+                    completed_at=dt_util.now(),
+                    approved=not chore.requires_approval,
+                    points_awarded=pts if not chore.requires_approval else 0,
+                    timed_duration_seconds=total_seconds,
+                )
+                if not chore.requires_approval:
+                    total_awarded = await self._award_points(child, pts)
+                    completion.approved = True
+                    completion.approved_at = dt_util.now()
+                    completion.points_awarded = total_awarded
+                self.storage.add_completion(completion)
+
+            self.storage.remove_timed_session(session.id)
+
+        if stale:
+            await self.storage.async_save()
+            await self.async_refresh()
+
+    async def _async_auto_stop_capped_sessions(self) -> None:
+        """Check running sessions against daily cap and auto-stop if exceeded."""
+        sessions = self.storage.get_timed_sessions()
+        for session in sessions:
+            if session.state != "running":
+                continue
+            chore = self.get_chore(session.chore_id)
+            if not chore or chore.timed_max_daily_minutes <= 0:
+                continue
+            elapsed = self._calc_session_seconds(session)
+            if elapsed >= chore.timed_max_daily_minutes * 60:
+                await self.async_stop_timed_task(session.chore_id, session.child_id)
 
     async def _async_expire_one_shot_chores(self) -> None:
         """Soft-disable one-shot chores whose created_date is before today."""

--- a/custom_components/taskmate/models.py
+++ b/custom_components/taskmate/models.py
@@ -59,6 +59,42 @@ def format_datetime(dt: datetime | None) -> str | None:
 
 
 @dataclass
+class TimedSession:
+    """Tracks an active or paused timed-task session."""
+
+    chore_id: str
+    child_id: str
+    state: str = "stopped"  # "running" | "paused" | "stopped"
+    segments: list[dict[str, Any]] = field(default_factory=list)
+    total_seconds_today: int = 0
+    session_date: str = ""  # ISO date this session belongs to
+    id: str = field(default_factory=generate_id)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "TimedSession":
+        return cls(
+            chore_id=data.get("chore_id", ""),
+            child_id=data.get("child_id", ""),
+            state=data.get("state", "stopped"),
+            segments=list(data.get("segments", [])),
+            total_seconds_today=data.get("total_seconds_today", 0),
+            session_date=data.get("session_date", ""),
+            id=data.get("id", generate_id()),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "chore_id": self.chore_id,
+            "child_id": self.child_id,
+            "state": self.state,
+            "segments": self.segments,
+            "total_seconds_today": self.total_seconds_today,
+            "session_date": self.session_date,
+            "id": self.id,
+        }
+
+
+@dataclass
 class BonusSubTask:
     """An optional bonus sub-task embedded within a parent chore."""
 
@@ -200,6 +236,11 @@ class Chore:
     publish_calendar_published_dates: list[str] = field(default_factory=list)
     # Bonus sub-tasks: optional extra-credit tasks that unlock after the parent chore is completed
     bonus_subtasks: list[BonusSubTask] = field(default_factory=list)
+    # Timed task fields
+    task_type: str = "standard"  # "standard" | "timed"
+    timed_rate_points: int = 10  # points awarded per rate window
+    timed_rate_minutes: int = 5  # rate window size in minutes
+    timed_max_daily_minutes: int = 0  # 0 = unlimited; caps total daily duration
     id: str = field(default_factory=generate_id)
 
     @classmethod
@@ -249,6 +290,10 @@ class Chore:
                 or ([data["publish_calendar_last_date"]] if data.get("publish_calendar_last_date") else [])
             ),
             bonus_subtasks=[BonusSubTask.from_dict(b) for b in data.get("bonus_subtasks", [])],
+            task_type=data.get("task_type", "standard"),
+            timed_rate_points=data.get("timed_rate_points", 10),
+            timed_rate_minutes=max(1, int(data.get("timed_rate_minutes", 5) or 5)),
+            timed_max_daily_minutes=max(0, int(data.get("timed_max_daily_minutes", 0) or 0)),
             id=data.get("id", generate_id()),
         )
 
@@ -285,6 +330,10 @@ class Chore:
             "publish_calendar_entities": self.publish_calendar_entities,
             "publish_calendar_published_dates": self.publish_calendar_published_dates,
             "bonus_subtasks": [b.to_dict() for b in self.bonus_subtasks],
+            "task_type": self.task_type,
+            "timed_rate_points": self.timed_rate_points,
+            "timed_rate_minutes": self.timed_rate_minutes,
+            "timed_max_daily_minutes": self.timed_max_daily_minutes,
             "id": self.id,
         }
 
@@ -351,6 +400,7 @@ class ChoreCompletion:
     approved_at: datetime | None = None
     points_awarded: int = 0
     bonus_subtask_id: str = ""  # Non-empty = this completion is for a bonus sub-task
+    timed_duration_seconds: int = 0
     id: str = field(default_factory=generate_id)
 
     @classmethod
@@ -367,6 +417,7 @@ class ChoreCompletion:
             approved_at=approved_at,
             points_awarded=data.get("points_awarded", 0),
             bonus_subtask_id=data.get("bonus_subtask_id", ""),
+            timed_duration_seconds=data.get("timed_duration_seconds", 0),
             id=data.get("id", generate_id()),
         )
 
@@ -380,6 +431,7 @@ class ChoreCompletion:
             "approved_at": format_datetime(self.approved_at),
             "points_awarded": self.points_awarded,
             "bonus_subtask_id": self.bonus_subtask_id,
+            "timed_duration_seconds": self.timed_duration_seconds,
             "id": self.id,
         }
 

--- a/custom_components/taskmate/sensor.py
+++ b/custom_components/taskmate/sensor.py
@@ -234,6 +234,12 @@ def _build_chores_list(coordinator: TaskMateCoordinator, common: dict) -> list[d
         completion_sound = getattr(c, 'completion_sound', 'coin')
         if completion_sound and completion_sound != 'coin':
             record["completion_sound"] = completion_sound
+        task_type = getattr(c, 'task_type', 'standard')
+        if task_type == "timed":
+            record["task_type"] = "timed"
+            record["timed_rate_points"] = getattr(c, 'timed_rate_points', 10)
+            record["timed_rate_minutes"] = getattr(c, 'timed_rate_minutes', 5)
+            record["timed_max_daily_minutes"] = getattr(c, 'timed_max_daily_minutes', 0)
         chores_list.append(record)
     return chores_list
 
@@ -278,7 +284,7 @@ def _build_todays_completions(common: dict) -> list[dict]:
         else:
             display_name = matched_chore.name if matched_chore else ""
             display_points = matched_chore.points if matched_chore else 0
-        out.append({
+        rec = {
             "completion_id": comp.id,
             "chore_id": comp.chore_id,
             "child_id": comp.child_id,
@@ -288,7 +294,53 @@ def _build_todays_completions(common: dict) -> list[dict]:
             "approved": comp.approved,
             "completed_at": comp.completed_at.isoformat() if hasattr(comp.completed_at, 'isoformat') else str(comp.completed_at),
             "bonus_subtask_id": bonus_subtask_id,
-        })
+        }
+        timed_secs = getattr(comp, "timed_duration_seconds", 0) or 0
+        if timed_secs > 0:
+            rec["timed_duration_seconds"] = timed_secs
+        out.append(rec)
+    return out
+
+
+def _build_active_timed_sessions(coordinator: TaskMateCoordinator) -> list[dict]:
+    """Build active timed sessions for frontend consumption."""
+    sessions = coordinator.data.get("timed_sessions", [])
+    out = []
+    for s in sessions:
+        if hasattr(s, 'state'):
+            state = s.state
+            if state not in ("running", "paused"):
+                continue
+            segments = s.segments or []
+            current_segment_start = ""
+            if state == "running" and segments:
+                last_seg = segments[-1]
+                if isinstance(last_seg, dict) and last_seg.get("end") is None:
+                    current_segment_start = last_seg.get("start", "")
+            out.append({
+                "chore_id": s.chore_id,
+                "child_id": s.child_id,
+                "state": state,
+                "total_seconds_today": s.total_seconds_today,
+                "current_segment_start": current_segment_start,
+            })
+        else:
+            state = s.get("state", "stopped") if isinstance(s, dict) else "stopped"
+            if state not in ("running", "paused"):
+                continue
+            segments = s.get("segments", []) if isinstance(s, dict) else []
+            current_segment_start = ""
+            if state == "running" and segments:
+                last_seg = segments[-1]
+                if isinstance(last_seg, dict) and last_seg.get("end") is None:
+                    current_segment_start = last_seg.get("start", "")
+            out.append({
+                "chore_id": s.get("chore_id", "") if isinstance(s, dict) else "",
+                "child_id": s.get("child_id", "") if isinstance(s, dict) else "",
+                "state": state,
+                "total_seconds_today": s.get("total_seconds_today", 0) if isinstance(s, dict) else 0,
+                "current_segment_start": current_segment_start,
+            })
     return out
 
 
@@ -655,6 +707,7 @@ class TaskMateChoresSensor(_CachedAttrsSensor):
             "chores": _build_chores_list(self.coordinator, common),
             "todays_completions": _build_todays_completions(common),
             "task_groups": task_groups,
+            "active_timed_sessions": _build_active_timed_sessions(self.coordinator),
         }
 
 

--- a/custom_components/taskmate/services.yaml
+++ b/custom_components/taskmate/services.yaml
@@ -601,3 +601,54 @@ remove_task_group:
       required: true
       selector:
         text:
+
+start_timed_task:
+  name: Start Timed Task
+  description: Start or resume the timer on a timed task
+  fields:
+    chore_id:
+      name: Chore ID
+      description: The ID of the timed chore
+      required: true
+      selector:
+        text:
+    child_id:
+      name: Child ID
+      description: The ID of the child starting the timer
+      required: true
+      selector:
+        text:
+
+pause_timed_task:
+  name: Pause Timed Task
+  description: Pause a running timed task timer
+  fields:
+    chore_id:
+      name: Chore ID
+      description: The ID of the timed chore
+      required: true
+      selector:
+        text:
+    child_id:
+      name: Child ID
+      description: The ID of the child pausing the timer
+      required: true
+      selector:
+        text:
+
+stop_timed_task:
+  name: Stop Timed Task
+  description: Stop a timed task timer and submit for approval
+  fields:
+    chore_id:
+      name: Chore ID
+      description: The ID of the timed chore
+      required: true
+      selector:
+        text:
+    child_id:
+      name: Child ID
+      description: The ID of the child stopping the timer
+      required: true
+      selector:
+        text:

--- a/custom_components/taskmate/storage.py
+++ b/custom_components/taskmate/storage.py
@@ -8,7 +8,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.storage import Store
 
 from .const import DOMAIN
-from .models import Bonus, Child, Chore, ChoreCompletion, Penalty, PoolAllocation, Reward, RewardClaim, PointsTransaction, TaskGroup
+from .models import Bonus, Child, Chore, ChoreCompletion, Penalty, PoolAllocation, Reward, RewardClaim, PointsTransaction, TaskGroup, TimedSession
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -56,6 +56,10 @@ class TaskMateStorage:
         # Ensure task_groups store exists (migration for existing installs)
         if "task_groups" not in self._data:
             self._data["task_groups"] = []
+
+        # Ensure timed_sessions store exists (migration for timed tasks feature)
+        if "timed_sessions" not in self._data:
+            self._data["timed_sessions"] = []
 
         # Run data migrations
         await self._migrate_assigned_to_child_ids()
@@ -602,6 +606,45 @@ class TaskMateStorage:
             del self._data["last_completed"][chore_id][child_id]
             if not self._data["last_completed"][chore_id]:
                 del self._data["last_completed"][chore_id]
+
+    # Timed sessions management
+    def get_timed_sessions(self) -> list[TimedSession]:
+        """Get all timed sessions."""
+        return [TimedSession.from_dict(s) for s in self._data.get("timed_sessions", [])]
+
+    def get_timed_session(self, chore_id: str, child_id: str, session_date: str) -> TimedSession | None:
+        """Get a timed session for a specific chore/child/date."""
+        for s in self._data.get("timed_sessions", []):
+            if (s.get("chore_id") == chore_id
+                    and s.get("child_id") == child_id
+                    and s.get("session_date") == session_date):
+                return TimedSession.from_dict(s)
+        return None
+
+    def get_active_timed_session(self, chore_id: str, child_id: str) -> TimedSession | None:
+        """Get a running or paused session for a chore/child pair."""
+        for s in self._data.get("timed_sessions", []):
+            if (s.get("chore_id") == chore_id
+                    and s.get("child_id") == child_id
+                    and s.get("state") in ("running", "paused")):
+                return TimedSession.from_dict(s)
+        return None
+
+    def save_timed_session(self, session: TimedSession) -> None:
+        """Insert or update a timed session."""
+        sessions = self._data.setdefault("timed_sessions", [])
+        for i, s in enumerate(sessions):
+            if s.get("id") == session.id:
+                sessions[i] = session.to_dict()
+                return
+        sessions.append(session.to_dict())
+
+    def remove_timed_session(self, session_id: str) -> None:
+        """Remove a timed session."""
+        self._data["timed_sessions"] = [
+            s for s in self._data.get("timed_sessions", [])
+            if s.get("id") != session_id
+        ]
 
     # Generic settings
     def get_setting(self, key: str, default: str = "") -> str:

--- a/custom_components/taskmate/websocket.py
+++ b/custom_components/taskmate/websocket.py
@@ -167,6 +167,7 @@ def _build_state_snapshot(coordinator: TaskMateCoordinator) -> dict[str, Any]:
         "bonuses":          list(data.get("bonuses", [])),
         "task_groups":      list(data.get("task_groups", [])),
         "pool_allocations": list(data.get("pool_allocations", [])),
+        "timed_sessions":   list(data.get("timed_sessions", [])),
         # Operational state — used by the panel's Activity tab + approval banner
         "completions":          completions,           # all (panel slices for display)
         "pending_completions":  [c for c in completions if not c.get("approved")],
@@ -272,6 +273,7 @@ _CHORE_EDITABLE_FIELDS = {
     "visibility_state", "visibility_operator", "enabled",
     "assignment_mode", "assignment_rotation_anchor", "require_availability",
     "publish_calendar_entities", "bonus_subtasks",
+    "task_type", "timed_rate_points", "timed_rate_minutes", "timed_max_daily_minutes",
 }
 
 
@@ -308,6 +310,10 @@ def _chore_payload_schema(*, require_name: bool):
             vol.Optional("description"): str,
             vol.Optional("id"): str,
         }],
+        vol.Optional("task_type"): vol.In(["standard", "timed"]),
+        vol.Optional("timed_rate_points"): vol.All(int, vol.Range(min=1)),
+        vol.Optional("timed_rate_minutes"): vol.All(int, vol.Range(min=1)),
+        vol.Optional("timed_max_daily_minutes"): vol.All(int, vol.Range(min=0)),
     }
 
 

--- a/custom_components/taskmate/www/taskmate-approvals-card.js
+++ b/custom_components/taskmate/www/taskmate-approvals-card.js
@@ -181,6 +181,21 @@ class TaskMateApprovalsCard extends LitElement {
         --mdi-icon-size: 14px;
       }
 
+      .duration-badge {
+        display: flex;
+        align-items: center;
+        gap: 4px;
+        background: rgba(26, 188, 156, 0.15);
+        color: #1abc9c;
+        padding: 2px 8px;
+        border-radius: 12px;
+        font-weight: 500;
+        font-size: 0.85em;
+      }
+      .duration-badge ha-icon {
+        --mdi-icon-size: 14px;
+      }
+
       .action-buttons {
         display: flex;
         gap: 8px;
@@ -695,6 +710,12 @@ class TaskMateApprovalsCard extends LitElement {
               <ha-icon icon="mdi:account"></ha-icon>
               ${completion.child_name}
             </span>
+            ${completion.timed_duration_seconds > 0 ? html`
+              <span class="duration-badge">
+                <ha-icon icon="mdi:timer-outline"></ha-icon>
+                ${Math.floor(completion.timed_duration_seconds / 60)} min
+              </span>
+            ` : ''}
             <span class="points-badge">
               <ha-icon icon="mdi:star"></ha-icon>
               ${completion.points}

--- a/custom_components/taskmate/www/taskmate-child-card.js
+++ b/custom_components/taskmate/www/taskmate-child-card.js
@@ -45,6 +45,34 @@ class TaskMateChildCard extends LitElement {
     this._optimisticCompletions = {};
     // Audio context for generating sounds (lazy initialized)
     this._audioContext = null;
+    // Timer intervals for live counters (timed tasks)
+    this._timerInterval = null;
+    this._timerTick = 0;
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    this._stopTimerTick();
+  }
+
+  updated(changedProperties) {
+    super.updated(changedProperties);
+    const attrs = (window.__taskmate_attrs && window.__taskmate_attrs(this.hass, this.config?.entity))
+      || this.hass?.states?.[this.config?.entity]?.attributes || {};
+    const sessions = attrs.active_timed_sessions || [];
+    const hasRunning = sessions.some(s => s.state === 'running' && s.child_id === this.config?.child_id);
+    if (hasRunning && !this._timerInterval) {
+      this._timerInterval = setInterval(() => { this._timerTick++; this.requestUpdate(); }, 1000);
+    } else if (!hasRunning && this._timerInterval) {
+      this._stopTimerTick();
+    }
+  }
+
+  _stopTimerTick() {
+    if (this._timerInterval) {
+      clearInterval(this._timerInterval);
+      this._timerInterval = null;
+    }
   }
 
   _t(key, params) {
@@ -1177,6 +1205,170 @@ class TaskMateChildCard extends LitElement {
         .chore-checkbox { width: 38px; height: 38px; min-width: 38px; border-radius: 9px; }
         .chore-checkbox ha-icon { --mdc-icon-size: 22px; }
       }
+
+      /* ── Timed task card ─── */
+      .timed-chore-card {
+        border-radius: 20px;
+        padding: 16px 18px;
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+        box-shadow: 0 3px 10px rgba(0, 0, 0, 0.08);
+        border: 3px solid var(--fun-cyan);
+        background: color-mix(in srgb, var(--fun-cyan) 8%, white);
+        transition: transform 0.15s ease, box-shadow 0.15s ease;
+        -webkit-user-select: none;
+        user-select: none;
+      }
+      .timed-chore-card.loading { opacity: 0.6; pointer-events: none; }
+
+      .timed-top-row {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+      }
+      .timed-rate {
+        margin-left: auto;
+        font-size: 0.8rem;
+        font-weight: 700;
+        color: var(--fun-cyan);
+        background: rgba(26, 188, 156, 0.12);
+        padding: 4px 10px;
+        border-radius: 12px;
+        white-space: nowrap;
+      }
+      .timer-display {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 12px;
+        padding: 10px 16px;
+        background: rgba(0, 0, 0, 0.03);
+        border-radius: 14px;
+      }
+      .timer-counter {
+        font-family: 'SF Mono', 'Fira Code', 'Courier New', monospace;
+        font-size: 2rem;
+        font-weight: 700;
+        color: var(--primary-text-color, #2c3e50);
+        letter-spacing: 0.05em;
+        min-width: 100px;
+        text-align: center;
+      }
+      .timer-counter.running { color: var(--fun-green); }
+      .timer-counter.paused { color: var(--fun-orange); }
+      .timer-points-live {
+        font-size: 1.1rem;
+        font-weight: 700;
+        color: var(--fun-orange);
+        display: flex;
+        align-items: center;
+        gap: 4px;
+      }
+      .timer-points-live ha-icon { --mdc-icon-size: 18px; color: var(--fun-yellow); }
+      .recording-dot {
+        width: 10px;
+        height: 10px;
+        border-radius: 50%;
+        background: var(--fun-green);
+        animation: pulse-dot 1.5s ease-in-out infinite;
+      }
+      @keyframes pulse-dot {
+        0%, 100% { opacity: 1; transform: scale(1); }
+        50% { opacity: 0.4; transform: scale(0.7); }
+      }
+      .paused-badge {
+        font-size: 0.7rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        color: var(--fun-orange);
+        background: rgba(230, 126, 34, 0.12);
+        padding: 3px 8px;
+        border-radius: 6px;
+        letter-spacing: 0.03em;
+      }
+      .timer-actions {
+        display: flex;
+        gap: 10px;
+        justify-content: center;
+      }
+      .timer-btn {
+        border: none;
+        border-radius: 14px;
+        padding: 12px 24px;
+        font-size: 1rem;
+        font-weight: 700;
+        cursor: pointer;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 8px;
+        transition: transform 0.1s ease, box-shadow 0.15s ease;
+        -webkit-user-select: none;
+        user-select: none;
+        -webkit-tap-highlight-color: transparent;
+      }
+      .timer-btn:active { transform: scale(0.95); }
+      .timer-btn.start, .timer-btn.resume {
+        background: linear-gradient(135deg, #2ecc71 0%, #27ae60 100%);
+        color: white;
+        box-shadow: 0 4px 12px rgba(46, 204, 113, 0.35);
+        flex: 1;
+      }
+      .timer-btn.start:hover, .timer-btn.resume:hover {
+        box-shadow: 0 6px 16px rgba(46, 204, 113, 0.5);
+        transform: scale(1.02);
+      }
+      .timer-btn.pause {
+        background: linear-gradient(135deg, #f39c12 0%, #e67e22 100%);
+        color: white;
+        box-shadow: 0 4px 12px rgba(243, 156, 18, 0.35);
+        flex: 1;
+      }
+      .timer-btn.pause:hover {
+        box-shadow: 0 6px 16px rgba(243, 156, 18, 0.5);
+        transform: scale(1.02);
+      }
+      .timer-btn.stop {
+        background: linear-gradient(135deg, #e74c3c 0%, #c0392b 100%);
+        color: white;
+        box-shadow: 0 4px 12px rgba(231, 76, 60, 0.35);
+        padding: 12px 20px;
+      }
+      .timer-btn.stop:hover {
+        box-shadow: 0 6px 16px rgba(231, 76, 60, 0.5);
+        transform: scale(1.02);
+      }
+      .btn-icon { font-size: 1.2rem; }
+      .daily-cap-bar {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        font-size: 0.75rem;
+        color: var(--secondary-text-color, #7f8c8d);
+        padding: 0 4px;
+      }
+      .cap-track {
+        flex: 1;
+        height: 6px;
+        background: rgba(0, 0, 0, 0.06);
+        border-radius: 3px;
+        overflow: hidden;
+      }
+      .cap-fill {
+        height: 100%;
+        border-radius: 3px;
+        background: linear-gradient(90deg, var(--fun-cyan), var(--fun-green));
+        transition: width 0.3s ease;
+      }
+      .cap-fill.warning {
+        background: linear-gradient(90deg, var(--fun-orange), var(--fun-red));
+      }
+      .cap-label {
+        font-weight: 600;
+        white-space: nowrap;
+      }
+      .cap-label.near-cap { color: var(--fun-red); font-weight: 700; }
     `;
   }
 
@@ -1352,8 +1544,12 @@ class TaskMateChildCard extends LitElement {
                   })() : ''}
                 </div>
                 ${childChores.map((chore, index) => html`
-                  ${this._renderChoreCard(chore, child, pointsIcon, todaysCompletions, index)}
-                  ${this._renderBonusSubtasks(chore, child, pointsIcon, todaysCompletions)}
+                  ${chore.task_type === 'timed'
+                    ? this._renderTimedChoreCard(chore, child, pointsIcon, todaysCompletions, index)
+                    : html`
+                      ${this._renderChoreCard(chore, child, pointsIcon, todaysCompletions, index)}
+                      ${this._renderBonusSubtasks(chore, child, pointsIcon, todaysCompletions)}
+                    `}
                 `)}
               `}
         </div>
@@ -1916,6 +2112,155 @@ class TaskMateChildCard extends LitElement {
               ? html`<ha-icon icon="mdi:lock-clock" class="chore-lock-icon"></ha-icon>`
               : html`<ha-icon icon="mdi:check-bold"></ha-icon>`}
         </div>
+      </div>
+    `;
+  }
+
+  _renderTimedChoreCard(chore, child, pointsIcon, todaysCompletions, choreIndex) {
+    const attrs = (window.__taskmate_attrs && window.__taskmate_attrs(this.hass, this.config.entity))
+      || this.hass?.states?.[this.config.entity]?.attributes || {};
+    const timedSessions = attrs.active_timed_sessions || [];
+    const session = timedSessions.find(s => s.chore_id === chore.id && s.child_id === child.id);
+    const state = session ? session.state : 'idle';
+    const isLoading = this._loading[`timed_${chore.id}`];
+
+    const colorClass = `color-${choreIndex % 8}`;
+    const choreNumber = choreIndex + 1;
+
+    // Calculate elapsed seconds
+    let elapsed = session ? (session.total_seconds_today || 0) : 0;
+    if (state === 'running' && session && session.current_segment_start) {
+      const startMs = new Date(session.current_segment_start).getTime();
+      const nowMs = Date.now();
+      elapsed += Math.max(0, Math.floor((nowMs - startMs) / 1000));
+    }
+
+    // Calculate earned points
+    const rateSeconds = (chore.timed_rate_minutes || 5) * 60;
+    const ratePoints = chore.timed_rate_points || 10;
+    const earnedPoints = Math.floor(elapsed / rateSeconds) * ratePoints;
+
+    // Format time as MM:SS
+    const minutes = Math.floor(elapsed / 60);
+    const seconds = elapsed % 60;
+    const timeStr = `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
+
+    // Rate display
+    const rateLabel = chore.timed_rate_minutes === 1
+      ? `${ratePoints} pts/min`
+      : `${ratePoints} pts/${chore.timed_rate_minutes} min`;
+
+    // Daily cap info
+    const maxMin = chore.timed_max_daily_minutes || 0;
+    const usedMin = Math.floor(elapsed / 60);
+    const capPct = maxMin > 0 ? Math.min(100, (elapsed / (maxMin * 60)) * 100) : 0;
+    const nearCap = maxMin > 0 && capPct >= 85;
+
+    const handleStart = (e) => {
+      e.stopPropagation();
+      if (isLoading) return;
+      this._loading = { ...this._loading, [`timed_${chore.id}`]: true };
+      this.hass.callService('taskmate', 'start_timed_task', {
+        chore_id: chore.id, child_id: child.id
+      }).then(() => {
+        this._loading = { ...this._loading, [`timed_${chore.id}`]: false };
+      }).catch(() => {
+        this._loading = { ...this._loading, [`timed_${chore.id}`]: false };
+      });
+    };
+
+    const handlePause = (e) => {
+      e.stopPropagation();
+      if (isLoading) return;
+      this._loading = { ...this._loading, [`timed_${chore.id}`]: true };
+      this.hass.callService('taskmate', 'pause_timed_task', {
+        chore_id: chore.id, child_id: child.id
+      }).then(() => {
+        this._loading = { ...this._loading, [`timed_${chore.id}`]: false };
+      }).catch(() => {
+        this._loading = { ...this._loading, [`timed_${chore.id}`]: false };
+      });
+    };
+
+    const handleStop = (e) => {
+      e.stopPropagation();
+      if (isLoading) return;
+      this._loading = { ...this._loading, [`timed_${chore.id}`]: true };
+      this.hass.callService('taskmate', 'stop_timed_task', {
+        chore_id: chore.id, child_id: child.id
+      }).then(() => {
+        this._loading = { ...this._loading, [`timed_${chore.id}`]: false };
+        const sound = chore.completion_sound || this.config.default_sound || 'coin';
+        this._playSound(sound);
+        this._celebrating = chore.id;
+        this._launchConfetti();
+        setTimeout(() => { this._celebrating = null; this.requestUpdate(); }, 2000);
+      }).catch(() => {
+        this._loading = { ...this._loading, [`timed_${chore.id}`]: false };
+      });
+    };
+
+    return html`
+      <div class="timed-chore-card ${state} ${isLoading ? 'loading' : ''}">
+        <div class="timed-top-row">
+          <div class="chore-number-wrapper">
+            <div class="chore-number-badge ${colorClass}">${choreNumber}</div>
+          </div>
+          <div class="chore-details">
+            <div class="chore-name">${chore.name}</div>
+          </div>
+          <div class="timed-rate">${rateLabel}</div>
+        </div>
+
+        ${state !== 'idle' ? html`
+          <div class="timer-display">
+            ${state === 'running' ? html`<div class="recording-dot"></div>` : ''}
+            ${state === 'paused' ? html`<div class="paused-badge">${this._t('child.paused') || 'PAUSED'}</div>` : ''}
+            <div class="timer-counter ${state}">${timeStr}</div>
+            <div class="timer-points-live">
+              <ha-icon icon="${pointsIcon}"></ha-icon>
+              ${earnedPoints}
+            </div>
+          </div>
+        ` : ''}
+
+        <div class="timer-actions">
+          ${state === 'idle' ? html`
+            <button class="timer-btn start" @click="${handleStart}" ?disabled="${isLoading}">
+              <span class="btn-icon">&#9654;</span>
+              ${this._t('child.start') || 'START'}
+            </button>
+          ` : ''}
+          ${state === 'running' ? html`
+            <button class="timer-btn pause" @click="${handlePause}" ?disabled="${isLoading}">
+              <span class="btn-icon">&#9208;</span>
+              ${this._t('child.pause') || 'PAUSE'}
+            </button>
+            <button class="timer-btn stop" @click="${handleStop}" ?disabled="${isLoading}">
+              <span class="btn-icon">&#9209;</span>
+              ${this._t('child.done') || 'DONE'}
+            </button>
+          ` : ''}
+          ${state === 'paused' ? html`
+            <button class="timer-btn resume" @click="${handleStart}" ?disabled="${isLoading}">
+              <span class="btn-icon">&#9654;</span>
+              ${this._t('child.resume') || 'RESUME'}
+            </button>
+            <button class="timer-btn stop" @click="${handleStop}" ?disabled="${isLoading}">
+              <span class="btn-icon">&#9209;</span>
+              ${this._t('child.done') || 'DONE'}
+            </button>
+          ` : ''}
+        </div>
+
+        ${maxMin > 0 ? html`
+          <div class="daily-cap-bar">
+            <span class="cap-label ${nearCap ? 'near-cap' : ''}">${usedMin} / ${maxMin} min</span>
+            <div class="cap-track">
+              <div class="cap-fill ${nearCap ? 'warning' : ''}" style="width: ${capPct}%"></div>
+            </div>
+          </div>
+        ` : ''}
       </div>
     `;
   }

--- a/custom_components/taskmate/www/taskmate-panel.js
+++ b/custom_components/taskmate/www/taskmate-panel.js
@@ -754,6 +754,10 @@ class TaskMatePanel extends HTMLElement {
         name: b.name.trim(), points: Number(b.points) || 5,
         description: b.description || "", ...(b.id ? {id: b.id} : {}),
       })),
+      task_type: d.task_type || "standard",
+      timed_rate_points: Number(d.timed_rate_points) || 10,
+      timed_rate_minutes: Math.max(1, Number(d.timed_rate_minutes) || 5),
+      timed_max_daily_minutes: Math.max(0, Number(d.timed_max_daily_minutes) || 0),
       manual_start_child_id: d.manual_start_child_id || null,
     };
     const payload = wasAdd
@@ -1669,11 +1673,24 @@ class TaskMatePanel extends HTMLElement {
       .filter(id => id.startsWith("calendar."))
       .sort();
 
+    const isTimedTask = d.task_type === "timed";
+
     return this._dialogShell(this._dialog.mode === "add" ? "Add chore" : "Edit chore",
       [
         this._field("Name", "name", d.name, "text"),
         this._field("Description (optional)", "description", d.description, "text"),
-        `<div class="tm-field-row">
+        this._select("Task type", "task_type", d.task_type || "standard", [
+          { v: "standard", l: "Standard — fixed points on completion" },
+          { v: "timed", l: "Timed — points per minute" },
+        ]),
+        isTimedTask ? `<div class="tm-field-row">
+          ${this._field("Points per window", "timed_rate_points", d.timed_rate_points || 10, "number")}
+          ${this._field("Window (minutes)", "timed_rate_minutes", d.timed_rate_minutes || 5, "number")}
+        </div>
+        <div class="tm-field-row">
+          ${this._field("Daily cap (minutes, 0 = unlimited)", "timed_max_daily_minutes", d.timed_max_daily_minutes || 0, "number")}
+          ${this._field("Daily limit", "daily_limit", d.daily_limit, "number")}
+        </div>` : `<div class="tm-field-row">
           ${this._field("Points", "points", d.points, "number")}
           ${this._field("Daily limit", "daily_limit", d.daily_limit, "number")}
         </div>`,

--- a/custom_components/taskmate/www/taskmate-parent-dashboard-card.js
+++ b/custom_components/taskmate/www/taskmate-parent-dashboard-card.js
@@ -330,6 +330,21 @@ class TaskMateParentDashboardCard extends LitElement {
       .empty-section ha-icon { --mdc-icon-size: 40px; opacity: 0.35; }
       .empty-section span { font-size: 0.9rem; }
 
+      .timed-sessions-section {
+        padding: 8px 0; margin-bottom: 8px;
+        border-bottom: 1px solid var(--divider-color, #e0e0e0);
+      }
+      .timed-session-row {
+        display: flex; align-items: center; gap: 8px;
+        padding: 6px 0; font-size: 0.9rem;
+      }
+      .timed-session-row ha-icon { --mdc-icon-size: 18px; }
+      .paused-tag {
+        font-size: 0.65rem; font-weight: 700; text-transform: uppercase;
+        color: #e67e22; background: rgba(230, 126, 34, 0.12);
+        padding: 2px 6px; border-radius: 4px;
+      }
+
       .error-state {
         display: flex; flex-direction: column; align-items: center;
         justify-content: center; padding: 40px 20px;
@@ -446,7 +461,33 @@ class TaskMateParentDashboardCard extends LitElement {
       new Date().toLocaleDateString('en-US', { weekday: 'long' }).toLowerCase();
     const availability = attrs.chore_availability || {};
 
+    const timedSessions = attrs.active_timed_sessions || [];
+    const childById = Object.fromEntries(children.map(c => [c.id, c]));
+    const choreById = Object.fromEntries(chores.map(c => [c.id, c]));
+
     return html`
+      ${timedSessions.length > 0 ? html`
+        <div class="timed-sessions-section">
+          ${timedSessions.map(s => {
+            const sChild = childById[s.child_id];
+            const sChore = choreById[s.chore_id];
+            if (!sChild || !sChore) return '';
+            let elapsed = s.total_seconds_today || 0;
+            if (s.state === 'running' && s.current_segment_start) {
+              elapsed += Math.max(0, Math.floor((Date.now() - new Date(s.current_segment_start).getTime()) / 1000));
+            }
+            const mins = Math.floor(elapsed / 60);
+            const secs = elapsed % 60;
+            return html`
+              <div class="timed-session-row">
+                <ha-icon icon="mdi:timer-outline" style="color: ${s.state === 'running' ? '#2ecc71' : '#e67e22'};"></ha-icon>
+                <span><strong>${sChild.name}</strong> — ${sChore.name} (${String(mins).padStart(2,'0')}:${String(secs).padStart(2,'0')})</span>
+                ${s.state === 'paused' ? html`<span class="paused-tag">PAUSED</span>` : ''}
+              </div>
+            `;
+          })}
+        </div>
+      ` : ''}
       ${children.map(child => {
         const childChores = chores.filter(c => {
           // Skip disabled chores (one-shot completed or expired)


### PR DESCRIPTION
## Summary

- Adds a new "timed" task type where points are earned based on duration (configurable rate, e.g. 10pts per 5 minutes)
- Children can start/pause/resume/stop a timer on the child card with a live counter
- Daily cap with hard auto-stop, full streak and weekend multiplier support
- Parent visibility of active sessions on the dashboard, duration shown on approval cards
- Timer state persists across HA restarts via wall-clock timestamps

Closes #121

## Changes

- **models.py**: New `TimedSession` dataclass, timed fields on `Chore`, `timed_duration_seconds` on `ChoreCompletion`
- **storage.py**: `timed_sessions` collection with CRUD
- **coordinator.py**: `start/pause/stop_timed_task` methods, auto-cap enforcement, midnight stale-session cleanup
- **__init__.py + services.yaml**: Three new HA services
- **websocket.py**: Timed fields in chore schema + state snapshot
- **sensor.py**: `active_timed_sessions` attribute, timed fields in chore records
- **taskmate-child-card.js**: Timer UI with live counter, start/pause/resume/stop buttons
- **taskmate-panel.js**: Task type selector and timed config fields in chore dialog
- **taskmate-approvals-card.js**: Duration badge on timed completions
- **taskmate-parent-dashboard-card.js**: Active sessions display in overview

## Test plan

- [ ] Create a timed chore via admin panel (e.g. Reading, 10pts/5min, 60min cap)
- [ ] Child card: tap START, verify live counter ticks
- [ ] Tap PAUSE, verify counter freezes; tap RESUME, verify continues
- [ ] Tap DONE, verify completion appears in approvals with duration
- [ ] Approve -> confirm points = floor(duration/rate) x rate_points
- [ ] Restart HA mid-session -> verify timer resumes correctly
- [ ] Hit daily cap -> verify auto-stop fires
- [ ] Verify standard chores unaffected