### PR TITLE
feat: configurable time-of-day boundaries

### DIFF
--- a/custom_components/taskmate/coord_calendar.py
+++ b/custom_components/taskmate/coord_calendar.py
@@ -24,20 +24,35 @@ _LOGGER = logging.getLogger(__name__)
 class CalendarMixin:
     """Mixin providing calendar projection and event publishing logic."""
 
-    # time_category -> (start_time, end_time). None means "anytime" -> all-day event.
-    _TIME_CATEGORY_WINDOWS: dict[str, tuple[time, time] | None] = {
-        "morning":   (time(6, 0),  time(12, 0)),
-        "afternoon": (time(12, 0), time(17, 0)),
-        "evening":   (time(17, 0), time(21, 0)),
-        "night":     (time(21, 0), time(23, 59)),
-        "anytime":   None,
+    _DEFAULT_TIME_BOUNDARIES: dict[str, tuple[str, str]] = {
+        "morning":   ("06:00", "12:00"),
+        "afternoon": ("12:00", "17:00"),
+        "evening":   ("17:00", "21:00"),
+        "night":     ("21:00", "23:59"),
     }
 
     _SCHEDULE_DOW = ("monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday")
 
+    def _get_time_boundaries(self) -> dict[str, tuple[time, time] | None]:
+        """Build time boundaries from storage settings with defaults."""
+        result: dict[str, tuple[time, time] | None] = {"anytime": None}
+        for cat, (def_start, def_end) in self._DEFAULT_TIME_BOUNDARIES.items():
+            start_str = self.storage.get_setting(f"time_{cat}_start", def_start)
+            end_str = self.storage.get_setting(f"time_{cat}_end", def_end)
+            try:
+                sh, sm = (int(x) for x in start_str.split(":"))
+                eh, em = (int(x) for x in end_str.split(":"))
+                result[cat] = (time(sh, sm), time(eh, em))
+            except (ValueError, TypeError):
+                sh, sm = (int(x) for x in def_start.split(":"))
+                eh, em = (int(x) for x in def_end.split(":"))
+                result[cat] = (time(sh, sm), time(eh, em))
+        return result
+
     def _time_category_window(self, category: str, today: date) -> tuple[datetime, datetime] | None:
         """Return (start, end) datetimes for a time_category, or None for all-day."""
-        window = self._TIME_CATEGORY_WINDOWS.get(category or "anytime")
+        boundaries = self._get_time_boundaries()
+        window = boundaries.get(category or "anytime")
         if window is None:
             return None
         start_t, end_t = window

--- a/custom_components/taskmate/sensor.py
+++ b/custom_components/taskmate/sensor.py
@@ -653,6 +653,17 @@ class TaskMateOverallStatsSensor(_CachedAttrsSensor):
         today_dow = dt_util.now().strftime("%A").lower()
         settings = data.get("settings", {})
 
+        time_boundaries = {
+            "morning_start": settings.get("time_morning_start", "06:00"),
+            "morning_end": settings.get("time_morning_end", "12:00"),
+            "afternoon_start": settings.get("time_afternoon_start", "12:00"),
+            "afternoon_end": settings.get("time_afternoon_end", "17:00"),
+            "evening_start": settings.get("time_evening_start", "17:00"),
+            "evening_end": settings.get("time_evening_end", "21:00"),
+            "night_start": settings.get("time_night_start", "21:00"),
+            "night_end": settings.get("time_night_end", "23:59"),
+        }
+
         return {
             "today_day_of_week": today_dow,
             "streak_reset_mode": settings.get("streak_reset_mode", "reset"),
@@ -671,6 +682,7 @@ class TaskMateOverallStatsSensor(_CachedAttrsSensor):
             "points_name": data.get("points_name", "Stars"),
             "points_icon": data.get("points_icon", "mdi:star"),
             "children": _build_children_summary(common),
+            "time_boundaries": time_boundaries,
         }
 
 

--- a/custom_components/taskmate/websocket.py
+++ b/custom_components/taskmate/websocket.py
@@ -736,6 +736,10 @@ _SUBKEY_SETTINGS = {
     "weekend_multiplier", "streak_milestones_enabled", "perfect_week_enabled",
     "perfect_week_bonus", "streak_milestones",
     "notify_service", "calendar_projection_days",
+    "time_morning_start", "time_morning_end",
+    "time_afternoon_start", "time_afternoon_end",
+    "time_evening_start", "time_evening_end",
+    "time_night_start", "time_night_end",
 }
 
 @websocket_api.websocket_command({
@@ -751,6 +755,14 @@ _SUBKEY_SETTINGS = {
     vol.Optional("streak_milestones"): str,
     vol.Optional("notify_service"): str,
     vol.Optional("calendar_projection_days"): vol.All(int, vol.Range(min=1, max=90)),
+    vol.Optional("time_morning_start"): vol.Match(r"^\d{2}:\d{2}$"),
+    vol.Optional("time_morning_end"): vol.Match(r"^\d{2}:\d{2}$"),
+    vol.Optional("time_afternoon_start"): vol.Match(r"^\d{2}:\d{2}$"),
+    vol.Optional("time_afternoon_end"): vol.Match(r"^\d{2}:\d{2}$"),
+    vol.Optional("time_evening_start"): vol.Match(r"^\d{2}:\d{2}$"),
+    vol.Optional("time_evening_end"): vol.Match(r"^\d{2}:\d{2}$"),
+    vol.Optional("time_night_start"): vol.Match(r"^\d{2}:\d{2}$"),
+    vol.Optional("time_night_end"): vol.Match(r"^\d{2}:\d{2}$"),
 })
 @websocket_api.async_response
 @_admin_only

--- a/custom_components/taskmate/www/taskmate-child-card.js
+++ b/custom_components/taskmate/www/taskmate-child-card.js
@@ -1810,32 +1810,48 @@ class TaskMateChildCard extends LitElement {
     return this.hass?.config?.time_zone || Intl.DateTimeFormat().resolvedOptions().timeZone;
   }
 
-  // Returns the current time period name based on HA-timezone-aware hour.
-  // morning: 0–11, afternoon: 12–16, evening: 17–20, night: 21–23
+  _getTimeBoundaries() {
+    const attrs = (window.__taskmate_attrs && window.__taskmate_attrs(this.hass, this.config?.entity))
+      || this.hass?.states?.[this.config?.entity]?.attributes || {};
+    const tb = attrs.time_boundaries || {};
+    return {
+      morning:   [this._parseHHMM(tb.morning_start, 6, 0),   this._parseHHMM(tb.morning_end, 12, 0)],
+      afternoon: [this._parseHHMM(tb.afternoon_start, 12, 0), this._parseHHMM(tb.afternoon_end, 17, 0)],
+      evening:   [this._parseHHMM(tb.evening_start, 17, 0),   this._parseHHMM(tb.evening_end, 21, 0)],
+      night:     [this._parseHHMM(tb.night_start, 21, 0),     this._parseHHMM(tb.night_end, 23, 59)],
+    };
+  }
+
+  _parseHHMM(str, defH, defM) {
+    if (!str) return defH + defM / 60;
+    const [h, m] = str.split(':').map(Number);
+    if (isNaN(h)) return defH + defM / 60;
+    return h + (m || 0) / 60;
+  }
+
   _getCurrentTimePeriod() {
     if (this.config.debug_time_period) return this.config.debug_time_period;
     const tz = this._getTimezone();
-    const hourStr = new Intl.DateTimeFormat('en-US', {
-      timeZone: tz,
-      hour: 'numeric',
-      hour12: false,
-    }).format(new Date());
-    const hour = parseInt(hourStr, 10);
-    if (hour < 12) return 'morning';
-    if (hour < 17) return 'afternoon';
-    if (hour < 21) return 'evening';
-    return 'night';
+    const parts = new Intl.DateTimeFormat('en-US', {
+      timeZone: tz, hour: 'numeric', minute: 'numeric', hour12: false,
+    }).formatToParts(new Date());
+    let hour = parseInt(parts.find(p => p.type === 'hour')?.value, 10);
+    const minute = parseInt(parts.find(p => p.type === 'minute')?.value, 10) || 0;
+    if (isNaN(hour)) hour = 0;
+    if (hour === 24) hour = 0;
+    const now = hour + minute / 60;
+    const b = this._getTimeBoundaries();
+    if (now >= b.night[0])     return 'night';
+    if (now >= b.evening[0])   return 'evening';
+    if (now >= b.afternoon[0]) return 'afternoon';
+    return 'morning';
   }
 
-  // Period hour bounds [startHour, endHour). Night caps at 24 (midnight).
   _getPeriodHours(period) {
-    switch (period) {
-      case 'morning': return [0, 12];
-      case 'afternoon': return [12, 17];
-      case 'evening': return [17, 21];
-      case 'night': return [21, 24];
-      default: return null;
-    }
+    const b = this._getTimeBoundaries();
+    const range = b[period];
+    if (!range) return null;
+    return [range[0], range[1]];
   }
 
   // Current {hour, minute} in HA timezone. Honours debug_time_period by
@@ -1843,7 +1859,7 @@ class TaskMateChildCard extends LitElement {
   _getCurrentHourMinute() {
     if (this.config.debug_time_period) {
       const hours = this._getPeriodHours(this.config.debug_time_period);
-      if (hours) return { hour: hours[0], minute: 0 };
+      if (hours) return { hour: Math.floor(hours[0]), minute: Math.round((hours[0] % 1) * 60) };
     }
     const tz = this._getTimezone();
     const parts = new Intl.DateTimeFormat('en-US', {
@@ -2047,7 +2063,7 @@ class TaskMateChildCard extends LitElement {
       ? (this._getPeriodHours(chore.time_category)?.[0] ?? null)
       : null;
     const lockedUntilLabel = isLockedPreview && periodStartHour !== null
-      ? this._t('child.chore_locked_until', { time: `${String(periodStartHour).padStart(2, '0')}:00` })
+      ? this._t('child.chore_locked_until', { time: `${String(Math.floor(periodStartHour)).padStart(2, '0')}:${String(Math.round((periodStartHour % 1) * 60)).padStart(2, '0')}` })
       : '';
     const handleRowClick = () => {
       if (isLoading) return;

--- a/custom_components/taskmate/www/taskmate-panel.js
+++ b/custom_components/taskmate/www/taskmate-panel.js
@@ -1961,6 +1961,44 @@ class TaskMatePanel extends HTMLElement {
         </div>
 
         <div class="tm-section">
+          <div class="tm-section-head"><div><h3>Time-of-day boundaries</h3><p class="tm-meta">When each time period starts and ends (HH:MM, 24-hour).</p></div></div>
+          <div class="tm-section-body">
+            <div class="tm-setting-row">
+              <div class="tm-setting-label">Morning<small>Default 06:00 – 12:00</small></div>
+              <div class="tm-time-pair">
+                <ha-textfield type="time" data-setting="time_morning_start" data-value="${s.time_morning_start || "06:00"}"></ha-textfield>
+                <span>–</span>
+                <ha-textfield type="time" data-setting="time_morning_end" data-value="${s.time_morning_end || "12:00"}"></ha-textfield>
+              </div>
+            </div>
+            <div class="tm-setting-row">
+              <div class="tm-setting-label">Afternoon<small>Default 12:00 – 17:00</small></div>
+              <div class="tm-time-pair">
+                <ha-textfield type="time" data-setting="time_afternoon_start" data-value="${s.time_afternoon_start || "12:00"}"></ha-textfield>
+                <span>–</span>
+                <ha-textfield type="time" data-setting="time_afternoon_end" data-value="${s.time_afternoon_end || "17:00"}"></ha-textfield>
+              </div>
+            </div>
+            <div class="tm-setting-row">
+              <div class="tm-setting-label">Evening<small>Default 17:00 – 21:00</small></div>
+              <div class="tm-time-pair">
+                <ha-textfield type="time" data-setting="time_evening_start" data-value="${s.time_evening_start || "17:00"}"></ha-textfield>
+                <span>–</span>
+                <ha-textfield type="time" data-setting="time_evening_end" data-value="${s.time_evening_end || "21:00"}"></ha-textfield>
+              </div>
+            </div>
+            <div class="tm-setting-row">
+              <div class="tm-setting-label">Night<small>Default 21:00 – 23:59</small></div>
+              <div class="tm-time-pair">
+                <ha-textfield type="time" data-setting="time_night_start" data-value="${s.time_night_start || "21:00"}"></ha-textfield>
+                <span>–</span>
+                <ha-textfield type="time" data-setting="time_night_end" data-value="${s.time_night_end || "23:59"}"></ha-textfield>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="tm-section">
           <div class="tm-section-head"><div><h3>Bonuses</h3></div></div>
           <div class="tm-section-body">
             <div class="tm-setting-row">
@@ -3260,6 +3298,11 @@ class TaskMatePanel extends HTMLElement {
       .tm-setting-row ha-select {
         max-width: 360px;
       }
+      .tm-time-pair {
+        display: flex; align-items: center; gap: 8px;
+      }
+      .tm-time-pair ha-textfield { max-width: 130px; }
+      .tm-time-pair span { color: var(--tm-text-faint); }
       .tm-settings-foot {
         display: flex; justify-content: flex-end;
         padding-top: 8px;


### PR DESCRIPTION
Allow users to customise when morning/afternoon/evening/night periods start and end via Settings > Time-of-day boundaries in the admin panel.

Defaults match the previous hardcoded values (06:00–12:00–17:00–21:00–23:59). Backend reads from storage settings with graceful fallback; the child card reads boundaries from the overview sensor attribute so period detection, claim windows, and locked-preview labels all respect the configured times.

**Changes:**
- `coord_calendar.py`: replaced hardcoded `_TIME_CATEGORY_WINDOWS` dict with `_get_time_boundaries()` that reads from storage
- `websocket.py`: added 8 new `time_*` settings keys with HH:MM regex validation
- `sensor.py`: exposed `time_boundaries` dict in overview sensor attributes
- `taskmate-panel.js`: added Time-of-day boundaries section with paired time inputs
- `taskmate-child-card.js`: `_getCurrentTimePeriod` and `_getPeriodHours` now read from sensor attributes