### PR TITLE
chore: release v3.6.4

### DIFF
--- a/custom_components/taskmate/manifest.json
+++ b/custom_components/taskmate/manifest.json
@@ -17,5 +17,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/tempus2016/taskmate/issues",
   "requirements": [],
-  "version": "3.6.3"
+  "version": "3.6.4"
 }


### PR DESCRIPTION
Version bump to 3.6.4 — hotfix for panel syntax error introduced in 3.6.3.