### PR TITLE
fix(i18n): localize Child Stats sensor unit_of_measurement

### DIFF
--- a/custom_components/taskmate/sensor.py
+++ b/custom_components/taskmate/sensor.py
@@ -933,6 +933,8 @@ class ChildPointsSensor(TaskMateBaseSensor):
 class ChildStatsSensor(TaskMateBaseSensor):
     """Sensor for a child's statistics."""
 
+    _attr_translation_key = "child_stats"
+
     def __init__(
         self,
         coordinator: TaskMateCoordinator,
@@ -951,11 +953,6 @@ class ChildStatsSensor(TaskMateBaseSensor):
         """Return the child's total chores completed."""
         child = self.coordinator.get_child(self.child_id)
         return child.total_chores_completed if child else 0
-
-    @property
-    def native_unit_of_measurement(self) -> str:
-        """Return the unit of measurement."""
-        return "chores"
 
     @property
     def icon(self) -> str:

--- a/custom_components/taskmate/translations/de.json
+++ b/custom_components/taskmate/translations/de.json
@@ -874,6 +874,12 @@
         }
       }
     }
+  },
+  "entity": {
+    "sensor": {
+      "child_stats": {
+        "unit_of_measurement": "Aufgaben"
+      }
+    }
   }
 }
-

--- a/custom_components/taskmate/translations/en-GB.json
+++ b/custom_components/taskmate/translations/en-GB.json
@@ -874,5 +874,12 @@
         }
       }
     }
+  },
+  "entity": {
+    "sensor": {
+      "child_stats": {
+        "unit_of_measurement": "chores"
+      }
+    }
   }
 }

--- a/custom_components/taskmate/translations/en.json
+++ b/custom_components/taskmate/translations/en.json
@@ -874,5 +874,12 @@
         }
       }
     }
+  },
+  "entity": {
+    "sensor": {
+      "child_stats": {
+        "unit_of_measurement": "chores"
+      }
+    }
   }
 }

--- a/custom_components/taskmate/translations/fr.json
+++ b/custom_components/taskmate/translations/fr.json
@@ -874,5 +874,12 @@
         }
       }
     }
+  },
+  "entity": {
+    "sensor": {
+      "child_stats": {
+        "unit_of_measurement": "tâches"
+      }
+    }
   }
 }

--- a/custom_components/taskmate/translations/nb.json
+++ b/custom_components/taskmate/translations/nb.json
@@ -874,5 +874,12 @@
         }
       }
     }
+  },
+  "entity": {
+    "sensor": {
+      "child_stats": {
+        "unit_of_measurement": "oppgaver"
+      }
+    }
   }
 }

--- a/custom_components/taskmate/translations/nn.json
+++ b/custom_components/taskmate/translations/nn.json
@@ -874,5 +874,12 @@
         }
       }
     }
+  },
+  "entity": {
+    "sensor": {
+      "child_stats": {
+        "unit_of_measurement": "oppgåver"
+      }
+    }
   }
 }

--- a/custom_components/taskmate/translations/pt-BR.json
+++ b/custom_components/taskmate/translations/pt-BR.json
@@ -874,5 +874,12 @@
         }
       }
     }
+  },
+  "entity": {
+    "sensor": {
+      "child_stats": {
+        "unit_of_measurement": "tarefas"
+      }
+    }
   }
 }

--- a/custom_components/taskmate/translations/pt.json
+++ b/custom_components/taskmate/translations/pt.json
@@ -874,5 +874,12 @@
         }
       }
     }
+  },
+  "entity": {
+    "sensor": {
+      "child_stats": {
+        "unit_of_measurement": "tarefas"
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary

- `ChildStatsSensor.native_unit_of_measurement` was hardcoded to `"chores"`, so users running HA in non-English locales saw e.g. `42 chores` instead of `42 tâches`.
- Replaced the hardcoded property with HA's standard translation mechanism: added `_attr_translation_key = "child_stats"` on the sensor and an `entity.sensor.child_stats.unit_of_measurement` block in all 8 locale files.
- HA now picks the localized unit from the locale file matching `hass.config.language`.

## Translations

| Locale | Unit |
|---|---|
| en, en-GB | chores |
| de | Aufgaben |
| fr | tâches |
| nb | oppgaver |
| nn | oppgåver |
| pt, pt-BR | tarefas |

## Notes

- Existing entity registry entries will keep their old unit (`chores`) until HA reloads the integration; the new unit applies on next config-entry reload or restart.
- `ChildBadgesSensor` has the same anti-pattern (hardcoded `"badges"`) — left out of this PR to keep the scope of the reported issue.

## Test plan

- [ ] Set HA system language to French → reload the TaskMate config entry → `sensor.taskmate_<child>_stats` shows `tâches` as `unit_of_measurement`.
- [ ] Switch to Portuguese → `tarefas`.
- [ ] Switch back to English → `chores`.
- [ ] Lint workflow passes.

Fixes #346