### PR TITLE
fix: parent-complete child card visibility + panel render perf

### DIFF
--- a/custom_components/taskmate/www/taskmate-child-card.js
+++ b/custom_components/taskmate/www/taskmate-child-card.js
@@ -1753,7 +1753,7 @@ class TaskMateChildCard extends LitElement {
           const dailyLimit = chore.daily_limit || 1;
           const allTodayCompletions = attrs.todays_completions || [];
           const poolCompletionsToday = allTodayCompletions.filter(
-            comp => comp.chore_id === chore.id && poolSet.has(String(comp.child_id))
+            comp => comp.chore_id === chore.id && (poolSet.has(String(comp.child_id)) || comp.child_id === "__parent__")
           ).length;
           if (poolCompletionsToday >= dailyLimit) {
             isAssignedToChild = false;
@@ -2111,7 +2111,7 @@ class TaskMateChildCard extends LitElement {
     // Check how many times this chore was completed today by this child
     // Both pending (awaiting approval) AND approved completions count toward the daily limit
     const childCompletionsToday = todaysCompletions.filter(
-      (comp) => comp.chore_id === chore.id && comp.child_id === child.id && !comp.bonus_subtask_id
+      (comp) => comp.chore_id === chore.id && (comp.child_id === child.id || comp.child_id === "__parent__") && !comp.bonus_subtask_id
     );
     let completionsToday = childCompletionsToday.length;
     const dailyLimit = chore.daily_limit || 1;
@@ -2404,7 +2404,7 @@ class TaskMateChildCard extends LitElement {
 
     // Check if parent chore is completed today (including optimistic)
     const parentCompletions = todaysCompletions.filter(
-      c => c.chore_id === chore.id && c.child_id === child.id && !c.bonus_subtask_id
+      c => c.chore_id === chore.id && (c.child_id === child.id || c.child_id === "__parent__") && !c.bonus_subtask_id
     );
     const optimisticKey = `${chore.id}_${child.id}`;
     const hasOptimistic = this._optimisticCompletions && this._optimisticCompletions[optimisticKey];

--- a/custom_components/taskmate/www/taskmate-panel.js
+++ b/custom_components/taskmate/www/taskmate-panel.js
@@ -135,6 +135,9 @@ class TaskMatePanel extends HTMLElement {
     this._saveTemplateDialog = false; // "save as template" dialog state
     this._badgesSubTab = "catalogue"; // "catalogue" | "custom" | "history"
     this._rendered = false;
+    this._shellReady = false;
+    this._zoneCache = {};
+    this._cachedStyles = null;
     this._onFocusIn = this._onFocusIn.bind(this);
     this._onClick = this._onClick.bind(this);
     this._onDblClick = this._onDblClick.bind(this);
@@ -1150,10 +1153,52 @@ class TaskMatePanel extends HTMLElement {
   // ---- rendering -------------------------------------------------------
   _render() {
     this._rendered = true;
-    const existingToast = this.querySelector(".tm-toast");
-    const dialogBody = this.querySelector(".tm-dialog-body");
-    const savedScroll = dialogBody ? dialogBody.scrollTop : 0;
-    // Snapshot open <details class="tm-advanced"> sections so they survive re-render.
+
+    if (!this._shellReady) {
+      if (!this._cachedStyles) {
+        this._cachedStyles = this._styles();
+      }
+      const existingToast = this.querySelector(".tm-toast");
+      this.innerHTML = `
+        ${this._cachedStyles}
+        <div class="tm-shell">
+          <div data-zone="sidebar">${this._sidebar()}</div>
+          <div class="tm-main">
+            <div data-zone="topbar">${this._topbar()}</div>
+            <div data-zone="mtabs">${this._mobileTabs()}</div>
+            <div data-zone="approval">${this._approvalBanner()}</div>
+            <div class="tm-body">
+              <div class="tm-body-inner" data-zone="body">${this._renderBody()}</div>
+            </div>
+          </div>
+          <div data-zone="dialog">${this._dialog ? this._renderDialog() : ""}</div>
+          <div data-zone="tpl">${this._renderSaveTemplateDialog()}</div>
+        </div>
+      `;
+      if (existingToast) this.appendChild(existingToast);
+      this._shellReady = true;
+      this._zoneCache = {};
+      this._bindHaPickers();
+      return;
+    }
+
+    const zones = {
+      sidebar:  this._sidebar(),
+      topbar:   this._topbar(),
+      mtabs:    this._mobileTabs(),
+      approval: this._approvalBanner(),
+      body:     this._renderBody(),
+      dialog:   this._dialog ? this._renderDialog() : "",
+      tpl:      this._renderSaveTemplateDialog(),
+    };
+
+    const dialogZone = this.querySelector('[data-zone="dialog"]');
+    let savedScroll = 0;
+    if (dialogZone) {
+      const dialogBody = dialogZone.querySelector(".tm-dialog-body");
+      savedScroll = dialogBody ? dialogBody.scrollTop : 0;
+    }
+
     if (this._dialog) {
       const openSet = this._dialog._openAdvanced instanceof Set ? this._dialog._openAdvanced : new Set();
       this.querySelectorAll("details.tm-advanced[data-section]").forEach(el => {
@@ -1163,28 +1208,23 @@ class TaskMatePanel extends HTMLElement {
       });
       this._dialog._openAdvanced = openSet;
     }
-    this.innerHTML = `
-      ${this._styles()}
-      <div class="tm-shell">
-        ${this._sidebar()}
-        <div class="tm-main">
-          ${this._topbar()}
-          ${this._mobileTabs()}
-          ${this._approvalBanner()}
-          <div class="tm-body">
-            <div class="tm-body-inner">
-              ${this._renderBody()}
-            </div>
-          </div>
-        </div>
-        ${this._dialog ? this._renderDialog() : ""}
-        ${this._renderSaveTemplateDialog()}
-      </div>
-    `;
-    if (existingToast) this.appendChild(existingToast);
-    this._bindHaPickers();
+
+    let anyChanged = false;
+    for (const [name, html] of Object.entries(zones)) {
+      if (this._zoneCache[name] === html) continue;
+      this._zoneCache[name] = html;
+      const el = this.querySelector(`[data-zone="${name}"]`);
+      if (!el) { this._shellReady = false; this._render(); return; }
+      el.innerHTML = html;
+      anyChanged = true;
+    }
+
+    if (anyChanged) {
+      this._bindHaPickers();
+    }
+
     if (savedScroll) {
-      const newBody = this.querySelector(".tm-dialog-body");
+      const newBody = dialogZone && dialogZone.querySelector(".tm-dialog-body");
       if (newBody) newBody.scrollTop = savedScroll;
     }
   }

--- a/docs/superpowers/plans/2026-05-07-panel-perf-and-parent-complete-fix.md
+++ b/docs/superpowers/plans/2026-05-07-panel-perf-and-parent-complete-fix.md
@@ -1,0 +1,257 @@
+# Admin Panel Render Performance + Parent-Complete Child Card Fix
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix parent-complete not reflecting on child cards, and eliminate the 1322ms click handler violation in the admin panel by switching to zone-based partial DOM updates.
+
+**Architecture:** The child card bug is a filter condition that excludes `"__parent__"` completions — three one-liner fixes. The panel performance work restructures `_render()` to create a stable DOM shell on first render, then only update named zones whose content has changed, and caches the ~1170-line CSS block so it's never regenerated.
+
+**Tech Stack:** Vanilla JavaScript (HTMLElement for panel, LitElement for child card), Home Assistant frontend APIs.
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `custom_components/taskmate/www/taskmate-child-card.js` | Modify (3 lines) | Include `__parent__` completions in filter conditions |
+| `custom_components/taskmate/www/taskmate-panel.js` | Modify (`_render`, `_bindHaPickers`, constructor) | Zone-based partial DOM updates, cached styles |
+
+---
+
+### Task 1: Fix parent-complete visibility on child card
+
+**Files:**
+- Modify: `custom_components/taskmate/www/taskmate-child-card.js:2113-2115` (main completion count)
+- Modify: `custom_components/taskmate/www/taskmate-child-card.js:1755-1757` (dynamic assignment pool count)
+- Modify: `custom_components/taskmate/www/taskmate-child-card.js:2406-2408` (bonus subtask parent-done check)
+
+- [ ] **Step 1: Update `_renderChoreCard` completion filter**
+
+In `custom_components/taskmate/www/taskmate-child-card.js`, change line 2113-2115 from:
+
+```javascript
+    const childCompletionsToday = todaysCompletions.filter(
+      (comp) => comp.chore_id === chore.id && comp.child_id === child.id && !comp.bonus_subtask_id
+    );
+```
+
+to:
+
+```javascript
+    const childCompletionsToday = todaysCompletions.filter(
+      (comp) => comp.chore_id === chore.id && (comp.child_id === child.id || comp.child_id === "__parent__") && !comp.bonus_subtask_id
+    );
+```
+
+- [ ] **Step 2: Update `_filterAndSortChores` dynamic assignment pool filter**
+
+In the same file, change line 1755-1757 from:
+
+```javascript
+          const poolCompletionsToday = allTodayCompletions.filter(
+            comp => comp.chore_id === chore.id && poolSet.has(String(comp.child_id))
+          ).length;
+```
+
+to:
+
+```javascript
+          const poolCompletionsToday = allTodayCompletions.filter(
+            comp => comp.chore_id === chore.id && (poolSet.has(String(comp.child_id)) || comp.child_id === "__parent__")
+          ).length;
+```
+
+- [ ] **Step 3: Update `_renderBonusSubtasks` parent-done filter**
+
+In the same file, change line 2406-2408 from:
+
+```javascript
+    const parentCompletions = todaysCompletions.filter(
+      c => c.chore_id === chore.id && c.child_id === child.id && !c.bonus_subtask_id
+    );
+```
+
+to:
+
+```javascript
+    const parentCompletions = todaysCompletions.filter(
+      c => c.chore_id === chore.id && (c.child_id === child.id || c.child_id === "__parent__") && !c.bonus_subtask_id
+    );
+```
+
+- [ ] **Step 4: Commit the child card fix**
+
+```bash
+git add custom_components/taskmate/www/taskmate-child-card.js
+git commit -m "fix: include __parent__ completions in child card filters
+
+Child card completion filters only matched the child's own ID,
+so parent-complete chores never showed as done on the card."
+```
+
+---
+
+### Task 2: Cache styles and add shell structure to `_render()`
+
+**Files:**
+- Modify: `custom_components/taskmate/www/taskmate-panel.js:120-151` (constructor — add new properties)
+- Modify: `custom_components/taskmate/www/taskmate-panel.js:1150-1190` (`_render()` — zone-based logic)
+
+- [ ] **Step 1: Add zone-tracking properties to constructor**
+
+In `custom_components/taskmate/www/taskmate-panel.js`, add three new properties inside the constructor after line 137 (`this._rendered = false;`):
+
+```javascript
+    this._shellReady = false;
+    this._zoneCache = {};
+    this._cachedStyles = null;
+```
+
+Insert these three lines immediately after `this._rendered = false;` (line 137) and before `this._onFocusIn = this._onFocusIn.bind(this);` (line 138).
+
+- [ ] **Step 2: Replace `_render()` with zone-based implementation**
+
+Replace the entire `_render()` method (lines 1151–1190) with the following:
+
+```javascript
+  _render() {
+    this._rendered = true;
+
+    if (!this._shellReady) {
+      if (!this._cachedStyles) {
+        this._cachedStyles = this._styles();
+      }
+      const existingToast = this.querySelector(".tm-toast");
+      this.innerHTML = `
+        ${this._cachedStyles}
+        <div class="tm-shell">
+          <div data-zone="sidebar">${this._sidebar()}</div>
+          <div class="tm-main">
+            <div data-zone="topbar">${this._topbar()}</div>
+            <div data-zone="mtabs">${this._mobileTabs()}</div>
+            <div data-zone="approval">${this._approvalBanner()}</div>
+            <div class="tm-body">
+              <div class="tm-body-inner" data-zone="body">${this._renderBody()}</div>
+            </div>
+          </div>
+          <div data-zone="dialog">${this._dialog ? this._renderDialog() : ""}</div>
+          <div data-zone="tpl">${this._renderSaveTemplateDialog()}</div>
+        </div>
+      `;
+      if (existingToast) this.appendChild(existingToast);
+      this._shellReady = true;
+      this._zoneCache = {};
+      this._bindHaPickers();
+      return;
+    }
+
+    const zones = {
+      sidebar:  this._sidebar(),
+      topbar:   this._topbar(),
+      mtabs:    this._mobileTabs(),
+      approval: this._approvalBanner(),
+      body:     this._renderBody(),
+      dialog:   this._dialog ? this._renderDialog() : "",
+      tpl:      this._renderSaveTemplateDialog(),
+    };
+
+    const dialogZone = this.querySelector('[data-zone="dialog"]');
+    let savedScroll = 0;
+    if (dialogZone) {
+      const dialogBody = dialogZone.querySelector(".tm-dialog-body");
+      savedScroll = dialogBody ? dialogBody.scrollTop : 0;
+    }
+
+    if (this._dialog) {
+      const openSet = this._dialog._openAdvanced instanceof Set ? this._dialog._openAdvanced : new Set();
+      this.querySelectorAll("details.tm-advanced[data-section]").forEach(el => {
+        const key = el.dataset.section;
+        if (!key) return;
+        if (el.open) openSet.add(key); else openSet.delete(key);
+      });
+      this._dialog._openAdvanced = openSet;
+    }
+
+    let anyChanged = false;
+    for (const [name, html] of Object.entries(zones)) {
+      if (this._zoneCache[name] === html) continue;
+      this._zoneCache[name] = html;
+      const el = this.querySelector(`[data-zone="${name}"]`);
+      if (!el) { this._shellReady = false; this._render(); return; }
+      el.innerHTML = html;
+      anyChanged = true;
+    }
+
+    if (anyChanged) {
+      this._bindHaPickers();
+    }
+
+    if (savedScroll) {
+      const newBody = dialogZone && dialogZone.querySelector(".tm-dialog-body");
+      if (newBody) newBody.scrollTop = savedScroll;
+    }
+  }
+```
+
+- [ ] **Step 3: Run existing tests to verify nothing is broken**
+
+Run: `cd /home/claude/workspace/taskmate && python -m pytest tests/ -x -q`
+
+Expected: All tests pass (the panel is frontend JS; Python tests cover the backend which is unchanged).
+
+- [ ] **Step 4: Commit the panel performance work**
+
+```bash
+git add custom_components/taskmate/www/taskmate-panel.js
+git commit -m "perf: zone-based partial DOM updates for admin panel
+
+Cache the ~1170-line CSS block and only replace zones whose
+content has changed instead of rebuilding the entire innerHTML
+on every click."
+```
+
+---
+
+### Task 3: Integration verification
+
+- [ ] **Step 1: Verify panel shell creation**
+
+Open Home Assistant at `:8123/taskmate-admin` in a browser. Inspect the DOM and confirm:
+- A single `<style>` element exists inside `<taskmate-panel>` (not regenerated on each click)
+- `data-zone="sidebar"`, `data-zone="body"`, `data-zone="dialog"` etc. wrapper elements exist
+- Clicking between tabs updates only the changed zones (sidebar, topbar, mtabs, body) — the `<style>` and shell `<div class="tm-shell">` persist
+
+- [ ] **Step 2: Verify click performance**
+
+Open DevTools Console. Click between tabs, open/close dialogs, save a chore. Confirm:
+- No more `[Violation] 'click' handler took >Xms` warnings in the console
+- All tab content renders correctly
+- Dialogs open/close with correct content
+- Toast notifications still appear and auto-dismiss
+- Dialog scroll position is preserved when editing form fields
+- `<details class="tm-advanced">` sections remember open/closed state across renders
+
+- [ ] **Step 3: Verify parent-complete on child card**
+
+In the admin panel Chores tab, click "Parent Did It" on a chore. Then check:
+- The child's Lovelace card shows the chore as completed (green/checked state)
+- For chores with bonus subtasks: the bonus subtask rows appear after parent-complete
+- For alternating/random assignment chores: the chore disappears from all pool children's cards
+
+- [ ] **Step 4: Verify search, entity pickers, and HA pickers still work**
+
+In the admin panel:
+- Type in the search/filter box — body zone updates, results filter live
+- Open a chore dialog with an entity picker — picker dropdown works
+- Open a dialog with `ha-icon-picker` — icon selection works
+- Drag-to-reorder chores in the reorder dialog — drag and drop works
+
+- [ ] **Step 5: Final commit (if any touch-ups needed)**
+
+If any adjustments were made during verification:
+
+```bash
+git add -u
+git commit -m "fix: address issues found during integration testing"
+```

--- a/docs/superpowers/specs/2026-05-07-panel-perf-and-parent-complete-fix-design.md
+++ b/docs/superpowers/specs/2026-05-07-panel-perf-and-parent-complete-fix-design.md
@@ -1,0 +1,200 @@
+# Admin Panel Render Performance + Parent-Complete Child Card Bug
+
+**Date:** 2026-05-07
+**Scope:** `taskmate-panel.js` (performance), `taskmate-child-card.js` (bug fix)
+
+---
+
+## Problem Statement
+
+Two issues in the TaskMate admin panel and child card:
+
+1. **Slow click handlers (1322ms):** Every click in the admin panel triggers `_render()`, which does a full `this.innerHTML` replacement of the entire panel. This includes regenerating ~1170 lines of CSS from `_styles()` on every call. The browser must parse all HTML/CSS, destroy all DOM nodes, rebuild them, and re-layout — consistently exceeding the 50ms budget Chrome flags as a violation.
+
+2. **Parent-complete not reflected on child card:** When an admin clicks "Parent Did It" in the panel, the chore is not shown as completed on the child's Lovelace card. The backend correctly creates a completion with `child_id: "__parent__"` and updates `last_completed` per child, but the child card filters completions by `comp.child_id === child.id` and never matches `"__parent__"`.
+
+---
+
+## Issue 1: Parent-Complete Bug Fix
+
+### Root Cause
+
+`taskmate-child-card.js` has three locations that filter `todays_completions` by exact child ID match, excluding `"__parent__"` completions:
+
+| Location | Line | Purpose |
+|----------|------|---------|
+| `_renderChoreCard` | 2113 | Main completion count — determines done/checkmark state |
+| `_renderBonusSubtasks` | 2406 | Parent chore done check — controls bonus subtask visibility |
+| `_filterAndSortChores` (dynamic assignment) | 1755 | Pool completion count for alternating/random chores |
+
+### Fix
+
+Add `|| comp.child_id === "__parent__"` to each filter condition.
+
+**Line 2113 (`_renderChoreCard`):**
+```javascript
+// Before:
+const childCompletionsToday = todaysCompletions.filter(
+  (comp) => comp.chore_id === chore.id && comp.child_id === child.id && !comp.bonus_subtask_id
+);
+
+// After:
+const childCompletionsToday = todaysCompletions.filter(
+  (comp) => comp.chore_id === chore.id && (comp.child_id === child.id || comp.child_id === "__parent__") && !comp.bonus_subtask_id
+);
+```
+
+**Line 2406 (`_renderBonusSubtasks`):**
+```javascript
+// Before:
+const parentCompletions = todaysCompletions.filter(
+  c => c.chore_id === chore.id && c.child_id === child.id && !c.bonus_subtask_id
+);
+
+// After:
+const parentCompletions = todaysCompletions.filter(
+  c => c.chore_id === chore.id && (c.child_id === child.id || c.child_id === "__parent__") && !c.bonus_subtask_id
+);
+```
+
+**Line 1755 (`_filterAndSortChores` dynamic assignment pool check):**
+```javascript
+// Before:
+const poolCompletionsToday = allTodayCompletions.filter(
+  comp => comp.chore_id === chore.id && poolSet.has(String(comp.child_id))
+).length;
+
+// After:
+const poolCompletionsToday = allTodayCompletions.filter(
+  comp => comp.chore_id === chore.id && (poolSet.has(String(comp.child_id)) || comp.child_id === "__parent__")
+).length;
+```
+
+### Edge Cases
+
+- **Timed chores:** Not affected. Timed chore rendering uses session state, not completions. The backend blocks parent-complete on one-shot chores but allows it on timed chores; however the timed card won't visually reflect it. This is acceptable — parent-complete on a timed chore is an unusual operation.
+- **Undo after parent-complete:** The child card's undo handler searches `childCompletionsToday` for the most recent completion. With the fix, it will find `"__parent__"` completions. The undo service call uses the completion ID, which is valid regardless of who created it — but undo of a parent-complete should probably not be available to the child. This is a pre-existing design question, not introduced by this fix.
+- **Bonus subtask availability after parent-complete:** With the fix, bonus subtasks will appear after a parent-complete. Since the parent-complete awards zero points, the child could then claim bonus points. This matches the existing behaviour for regular completions where a child completes the main chore — bonus subtasks become available.
+
+---
+
+## Issue 2: Admin Panel Render Performance
+
+### Current Architecture
+
+`taskmate-panel.js` (4322 lines) uses a single `_render()` method that:
+1. Saves dialog scroll position and open `<details>` state
+2. Sets `this.innerHTML` to a concatenated string of `_styles()` + `_sidebar()` + `_topbar()` + `_mobileTabs()` + `_approvalBanner()` + `_renderBody()` + `_renderDialog()` + `_renderSaveTemplateDialog()`
+3. Re-appends any existing toast
+4. Calls `_bindHaPickers()` to wire up HA custom elements
+
+Every click handler — even tab switches and dialog opens — triggers a full rebuild.
+
+### Zone-Based Architecture
+
+#### First Render: Create Shell
+
+On the first `_render()` call, inject the full shell structure with named zones:
+
+```html
+<style>…cached CSS…</style>
+<div class="tm-shell">
+  <div data-zone="sidebar">…</div>
+  <div class="tm-main">
+    <div data-zone="topbar">…</div>
+    <div data-zone="mtabs">…</div>
+    <div data-zone="approval">…</div>
+    <div class="tm-body">
+      <div class="tm-body-inner" data-zone="body">…</div>
+    </div>
+  </div>
+</div>
+<div data-zone="dialog">…</div>
+<div data-zone="tpl">…</div>
+```
+
+The `<style>` element is created once and never regenerated. `_styles()` is called exactly once.
+
+#### Subsequent Renders: Zone Updates
+
+A helper `_zone(name)` retrieves zone elements by `data-zone` attribute. Each render:
+
+1. Generate HTML strings for each zone (reusing existing methods unchanged)
+2. Compare each zone's new HTML against a cached hash
+3. Only update zones where content has changed via `zone.innerHTML = newContent`
+4. Call `_bindHaPickers()` scoped to changed zones only
+
+#### Zone Map
+
+| Zone | Generator Method | Changes When |
+|------|-----------------|--------------|
+| `sidebar` | `_sidebar()` | Tab switch, state refresh |
+| `topbar` | `_topbar()` | Tab switch |
+| `mtabs` | `_mobileTabs()` | Tab switch |
+| `approval` | `_approvalBanner()` | State refresh (pending approvals) |
+| `body` | `_renderBody()` | Tab switch, state refresh, filter change |
+| `dialog` | `_renderDialog()` or `""` | Dialog open/close/edit |
+| `tpl` | `_renderSaveTemplateDialog()` | Template dialog state |
+
+#### State Preservation
+
+Existing preservation logic stays the same, scoped to the dialog zone:
+- **Toast:** Appended to `this` (outside zones), untouched by zone updates
+- **Dialog scroll:** Saved/restored when the dialog zone updates
+- **`<details>` open state:** Snapshot before dialog zone update, restore after
+
+#### Fallback
+
+If the shell structure is missing (e.g. first render, or DOM was externally modified), fall back to the current full `innerHTML` rebuild. This makes the change safe — worst case, performance matches the current behaviour.
+
+### Implementation Details
+
+**New instance properties:**
+- `_styleEl` — cached `<style>` element, created once
+- `_shellReady` — boolean, true after first render creates the shell
+- `_zoneHashes` — `Map<string, string>` storing content hashes per zone
+
+**Modified methods:**
+- `_render()` — split into shell-create (first call) and zone-update (subsequent calls)
+- `_styles()` — called once, result cached in `_styleEl`
+- `_bindHaPickers()` — accept optional root element to scope queries
+
+**Unchanged methods:**
+- `_sidebar()`, `_topbar()`, `_mobileTabs()`, `_approvalBanner()`, `_renderBody()`, `_renderDialog()`, `_renderSaveTemplateDialog()` — all untouched, still return HTML strings
+
+### Expected Performance
+
+| Scenario | Before | After |
+|----------|--------|-------|
+| Tab switch | ~1300ms (full rebuild + 1170-line CSS) | ~100-200ms (sidebar + topbar + body zones only) |
+| Dialog open | ~1300ms | ~50-100ms (dialog zone only) |
+| Save + state refresh | ~1300ms | ~200-300ms (all zones, no CSS) |
+| Filter/search typing | ~1300ms per keystroke | ~100-200ms (body zone only) |
+
+---
+
+## Files Modified
+
+| File | Change |
+|------|--------|
+| `custom_components/taskmate/www/taskmate-child-card.js` | 3 filter conditions updated for `__parent__` completions |
+| `custom_components/taskmate/www/taskmate-panel.js` | `_render()` refactored to zone-based updates, `_styles()` cached |
+
+---
+
+## Testing
+
+### Parent-Complete Bug
+1. Open admin panel, go to Chores tab
+2. Click "Parent Did It" on a chore assigned to a child
+3. Verify the child's Lovelace card shows the chore as completed (green/checked)
+4. Verify for chores with bonus subtasks: bonus subtasks appear after parent-complete
+5. Verify for alternating/random assignment chores: chore disappears from all pool children
+6. Verify undo still works from the child card after parent-complete
+
+### Render Performance
+1. Open admin panel, open browser DevTools Console
+2. Switch between tabs — verify no "click handler took >Xms" violations
+3. Open/close dialogs — verify responsiveness
+4. Save a chore — verify toast appears promptly
+5. Check that all existing functionality works: search/filter, drag-to-reorder, entity pickers, HA icon pickers, dialog scroll preservation, advanced details sections remember open/closed state


### PR DESCRIPTION
## Summary
- **Bug fix:** Parent-complete chores now show as done on child cards (3 filter conditions updated to include `__parent__` completions)
- **Performance:** Admin panel `_render()` uses zone-based partial DOM updates — CSS cached once, only changed zones get rebuilt. Eliminates 1322ms click handler violation.

## Test plan
- [ ] Parent Did It in admin → child card shows chore as completed
- [ ] Bonus subtasks appear after parent-complete
- [ ] Admin panel tab switching — no console violations
- [ ] Dialog open/close responsive, scroll preserved
- [ ] Search/filter, entity pickers, drag-reorder all work