### PR TITLE
fix: enable card previews in HA dashboard picker for all cards

### DIFF
--- a/custom_components/taskmate/www/taskmate-approvals-card.js
+++ b/custom_components/taskmate/www/taskmate-approvals-card.js
@@ -343,7 +343,7 @@ class TaskMateApprovalsCard extends LitElement {
 
   static getStubConfig() {
     return {
-      entity: "sensor.pending_approvals",
+      entity: "sensor.taskmate_overview",
       title: "Pending Approvals",
     };
   }

--- a/custom_components/taskmate/www/taskmate-badges-card.js
+++ b/custom_components/taskmate/www/taskmate-badges-card.js
@@ -303,7 +303,7 @@ class TaskMateBadgesCard extends LitElement {
 
   static getConfigElement() { return document.createElement("taskmate-badges-card-editor"); }
   static getStubConfig() {
-    return { entity: "sensor.taskmate_badges_child" };
+    return { entity: "sensor.taskmate_overview" };
   }
 
   _tierLabel(tier) {
@@ -331,9 +331,15 @@ class TaskMateBadgesCard extends LitElement {
     }
 
     const attrs = entity.attributes || {};
-    const earned = attrs.earned || [];
-    const available = attrs.available || [];
-    const childName = attrs.child_name || attrs.name || "";
+    const isPreview = !attrs.earned && !attrs.available;
+    const earned = isPreview
+      ? [{ id: "s1", name: "Early Bird", icon: "mdi:weather-sunny", tier: "gold", point_bonus: 10, earned_at: new Date().toISOString() },
+         { id: "s2", name: "Streak Star", icon: "mdi:fire", tier: "silver", point_bonus: 5, earned_at: new Date().toISOString() }]
+      : (attrs.earned || []);
+    const available = isPreview
+      ? [{ id: "s3", name: "Helping Hand", icon: "mdi:hand-heart", tier: "bronze", point_bonus: 5, progress_pct: 60, progress_label: "3 / 5" }]
+      : (attrs.available || []);
+    const childName = isPreview ? "Child" : (attrs.child_name || attrs.name || "");
     const childAvatar = attrs.child_avatar || "mdi:account-circle";
     const totalBadges = attrs.total_badges || (earned.length + available.length);
 
@@ -443,7 +449,7 @@ window.customCards.push({
   type: "taskmate-badges-card",
   name: "TaskMate Badges",
   description: "Achievement badge grid for a single child",
-  preview: false,
+  preview: true,
 });
 
 const _tmBadgesVersion = new URLSearchParams(

--- a/custom_components/taskmate/www/taskmate-bonuses-card.js
+++ b/custom_components/taskmate/www/taskmate-bonuses-card.js
@@ -824,7 +824,7 @@ window.customCards.push({
   type: "taskmate-bonuses-card",
   name: "TaskMate Bonuses",
   description: "Apply point-awarding bonuses to children",
-  preview: false,
+  preview: true,
 });
 
 // Version is injected by the HA resource URL (?v=x.x.x) and read from the DOM

--- a/custom_components/taskmate/www/taskmate-child-card.js
+++ b/custom_components/taskmate/www/taskmate-child-card.js
@@ -1528,7 +1528,8 @@ class TaskMateChildCard extends LitElement {
     // Get child info
     const attrs = (window.__taskmate_attrs && window.__taskmate_attrs(this.hass, this.config.entity)) || entity.attributes || {};
     const children = attrs.children || [];
-    const child = children.find(c => c.id === this.config.child_id);
+    const child = children.find(c => c.id === this.config.child_id)
+      || (!this.config.child_id && children[0]);
 
     if (!child) {
       return html`

--- a/custom_components/taskmate/www/taskmate-penalties-card.js
+++ b/custom_components/taskmate/www/taskmate-penalties-card.js
@@ -822,7 +822,7 @@ window.customCards.push({
   type: "taskmate-penalties-card",
   name: "TaskMate Penalties",
   description: "Apply point-deduction penalties to children",
-  preview: false,
+  preview: true,
 });
 
 // Version is injected by the HA resource URL (?v=x.x.x) and read from the DOM

--- a/custom_components/taskmate/www/taskmate-points-display-card.js
+++ b/custom_components/taskmate/www/taskmate-points-display-card.js
@@ -519,6 +519,10 @@ class TaskMatePointsDisplayCard extends LitElement {
     return document.createElement("taskmate-points-display-card-editor");
   }
 
+  static getStubConfig() {
+    return { entity: "sensor.taskmate_overview", mode: "multi" };
+  }
+
   getCardSize() { return 3; }
 
   /* ── Data helpers ───────────────────────────────────────────────────── */

--- a/custom_components/taskmate/www/taskmate-reorder-card.js
+++ b/custom_components/taskmate/www/taskmate-reorder-card.js
@@ -476,7 +476,8 @@ class TaskMateReorderCard extends LitElement {
 
     const attrs = (window.__taskmate_attrs && window.__taskmate_attrs(this.hass, this.config.entity)) || entity.attributes || {};
     const children = attrs.children || [];
-    const child = children.find((c) => c.id === this.config.child_id);
+    const child = children.find((c) => c.id === this.config.child_id)
+      || (!this.config.child_id && children[0]);
     if (!child) return;
 
     // Only initialize if we don't have local changes
@@ -585,7 +586,8 @@ class TaskMateReorderCard extends LitElement {
 
     const attrs = (window.__taskmate_attrs && window.__taskmate_attrs(this.hass, this.config.entity)) || entity.attributes || {};
     const children = attrs.children || [];
-    const child = children.find((c) => c.id === this.config.child_id);
+    const child = children.find((c) => c.id === this.config.child_id)
+      || (!this.config.child_id && children[0]);
 
     if (!child) {
       return html`


### PR DESCRIPTION
Seven cards were showing blank or text-only previews in the HA "Add to dashboard" card picker.

**Fixed:**
- **Badges, Bonuses, Penalties** — changed `preview: false` to `preview: true`
- **Badges** — stub entity changed from non-existent `sensor.taskmate_badges_child` to `sensor.taskmate_overview`, with sample badge data rendered in preview context
- **Approvals** — stub entity changed from `sensor.pending_approvals` to `sensor.taskmate_overview`
- **Child Card, Reorder Card** — fall back to first child when `child_id` is empty (stub config), instead of showing error state
- **Points Display** — added missing `getStubConfig()` with multi mode