### PR TITLE
fix(panel): coerce numeric settings via type attribute, not property

### DIFF
--- a/custom_components/taskmate/www/taskmate-panel.js
+++ b/custom_components/taskmate/www/taskmate-panel.js
@@ -1213,9 +1213,10 @@ class TaskMatePanel extends HTMLElement {
     const payload = { type: "taskmate/update_settings" };
     fields.forEach(el => {
       const name = el.dataset.setting;
+      const declaredType = el.getAttribute("type") || el.type;
       let v;
-      if (el.type === "checkbox" || el.tagName === "HA-SWITCH") v = el.checked;
-      else if (el.type === "number") v = el.value === "" ? undefined : Number(el.value);
+      if (declaredType === "checkbox" || el.tagName === "HA-SWITCH") v = el.checked;
+      else if (declaredType === "number") v = el.value === "" ? undefined : Number(el.value);
       else v = el.value;
       if (v !== undefined) payload[name] = v;
     });


### PR DESCRIPTION
## Summary

Fixes #350 — saving Settings on the TaskMate panel returns *"Message malformé"* / *"expected int for dictionary value"* for `history_days`, `perfect_week_bonus`, and `calendar_projection_days`.

## Root cause

`_doSaveSettings()` detected number inputs with `el.type === "number"`. `ha-textfield` does not reliably reflect the HTML `type="number"` attribute onto its `.type` property, so the branch was skipped and `el.value` (a raw string like `"14"`) was sent. The WS schema uses `vol.All(int, ...)` which rejects strings — hence the malformed-message toast surfaced by HA's voluptuous validator.

## Fix

Read the declared type via `el.getAttribute("type")` first, falling back to `el.type` — this works for both native `<input>` and HA's `<ha-textfield>` wrapper. Switches are still detected by `tagName === "HA-SWITCH"`.

## Test plan

- [ ] Open TaskMate panel → Settings
- [ ] Toggle *Confirm before skipping*, change any numeric field, hit *Save settings*
- [ ] No error toast; values persist after reload