### PR TITLE
chore: bump manifest to 3.9.5-beta.2

### DIFF
--- a/custom_components/taskmate/manifest.json
+++ b/custom_components/taskmate/manifest.json
@@ -17,5 +17,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/tempus2016/taskmate/issues",
   "requirements": [],
-  "version": "3.9.5-beta.1"
+  "version": "3.9.5-beta.2"
 }


### PR DESCRIPTION
Bump for the v3.9.5-beta.2 tag. Includes #376 (per-card editor switches for the Activity card redesign features).