### PR TITLE
fix(i18n): localize Child Badges sensor unit_of_measurement

### DIFF
--- a/custom_components/taskmate/sensor.py
+++ b/custom_components/taskmate/sensor.py
@@ -1003,6 +1003,7 @@ class ChildBadgesSensor(TaskMateBaseSensor):
     """Sensor exposing a child's earned and available badges."""
 
     _attr_icon = "mdi:trophy-award"
+    _attr_translation_key = "child_badges"
 
     def __init__(
         self,
@@ -1021,10 +1022,6 @@ class ChildBadgesSensor(TaskMateBaseSensor):
         return len(
             self.coordinator.storage.get_awarded_badges_for_child(self.child_id)
         )
-
-    @property
-    def native_unit_of_measurement(self) -> str:
-        return "badges"
 
     @property
     def extra_state_attributes(self) -> dict:

--- a/custom_components/taskmate/translations/de.json
+++ b/custom_components/taskmate/translations/de.json
@@ -879,6 +879,9 @@
     "sensor": {
       "child_stats": {
         "unit_of_measurement": "Aufgaben"
+      },
+      "child_badges": {
+        "unit_of_measurement": "Abzeichen"
       }
     }
   }

--- a/custom_components/taskmate/translations/en-GB.json
+++ b/custom_components/taskmate/translations/en-GB.json
@@ -879,6 +879,9 @@
     "sensor": {
       "child_stats": {
         "unit_of_measurement": "chores"
+      },
+      "child_badges": {
+        "unit_of_measurement": "badges"
       }
     }
   }

--- a/custom_components/taskmate/translations/en.json
+++ b/custom_components/taskmate/translations/en.json
@@ -879,6 +879,9 @@
     "sensor": {
       "child_stats": {
         "unit_of_measurement": "chores"
+      },
+      "child_badges": {
+        "unit_of_measurement": "badges"
       }
     }
   }

--- a/custom_components/taskmate/translations/fr.json
+++ b/custom_components/taskmate/translations/fr.json
@@ -879,6 +879,9 @@
     "sensor": {
       "child_stats": {
         "unit_of_measurement": "tâches"
+      },
+      "child_badges": {
+        "unit_of_measurement": "badges"
       }
     }
   }

--- a/custom_components/taskmate/translations/nb.json
+++ b/custom_components/taskmate/translations/nb.json
@@ -879,6 +879,9 @@
     "sensor": {
       "child_stats": {
         "unit_of_measurement": "oppgaver"
+      },
+      "child_badges": {
+        "unit_of_measurement": "merker"
       }
     }
   }

--- a/custom_components/taskmate/translations/nn.json
+++ b/custom_components/taskmate/translations/nn.json
@@ -879,6 +879,9 @@
     "sensor": {
       "child_stats": {
         "unit_of_measurement": "oppgåver"
+      },
+      "child_badges": {
+        "unit_of_measurement": "merke"
       }
     }
   }

--- a/custom_components/taskmate/translations/pt-BR.json
+++ b/custom_components/taskmate/translations/pt-BR.json
@@ -879,6 +879,9 @@
     "sensor": {
       "child_stats": {
         "unit_of_measurement": "tarefas"
+      },
+      "child_badges": {
+        "unit_of_measurement": "medalhas"
       }
     }
   }

--- a/custom_components/taskmate/translations/pt.json
+++ b/custom_components/taskmate/translations/pt.json
@@ -879,6 +879,9 @@
     "sensor": {
       "child_stats": {
         "unit_of_measurement": "tarefas"
+      },
+      "child_badges": {
+        "unit_of_measurement": "medalhas"
       }
     }
   }


### PR DESCRIPTION
## Summary

Follow-up to #347. Same anti-pattern: `ChildBadgesSensor.native_unit_of_measurement` was hardcoded to `"badges"`. Replaced with `_attr_translation_key = "child_badges"` and entity translations in all 8 locale files.

## Translations

| Locale | Unit |
|---|---|
| en, en-GB, fr | badges |
| de | Abzeichen |
| nb | merker |
| nn | merke |
| pt, pt-BR | medalhas |

## Test plan

- [ ] Set HA system language to German → reload TaskMate config entry → `sensor.taskmate_<child>_badges` shows `Abzeichen` as `unit_of_measurement`.
- [ ] Switch to Portuguese → `medalhas`.
- [ ] Switch back to English → `badges`.
- [ ] Lint workflow passes.

Related: #348 (broader entity-name localization tracker).