### PR TITLE
fix(sensor): expose claim_allowance_minutes in chores attributes

### DIFF
--- a/custom_components/taskmate/sensor.py
+++ b/custom_components/taskmate/sensor.py
@@ -204,6 +204,9 @@ def _build_chores_list(coordinator: TaskMateCoordinator, common: dict) -> list[d
         daily_limit = getattr(c, 'daily_limit', 1)
         if daily_limit != 1:
             record["daily_limit"] = daily_limit
+        claim_allowance_minutes = getattr(c, 'claim_allowance_minutes', 0) or 0
+        if claim_allowance_minutes:
+            record["claim_allowance_minutes"] = claim_allowance_minutes
         due_days = getattr(c, 'due_days', []) or []
         if due_days:
             record["due_days"] = due_days


### PR DESCRIPTION
## Summary
- The `taskmate_chores` sensor's `_build_chores_list` emits a curated subset of chore fields and was missing `claim_allowance_minutes`. The child card reads chores from sensor attributes, so `chore.claim_allowance_minutes` was always `undefined` → effective grace window of 0.
- Result: an Afternoon chore with a 180-minute allowance still grayed out at 17:00 instead of staying claimable until 20:00.
- The panel was unaffected because it reads chore data via the WebSocket API, which already includes the field.
- Fix emits the field on the chore record when non-zero, matching the existing "skip defaults to save bytes" pattern.

## Test plan
- [x] `pytest tests/` — 390 passed
- [ ] Set Afternoon chore with `claim_allowance_minutes = 180` → at 18:30 it stays clickable on the child card
- [ ] Verify chores with no allowance still gray out as before once the period ends
- [ ] Night chores still cap at midnight (`Math.min(24*60, ...)` already enforces this on the client)

Fixes #293