### PR TITLE
fix: remove window.confirm gate from skip button

### DIFF
--- a/custom_components/taskmate/www/taskmate-parent-dashboard-card.js
+++ b/custom_components/taskmate/www/taskmate-parent-dashboard-card.js
@@ -803,12 +803,6 @@ class TaskMateParentDashboardCard extends LitElement {
 
   async _handleSkip(choreId) {
     const key = `skip_${choreId}`;
-    // Guard rail: ask before skipping — this affects today's rotation only,
-    // but parents often tap it by mistake.
-    if (typeof window !== 'undefined' && typeof window.confirm === 'function') {
-      const prompt = this._t('dashboard.rotation_skip_confirm', {}, "Skip today's assignee for this chore?");
-      if (!window.confirm(prompt)) return;
-    }
     this._loading = { ...this._loading, [key]: true };
     this.requestUpdate();
     try {


### PR DESCRIPTION
## Summary

- The skip button in the parent dashboard card used `window.confirm()` to guard the action
- `window.confirm()` silently returns `false` in HA Companion App WebViews, kiosk dashboards, and other restricted contexts, causing `_handleSkip` to abort before the service call
- Removed the confirm dialog — the skip action is ephemeral (today only, resets at midnight) and matches approve/reject which also proceed without confirmation

Fixes #308