### PR TITLE
fix(child-card): themed background for idle timed chore card

### DIFF
--- a/custom_components/taskmate/www/taskmate-child-card.js
+++ b/custom_components/taskmate/www/taskmate-child-card.js
@@ -1222,7 +1222,7 @@ class TaskMateChildCard extends LitElement {
         gap: 12px;
         box-shadow: 0 3px 10px rgba(0, 0, 0, 0.08);
         border: 3px solid var(--fun-cyan);
-        background: color-mix(in srgb, var(--fun-cyan) 8%, white);
+        background: color-mix(in srgb, var(--fun-cyan) 10%, var(--card-background-color, #fff));
         transition: transform 0.15s ease, box-shadow 0.15s ease;
         -webkit-user-select: none;
         user-select: none;


### PR DESCRIPTION
## Summary

The idle-state timed chore card kept a near-white background in dark mode because its style mixed `--fun-cyan` with a literal `white`. Other chore-card variants (line 628 / 634 / 640 / 646) mix with `var(--card-background-color, #fff)` which tracks the theme — this card now does the same.

## Root cause

`taskmate-child-card.js:1225`:
```css
background: color-mix(in srgb, var(--fun-cyan) 8%, white);
```
Replaced with:
```css
background: color-mix(in srgb, var(--fun-cyan) 10%, var(--card-background-color, #fff));
```
(10% to match the other chore-card variants for consistency.)

## Test plan

- [ ] Dark mode: idle timed chore card matches the dark surface tint of standard chore cards.
- [ ] Light mode: idle timed chore card unchanged.
- [ ] Running / paused timer states (`.timer-display` already uses `--secondary-background-color`) still render correctly.

Refs #255