### PR TITLE
chore: bump version to 3.9.1

### DIFF
--- a/custom_components/taskmate/manifest.json
+++ b/custom_components/taskmate/manifest.json
@@ -17,5 +17,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/tempus2016/taskmate/issues",
   "requirements": [],
-  "version": "3.9.0"
+  "version": "3.9.1"
 }


### PR DESCRIPTION
Patch release covering two v3.9.0 regressions:
- #358 Notifications tab missing from sidebar
- #359 Mobile hamburger menu missing