### PR TITLE
fix: include bonus_subtasks in chore sensor data for child card

### DIFF
--- a/custom_components/taskmate/sensor.py
+++ b/custom_components/taskmate/sensor.py
@@ -242,6 +242,12 @@ def _build_chores_list(coordinator: TaskMateCoordinator, common: dict) -> list[d
             record["timed_rate_points"] = getattr(c, 'timed_rate_points', 10)
             record["timed_rate_minutes"] = getattr(c, 'timed_rate_minutes', 5)
             record["timed_max_daily_minutes"] = getattr(c, 'timed_max_daily_minutes', 0)
+        bonus_subtasks = getattr(c, 'bonus_subtasks', [])
+        if bonus_subtasks:
+            record["bonus_subtasks"] = [
+                {"id": b.id, "name": b.name, "points": b.points}
+                for b in bonus_subtasks
+            ]
         chores_list.append(record)
     return chores_list
 


### PR DESCRIPTION
## Summary

`_build_chores_list()` in `sensor.py` omitted the `bonus_subtasks` field when building chore records for the sensor. The child card's `_renderBonusSubtasks()` method (line 2401) was already fully implemented but always received `undefined` because the data was never sent.

The panel wasn't affected because it fetches chore data via WebSocket calls that include the full object.

**Fix:** Add `bonus_subtasks` as an optional field (only emitted when non-empty) in `_build_chores_list()`, consistent with the existing pattern for optional fields.

Fixes #287