### PR TITLE
fix(lint): remove unused imports flagged by ruff

### DIFF
--- a/custom_components/taskmate/coord_notifications.py
+++ b/custom_components/taskmate/coord_notifications.py
@@ -25,8 +25,6 @@ from .const import (
     NOTIF_TYPE_PENDING_REWARD_CLAIM,
     NOTIF_TYPE_STREAK_AT_RISK,
 )
-from .models import NotificationRoute
-
 _LOGGER = logging.getLogger(__name__)
 
 

--- a/tests/test_notifications_dispatch.py
+++ b/tests/test_notifications_dispatch.py
@@ -5,12 +5,8 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from custom_components.taskmate.coord_notifications import (
-    NOTIFICATION_TYPES_BY_ID, NotificationCoordinator,
-)
-from custom_components.taskmate.models import (
-    Child, NotificationRoute, ParentRecipient,
-)
+from custom_components.taskmate.coord_notifications import NotificationCoordinator
+from custom_components.taskmate.models import NotificationRoute, ParentRecipient
 from custom_components.taskmate.storage import TaskMateStorage
 
 

--- a/tests/test_notifications_storage.py
+++ b/tests/test_notifications_storage.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import pytest
 
 from custom_components.taskmate.models import (
-    CustomNotification, NotificationConfig, NotificationRoute, ParentRecipient,
+    CustomNotification, NotificationRoute, ParentRecipient,
 )
 from custom_components.taskmate.storage import TaskMateStorage
 


### PR DESCRIPTION
Fixes the Lint workflow failure on main (#342 merge introduced 4 unused imports).

- `coord_notifications.py`: drop unused `NotificationRoute` import
- `tests/test_notifications_dispatch.py`: drop unused `NOTIFICATION_TYPES_BY_ID` and `Child`
- `tests/test_notifications_storage.py`: drop unused `NotificationConfig`

All tests still pass.