### PR TITLE
fix(lint): drop unused pytest import

### DIFF
--- a/tests/test_notifications_events.py
+++ b/tests/test_notifications_events.py
@@ -6,7 +6,6 @@ import datetime as dt
 from datetime import timezone
 from unittest.mock import MagicMock, patch
 
-import pytest
 
 from custom_components.taskmate.coordinator import TaskMateCoordinator
 from custom_components.taskmate.storage import TaskMateStorage


### PR DESCRIPTION
Pre-empts a Lint CI failure on main from #344 — `pytest` is imported but unused in `tests/test_notifications_events.py`.