### PR TITLE
fix: preload HA web components before panel render

### DIFF
--- a/custom_components/taskmate/www/taskmate-panel.js
+++ b/custom_components/taskmate/www/taskmate-panel.js
@@ -152,6 +152,18 @@ class TaskMatePanel extends HTMLElement {
     this._onVisibilityChange = this._onVisibilityChange.bind(this);
     this._lastConnected = null;
     this._showIds = localStorage.getItem("taskmate-show-ids") === "true";
+    this._ensureHaComponents();
+  }
+
+  async _ensureHaComponents() {
+    if (customElements.get("ha-textfield")) return;
+    try { await window.loadCardHelpers?.(); } catch (_) {}
+    await Promise.all([
+      customElements.whenDefined("ha-textfield").catch(() => {}),
+      customElements.whenDefined("ha-switch").catch(() => {}),
+      customElements.whenDefined("ha-icon-picker").catch(() => {}),
+    ]);
+    if (this._rendered) this._render();
   }
 
   set hass(value) {


### PR DESCRIPTION
Fixes #324

`ha-textfield`, `ha-switch` and `ha-icon-picker` are lazy-loaded by HA and not guaranteed to be registered when the panel first renders. If a user navigates directly to the TaskMate panel without visiting other HA pages first, the settings inputs render as invisible zero-height elements.

Calls `loadCardHelpers()` in the constructor and waits for the custom elements to be defined, then re-renders if needed.