### PR TITLE
fix: resolve 30 ruff lint issues in badge code

### DIFF
--- a/custom_components/taskmate/storage.py
+++ b/custom_components/taskmate/storage.py
@@ -9,7 +9,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.storage import Store
 
 from .const import DOMAIN
-from .models import Badge, BadgeCriterion, AwardedBadge, Bonus, Child, Chore, ChoreCompletion, Penalty, PoolAllocation, Reward, RewardClaim, PointsTransaction, TaskGroup, TimedSession
+from .models import Badge, AwardedBadge, Bonus, Child, Chore, ChoreCompletion, Penalty, PoolAllocation, Reward, RewardClaim, PointsTransaction, TaskGroup, TimedSession
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/tests/test_badge_services.py
+++ b/tests/test_badge_services.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 import pytest
 from unittest.mock import AsyncMock, MagicMock
 
-from custom_components.taskmate.models import Badge, BadgeCriterion, AwardedBadge
+from custom_components.taskmate.coord_badges import BadgeCoordinator
+from custom_components.taskmate.models import Badge, BadgeCriterion, AwardedBadge, Child
 
 
 @pytest.fixture
 def coord_with_badges():
     """A coordinator-like object exposing storage + badges as the service handlers see it."""
-    from custom_components.taskmate.coord_badges import BadgeCoordinator
     hass = MagicMock()
     hass.bus = MagicMock()
     hass.bus.async_fire = MagicMock()
@@ -44,8 +44,8 @@ class TestBadgeServiceHelpers:
 
     async def test_award_manually_uses_coord(self, coord_with_badges):
         coord = coord_with_badges
-        from custom_components.taskmate.models import Child
-        child = Child(name="Mia"); child.id = "c1"
+        child = Child(name="Mia")
+        child.id = "c1"
         coord.storage.get_child.return_value = child
         b = Badge(name="X", point_bonus=10)
         b.id = "b1"

--- a/tests/test_badge_storage.py
+++ b/tests/test_badge_storage.py
@@ -5,6 +5,7 @@ import pytest
 from unittest.mock import MagicMock
 
 from custom_components.taskmate.models import Badge, BadgeCriterion, AwardedBadge, Child
+from custom_components.taskmate.coord_badges import BUILTIN_CATALOGUE
 from custom_components.taskmate.storage import TaskMateStorage
 
 
@@ -107,9 +108,6 @@ class TestBadgeStorage:
         remaining = storage.get_awarded_badges()
         assert len(remaining) == 1
         assert remaining[0].child_id == "other"
-
-
-from custom_components.taskmate.coord_badges import BUILTIN_CATALOGUE
 
 
 class TestCatalogueSeeding:

--- a/tests/test_coord_badges.py
+++ b/tests/test_coord_badges.py
@@ -1,11 +1,12 @@
 """Tests for coord_badges."""
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+import pytest
+from unittest.mock import AsyncMock, MagicMock
 from datetime import datetime, timezone
 
-from custom_components.taskmate.coord_badges import BUILTIN_CATALOGUE, resolve_metric, TRIGGER_METRICS, badge_relevant_to_trigger
-from custom_components.taskmate.models import Badge, BadgeCriterion, Child, RewardClaim
+from custom_components.taskmate.coord_badges import BUILTIN_CATALOGUE, BadgeCoordinator, resolve_metric, TRIGGER_METRICS, badge_relevant_to_trigger
+from custom_components.taskmate.models import AwardedBadge, Badge, BadgeCriterion, Child, RewardClaim
 
 
 class TestBuiltinCatalogue:
@@ -151,11 +152,6 @@ class TestTriggerMap:
         assert badge_relevant_to_trigger(b, "made_up") is False
 
 
-import pytest
-from unittest.mock import AsyncMock, MagicMock
-from custom_components.taskmate.coord_badges import BadgeCoordinator
-
-
 @pytest.fixture
 def coord():
     hass = MagicMock()
@@ -180,7 +176,6 @@ class TestBadgeCoordinatorBasic:
 
 class TestEvaluationCore:
     def _setup(self, coord, child_kwargs=None, badges=None, awarded=None):
-        from custom_components.taskmate.models import Child
         kwargs = {
             "name": "Mia",
             "total_points_earned": 0,
@@ -229,7 +224,6 @@ class TestEvaluationCore:
         assert awards == []
 
     async def test_already_awarded_no_double_award(self, coord):
-        from custom_components.taskmate.models import AwardedBadge
         b = Badge(
             name="100 Points",
             criteria=[BadgeCriterion("total_points", ">=", 100)],
@@ -354,7 +348,6 @@ class TestEvaluationCore:
 
 class TestManualOps:
     async def test_award_manually_creates_award(self, coord):
-        from custom_components.taskmate.models import Child
         child = Child(name="Mia")
         child.id = "c1"
         coord.storage.get_child.return_value = child
@@ -372,22 +365,21 @@ class TestManualOps:
     async def test_award_manually_blocks_double(self, coord):
         coord.storage.has_awarded.return_value = True
         coord.storage.get_badge.return_value = Badge(name="x")
-        from custom_components.taskmate.models import Child
-        child = Child(name="Mia"); child.id = "c1"
+        child = Child(name="Mia")
+        child.id = "c1"
         coord.storage.get_child.return_value = child
         award = await coord.award_manually("c1", "b1")
         assert award is None
 
     async def test_award_manually_missing_badge_returns_none(self, coord):
-        from custom_components.taskmate.models import Child
-        child = Child(name="Mia"); child.id = "c1"
+        child = Child(name="Mia")
+        child.id = "c1"
         coord.storage.get_child.return_value = child
         coord.storage.get_badge.return_value = None
         award = await coord.award_manually("c1", "missing")
         assert award is None
 
     async def test_revoke_with_bonus_credited_reverses_points(self, coord):
-        from custom_components.taskmate.models import AwardedBadge
         a = AwardedBadge(child_id="c1", badge_id="b1", bonus_credited=50)
         coord.storage.get_awarded_badges.return_value = [a]
         coord.storage.get_badge.return_value = Badge(name="X")
@@ -398,7 +390,6 @@ class TestManualOps:
         coord.points_coord.remove_points.assert_awaited_once()
 
     async def test_revoke_zero_bonus_no_points_change(self, coord):
-        from custom_components.taskmate.models import AwardedBadge
         a = AwardedBadge(child_id="c1", badge_id="b1", bonus_credited=0)
         coord.storage.get_awarded_badges.return_value = [a]
         coord.storage.get_badge.return_value = Badge(name="X")
@@ -412,9 +403,10 @@ class TestManualOps:
         assert result is False
 
     async def test_rebuild_walks_all_children_silently(self, coord):
-        from custom_components.taskmate.models import Child
-        c1 = Child(name="Mia"); c1.id = "c1"
-        c2 = Child(name="Leo"); c2.id = "c2"
+        c1 = Child(name="Mia")
+        c1.id = "c1"
+        c2 = Child(name="Leo")
+        c2.id = "c2"
         coord.storage.get_children.return_value = [c1, c2]
         coord.storage.get_child.side_effect = lambda i: {"c1": c1, "c2": c2}.get(i)
         coord.storage.get_badges.return_value = []
@@ -431,7 +423,6 @@ class TestNotifications:
             criteria=[BadgeCriterion("total_points", ">=", 10)],
         )
         b.id = "b1"
-        from custom_components.taskmate.models import Child
         child = Child(name="Mia", total_points_earned=20)
         child.id = "c1"
         coord.storage.get_child.return_value = child
@@ -452,8 +443,8 @@ class TestNotifications:
             criteria=[BadgeCriterion("total_points", ">=", 10)],
         )
         b.id = "b1"
-        from custom_components.taskmate.models import Child
-        child = Child(name="Mia", total_points_earned=20); child.id = "c1"
+        child = Child(name="Mia", total_points_earned=20)
+        child.id = "c1"
         coord.storage.get_child.return_value = child
         coord.storage.get_badge.return_value = b
         coord.storage.get_badges.return_value = [b]
@@ -463,7 +454,6 @@ class TestNotifications:
         coord.storage.get_setting = MagicMock(return_value="")
 
         await coord.evaluate_for_child("c1", "manual", silent=True)
-        # No notification call (silent path)
         coord.hass.async_create_task.assert_not_called()
 
     async def test_notify_on_earn_false_suppresses_notification(self, coord):
@@ -473,8 +463,8 @@ class TestNotifications:
             notify_on_earn=False,
         )
         b.id = "b1"
-        from custom_components.taskmate.models import Child
-        child = Child(name="Mia", total_points_earned=20); child.id = "c1"
+        child = Child(name="Mia", total_points_earned=20)
+        child.id = "c1"
         coord.storage.get_child.return_value = child
         coord.storage.get_badge.return_value = b
         coord.storage.get_badges.return_value = [b]
@@ -487,13 +477,15 @@ class TestNotifications:
         coord.hass.async_create_task.assert_not_called()
 
     async def test_3_plus_awards_in_one_pass_batched(self, coord):
-        # Three badges all pass at once
-        from custom_components.taskmate.models import Child
-        b1 = Badge(name="A", criteria=[BadgeCriterion("total_points", ">=", 10)]); b1.id = "b1"
-        b2 = Badge(name="B", criteria=[BadgeCriterion("total_points", ">=", 20)]); b2.id = "b2"
-        b3 = Badge(name="C", criteria=[BadgeCriterion("total_points", ">=", 30)]); b3.id = "b3"
+        b1 = Badge(name="A", criteria=[BadgeCriterion("total_points", ">=", 10)])
+        b1.id = "b1"
+        b2 = Badge(name="B", criteria=[BadgeCriterion("total_points", ">=", 20)])
+        b2.id = "b2"
+        b3 = Badge(name="C", criteria=[BadgeCriterion("total_points", ">=", 30)])
+        b3.id = "b3"
 
-        child = Child(name="Mia", total_points_earned=100); child.id = "c1"
+        child = Child(name="Mia", total_points_earned=100)
+        child.id = "c1"
         coord.storage.get_child.return_value = child
         # get_badge will be called for each notification dispatch — return matching badge
         def _get_badge(bid):

--- a/tests/test_sensor_attributes.py
+++ b/tests/test_sensor_attributes.py
@@ -17,6 +17,9 @@ from unittest.mock import MagicMock
 from custom_components.taskmate import sensor as sensor_module
 from .conftest import dt_util_mock
 from custom_components.taskmate.models import (
+    AwardedBadge,
+    Badge,
+    BadgeCriterion,
     Bonus,
     Child,
     Chore,
@@ -27,6 +30,7 @@ from custom_components.taskmate.models import (
     Reward,
     RewardClaim,
 )
+from custom_components.taskmate.sensor import ChildBadgesSensor
 
 
 MAX_ATTR_BYTES = 16384  # Home Assistant recorder limit
@@ -324,10 +328,6 @@ class _MockEntry:
     entry_id = "test_entry"
 
 
-from custom_components.taskmate.models import Badge, BadgeCriterion, AwardedBadge
-from custom_components.taskmate.sensor import ChildBadgesSensor
-
-
 class TestChildBadgesSensor:
     def _coordinator_for(self, child, badges, awarded):
         coord = MagicMock()
@@ -339,9 +339,12 @@ class TestChildBadgesSensor:
         return coord
 
     def test_state_is_earned_count(self, hass):
-        child = Child(name="Mia"); child.id = "c1"
-        b1 = Badge(name="A"); b1.id = "b1"
-        b2 = Badge(name="B"); b2.id = "b2"
+        child = Child(name="Mia")
+        child.id = "c1"
+        b1 = Badge(name="A")
+        b1.id = "b1"
+        b2 = Badge(name="B")
+        b2.id = "b2"
         awarded = [
             AwardedBadge(child_id="c1", badge_id="b1"),
             AwardedBadge(child_id="c1", badge_id="b2"),
@@ -351,12 +354,15 @@ class TestChildBadgesSensor:
         assert sensor.native_value == 2
 
     def test_attrs_include_earned_and_available(self, hass):
-        child = Child(name="Mia", total_chores_completed=5); child.id = "c1"
-        earned = Badge(name="Earned"); earned.id = "earned"
+        child = Child(name="Mia", total_chores_completed=5)
+        child.id = "c1"
+        earned = Badge(name="Earned")
+        earned.id = "earned"
         locked = Badge(
             name="Locked",
             criteria=[BadgeCriterion("total_chores", ">=", 10)],
-        ); locked.id = "locked"
+        )
+        locked.id = "locked"
         awarded = [AwardedBadge(child_id="c1", badge_id="earned")]
         coord = self._coordinator_for(child, [earned, locked], awarded)
         sensor = ChildBadgesSensor(coord, _MockEntry(), child)
@@ -370,17 +376,22 @@ class TestChildBadgesSensor:
         assert attrs["available"][0]["progress_pct"] == 50
 
     def test_excludes_disabled_badges(self, hass):
-        child = Child(name="Mia"); child.id = "c1"
-        disabled = Badge(name="Disabled", enabled=False); disabled.id = "x"
+        child = Child(name="Mia")
+        child.id = "c1"
+        disabled = Badge(name="Disabled", enabled=False)
+        disabled.id = "x"
         coord = self._coordinator_for(child, [disabled], [])
         sensor = ChildBadgesSensor(coord, _MockEntry(), child)
         attrs = sensor.extra_state_attributes
         assert attrs["total_badges"] == 0
 
     def test_filters_by_assigned_to(self, hass):
-        child = Child(name="Mia"); child.id = "c1"
-        not_for_me = Badge(name="Other", assigned_to=["c2"]); not_for_me.id = "x"
-        for_all = Badge(name="All"); for_all.id = "y"
+        child = Child(name="Mia")
+        child.id = "c1"
+        not_for_me = Badge(name="Other", assigned_to=["c2"])
+        not_for_me.id = "x"
+        for_all = Badge(name="All")
+        for_all.id = "y"
         coord = self._coordinator_for(child, [not_for_me, for_all], [])
         sensor = ChildBadgesSensor(coord, _MockEntry(), child)
         attrs = sensor.extra_state_attributes


### PR DESCRIPTION
Remove unused import, fix semicolons (E702), consolidate mid-file imports to top (E402), remove redefined MagicMock (F811).