### PR TITLE
chore: bump version to 3.8.0-beta.9

### DIFF
--- a/custom_components/taskmate/manifest.json
+++ b/custom_components/taskmate/manifest.json
@@ -17,5 +17,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/tempus2016/taskmate/issues",
   "requirements": [],
-  "version": "3.8.0-beta.8"
+  "version": "3.8.0-beta.9"
 }


### PR DESCRIPTION
Version bump for v3.8.0-beta.9 release.