### PR TITLE
fix: clean up orphaned timed sessions on startup

### DIFF
--- a/custom_components/taskmate/coordinator.py
+++ b/custom_components/taskmate/coordinator.py
@@ -46,6 +46,7 @@ class TaskMateCoordinator(DataUpdateCoordinator):
     async def async_initialize(self) -> None:
         """Initialize the coordinator."""
         await self.storage.async_load()
+        await self._async_stop_stale_timed_sessions()
         await self.async_refresh()
         # Schedule midnight streak check at 00:00:05
         self._unsub_midnight = async_track_time_change(

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -7,7 +7,6 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from custom_components.taskmate.storage import TaskMateStorage
-from custom_components.taskmate.templates import BUILT_IN_TEMPLATES, BUILT_IN_IDS
 
 
 @pytest.fixture


### PR DESCRIPTION
Call _async_stop_stale_timed_sessions() during async_initialize so any sessions left running from a previous day (HA restart, crash) get properly closed and credited before the first refresh.

Also removes unused imports in test_templates.py (ruff F401).