### PR TITLE
chore: bump version to 3.9.2

### DIFF
--- a/custom_components/taskmate/manifest.json
+++ b/custom_components/taskmate/manifest.json
@@ -17,5 +17,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/tempus2016/taskmate/issues",
   "requirements": [],
-  "version": "3.9.1"
+  "version": "3.9.2"
 }


### PR DESCRIPTION
Bump manifest to 3.9.2 to ship the Notifications-tab polish merged in #362.

See the release notes for details.