### PR TITLE
ci: remove pull_request triggers to avoid branch-deleted race

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,7 +3,6 @@ name: Lint
 on:
   push:
     branches: [main]
-  pull_request:
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,7 +3,6 @@ name: Validate & Test
 on:
   push:
     branches: [main]
-  pull_request:
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -3,7 +3,6 @@ name: HACS Validation
 on:
   push:
     branches: [main]
-  pull_request:
   schedule:
     - cron: "0 0 * * *"
 


### PR DESCRIPTION
Since PRs are merged and branches deleted immediately via API, CI jobs that trigger on pull_request find the branch already gone and fail.

Workflows now only run on push to main (post-merge) and on schedule/manual dispatch.