### PR TITLE
fix(panel): add Notifications tab to sidebar nav

### DIFF
--- a/custom_components/taskmate/www/taskmate-panel.js
+++ b/custom_components/taskmate/www/taskmate-panel.js
@@ -1461,6 +1461,7 @@ class TaskMatePanel extends HTMLElement {
         { id: "templates", label: this._t("panel.tab_templates"), icon: "mdi:clipboard-list-outline" },
       ]},
       { head: this._t("panel.nav_system"), items: [
+        { id: "notifications", label: this._t("panel.tab_notifications"), icon: "mdi:bell-outline" },
         { id: "settings", label: this._t("panel.tab_settings"), icon: "mdi:cog-outline" },
       ]},
     ].map(g => ({


### PR DESCRIPTION
## Summary

The Notifications tab introduced in v3.9.0 is unreachable from the panel UI — `_sidebarGroups()` (which actually drives the visible nav) was never updated to include it. The `TABS` constant at the top of `taskmate-panel.js` and the `_renderTab()` switch case both reference `notifications`, but the sidebar render had its own hardcoded list that omitted it.

Add it to the **System** group alongside Settings (icon: `mdi:bell-outline`).

## Test plan

- [ ] Open TaskMate panel → sidebar shows **Notifications** under *System*
- [ ] Clicking it loads the Notifications tab (recipients, matrix, custom alerts)