### PR TITLE
fix: re-export dt_util for test compatibility after mixin split

### DIFF
--- a/custom_components/taskmate/coordinator.py
+++ b/custom_components/taskmate/coordinator.py
@@ -9,6 +9,7 @@ from typing import Any
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.event import async_track_time_change
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.util import dt as dt_util  # noqa: F401 — used by tests as patch target
 
 from .const import DOMAIN
 from .coord_assignments import AssignmentsMixin


### PR DESCRIPTION
Tests patch dt_util.now via the coordinator module reference. After the mixin split, coordinator.py no longer imported dt_util, breaking all time-dependent tests (88 tests). Re-adding the import restores the patch target.

All 88 tests pass.