### PR TITLE
chore: bump version to 3.8.0-beta.3

### DIFF
--- a/custom_components/taskmate/manifest.json
+++ b/custom_components/taskmate/manifest.json
@@ -17,5 +17,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/tempus2016/taskmate/issues",
   "requirements": [],
-  "version": "3.8.0-beta.2"
+  "version": "3.8.0-beta.3"
 }


### PR DESCRIPTION
Release branch for v3.8.0-beta.3.

Includes since beta.2:
- fix(panel): badge table rows now use vertical-align: middle uniformly (190219b)
- fix(sensor): expose claim_allowance_minutes in chores attributes — fixes child-card grace period being ignored (#294, fixes #293)