### PR TITLE
chore: bump version to 3.6.5

### DIFF
--- a/custom_components/taskmate/manifest.json
+++ b/custom_components/taskmate/manifest.json
@@ -17,5 +17,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/tempus2016/taskmate/issues",
   "requirements": [],
-  "version": "3.6.4"
+  "version": "3.6.5"
 }


### PR DESCRIPTION
Bump version to 3.6.5 for hotfix release.

Fixes remaining panel syntax error from v3.6.4 (#266).