### PR TITLE
fix: remove unused duration_min variable

### DIFF
--- a/custom_components/taskmate/coordinator.py
+++ b/custom_components/taskmate/coordinator.py
@@ -1998,7 +1998,6 @@ class TaskMateCoordinator(DataUpdateCoordinator):
         await self.storage.async_save()
 
         if chore.requires_approval:
-            duration_min = total_seconds // 60
             await self._async_notify_pending_approval(
                 child.name, chore.name, pts,
             )


### PR DESCRIPTION
Removes unused `duration_min` assignment in timed task completion (ruff F841).