### PR TITLE
chore: bump version to 3.9.3

### DIFF
--- a/custom_components/taskmate/manifest.json
+++ b/custom_components/taskmate/manifest.json
@@ -17,5 +17,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/tempus2016/taskmate/issues",
   "requirements": [],
-  "version": "3.9.2"
+  "version": "3.9.3"
 }


### PR DESCRIPTION
Bumps manifest to 3.9.3 for patch release covering #366 (Fixes #365).