### PR TITLE
fix: guard against hasChanged race condition in all cards

### DIFF
--- a/custom_components/taskmate/www/taskmate-activity-card.js
+++ b/custom_components/taskmate/www/taskmate-activity-card.js
@@ -23,7 +23,9 @@ class TaskMateActivityCard extends LitElement {
 
   shouldUpdate(changedProps) {
     if (changedProps.has("hass")) {
-      return window.__taskmate_hasChanged(changedProps.get("hass"), this.hass, this.config?.entity);
+      return window.__taskmate_hasChanged
+        ? window.__taskmate_hasChanged(changedProps.get("hass"), this.hass, this.config?.entity)
+        : true;
     }
     return true;
   }

--- a/custom_components/taskmate/www/taskmate-approvals-card.js
+++ b/custom_components/taskmate/www/taskmate-approvals-card.js
@@ -21,7 +21,9 @@ class TaskMateApprovalsCard extends LitElement {
 
   shouldUpdate(changedProps) {
     if (changedProps.has("hass")) {
-      return window.__taskmate_hasChanged(changedProps.get("hass"), this.hass, this.config?.entity);
+      return window.__taskmate_hasChanged
+        ? window.__taskmate_hasChanged(changedProps.get("hass"), this.hass, this.config?.entity)
+        : true;
     }
     return true;
   }

--- a/custom_components/taskmate/www/taskmate-bonuses-card.js
+++ b/custom_components/taskmate/www/taskmate-bonuses-card.js
@@ -30,7 +30,9 @@ class TaskMateBonusesCard extends LitElement {
 
   shouldUpdate(changedProps) {
     if (changedProps.has("hass")) {
-      return window.__taskmate_hasChanged(changedProps.get("hass"), this.hass, this.config?.entity);
+      return window.__taskmate_hasChanged
+        ? window.__taskmate_hasChanged(changedProps.get("hass"), this.hass, this.config?.entity)
+        : true;
     }
     return true;
   }

--- a/custom_components/taskmate/www/taskmate-calendar-card.js
+++ b/custom_components/taskmate/www/taskmate-calendar-card.js
@@ -52,7 +52,9 @@ class TaskMateCalendarCard extends LitElement {
 
   shouldUpdate(changedProps) {
     if (changedProps.has("hass")) {
-      return window.__taskmate_hasChanged(changedProps.get("hass"), this.hass, this.config?.entity);
+      return window.__taskmate_hasChanged
+        ? window.__taskmate_hasChanged(changedProps.get("hass"), this.hass, this.config?.entity)
+        : true;
     }
     return true;
   }

--- a/custom_components/taskmate/www/taskmate-child-card.js
+++ b/custom_components/taskmate/www/taskmate-child-card.js
@@ -39,7 +39,9 @@ class TaskMateChildCard extends LitElement {
 
   shouldUpdate(changedProps) {
     if (changedProps.has("hass")) {
-      return window.__taskmate_hasChanged(changedProps.get("hass"), this.hass, this.config?.entity);
+      return window.__taskmate_hasChanged
+        ? window.__taskmate_hasChanged(changedProps.get("hass"), this.hass, this.config?.entity)
+        : true;
     }
     return true;
   }

--- a/custom_components/taskmate/www/taskmate-graph-card.js
+++ b/custom_components/taskmate/www/taskmate-graph-card.js
@@ -35,7 +35,9 @@ class TaskMateGraphCard extends LitElement {
 
   shouldUpdate(changedProps) {
     if (changedProps.has("hass")) {
-      return window.__taskmate_hasChanged(changedProps.get("hass"), this.hass, this.config?.entity);
+      return window.__taskmate_hasChanged
+        ? window.__taskmate_hasChanged(changedProps.get("hass"), this.hass, this.config?.entity)
+        : true;
     }
     return true;
   }

--- a/custom_components/taskmate/www/taskmate-leaderboard-card.js
+++ b/custom_components/taskmate/www/taskmate-leaderboard-card.js
@@ -22,7 +22,9 @@ class TaskMateLeaderboardCard extends LitElement {
 
   shouldUpdate(changedProps) {
     if (changedProps.has("hass")) {
-      return window.__taskmate_hasChanged(changedProps.get("hass"), this.hass, this.config?.entity);
+      return window.__taskmate_hasChanged
+        ? window.__taskmate_hasChanged(changedProps.get("hass"), this.hass, this.config?.entity)
+        : true;
     }
     return true;
   }

--- a/custom_components/taskmate/www/taskmate-overview-card.js
+++ b/custom_components/taskmate/www/taskmate-overview-card.js
@@ -24,7 +24,9 @@ class TaskMateOverviewCard extends LitElement {
 
   shouldUpdate(changedProps) {
     if (changedProps.has("hass")) {
-      return window.__taskmate_hasChanged(changedProps.get("hass"), this.hass, this.config?.entity);
+      return window.__taskmate_hasChanged
+        ? window.__taskmate_hasChanged(changedProps.get("hass"), this.hass, this.config?.entity)
+        : true;
     }
     return true;
   }

--- a/custom_components/taskmate/www/taskmate-parent-dashboard-card.js
+++ b/custom_components/taskmate/www/taskmate-parent-dashboard-card.js
@@ -24,7 +24,9 @@ class TaskMateParentDashboardCard extends LitElement {
 
   shouldUpdate(changedProps) {
     if (changedProps.has("hass")) {
-      return window.__taskmate_hasChanged(changedProps.get("hass"), this.hass, this.config?.entity);
+      return window.__taskmate_hasChanged
+        ? window.__taskmate_hasChanged(changedProps.get("hass"), this.hass, this.config?.entity)
+        : true;
     }
     return true;
   }

--- a/custom_components/taskmate/www/taskmate-penalties-card.js
+++ b/custom_components/taskmate/www/taskmate-penalties-card.js
@@ -30,7 +30,9 @@ class TaskMatePenaltiesCard extends LitElement {
 
   shouldUpdate(changedProps) {
     if (changedProps.has("hass")) {
-      return window.__taskmate_hasChanged(changedProps.get("hass"), this.hass, this.config?.entity);
+      return window.__taskmate_hasChanged
+        ? window.__taskmate_hasChanged(changedProps.get("hass"), this.hass, this.config?.entity)
+        : true;
     }
     return true;
   }

--- a/custom_components/taskmate/www/taskmate-points-card.js
+++ b/custom_components/taskmate/www/taskmate-points-card.js
@@ -24,7 +24,9 @@ class TaskMatePointsCard extends LitElement {
 
   shouldUpdate(changedProps) {
     if (changedProps.has("hass")) {
-      return window.__taskmate_hasChanged(changedProps.get("hass"), this.hass, this.config?.entity);
+      return window.__taskmate_hasChanged
+        ? window.__taskmate_hasChanged(changedProps.get("hass"), this.hass, this.config?.entity)
+        : true;
     }
     return true;
   }

--- a/custom_components/taskmate/www/taskmate-points-display-card.js
+++ b/custom_components/taskmate/www/taskmate-points-display-card.js
@@ -88,7 +88,9 @@ class TaskMatePointsDisplayCard extends LitElement {
 
   shouldUpdate(changedProps) {
     if (changedProps.has("hass")) {
-      return window.__taskmate_hasChanged(changedProps.get("hass"), this.hass, this.config?.entity);
+      return window.__taskmate_hasChanged
+        ? window.__taskmate_hasChanged(changedProps.get("hass"), this.hass, this.config?.entity)
+        : true;
     }
     return true;
   }

--- a/custom_components/taskmate/www/taskmate-reorder-card.js
+++ b/custom_components/taskmate/www/taskmate-reorder-card.js
@@ -27,7 +27,9 @@ class TaskMateReorderCard extends LitElement {
 
   shouldUpdate(changedProps) {
     if (changedProps.has("hass")) {
-      return window.__taskmate_hasChanged(changedProps.get("hass"), this.hass, this.config?.entity);
+      return window.__taskmate_hasChanged
+        ? window.__taskmate_hasChanged(changedProps.get("hass"), this.hass, this.config?.entity)
+        : true;
     }
     return true;
   }

--- a/custom_components/taskmate/www/taskmate-reward-progress-card.js
+++ b/custom_components/taskmate/www/taskmate-reward-progress-card.js
@@ -19,7 +19,9 @@ class TaskMateRewardProgressCard extends LitElement {
 
   shouldUpdate(changedProps) {
     if (changedProps.has("hass")) {
-      return window.__taskmate_hasChanged(changedProps.get("hass"), this.hass, this.config?.entity);
+      return window.__taskmate_hasChanged
+        ? window.__taskmate_hasChanged(changedProps.get("hass"), this.hass, this.config?.entity)
+        : true;
     }
     return true;
   }

--- a/custom_components/taskmate/www/taskmate-rewards-card.js
+++ b/custom_components/taskmate/www/taskmate-rewards-card.js
@@ -28,7 +28,9 @@ class TaskMateRewardsCard extends LitElement {
 
   shouldUpdate(changedProps) {
     if (changedProps.has("hass")) {
-      return window.__taskmate_hasChanged(changedProps.get("hass"), this.hass, this.config?.entity);
+      return window.__taskmate_hasChanged
+        ? window.__taskmate_hasChanged(changedProps.get("hass"), this.hass, this.config?.entity)
+        : true;
     }
     return true;
   }

--- a/custom_components/taskmate/www/taskmate-streak-card.js
+++ b/custom_components/taskmate/www/taskmate-streak-card.js
@@ -24,7 +24,9 @@ class TaskMateStreakCard extends LitElement {
 
   shouldUpdate(changedProps) {
     if (changedProps.has("hass")) {
-      return window.__taskmate_hasChanged(changedProps.get("hass"), this.hass, this.config?.entity);
+      return window.__taskmate_hasChanged
+        ? window.__taskmate_hasChanged(changedProps.get("hass"), this.hass, this.config?.entity)
+        : true;
     }
     return true;
   }

--- a/custom_components/taskmate/www/taskmate-weekly-card.js
+++ b/custom_components/taskmate/www/taskmate-weekly-card.js
@@ -24,7 +24,9 @@ class TaskMateWeeklyCard extends LitElement {
 
   shouldUpdate(changedProps) {
     if (changedProps.has("hass")) {
-      return window.__taskmate_hasChanged(changedProps.get("hass"), this.hass, this.config?.entity);
+      return window.__taskmate_hasChanged
+        ? window.__taskmate_hasChanged(changedProps.get("hass"), this.hass, this.config?.entity)
+        : true;
     }
     return true;
   }


### PR DESCRIPTION
Cards crash with `window.__taskmate_hasChanged is not a function` when they load before `taskmate-attr-resolver.js` has set the global. The badges card already had a guard; this adds the same pattern to all 15 other cards.

Falls back to `true` (always update) when the resolver has not loaded yet.

**Affected cards:** activity, approvals, bonuses, calendar, child, graph, leaderboard, overview, parent-dashboard, penalties, points, points-display, reorder, reward-progress, rewards, streak, weekly