### PR TITLE
fix: show timed rate in chore table points column

### DIFF
--- a/custom_components/taskmate/www/taskmate-panel.js
+++ b/custom_components/taskmate/www/taskmate-panel.js
@@ -1666,7 +1666,7 @@ class TaskMatePanel extends HTMLElement {
     return `
       <tr class="tm-row ${c.enabled === false ? "tm-row-disabled" : ""}">
         <td>${nameCell}</td>
-        <td><strong class="tm-numeric">${c.points}</strong></td>
+        <td><strong class="tm-numeric">${c.task_type === "timed" ? `${c.timed_rate_points || 0}/${c.timed_rate_minutes || 1} min` : c.points}</strong></td>
         <td><span class="tm-pill">${this._t("panel.time_" + (c.time_category || "anytime"))}</span></td>
         <td>${assignedNames} ${modeBadge}</td>
         <td><span class="tm-pill ${schedClass} tm-pill-dot">${this._esc(schedLabel)}</span></td>


### PR DESCRIPTION
## Summary

- For timed tasks, the Points column now shows the rate (e.g. `2/1 min` or `10/5 min`) instead of the stale fixed-points value
- Standard tasks continue to show the fixed point value as before
- No backend changes needed — uses existing `timed_rate_points` and `timed_rate_minutes` fields already in the state

Fixes #322