### PR TITLE
fix: make skip_chore cyclical — pool → unassigned → back to first

### DIFF
--- a/custom_components/taskmate/coord_chores.py
+++ b/custom_components/taskmate/coord_chores.py
@@ -246,16 +246,23 @@ class ChoresMixin:
             chore.skip_date = today_iso
             chore.skip_count = 0
 
-        # Clamp: a full pool's worth of skips returns to the original child, so
-        # anything beyond pool_size-1 is a no-op.
-        if chore.skip_count >= len(pool) - 1:
-            return chore
-        chore.skip_count += 1
+        # Cyclical: A → B → … → unassigned → back to A.
+        # skip_count < pool_size  → advance to next child
+        # skip_count == pool_size → unassigned (no child today)
+        # skip_count >  pool_size → reset to 0, back to original assignee
+        if chore.skip_count >= len(pool):
+            chore.skip_count = 0
+        else:
+            chore.skip_count += 1
 
-        # Recompute with the group-aware map so sticky followers shift too.
         self.storage.update_chore(chore)
-        daily = self._compute_daily_assignments(today)
-        chore.assignment_current_child_id = daily.get(chore_id, "")
+
+        if chore.skip_count == len(pool):
+            chore.assignment_current_child_id = ""
+        else:
+            daily = self._compute_daily_assignments(today)
+            chore.assignment_current_child_id = daily.get(chore_id, "")
+
         self.storage.update_chore(chore)
 
         # Propagate to sticky followers (their cached current_child_id shifts

--- a/tests/test_assignment_modes.py
+++ b/tests/test_assignment_modes.py
@@ -846,7 +846,7 @@ class TestSkipChore:
             return
         raise AssertionError("Expected ValueError for single-child pool skip")
 
-    def test_skip_is_noop_past_pool_size(self):
+    def test_skip_cycles_through_unassigned_and_back(self):
         a, b = Child(name="A"), Child(name="B")
         coord = _coord([a, b])
         chore = Chore(
@@ -857,11 +857,27 @@ class TestSkipChore:
         )
         coord.storage.add_chore(chore)
         dt_util_mock._now = dt.datetime(2026, 4, 20, 12, 0, tzinfo=UTC)
-        run_async(coord.async_skip_chore(chore.id))  # 0 → 1 (B)
-        # Second skip would wrap to A, same as original — clamp at pool-1.
-        run_async(coord.async_skip_chore(chore.id))  # still 1
+
+        # A is the initial assignee.
+        assert coord._compute_active_children(chore, date(2026, 4, 20)) == [a.id]
+
+        # Skip 1: A → B
+        run_async(coord.async_skip_chore(chore.id))
         updated = coord.storage.get_chore(chore.id)
         assert updated.skip_count == 1
+        assert updated.assignment_current_child_id == b.id
+
+        # Skip 2: B → unassigned
+        run_async(coord.async_skip_chore(chore.id))
+        updated = coord.storage.get_chore(chore.id)
+        assert updated.skip_count == 2
+        assert updated.assignment_current_child_id == ""
+
+        # Skip 3: unassigned → back to A
+        run_async(coord.async_skip_chore(chore.id))
+        updated = coord.storage.get_chore(chore.id)
+        assert updated.skip_count == 0
+        assert updated.assignment_current_child_id == a.id
 
     def test_skip_affects_random_mode(self):
         a, b = Child(name="A"), Child(name="B")


### PR DESCRIPTION
## Summary

- Changes skip_chore from a clamped one-shot to a cyclical flow: A → B → … → unassigned → back to A
- Previously, with a 2-child pool skip worked once then got stuck (clamp at pool_size - 1)
- Now after exhausting all pool members, one more skip sets the chore to unassigned, and the next resets back to the original assignee
- Updated test to verify the full cycle including the unassigned state
- All 400 tests pass

Fixes #308