### PR TITLE
fix(parent-complete): clear today's assignee for rotation chores

### DIFF
--- a/custom_components/taskmate/coord_assignments.py
+++ b/custom_components/taskmate/coord_assignments.py
@@ -443,7 +443,10 @@ class AssignmentsMixin:
         for comp in self.storage.get_completions():
             if comp.chore_id != chore.id:
                 continue
-            if comp.child_id not in pool:
+            # A parent-completion (`__parent__`) covers the whole rotation
+            # for today, so it counts toward the daily quota even though the
+            # sentinel id isn't in the pool.
+            if comp.child_id not in pool and comp.child_id != "__parent__":
                 continue
             comp_dt = comp.completed_at
             try:

--- a/custom_components/taskmate/coord_chores.py
+++ b/custom_components/taskmate/coord_chores.py
@@ -470,6 +470,14 @@ class ChoresMixin:
         for cid in child_ids:
             self.storage.set_last_completed(chore_id, cid, now.isoformat())
 
+        # Clear today's cached current assignee for rotation-mode chores so
+        # the "Current" column / child-stats card stops pointing at the
+        # original child. The pointer recomputes at the next midnight refresh.
+        if getattr(chore, "assignment_mode", "everyone") != "everyone":
+            if getattr(chore, "assignment_current_child_id", ""):
+                chore.assignment_current_child_id = ""
+                self.storage.update_chore(chore)
+
         await self.storage.async_save()
         await self.async_refresh()
 

--- a/tests/test_parent_complete.py
+++ b/tests/test_parent_complete.py
@@ -234,7 +234,11 @@ class TestParentCompleteIntegration:
         with patch.object(_mod.dt_util, "now", return_value=seven_days):
             assert coord.is_chore_available_for_child(chore, child.id) is True
 
-    def test_parent_complete_does_not_change_rotation_pointer(self):
+    def test_parent_complete_clears_rotation_pointer_today(self):
+        """For rotation-mode chores, parent_complete should clear today's
+        cached current assignee so the chore stops pointing at the original
+        child. The next midnight refresh recomputes the pointer normally.
+        """
         coord, storage, _mod = _make_system()
         now = _now()
 
@@ -247,11 +251,57 @@ class TestParentCompleteIntegration:
                 assigned_to=[alice.id, bob.id],
                 assignment_mode="alternating",
             ))
-
-        original_pointer = chore.assignment_current_child_id
+            chore.assignment_current_child_id = alice.id
+            storage.update_chore(chore)
 
         with patch.object(_mod.dt_util, "now", return_value=now):
             run(coord.async_parent_complete_chore(chore.id))
 
         updated_chore = storage.get_chore(chore.id)
-        assert updated_chore.assignment_current_child_id == original_pointer
+        assert updated_chore.assignment_current_child_id == ""
+
+    def test_parent_complete_preserves_everyone_mode_pointer(self):
+        """Everyone-mode chores don't use the assignment_current_child_id
+        cache. Make sure parent_complete leaves it untouched (still empty)
+        and doesn't error.
+        """
+        coord, storage, _mod = _make_system()
+        now = _now()
+
+        with patch.object(_mod.dt_util, "now", return_value=now):
+            run(coord.async_add_child("Alice"))
+            chore = run(coord.async_add_chore(
+                "Brush teeth", points=2, requires_approval=False,
+                schedule_mode="recurring", recurrence="daily",
+                assigned_to=[],  # everyone
+            ))
+
+        with patch.object(_mod.dt_util, "now", return_value=now):
+            run(coord.async_parent_complete_chore(chore.id))
+
+        updated_chore = storage.get_chore(chore.id)
+        assert updated_chore.assignment_current_child_id == ""
+
+    def test_parent_complete_counts_toward_rotation_done_today(self):
+        """A `__parent__` completion fills today's quota for the rotation
+        pool, so `_is_rotation_done_today` returns True afterwards.
+        """
+        coord, storage, _mod = _make_system()
+        now = _now()
+
+        with patch.object(_mod.dt_util, "now", return_value=now):
+            alice = run(coord.async_add_child("Alice"))
+            bob = run(coord.async_add_child("Bob"))
+            chore = run(coord.async_add_chore(
+                "Bins", points=5, requires_approval=False,
+                schedule_mode="recurring", recurrence="weekly",
+                assigned_to=[alice.id, bob.id],
+                assignment_mode="alternating",
+            ))
+
+        with patch.object(_mod.dt_util, "now", return_value=now):
+            assert coord._is_rotation_done_today(chore) is False
+            run(coord.async_parent_complete_chore(chore.id))
+            # Re-fetch since parent_complete may have mutated the chore.
+            chore = storage.get_chore(chore.id)
+            assert coord._is_rotation_done_today(chore) is True


### PR DESCRIPTION
## Summary

Clicking **Parents did it** on a rotation-mode chore (alternating / random / balanced) showed a success toast but left the chore visually assigned to the same child for the rest of the day — both on the child's stats card and in the Manage Chores **Current** column.

## Root cause

Two gaps in the parent-completion path:

1. **`coord_assignments.py` `_is_rotation_done_today`** filtered with `if comp.child_id not in pool: continue`. The `__parent__` sentinel id is never in the rotation pool, so a parent-completion didn't count toward `daily_limit` and the chore stayed visible on the active child's list. This contradicted the docstring above the call site in `coord_chores.py` which already noted that parent completions should retire the chore for the whole pool.
2. **`coord_chores.py` `async_parent_complete_chore`** wrote a completion + per-child `last_completed`, but never cleared `chore.assignment_current_child_id`. The midnight refresh recomputes it next day, but until then the **Current** column kept pointing at the original child.

## Fix

- `_is_rotation_done_today`: also count `comp.child_id == "__parent__"` toward the daily quota.
- `async_parent_complete_chore`: clear `chore.assignment_current_child_id` for non-everyone modes and persist via `update_chore`. The midnight refresh restores it normally for the next day.

Everyone-mode chores are untouched (they don't cache a current assignee).

## Tests

- Renamed `test_parent_complete_does_not_change_rotation_pointer` → `test_parent_complete_clears_rotation_pointer_today` and flipped the assertion. The old name captured the broken behavior, not the desired one.
- Added `test_parent_complete_preserves_everyone_mode_pointer` (no-op for everyone-mode).
- Added `test_parent_complete_counts_toward_rotation_done_today` (asserts `_is_rotation_done_today` flips to True after a parent completion).
- Full suite: **454 passed**. Ruff: clean.

## Test plan

- [ ] Manage Chores → pick a chore in alternating/random/balanced mode. Confirm **Current** column shows a child.
- [ ] Click **Parents did it** (👤✓), accept the confirmation.
- [ ] **Current** column now shows `—`.
- [ ] The chore disappears from the child's stats card / active list for the rest of the day.
- [ ] After next midnight, the rotation recomputes normally (same alternating cadence as if the chore had not been completed by a child).

Fixes #351