### PR TITLE
fix(rotation): keep chore visible while bonus sub-tasks are pending

### DIFF
--- a/custom_components/taskmate/coord_assignments.py
+++ b/custom_components/taskmate/coord_assignments.py
@@ -432,6 +432,11 @@ class AssignmentsMixin:
         rotation" and should disappear from every pool member's list — not
         just the child who happened to complete it. Returns False for
         everyone-mode chores since they don't share a single daily quota.
+
+        Exception: bonus sub-tasks render inside the parent chore card, so
+        hiding the chore would also hide any pending bonus sub-tasks. If the
+        active child still has uncompleted bonus sub-tasks for today, keep
+        the chore visible (return False) so they remain reachable.
         """
         if getattr(chore, 'assignment_mode', 'everyone') == 'everyone':
             return False
@@ -439,14 +444,11 @@ class AssignmentsMixin:
         if not pool:
             return False
         today = dt_util.as_local(dt_util.now()).date()
+        active_child_id = getattr(chore, 'assignment_current_child_id', '') or ''
         completions_today = 0
+        completed_bonus_ids_today: set[str] = set()
         for comp in self.storage.get_completions():
             if comp.chore_id != chore.id:
-                continue
-            # A parent-completion (`__parent__`) covers the whole rotation
-            # for today, so it counts toward the daily quota even though the
-            # sentinel id isn't in the pool.
-            if comp.child_id not in pool and comp.child_id != "__parent__":
                 continue
             comp_dt = comp.completed_at
             try:
@@ -455,10 +457,30 @@ class AssignmentsMixin:
                 comp_date = comp_dt.date() if hasattr(comp_dt, 'date') else None
             except (AttributeError, TypeError, ValueError):
                 continue
-            if comp_date == today:
+            if comp_date != today:
+                continue
+            bonus_id = getattr(comp, 'bonus_subtask_id', None)
+            if bonus_id:
+                # Bonus completions don't count toward the parent's daily
+                # quota; track them only to decide whether the active child
+                # still has bonus work pending.
+                if active_child_id and comp.child_id == active_child_id:
+                    completed_bonus_ids_today.add(bonus_id)
+                continue
+            # Parent completions count toward the quota. A `__parent__`
+            # sentinel covers the whole rotation for today.
+            if comp.child_id in pool or comp.child_id == "__parent__":
                 completions_today += 1
         daily_limit = getattr(chore, 'daily_limit', 1) or 1
-        return completions_today >= daily_limit
+        if completions_today < daily_limit:
+            return False
+        bonus_subtasks = getattr(chore, 'bonus_subtasks', None) or []
+        if bonus_subtasks and active_child_id:
+            for bst in bonus_subtasks:
+                bst_id = bst.get('id') if isinstance(bst, dict) else getattr(bst, 'id', None)
+                if bst_id and bst_id not in completed_bonus_ids_today:
+                    return False
+        return True
 
     async def _async_refresh_assignments_and_publish(self) -> None:
         """Recompute today's active child per chore and publish to calendars.

--- a/custom_components/taskmate/www/taskmate-child-card.js
+++ b/custom_components/taskmate/www/taskmate-child-card.js
@@ -1759,7 +1759,19 @@ class TaskMateChildCard extends LitElement {
             comp => comp.chore_id === chore.id && (poolSet.has(String(comp.child_id)) || comp.child_id === "__parent__") && !comp.bonus_subtask_id
           ).length;
           if (poolCompletionsToday >= dailyLimit) {
-            isAssignedToChild = false;
+            // Bonus sub-tasks render inside the parent card; if the active
+            // child still has any pending, keep the chore visible so they
+            // remain reachable.
+            const bonusSubtasks = chore.bonus_subtasks || [];
+            const completedBonusIds = new Set(
+              allTodayCompletions
+                .filter(c => c.chore_id === chore.id && String(c.child_id) === activeId && c.bonus_subtask_id)
+                .map(c => c.bonus_subtask_id)
+            );
+            const hasPendingBonus = bonusSubtasks.some(b => b && b.id && !completedBonusIds.has(b.id));
+            if (!hasPendingBonus) {
+              isAssignedToChild = false;
+            }
           }
         }
       }

--- a/tests/test_assignment_modes.py
+++ b/tests/test_assignment_modes.py
@@ -222,6 +222,72 @@ def test_rotation_chore_clears_for_pool_when_off_rotation_child_completes():
     assert coord.is_chore_available_for_child(chore, a.id) is True
 
 
+def test_rotation_chore_with_pending_bonus_subtasks_stays_visible():
+    """Regression for issue #365: when a rotation chore has bonus sub-tasks,
+    completing the parent fills the daily quota (e.g. 1/1) — but the bonus
+    sub-tasks render inside the parent card and must remain reachable until
+    the active child has completed them. The chore should stay visible while
+    bonus sub-tasks are pending."""
+    from custom_components.taskmate.models import BonusSubTask, ChoreCompletion
+
+    a, b = Child(name="A"), Child(name="B")
+    coord = _coord([a, b])
+    coord.storage.get_last_completed = MagicMock(return_value={})
+    anchor = date(2026, 4, 20)
+    dt_util_mock._now = dt.datetime.combine(anchor, dt.time(12, 0), tzinfo=UTC)
+    bonus = BonusSubTask(name="Extra wipe-down", points=2)
+    chore = Chore(
+        name="Bins",
+        assigned_to=[a.id, b.id],
+        assignment_mode="alternating",
+        assignment_rotation_anchor=anchor.isoformat(),
+        daily_limit=1,
+        bonus_subtasks=[bonus],
+    )
+    # A is the active child today.
+    assert coord._compute_active_children(chore, anchor) == [a.id]
+    chore.assignment_current_child_id = a.id
+
+    # A completes the parent — daily_limit is filled (1/1) but the bonus
+    # sub-task is still pending, so the chore must stay visible.
+    parent_completion = ChoreCompletion(
+        chore_id=chore.id, child_id=a.id,
+        completed_at=dt_util_mock.now(), approved=True,
+    )
+    coord.storage.get_completions = MagicMock(return_value=[parent_completion])
+    assert coord._is_rotation_done_today(chore) is False
+    assert coord.is_chore_available_for_child(chore, a.id) is True
+
+    # Once A completes the bonus sub-task, the chore is fully done and hides.
+    bonus_completion = ChoreCompletion(
+        chore_id=chore.id, child_id=a.id,
+        completed_at=dt_util_mock.now(), approved=True,
+        bonus_subtask_id=bonus.id,
+    )
+    coord.storage.get_completions = MagicMock(
+        return_value=[parent_completion, bonus_completion]
+    )
+    assert coord._is_rotation_done_today(chore) is True
+    assert coord.is_chore_available_for_child(chore, a.id) is False
+
+    # Sanity: a rotation chore *without* bonus sub-tasks still hides as soon
+    # as its quota is met (existing behaviour preserved).
+    chore_no_bonus = Chore(
+        name="Bins (no bonus)",
+        assigned_to=[a.id, b.id],
+        assignment_mode="alternating",
+        assignment_rotation_anchor=anchor.isoformat(),
+        daily_limit=1,
+    )
+    chore_no_bonus.assignment_current_child_id = a.id
+    plain_completion = ChoreCompletion(
+        chore_id=chore_no_bonus.id, child_id=a.id,
+        completed_at=dt_util_mock.now(), approved=True,
+    )
+    coord.storage.get_completions = MagicMock(return_value=[plain_completion])
+    assert coord._is_rotation_done_today(chore_no_bonus) is True
+
+
 def test_everyone_mode_unaffected_by_rotation_done_helper():
     """Everyone-mode chores share no single daily quota across the pool, so
     the helper must not retire them after one child completes."""


### PR DESCRIPTION
## Summary

Completes the fix for #365. PR #366 (shipped in v3.9.3) addressed the client-side rotation-pool filter but the same bug remained on the backend in `coord_assignments._is_rotation_done_today`. For rotation chores (alternating/random) with `daily_limit=1` and bonus sub-tasks, the parent's own completion fills the quota, the backend strips the chore from `assigned_chores`, and the chore vanishes from the child card before the user can reach the bonus sub-tasks (which render inside the parent card).

- Backend `_is_rotation_done_today`: collect today's bonus completions for the active child while counting parent quota; if any bonus sub-task is still pending for the active child, return `False` so the chore stays visible.
- Frontend `taskmate-child-card.js`: mirror the same guard in the rotation-pool visibility filter so the client agrees with the backend.
- Regression test in `test_assignment_modes.py` covers parent-done/bonus-pending, parent+bonus done, and a no-bonus baseline (existing rotation-done behaviour preserved).

## Test plan
- [x] Standalone runner exercising `_is_rotation_done_today` and `is_chore_available_for_child` for all five scenarios passes (bonus pending stays visible; bonus done hides; no-bonus chore still hides; everyone-mode untouched; off-rotation parent credit still hides).
- [ ] HACS install on John's HA: rotation chore, `daily_limit=1`, add a bonus sub-task. Complete parent → confirm card stays visible. Tick bonus → confirm card hides.

Fixes #365