### PR TITLE
fix: timed task points mismatch and dialog re-render

### DIFF
--- a/custom_components/taskmate/sensor.py
+++ b/custom_components/taskmate/sensor.py
@@ -286,6 +286,11 @@ def _build_todays_completions(common: dict) -> list[dict]:
         else:
             display_name = matched_chore.name if matched_chore else ""
             display_points = matched_chore.points if matched_chore else 0
+        timed_secs = getattr(comp, "timed_duration_seconds", 0) or 0
+        if timed_secs > 0 and matched_chore and getattr(matched_chore, "task_type", "") == "timed":
+            rate_seconds = matched_chore.timed_rate_minutes * 60
+            if rate_seconds > 0:
+                display_points = (timed_secs // rate_seconds) * matched_chore.timed_rate_points
         rec = {
             "completion_id": comp.id,
             "chore_id": comp.chore_id,
@@ -297,7 +302,6 @@ def _build_todays_completions(common: dict) -> list[dict]:
             "completed_at": comp.completed_at.isoformat() if hasattr(comp.completed_at, 'isoformat') else str(comp.completed_at),
             "bonus_subtask_id": bonus_subtask_id,
         }
-        timed_secs = getattr(comp, "timed_duration_seconds", 0) or 0
         if timed_secs > 0:
             rec["timed_duration_seconds"] = timed_secs
         out.append(rec)

--- a/custom_components/taskmate/www/taskmate-child-card.js
+++ b/custom_components/taskmate/www/taskmate-child-card.js
@@ -2386,7 +2386,13 @@ class TaskMateChildCard extends LitElement {
     const celebratingChore = (attrs.chores || []).find(
       c => c.id === this._celebrating
     );
-    const points = celebratingChore?.points || 0;
+    const completions = attrs.todays_completions || [];
+    const latestCompletion = completions.filter(
+      c => c.chore_id === this._celebrating && c.child_id === this.config.child_id
+    ).pop();
+    const points = (latestCompletion && latestCompletion.points != null)
+      ? latestCompletion.points
+      : (celebratingChore?.points || 0);
 
     return html`
       <div class="celebration-overlay" @click="${this._closeCelebration}">

--- a/custom_components/taskmate/www/taskmate-panel.js
+++ b/custom_components/taskmate/www/taskmate-panel.js
@@ -2145,7 +2145,7 @@ class TaskMatePanel extends HTMLElement {
         this._select("Task type", "task_type", d.task_type || "standard", [
           { v: "standard", l: "Standard — fixed points on completion" },
           { v: "timed", l: "Timed — points per minute" },
-        ]),
+        ], "", true),
         isTimedTask ? `<div class="tm-field-row">
           ${this._field("Points per window", "timed_rate_points", d.timed_rate_points || 10, "number")}
           ${this._field("Window (minutes)", "timed_rate_minutes", d.timed_rate_minutes || 5, "number")}


### PR DESCRIPTION
## Summary

- **Chore config dialog**: Selecting "Timed" task type now immediately shows timed fields (points per window, window minutes, daily cap) without needing to save and reopen
- **Sensor**: Timed task completions now report calculated points (duration x rate) instead of base chore points - fixes pending approval badge and parent dashboard showing wrong values
- **Celebration popup**: Now reads points from the completion record instead of the chore definition, so timed tasks display correct earned points (e.g. +20 for 2 min at 10 pts/min)

### Root cause
The sensor used the base chore points field for all tasks. For timed tasks it should calculate from duration and rate config. The celebration popup had the same problem.