### PR TITLE
fix: use correct async method names for badge point operations

### DIFF
--- a/custom_components/taskmate/coord_badges.py
+++ b/custom_components/taskmate/coord_badges.py
@@ -172,7 +172,7 @@ class BadgeCoordinator:
 
             if not silent:
                 if bonus > 0:
-                    await self.points_coord.add_points(
+                    await self.points_coord.async_add_points(
                         child_id,
                         bonus,
                         reason=f"Badge: {badge.name}",
@@ -218,7 +218,7 @@ class BadgeCoordinator:
         )
         self.storage.add_awarded_badge(award)
         if bonus > 0:
-            await self.points_coord.add_points(
+            await self.points_coord.async_add_points(
                 child_id, bonus, reason=f"Badge: {badge.name}",
             )
         self.hass.bus.async_fire(
@@ -250,7 +250,7 @@ class BadgeCoordinator:
 
         self.storage.remove_awarded_badge(awarded_id)
         if award.bonus_credited > 0:
-            await self.points_coord.remove_points(
+            await self.points_coord.async_remove_points(
                 award.child_id,
                 award.bonus_credited,
                 reason=f"Badge revoked: {badge_name}",

--- a/tests/test_badge_services.py
+++ b/tests/test_badge_services.py
@@ -19,8 +19,8 @@ def coord_with_badges():
     storage.async_save = AsyncMock()
     storage._data = {"badges": [], "awarded_badges": [], "children": []}
     points_coord = MagicMock()
-    points_coord.add_points = AsyncMock()
-    points_coord.remove_points = AsyncMock()
+    points_coord.async_add_points = AsyncMock()
+    points_coord.async_remove_points = AsyncMock()
     badges = BadgeCoordinator(hass, storage, points_coord)
     coord = MagicMock()
     coord.storage = storage

--- a/tests/test_coord_badges.py
+++ b/tests/test_coord_badges.py
@@ -162,8 +162,8 @@ def coord():
     storage = MagicMock()
     storage.async_save = AsyncMock()
     points_coord = MagicMock()
-    points_coord.add_points = AsyncMock()
-    points_coord.remove_points = AsyncMock()
+    points_coord.async_add_points = AsyncMock()
+    points_coord.async_remove_points = AsyncMock()
     return BadgeCoordinator(hass, storage, points_coord)
 
 
@@ -306,8 +306,8 @@ class TestEvaluationCore:
         self._setup(coord, child_kwargs={"total_points_earned": 150}, badges=[b])
         awards = await coord.evaluate_for_child("c1", "points_changed")
         assert awards[0].bonus_credited == 50
-        coord.points_coord.add_points.assert_awaited_once()
-        call = coord.points_coord.add_points.call_args
+        coord.points_coord.async_add_points.assert_awaited_once()
+        call = coord.points_coord.async_add_points.call_args
         assert "Badge: With Bonus" in str(call)
 
     async def test_silent_award_skips_bonus_and_event(self, coord):
@@ -322,7 +322,7 @@ class TestEvaluationCore:
         assert len(awards) == 1
         assert awards[0].silent is True
         assert awards[0].bonus_credited == 0
-        coord.points_coord.add_points.assert_not_awaited()
+        coord.points_coord.async_add_points.assert_not_awaited()
         coord.hass.bus.async_fire.assert_not_called()
 
     async def test_event_fired_on_normal_award(self, coord):
@@ -360,7 +360,7 @@ class TestManualOps:
         assert award is not None
         assert award.manually_awarded is True
         assert award.bonus_credited == 30
-        coord.points_coord.add_points.assert_awaited_once()
+        coord.points_coord.async_add_points.assert_awaited_once()
 
     async def test_award_manually_blocks_double(self, coord):
         coord.storage.has_awarded.return_value = True
@@ -387,7 +387,7 @@ class TestManualOps:
         result = await coord.revoke(a.id)
         assert result is True
         coord.storage.remove_awarded_badge.assert_called_once_with(a.id)
-        coord.points_coord.remove_points.assert_awaited_once()
+        coord.points_coord.async_remove_points.assert_awaited_once()
 
     async def test_revoke_zero_bonus_no_points_change(self, coord):
         a = AwardedBadge(child_id="c1", badge_id="b1", bonus_credited=0)
@@ -395,7 +395,7 @@ class TestManualOps:
         coord.storage.get_badge.return_value = Badge(name="X")
 
         await coord.revoke(a.id)
-        coord.points_coord.remove_points.assert_not_awaited()
+        coord.points_coord.async_remove_points.assert_not_awaited()
 
     async def test_revoke_missing_returns_false(self, coord):
         coord.storage.get_awarded_badges.return_value = []


### PR DESCRIPTION
BadgeCoordinator called `points_coord.add_points()` and `remove_points()` but the actual methods on PointsMixin are `async_add_points()` and `async_remove_points()`. This raised `AttributeError` whenever a badge with bonus points was earned during chore approval.

The approval itself succeeded (data saved before badge evaluation), but the exception propagated back to the frontend as "Unknown error". Since the badge award was never persisted (the exception prevented `async_save()`), it re-triggered on every subsequent approval — explaining the "always" repro.

Also affected: manual badge awards and badge revocations.

Fixes #305