### PR TITLE
chore: bump version to 3.9.4

### DIFF
--- a/custom_components/taskmate/manifest.json
+++ b/custom_components/taskmate/manifest.json
@@ -17,5 +17,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/tempus2016/taskmate/issues",
   "requirements": [],
-  "version": "3.9.3"
+  "version": "3.9.4"
 }


### PR DESCRIPTION
Release v3.9.4. See milestone https://github.com/tempus2016/taskmate/milestone/9 for included changes.