### PR TITLE
fix: second panel syntax error in reorder dialog

### DIFF
--- a/custom_components/taskmate/www/taskmate-panel.js
+++ b/custom_components/taskmate/www/taskmate-panel.js
@@ -2449,7 +2449,7 @@ class TaskMatePanel extends HTMLElement {
   _renderReorderDialog() {
     const d = this._dialog.data;
     const choreById = Object.fromEntries((this._state.chores || []).map(c => [c.id, c]));
-    return this._dialogShell(this._t("panel.reorder_title", {name: d.name})),
+    return this._dialogShell(this._t("panel.reorder_title", {name: d.name}),
       `<p class="tm-meta">${this._t("panel.reorder_hint")}</p>
        <div class="tm-reorder-list">
          ${(d.order || []).map(id => {


### PR DESCRIPTION
Same stray `)` pattern as #263 but in `_renderReorderDialog()` (line 2452). Closes `_dialogShell()` prematurely, crashing the panel.

All 8 `_dialogShell` call sites verified — no more instances remain.