### PR TITLE
fix(panel): expose HA hamburger menu on mobile

### DIFF
--- a/custom_components/taskmate/www/taskmate-panel.js
+++ b/custom_components/taskmate/www/taskmate-panel.js
@@ -395,6 +395,7 @@ class TaskMatePanel extends HTMLElement {
     }
     if (act === "retry")        { this._fetchState(); return; }
     if (act === "switch-to-activity") { this._activeTab = "activity"; this._render(); return; }
+    if (act === "toggle-ha-menu") { this.dispatchEvent(new CustomEvent("hass-toggle-menu", { bubbles: true, composed: true })); return; }
     if (act === "copy-id") { navigator.clipboard.writeText(t.dataset.id).then(() => this._showToast("ok", this._t("panel.toast_copied"))); return; }
 
     // Children
@@ -1514,6 +1515,9 @@ class TaskMatePanel extends HTMLElement {
       : 0;
     return `
       <div class="tm-topbar">
+        <button type="button" class="tm-menu-btn" data-act="toggle-ha-menu" aria-label="Menu">
+          <ha-icon icon="mdi:menu"></ha-icon>
+        </button>
         <div class="tm-crumbs">
           <span class="tm-crumbs-root">TaskMate</span>
           <span class="tm-crumbs-sep">/</span>
@@ -3814,6 +3818,19 @@ class TaskMatePanel extends HTMLElement {
         background: var(--tm-surface-0);
         flex-shrink: 0;
       }
+      .tm-menu-btn {
+        display: none;
+        background: transparent;
+        border: 0;
+        color: var(--tm-text);
+        padding: 6px;
+        margin-left: -6px;
+        border-radius: 8px;
+        cursor: pointer;
+        align-items: center; justify-content: center;
+      }
+      .tm-menu-btn:hover { background: var(--tm-surface-2); }
+      .tm-menu-btn ha-icon { --mdc-icon-size: 22px; }
       .tm-crumbs {
         display: flex; align-items: center; gap: 8px;
         font-size: 13px;
@@ -4737,6 +4754,8 @@ class TaskMatePanel extends HTMLElement {
       @media (max-width: 900px) {
         .tm-shell { grid-template-columns: 1fr; }
         .tm-sidebar { display: none; }
+        .tm-menu-btn { display: inline-flex; }
+        .tm-topbar { padding: 0 12px; }
         .tm-mobile-tabs {
           display: flex;
           overflow-x: auto;


### PR DESCRIPTION
## Summary

The TaskMate panel is registered with `embed_iframe=False`, which means HA does NOT render its own app header — the panel owns the full content area. On desktop this is fine (HA sidebar is always visible), but on the **mobile companion app** the HA sidebar collapses behind a hamburger menu, and the panel had no equivalent control. Users were trapped inside TaskMate with no way to navigate back to other HA pages without a full reload.

Reported in conversation.

## Fix

Add a hamburger button at the start of the topbar that dispatches the standard `hass-toggle-menu` custom event (the same event HA's own `ha-menu-button` uses). The button is hidden via CSS on viewports wider than 900px, matching the existing breakpoint that hides the in-panel sidebar.

Kept the implementation lightweight — a plain `<button>` with `mdi:menu` and an event dispatch — instead of wiring `<ha-menu-button>` and its `.hass`/`.narrow` JS-property bindings.

## Test plan
- [ ] Open TaskMate panel on the HA mobile companion app
- [ ] Hamburger appears at the top-left of the panel
- [ ] Tapping it slides in the HA navigation drawer
- [ ] On desktop (>900px) the button is invisible (HA sidebar is already shown)