### PR TITLE
fix(panel): show actual earned points on pending approvals for timed chores

### DIFF
--- a/custom_components/taskmate/www/taskmate-panel.js
+++ b/custom_components/taskmate/www/taskmate-panel.js
@@ -1350,6 +1350,13 @@ class TaskMatePanel extends HTMLElement {
               if (c.bonus_subtask_id && chore) {
                 const sub = (chore.bonus_subtasks || []).find(b => b.id === c.bonus_subtask_id);
                 if (sub) { choreName = `${chore.name} › ${sub.name}`; chorePoints = sub.points; }
+              } else if (chore && chore.task_type === "timed" && (c.timed_duration_seconds || 0) > 0) {
+                // Timed chores accrue points by elapsed-time rate, so the actual
+                // earned points can be lower than chore.points. Mirror sensor.py.
+                const rateSeconds = (chore.timed_rate_minutes || 0) * 60;
+                if (rateSeconds > 0) {
+                  chorePoints = Math.floor(c.timed_duration_seconds / rateSeconds) * (chore.timed_rate_points || 0);
+                }
               }
               return `
                 <div class="tm-approval-item">


### PR DESCRIPTION
## Summary

Fixes a discrepancy in the Activity tab's **Pending Approvals** list where the displayed point value reflected the chore's *maximum* points (e.g. `60`) instead of the points actually earned (e.g. `2`). This contradicted the value shown in the Approvals Lovelace card and the parent card.

## Root cause

`taskmate-panel.js` looked up `chore.points` directly when rendering pending completions. The `pending_approvals` sensor (`sensor.py:1021-1026`) already computes the correct value for timed chores by deriving points from `timed_duration_seconds` × the chore's rate, which is why the Lovelace card displayed `+2` correctly.

## Fix

Mirror the sensor logic in the panel:
- Standard chores → `chore.points` (unchanged)
- Bonus subtasks → `subtask.points` (unchanged)
- Timed chores with a recorded duration → `floor(duration / rate_window) × rate_points`

## Test plan

- [x] Unit-tested the calculation against six scenarios (timed full/partial/zero, standard, bonus subtask, deleted chore) — all return the expected value.
- [ ] Verify in HA: timed chore part-completed → Activity tab Pending Approvals matches Approvals Lovelace card.
- [ ] Verify in HA: standard chore pending approval still shows full configured points.
- [ ] Verify in HA: bonus-subtask completions still show subtask points.

Fixes #270