### PR TITLE
fix: career graph shows flat line for users without history

### DIFF
--- a/custom_components/taskmate/coordinator.py
+++ b/custom_components/taskmate/coordinator.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta
 import logging
 from typing import Any
 
@@ -54,6 +54,7 @@ class TaskMateCoordinator(
     async def async_initialize(self) -> None:
         """Initialize the coordinator."""
         await self.storage.async_load()
+        await self._async_backfill_career_history()
         await self._async_stop_stale_timed_sessions()
         await self.async_refresh()
         # Schedule midnight streak check at 00:00:05
@@ -70,6 +71,66 @@ class TaskMateCoordinator(
         self._unsub_availability = self.hass.bus.async_listen(
             "state_changed", self._availability_state_changed
         )
+
+    async def _async_backfill_career_history(self) -> None:
+        """Backfill career_score_history from completions and transactions.
+
+        Runs once on startup for children whose history is sparse (fewer than
+        7 entries). Uses all stored completions and transactions — not the
+        capped sensor attributes — so coverage matches the 90-day retention.
+        """
+        children = self.storage.get_children()
+        if not children:
+            return
+
+        needs_save = False
+        completions = self.storage.get_completions()
+        transactions = self.storage.get_points_transactions()
+        chore_lookup = {ch.id: ch for ch in self.storage.get_chores()}
+
+        for child in children:
+            existing = self.storage.get_career_score_history(child.id)
+            if len(existing) >= 7:
+                continue
+
+            daily_net: dict[str, int] = {}
+            for comp in completions:
+                if comp.child_id != child.id or not comp.approved:
+                    continue
+                day = comp.completed_at.date().isoformat()
+                pts = comp.points_awarded
+                if not pts:
+                    chore = chore_lookup.get(comp.chore_id)
+                    pts = chore.points if chore else 0
+                daily_net[day] = daily_net.get(day, 0) + pts
+
+            for txn in transactions:
+                if txn.child_id != child.id:
+                    continue
+                day = txn.created_at.date().isoformat()
+                daily_net[day] = daily_net.get(day, 0) + txn.points
+
+            if not daily_net:
+                continue
+
+            sorted_days = sorted(daily_net.keys())
+            total_net = sum(daily_net.values())
+            start_score = (child.career_score or 0) - total_net
+
+            running = start_score
+            for day in sorted_days:
+                running += daily_net[day]
+                self.storage.append_career_score_snapshot(
+                    child.id, day, running
+                )
+            needs_save = True
+            _LOGGER.info(
+                "Backfilled %d career history entries for %s",
+                len(sorted_days), child.name,
+            )
+
+        if needs_save:
+            await self.storage.async_save()
 
     async def async_shutdown(self) -> None:
         """Shutdown the coordinator and clean up listeners."""

--- a/custom_components/taskmate/www/taskmate-graph-card.js
+++ b/custom_components/taskmate/www/taskmate-graph-card.js
@@ -279,7 +279,7 @@ class TaskMateGraphCard extends LitElement {
         child.id, dateRange, allCompletions, allTransactions, chorePointsMap, tz
       );
       const cumulativePoints = this._buildCumulative(dailyPoints);
-      const careerPoints = this._buildCareerSeries(child, careerHistory[child.id] || [], dateRange);
+      const careerPoints = this._buildCareerSeries(child, careerHistory[child.id] || [], dateRange, allCompletions, allTransactions, chorePointsMap, tz);
       return { child, color, dailyPoints, cumulativePoints, careerPoints };
     });
 
@@ -623,29 +623,39 @@ class TaskMateGraphCard extends LitElement {
     return dailyPoints.map(v => { running += v; return running; });
   }
 
-  _buildCareerSeries(child, history, dateRange) {
+  _buildCareerSeries(child, history, dateRange, completions, transactions, chorePointsMap, tz) {
     const historyMap = {};
     (history || []).forEach(h => { historyMap[h.date] = h.score; });
-    let lastKnown = child.career_score || 0;
-    // Walk backwards through history to find the earliest known value
-    // then walk forward with carry-forward
-    const earliest = dateRange[0];
-    for (let i = history.length - 1; i >= 0; i--) {
-      if (history[i].date <= earliest) {
-        lastKnown = history[i].score;
-        break;
+    const historyDatesInRange = dateRange.filter(d => d in historyMap).length;
+
+    if (historyDatesInRange >= Math.min(dateRange.length * 0.5, 7)) {
+      let lastKnown = child.career_score || 0;
+      const earliest = dateRange[0];
+      for (let i = history.length - 1; i >= 0; i--) {
+        if (history[i].date <= earliest) { lastKnown = history[i].score; break; }
       }
+      if (history.length > 0 && history[0].date > earliest) {
+        lastKnown = history[0].score;
+      }
+      let carry = lastKnown;
+      return dateRange.map(d => { if (d in historyMap) carry = historyMap[d]; return carry; });
     }
-    // If no history before the range, use the first history entry in range or current score
-    if (history.length > 0 && history[0].date > earliest) {
-      // Carry back from the earliest known history point
-      lastKnown = history[0].score;
-    }
-    let carry = lastKnown;
-    return dateRange.map(d => {
-      if (d in historyMap) carry = historyMap[d];
-      return carry;
+
+    const byDay = {};
+    dateRange.forEach(d => { byDay[d] = 0; });
+    (completions || []).filter(c => c.child_id === child.id).forEach(c => {
+      const day = new Date(c.completed_at).toLocaleDateString("en-CA", { timeZone: tz });
+      if (day in byDay) byDay[day] += c.points !== undefined ? c.points : (chorePointsMap[c.chore_id] || 0);
     });
+    (transactions || []).filter(t => t.child_id === child.id).forEach(t => {
+      const day = new Date(t.created_at).toLocaleDateString("en-CA", { timeZone: tz });
+      if (day in byDay) byDay[day] += t.points || 0;
+    });
+    const dailyNets = dateRange.map(d => byDay[d]);
+    const totalNet = dailyNets.reduce((a, b) => a + b, 0);
+    const startScore = (child.career_score || 0) - totalNet;
+    let running = startScore;
+    return dailyNets.map(v => { running += v; return running; });
   }
 
   _niceMax(val) {


### PR DESCRIPTION
## Summary
- Career graph showed a flat line for users who had TaskMate before the career feature was added, because `career_score_history` had no entries
- Backend now backfills career history from stored completions/transactions on startup when history is sparse (<7 entries)
- Frontend falls back to reconstructing career evolution from completion/transaction data when history coverage is low

Fixes #256

## Test plan
- [ ] Existing user with sparse career history sees an evolution line instead of flat
- [ ] New user accumulating points sees career graph update correctly
- [ ] Daily and cumulative graph modes still work as before
- [ ] Backend logs show backfill count on first startup after update