### PR TITLE
feat: add parent_complete_chore WS command and parent_completable state

### DIFF
--- a/custom_components/taskmate/coord_chores.py
+++ b/custom_components/taskmate/coord_chores.py
@@ -408,6 +408,54 @@ class ChoresMixin:
 
         return completion
 
+    async def async_parent_complete_chore(self, chore_id: str) -> ChoreCompletion:
+        """Mark a chore as completed by the parent — zero points, advances recurrence."""
+        chore = self.get_chore(chore_id)
+        if not chore:
+            raise ValueError(f"Chore {chore_id} not found")
+
+        if not getattr(chore, 'enabled', True):
+            raise ValueError(f"Chore '{chore.name}' is disabled")
+
+        schedule_mode = getattr(chore, 'schedule_mode', 'specific_days')
+        if schedule_mode == 'one_shot':
+            raise ValueError(
+                f"Chore '{chore.name}' is a one-shot chore and cannot be parent-completed"
+            )
+
+        now = dt_util.now()
+
+        # Determine child pool — empty assigned_to means all children
+        assigned = getattr(chore, 'assigned_to', []) or []
+        if assigned:
+            child_ids = list(assigned)
+        else:
+            child_ids = [c.id for c in self.storage.get_children()]
+
+        if not child_ids:
+            raise ValueError(f"Chore '{chore.name}' has no children to suppress")
+
+        completion = ChoreCompletion(
+            chore_id=chore_id,
+            child_id="__parent__",
+            completed_at=now,
+            approved=True,
+            approved_at=now,
+            points_awarded=0,
+        )
+
+        self.storage.add_completion(completion)
+
+        # Update last_completed for ALL children in the pool so the chore
+        # disappears from their views until the next recurrence window.
+        for cid in child_ids:
+            self.storage.set_last_completed(chore_id, cid, now.isoformat())
+
+        await self.storage.async_save()
+        await self.async_refresh()
+
+        return completion
+
     async def async_complete_bonus_subtask(
         self, chore_id: str, bonus_subtask_id: str, child_id: str
     ) -> ChoreCompletion:

--- a/custom_components/taskmate/websocket.py
+++ b/custom_components/taskmate/websocket.py
@@ -97,6 +97,7 @@ WS_APPROVE_REWARD: Final      = "taskmate/approve_reward"
 WS_REJECT_REWARD: Final       = "taskmate/reject_reward"
 WS_SET_CHORE_ORDER: Final     = "taskmate/set_chore_order"
 WS_ADD_CHORES_BULK: Final     = "taskmate/add_chores_bulk"
+WS_PARENT_COMPLETE_CHORE: Final = "taskmate/parent_complete_chore"
 
 # Templates
 WS_TEMPLATES_LIST: Final       = "taskmate/templates/list"
@@ -167,6 +168,21 @@ def _build_state_snapshot(coordinator: TaskMateCoordinator) -> dict[str, Any]:
     completions = list(data.get("completions", []))
     reward_claims = list(data.get("reward_claims", []))
     transactions = list(data.get("points_transactions", []))
+
+    # Compute which chores are currently due for at least one child (parent can complete)
+    parent_completable = {}
+    children = coordinator.storage.get_children()
+    for chore_dict in data.get("chores", []):
+        chore = coordinator.get_chore(chore_dict.get("id", ""))
+        if not chore or not getattr(chore, "enabled", True):
+            continue
+        if getattr(chore, "schedule_mode", "specific_days") == "one_shot":
+            continue
+        for child in children:
+            if coordinator.is_chore_available_for_child(chore, child.id):
+                parent_completable[chore.id] = True
+                break
+
     return {
         "version": "2",
         "children":         list(data.get("children", [])),
@@ -191,6 +207,7 @@ def _build_state_snapshot(coordinator: TaskMateCoordinator) -> dict[str, Any]:
             "points_icon":       data.get("points_icon", "mdi:star"),
             **(data.get("settings", {}) or {}),
         },
+        "parent_completable": parent_completable,
     }
 
 
@@ -853,6 +870,17 @@ async def _ws_reject_reward(hass, connection, msg, coordinator):
 
 
 @websocket_api.websocket_command({
+    vol.Required("type"): WS_PARENT_COMPLETE_CHORE,
+    vol.Required("chore_id"): str,
+})
+@websocket_api.async_response
+@_admin_only
+async def _ws_parent_complete_chore(hass, connection, msg, coordinator):
+    await coordinator.async_parent_complete_chore(msg["chore_id"])
+    connection.send_result(msg["id"], {"ok": True})
+
+
+@websocket_api.websocket_command({
     vol.Required("type"): WS_SET_CHORE_ORDER,
     vol.Required("child_id"): str,
     vol.Required("chore_order"): [str],
@@ -1036,6 +1064,7 @@ _COMMANDS = (
     _ws_update_settings,
     _ws_complete_bonus_subtask,
     _ws_approve_chore, _ws_reject_chore, _ws_approve_reward, _ws_reject_reward,
+    _ws_parent_complete_chore,
     _ws_set_chore_order, _ws_add_chores_bulk,
     _ws_templates_list, _ws_templates_get, _ws_templates_apply,
     _ws_templates_save_from, _ws_templates_create, _ws_templates_update,

--- a/tests/test_parent_complete.py
+++ b/tests/test_parent_complete.py
@@ -1,0 +1,201 @@
+"""Tests for parent_complete_chore coordinator method."""
+from __future__ import annotations
+
+import asyncio
+import datetime as dt
+from datetime import timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from custom_components.taskmate.coordinator import TaskMateCoordinator
+from custom_components.taskmate.storage import TaskMateStorage
+
+UTC = timezone.utc
+
+
+def run(coro):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+def _now(year=2024, month=3, day=20, hour=12):
+    return dt.datetime(year, month, day, hour, 0, 0, tzinfo=UTC)
+
+
+def _make_system(now=None):
+    from tests.conftest import FakeHass, FakeStore
+
+    if now is None:
+        now = _now()
+
+    hass = FakeHass()
+    hass.states = type("FakeStates", (), {"get": lambda self, entity_id: None})()
+
+    storage = TaskMateStorage.__new__(TaskMateStorage)
+    storage.entry_id = "test_entry"
+    storage._store = FakeStore(None, 1, "test")
+    storage._data = {}
+    run(storage.async_load())
+
+    coord = object.__new__(TaskMateCoordinator)
+    coord.hass = hass
+    coord.data = {}
+    coord.storage = storage
+    coord._unsub_midnight = None
+    coord._unsub_prune = None
+    coord._unsub_availability = None
+
+    import custom_components.taskmate.coordinator as _mod
+    coord._dt_now = now
+    coord.async_refresh = AsyncMock()
+
+    return coord, storage, _mod
+
+
+class TestParentCompleteChore:
+    def test_parent_complete_creates_completion_with_zero_points(self):
+        coord, storage, _mod = _make_system()
+        now = _now()
+
+        with patch.object(_mod.dt_util, "now", return_value=now):
+            child = run(coord.async_add_child("Alice"))
+            chore = run(coord.async_add_chore(
+                "Vacuum", points=10, requires_approval=False,
+                schedule_mode="recurring", recurrence="weekly",
+                assigned_to=[child.id],
+            ))
+
+        with patch.object(_mod.dt_util, "now", return_value=now):
+            result = run(coord.async_parent_complete_chore(chore.id))
+
+        completions = storage.get_completions()
+        assert len(completions) == 1
+        assert completions[0].child_id == "__parent__"
+        assert completions[0].points_awarded == 0
+        assert completions[0].approved is True
+
+    def test_parent_complete_updates_last_completed_for_all_children(self):
+        coord, storage, _mod = _make_system()
+        now = _now()
+
+        with patch.object(_mod.dt_util, "now", return_value=now):
+            alice = run(coord.async_add_child("Alice"))
+            bob = run(coord.async_add_child("Bob"))
+            chore = run(coord.async_add_chore(
+                "Dishes", points=5, requires_approval=False,
+                schedule_mode="recurring", recurrence="weekly",
+                assigned_to=[alice.id, bob.id],
+            ))
+
+        with patch.object(_mod.dt_util, "now", return_value=now):
+            run(coord.async_parent_complete_chore(chore.id))
+
+        alice_lc = storage.get_last_completed(chore.id, alice.id)
+        bob_lc = storage.get_last_completed(chore.id, bob.id)
+        assert alice_lc.get("current") == now.isoformat()
+        assert bob_lc.get("current") == now.isoformat()
+
+    def test_parent_complete_rejects_one_shot_chore(self):
+        coord, storage, _mod = _make_system()
+        now = _now()
+
+        with patch.object(_mod.dt_util, "now", return_value=now):
+            child = run(coord.async_add_child("Alice"))
+            chore = run(coord.async_add_chore(
+                "Special task", points=10, requires_approval=False,
+                schedule_mode="one_shot",
+                assigned_to=[child.id],
+            ))
+
+        with patch.object(_mod.dt_util, "now", return_value=now):
+            with pytest.raises(ValueError, match="one.shot"):
+                run(coord.async_parent_complete_chore(chore.id))
+
+    def test_parent_complete_rejects_nonexistent_chore(self):
+        coord, storage, _mod = _make_system()
+        now = _now()
+
+        with patch.object(_mod.dt_util, "now", return_value=now):
+            with pytest.raises(ValueError, match="not found"):
+                run(coord.async_parent_complete_chore("fake_id"))
+
+    def test_parent_complete_rejects_disabled_chore(self):
+        coord, storage, _mod = _make_system()
+        now = _now()
+
+        with patch.object(_mod.dt_util, "now", return_value=now):
+            child = run(coord.async_add_child("Alice"))
+            chore = run(coord.async_add_chore(
+                "Mop", points=5, requires_approval=False,
+                schedule_mode="recurring", recurrence="weekly",
+                assigned_to=[child.id],
+            ))
+            chore.enabled = False
+            storage.update_chore(chore)
+
+        with patch.object(_mod.dt_util, "now", return_value=now):
+            with pytest.raises(ValueError, match="disabled"):
+                run(coord.async_parent_complete_chore(chore.id))
+
+    def test_parent_complete_does_not_award_points(self):
+        coord, storage, _mod = _make_system()
+        now = _now()
+
+        with patch.object(_mod.dt_util, "now", return_value=now):
+            child = run(coord.async_add_child("Alice"))
+            chore = run(coord.async_add_chore(
+                "Sweep", points=15, requires_approval=False,
+                schedule_mode="recurring", recurrence="weekly",
+                assigned_to=[child.id],
+            ))
+
+        with patch.object(_mod.dt_util, "now", return_value=now):
+            run(coord.async_parent_complete_chore(chore.id))
+
+        updated_child = storage.get_child(child.id)
+        assert updated_child.points == 0
+        assert updated_child.current_streak == 0
+
+    def test_parent_complete_suppresses_availability_for_children(self):
+        coord, storage, _mod = _make_system()
+        now = _now()
+
+        with patch.object(_mod.dt_util, "now", return_value=now):
+            child = run(coord.async_add_child("Alice"))
+            chore = run(coord.async_add_chore(
+                "Laundry", points=5, requires_approval=False,
+                schedule_mode="recurring", recurrence="weekly",
+                assigned_to=[child.id],
+            ))
+
+        with patch.object(_mod.dt_util, "now", return_value=now):
+            run(coord.async_parent_complete_chore(chore.id))
+
+        with patch.object(_mod.dt_util, "now", return_value=now):
+            available = coord.is_chore_available_for_child(chore, child.id)
+        assert available is False
+
+    def test_parent_complete_everyone_mode_updates_all_children(self):
+        coord, storage, _mod = _make_system()
+        now = _now()
+
+        with patch.object(_mod.dt_util, "now", return_value=now):
+            alice = run(coord.async_add_child("Alice"))
+            bob = run(coord.async_add_child("Bob"))
+            chore = run(coord.async_add_chore(
+                "Tidy", points=5, requires_approval=False,
+                schedule_mode="recurring", recurrence="weekly",
+                assigned_to=[],  # empty = everyone
+            ))
+
+        with patch.object(_mod.dt_util, "now", return_value=now):
+            run(coord.async_parent_complete_chore(chore.id))
+
+        alice_lc = storage.get_last_completed(chore.id, alice.id)
+        bob_lc = storage.get_last_completed(chore.id, bob.id)
+        assert alice_lc.get("current") == now.isoformat()
+        assert bob_lc.get("current") == now.isoformat()


### PR DESCRIPTION
Task 2 of the Parent Did It feature.

- Adds `taskmate/parent_complete_chore` WebSocket command (admin-only) that calls `coordinator.async_parent_complete_chore()`
- Adds `parent_completable` map to `_build_state_snapshot()` so the panel knows which chores are currently due for at least one child
- Registers the new handler in the `_COMMANDS` tuple

All 398 tests pass.