### PR TITLE
fix: timed task points display in celebration and approvals

### DIFF
--- a/custom_components/taskmate/sensor.py
+++ b/custom_components/taskmate/sensor.py
@@ -1018,17 +1018,26 @@ class PendingApprovalsSensor(TaskMateBaseSensor):
             child = self.coordinator.get_child(comp.child_id)
             chore = self.coordinator.get_chore(comp.chore_id)
             if child and chore:
-                completion_details.append({
+                pts = chore.points
+                timed_secs = getattr(comp, "timed_duration_seconds", 0) or 0
+                if timed_secs > 0 and getattr(chore, "task_type", "") == "timed":
+                    rate_seconds = chore.timed_rate_minutes * 60
+                    if rate_seconds > 0:
+                        pts = (timed_secs // rate_seconds) * chore.timed_rate_points
+                detail = {
                     "completion_id": comp.id,
                     "type": "chore",
                     "child_name": child.name,
                     "child_id": child.id,
                     "chore_name": chore.name,
                     "chore_id": chore.id,
-                    "points": chore.points,
+                    "points": pts,
                     "time_category": chore.time_category,
                     "completed_at": comp.completed_at.isoformat(),
-                })
+                }
+                if timed_secs > 0:
+                    detail["timed_duration_seconds"] = timed_secs
+                completion_details.append(detail)
 
         reward_details = []
         for claim in pending_rewards:

--- a/custom_components/taskmate/www/taskmate-child-card.js
+++ b/custom_components/taskmate/www/taskmate-child-card.js
@@ -2208,6 +2208,7 @@ class TaskMateChildCard extends LitElement {
     const handleStop = (e) => {
       e.stopPropagation();
       if (isLoading) return;
+      this._celebrationPoints = earnedPoints;
       this._loading = { ...this._loading, [`timed_${chore.id}`]: true };
       this.hass.callService('taskmate', 'stop_timed_task', {
         chore_id: chore.id, child_id: child.id
@@ -2217,7 +2218,7 @@ class TaskMateChildCard extends LitElement {
         this._playSound(sound);
         this._celebrating = chore.id;
         this._launchConfetti();
-        setTimeout(() => { this._celebrating = null; this.requestUpdate(); }, 2000);
+        setTimeout(() => { this._celebrating = null; this._celebrationPoints = null; this.requestUpdate(); }, 2000);
       }).catch(() => {
         this._loading = { ...this._loading, [`timed_${chore.id}`]: false };
       });
@@ -2390,9 +2391,11 @@ class TaskMateChildCard extends LitElement {
     const latestCompletion = completions.filter(
       c => c.chore_id === this._celebrating && c.child_id === this.config.child_id
     ).pop();
-    const points = (latestCompletion && latestCompletion.points != null)
-      ? latestCompletion.points
-      : (celebratingChore?.points || 0);
+    const points = (this._celebrationPoints != null)
+      ? this._celebrationPoints
+      : (latestCompletion && latestCompletion.points != null)
+        ? latestCompletion.points
+        : (celebratingChore?.points || 0);
 
     return html`
       <div class="celebration-overlay" @click="${this._closeCelebration}">

--- a/custom_components/taskmate/www/taskmate-panel.js
+++ b/custom_components/taskmate/www/taskmate-panel.js
@@ -751,6 +751,8 @@ class TaskMatePanel extends HTMLElement {
   _openChoreDialog(id) {
     const blank = {
       name: "", description: "", points: 10,
+      task_type: "standard",
+      timed_rate_points: 10, timed_rate_minutes: 5, timed_max_daily_minutes: 0,
       assigned_to: [], requires_approval: true,
       time_category: "anytime", completion_sound: "coin", daily_limit: 1,
       claim_allowance_minutes: 0,


### PR DESCRIPTION
## Summary

- **Celebration popup**: Was showing the static chore `points` field (e.g. 10) instead of the calculated timed points (e.g. 20 for 2 min at 10 pts/min). Now captures `earnedPoints` before calling `stop_timed_task` and displays that in the popup, avoiding the race condition with the entity state update.

- **Pending approvals sensor**: Was exposing `chore.points` for all task types including timed. Now calculates points from `timed_duration_seconds` using the same formula as `todays_completions` and the approval handler.

- **Panel chore defaults**: Added `task_type`, `timed_rate_points`, `timed_rate_minutes`, `timed_max_daily_minutes` to the blank chore dialog object for consistency when switching task types.

## Files changed
- `custom_components/taskmate/www/taskmate-child-card.js` — celebration points fix
- `custom_components/taskmate/sensor.py` — pending approval points calculation
- `custom_components/taskmate/www/taskmate-panel.js` — blank chore defaults