### PR TITLE
chore: set manifest version to 3.9.5-beta.1

### DIFF
--- a/custom_components/taskmate/manifest.json
+++ b/custom_components/taskmate/manifest.json
@@ -17,5 +17,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/tempus2016/taskmate/issues",
   "requirements": [],
-  "version": "3.9.5"
+  "version": "3.9.5-beta.1"
 }


### PR DESCRIPTION
Match the manifest version to the beta tag (`3.9.5-beta.1`) so HACS and the in-card console banner report the exact pre-release identifier. Every prior beta (v3.8.0-beta.1..10) followed this convention; the previous bump to a bare `3.9.5` was inconsistent.

Follow-up to #373. The bad tag/release have been deleted and will be re-created once this merges.