### PR TITLE
perf: skip card re-renders for non-TaskMate state changes

### DIFF
--- a/custom_components/taskmate/www/taskmate-activity-card.js
+++ b/custom_components/taskmate/www/taskmate-activity-card.js
@@ -21,6 +21,13 @@ class TaskMateActivityCard extends LitElement {
     };
   }
 
+  shouldUpdate(changedProps) {
+    if (changedProps.has("hass")) {
+      return window.__taskmate_hasChanged(changedProps.get("hass"), this.hass, this.config?.entity);
+    }
+    return true;
+  }
+
   _t(key, params) {
     const fn = window.__taskmate_localize;
     return fn ? fn(this.hass, key, params) : key;

--- a/custom_components/taskmate/www/taskmate-approvals-card.js
+++ b/custom_components/taskmate/www/taskmate-approvals-card.js
@@ -19,6 +19,13 @@ class TaskMateApprovalsCard extends LitElement {
     };
   }
 
+  shouldUpdate(changedProps) {
+    if (changedProps.has("hass")) {
+      return window.__taskmate_hasChanged(changedProps.get("hass"), this.hass, this.config?.entity);
+    }
+    return true;
+  }
+
   constructor() {
     super();
     this._loading = {};

--- a/custom_components/taskmate/www/taskmate-attr-resolver.js
+++ b/custom_components/taskmate/www/taskmate-attr-resolver.js
@@ -63,6 +63,47 @@
   window.__taskmate_attrs = resolveAttrs;
 
   /**
+   * Event-driven update guard for LitElement cards.
+   *
+   * HA sets a new `hass` object on every card whenever ANY entity changes.
+   * Cards that don't filter will re-render for every light toggle, thermostat
+   * update, etc. This helper compares only TaskMate-relevant entities so
+   * cards skip renders that can't possibly change their output.
+   *
+   * Usage inside a card class:
+   *   shouldUpdate(changedProps) {
+   *     if (changedProps.has("hass")) {
+   *       return window.__taskmate_hasChanged(changedProps.get("hass"), this.hass, this.config?.entity);
+   *     }
+   *     return true;
+   *   }
+   */
+  const TASKMATE_BUTTON_PREFIX = "button.taskmate_";
+
+  function hasRelevantChange(oldHass, newHass, primaryEntityId) {
+    if (!oldHass || !oldHass.states || !newHass || !newHass.states) return true;
+    if (oldHass.states === newHass.states) return false;
+
+    if (primaryEntityId) {
+      if (oldHass.states[primaryEntityId] !== newHass.states[primaryEntityId]) return true;
+    }
+
+    for (const id of COMPANIONS) {
+      if (oldHass.states[id] !== newHass.states[id]) return true;
+    }
+
+    for (const id in newHass.states) {
+      if (id.startsWith(TASKMATE_BUTTON_PREFIX)) {
+        if (oldHass.states[id] !== newHass.states[id]) return true;
+      }
+    }
+
+    return false;
+  }
+
+  window.__taskmate_hasChanged = hasRelevantChange;
+
+  /**
    * Find the entity id of a TaskMate button by (child_id, action, target_id).
    *
    * TaskMate creates per-child/per-chore and per-child/per-reward button

--- a/custom_components/taskmate/www/taskmate-bonuses-card.js
+++ b/custom_components/taskmate/www/taskmate-bonuses-card.js
@@ -28,6 +28,13 @@ class TaskMateBonusesCard extends LitElement {
     };
   }
 
+  shouldUpdate(changedProps) {
+    if (changedProps.has("hass")) {
+      return window.__taskmate_hasChanged(changedProps.get("hass"), this.hass, this.config?.entity);
+    }
+    return true;
+  }
+
   _t(key, params) {
     const fn = window.__taskmate_localize;
     return fn ? fn(this.hass, key, params) : key;

--- a/custom_components/taskmate/www/taskmate-calendar-card.js
+++ b/custom_components/taskmate/www/taskmate-calendar-card.js
@@ -50,6 +50,13 @@ class TaskMateCalendarCard extends LitElement {
     };
   }
 
+  shouldUpdate(changedProps) {
+    if (changedProps.has("hass")) {
+      return window.__taskmate_hasChanged(changedProps.get("hass"), this.hass, this.config?.entity);
+    }
+    return true;
+  }
+
   constructor() {
     super();
     this._dayOffset = 0;

--- a/custom_components/taskmate/www/taskmate-child-card.js
+++ b/custom_components/taskmate/www/taskmate-child-card.js
@@ -35,6 +35,13 @@ class TaskMateChildCard extends LitElement {
     };
   }
 
+  shouldUpdate(changedProps) {
+    if (changedProps.has("hass")) {
+      return window.__taskmate_hasChanged(changedProps.get("hass"), this.hass, this.config?.entity);
+    }
+    return true;
+  }
+
   constructor() {
     super();
     this._loading = {};

--- a/custom_components/taskmate/www/taskmate-graph-card.js
+++ b/custom_components/taskmate/www/taskmate-graph-card.js
@@ -33,6 +33,13 @@ class TaskMateGraphCard extends LitElement {
     };
   }
 
+  shouldUpdate(changedProps) {
+    if (changedProps.has("hass")) {
+      return window.__taskmate_hasChanged(changedProps.get("hass"), this.hass, this.config?.entity);
+    }
+    return true;
+  }
+
   constructor() {
     super();
     this._mode = "daily";

--- a/custom_components/taskmate/www/taskmate-leaderboard-card.js
+++ b/custom_components/taskmate/www/taskmate-leaderboard-card.js
@@ -20,6 +20,13 @@ class TaskMateLeaderboardCard extends LitElement {
     return { hass: { type: Object }, config: { type: Object } };
   }
 
+  shouldUpdate(changedProps) {
+    if (changedProps.has("hass")) {
+      return window.__taskmate_hasChanged(changedProps.get("hass"), this.hass, this.config?.entity);
+    }
+    return true;
+  }
+
   _t(key, params) {
     const fn = window.__taskmate_localize;
     return fn ? fn(this.hass, key, params) : key;

--- a/custom_components/taskmate/www/taskmate-overview-card.js
+++ b/custom_components/taskmate/www/taskmate-overview-card.js
@@ -22,6 +22,13 @@ class TaskMateOverviewCard extends LitElement {
     };
   }
 
+  shouldUpdate(changedProps) {
+    if (changedProps.has("hass")) {
+      return window.__taskmate_hasChanged(changedProps.get("hass"), this.hass, this.config?.entity);
+    }
+    return true;
+  }
+
   _t(key, params) {
     const fn = window.__taskmate_localize;
     return fn ? fn(this.hass, key, params) : key;

--- a/custom_components/taskmate/www/taskmate-parent-dashboard-card.js
+++ b/custom_components/taskmate/www/taskmate-parent-dashboard-card.js
@@ -22,6 +22,13 @@ class TaskMateParentDashboardCard extends LitElement {
     };
   }
 
+  shouldUpdate(changedProps) {
+    if (changedProps.has("hass")) {
+      return window.__taskmate_hasChanged(changedProps.get("hass"), this.hass, this.config?.entity);
+    }
+    return true;
+  }
+
   _t(key, params) {
     const fn = window.__taskmate_localize;
     return fn ? fn(this.hass, key, params) : key;

--- a/custom_components/taskmate/www/taskmate-penalties-card.js
+++ b/custom_components/taskmate/www/taskmate-penalties-card.js
@@ -28,6 +28,13 @@ class TaskMatePenaltiesCard extends LitElement {
     };
   }
 
+  shouldUpdate(changedProps) {
+    if (changedProps.has("hass")) {
+      return window.__taskmate_hasChanged(changedProps.get("hass"), this.hass, this.config?.entity);
+    }
+    return true;
+  }
+
   _t(key, params) {
     const fn = window.__taskmate_localize;
     return fn ? fn(this.hass, key, params) : key;

--- a/custom_components/taskmate/www/taskmate-points-card.js
+++ b/custom_components/taskmate/www/taskmate-points-card.js
@@ -22,6 +22,13 @@ class TaskMatePointsCard extends LitElement {
     };
   }
 
+  shouldUpdate(changedProps) {
+    if (changedProps.has("hass")) {
+      return window.__taskmate_hasChanged(changedProps.get("hass"), this.hass, this.config?.entity);
+    }
+    return true;
+  }
+
   _t(key, params) {
     const fn = window.__taskmate_localize;
     return fn ? fn(this.hass, key, params) : key;

--- a/custom_components/taskmate/www/taskmate-points-display-card.js
+++ b/custom_components/taskmate/www/taskmate-points-display-card.js
@@ -86,6 +86,13 @@ class TaskMatePointsDisplayCard extends LitElement {
     };
   }
 
+  shouldUpdate(changedProps) {
+    if (changedProps.has("hass")) {
+      return window.__taskmate_hasChanged(changedProps.get("hass"), this.hass, this.config?.entity);
+    }
+    return true;
+  }
+
   constructor() {
     super();
     this._animated = {};

--- a/custom_components/taskmate/www/taskmate-reorder-card.js
+++ b/custom_components/taskmate/www/taskmate-reorder-card.js
@@ -25,6 +25,13 @@ class TaskMateReorderCard extends LitElement {
     };
   }
 
+  shouldUpdate(changedProps) {
+    if (changedProps.has("hass")) {
+      return window.__taskmate_hasChanged(changedProps.get("hass"), this.hass, this.config?.entity);
+    }
+    return true;
+  }
+
   _t(key, params) {
     const fn = window.__taskmate_localize;
     return fn ? fn(this.hass, key, params) : key;

--- a/custom_components/taskmate/www/taskmate-reward-progress-card.js
+++ b/custom_components/taskmate/www/taskmate-reward-progress-card.js
@@ -17,6 +17,13 @@ class TaskMateRewardProgressCard extends LitElement {
     return { hass: { type: Object }, config: { type: Object } };
   }
 
+  shouldUpdate(changedProps) {
+    if (changedProps.has("hass")) {
+      return window.__taskmate_hasChanged(changedProps.get("hass"), this.hass, this.config?.entity);
+    }
+    return true;
+  }
+
   _t(key, params) {
     const fn = window.__taskmate_localize;
     return fn ? fn(this.hass, key, params) : key;

--- a/custom_components/taskmate/www/taskmate-rewards-card.js
+++ b/custom_components/taskmate/www/taskmate-rewards-card.js
@@ -25,6 +25,13 @@ class TaskMateRewardsCard extends LitElement {
     };
   }
 
+  shouldUpdate(changedProps) {
+    if (changedProps.has("hass")) {
+      return window.__taskmate_hasChanged(changedProps.get("hass"), this.hass, this.config?.entity);
+    }
+    return true;
+  }
+
   constructor() {
     super();
     this._loading = {};

--- a/custom_components/taskmate/www/taskmate-streak-card.js
+++ b/custom_components/taskmate/www/taskmate-streak-card.js
@@ -22,6 +22,13 @@ class TaskMateStreakCard extends LitElement {
     };
   }
 
+  shouldUpdate(changedProps) {
+    if (changedProps.has("hass")) {
+      return window.__taskmate_hasChanged(changedProps.get("hass"), this.hass, this.config?.entity);
+    }
+    return true;
+  }
+
   _t(key, params) {
     const fn = window.__taskmate_localize;
     return fn ? fn(this.hass, key, params) : key;

--- a/custom_components/taskmate/www/taskmate-weekly-card.js
+++ b/custom_components/taskmate/www/taskmate-weekly-card.js
@@ -22,6 +22,13 @@ class TaskMateWeeklyCard extends LitElement {
     };
   }
 
+  shouldUpdate(changedProps) {
+    if (changedProps.has("hass")) {
+      return window.__taskmate_hasChanged(changedProps.get("hass"), this.hass, this.config?.entity);
+    }
+    return true;
+  }
+
   _t(key, params) {
     const fn = window.__taskmate_localize;
     return fn ? fn(this.hass, key, params) : key;


### PR DESCRIPTION
All 17 Lovelace cards now implement shouldUpdate() to skip re-renders when unrelated HA entities change (lights, thermostats, etc.).

A shared __taskmate_hasChanged() helper in attr-resolver.js compares entity object references for:
- The primary sensor (sensor.taskmate_overview)
- 5 companion sensors (chores, availability, rewards, activity, incentives)
- Any button.taskmate_* entities

Cards only re-render when one of these actually changes. Timer ticks (timed sessions) still update via requestUpdate() as before.