### PR TITLE
fix(child-card): don't hide parent chore when bonus sub-task is completed (rotation mode)

### DIFF
--- a/custom_components/taskmate/www/taskmate-child-card.js
+++ b/custom_components/taskmate/www/taskmate-child-card.js
@@ -1756,7 +1756,7 @@ class TaskMateChildCard extends LitElement {
           const dailyLimit = chore.daily_limit || 1;
           const allTodayCompletions = attrs.todays_completions || [];
           const poolCompletionsToday = allTodayCompletions.filter(
-            comp => comp.chore_id === chore.id && (poolSet.has(String(comp.child_id)) || comp.child_id === "__parent__")
+            comp => comp.chore_id === chore.id && (poolSet.has(String(comp.child_id)) || comp.child_id === "__parent__") && !comp.bonus_subtask_id
           ).length;
           if (poolCompletionsToday >= dailyLimit) {
             isAssignedToChild = false;


### PR DESCRIPTION
## Summary
- Bonus sub-task completions were counted toward the parent chore's daily limit in the child-card's dynamic-assignment (alternating/random) pool filter.
- With `daily_limit: 1`, completing a single sub-task therefore exhausted the parent's quota and the parent disappeared from the child card before remaining sub-tasks could be completed.
- Filter now excludes records with a `bonus_subtask_id`, matching the existing pattern in `_renderChoreCard` (line 2117).

## Root cause
`taskmate-child-card.js:1758` filtered `todays_completions` by `chore_id` + pool membership only. Bonus sub-task completions share the parent's `chore_id` and carry a `bonus_subtask_id`, so they were silently inflating the count.

## Test plan
- [ ] Create a chore with `daily_completion_limit: 1`, assignment mode = alternating, with at least one sub-task
- [ ] Open the Child Card for today's active child
- [ ] Complete a sub-task — parent chore should remain visible
- [ ] Verify parent disappears only after the parent itself is completed (or daily limit reached via parent completions)
- [ ] Sanity check: `everyone` mode chores behave the same as before

Fixes #365