### PR TITLE
fix: search input overflowing toolbar and hiding buttons

### DIFF
--- a/custom_components/taskmate/www/taskmate-panel.js
+++ b/custom_components/taskmate/www/taskmate-panel.js
@@ -2869,6 +2869,7 @@ class TaskMatePanel extends HTMLElement {
       }
       .tm-search {
         width: 100%;
+        box-sizing: border-box;
         background: var(--tm-surface-0);
         border: 1px solid var(--tm-border);
         border-radius: var(--tm-radius-sm);


### PR DESCRIPTION
## Summary
- The `.tm-search` input had `width: 100%` with padding and border but no `box-sizing: border-box`, making it ~44px wider than its flex container
- This caused it to visually overlap and hide adjacent action buttons (e.g. "Bulk add", "+ Add chore") on all panel tabs that have a search box
- Added `box-sizing: border-box` so the input respects its container width