### PR TITLE
fix(panel): keep raised-button text readable on hover

### DIFF
--- a/custom_components/taskmate/www/taskmate-panel.js
+++ b/custom_components/taskmate/www/taskmate-panel.js
@@ -3683,7 +3683,7 @@ class TaskMatePanel extends HTMLElement {
         --tm-text-vfaint:   var(--disabled-text-color, #bdbdbd);
 
         --tm-accent:        var(--primary-color, #03a9f4);
-        --tm-accent-hover:  var(--primary-color, #03a9f4);
+        --tm-accent-hover:  color-mix(in srgb, var(--primary-color, #03a9f4), #000 14%);
         --tm-accent-press:  var(--primary-color, #03a9f4);
         --tm-accent-soft:   color-mix(in srgb, var(--primary-color, #03a9f4), transparent 90%);
         --tm-accent-border: color-mix(in srgb, var(--primary-color, #03a9f4), transparent 70%);
@@ -3997,7 +3997,9 @@ class TaskMatePanel extends HTMLElement {
         box-shadow: var(--tm-shadow-xs);
       }
       .tm-btn-raised:hover {
-        filter: brightness(1.1);
+        background: var(--tm-accent-hover);
+        border-color: var(--tm-accent-hover);
+        color: var(--text-primary-color, #fff);
         box-shadow: var(--tm-shadow-sm);
       }
       .tm-btn-sm {
@@ -4836,10 +4838,9 @@ class TaskMatePanel extends HTMLElement {
         border-color: var(--tm-accent);
       }
       .tm-notif-toggle-on:hover {
-        background: var(--tm-accent);
+        background: var(--tm-accent-hover);
         color: var(--text-primary-color, #fff);
-        border-color: var(--tm-accent);
-        filter: brightness(1.1);
+        border-color: var(--tm-accent-hover);
       }
 
       /* Notification toggle switches (CSS-only on native checkbox) */


### PR DESCRIPTION
## Problem

Hovering a raised button (`+ Add bonus`, `+ Add group`, `+ Add child`, `Approve`, the "on" notification toggle, etc.) made the background lighter but the white label hard to read.

## Root cause

`.tm-btn-raised:hover` and `.tm-notif-toggle-on:hover` used `filter: brightness(1.1)`, which brightens the **whole element**. The accent background lightens toward white while the white label is already at maximum brightness and cannot compensate, so the foreground/background contrast collapses.

White-on-background WCAG contrast (higher = better):

| Accent | rest | `brightness(1.1)` (old) | darken 14% (new) |
|---|---|---|---|
| `#03a9f4` (HA default) | 2.63 | **2.22 ↓** | 3.51 ↑ |
| `#1f6fc4` (deep) | 5.09 | **4.34 ↓** | 6.45 ↑ |
| `#4fc3f7` (pale) | 2.00 | **1.67 ↓** | 2.69 ↑ |

The old hover reduced readability in every theme; the fix improves it.

## Fix

- Repurpose the previously-unused `--tm-accent-hover` token to a darkened accent: `color-mix(in srgb, var(--primary-color), #000 14%)`.
- `.tm-btn-raised:hover` and `.tm-notif-toggle-on:hover` now darken the background via that token instead of `filter: brightness(1.1)`. The label colour is left untouched, so contrast increases on hover.

`.tm-approval-pill:hover` (which *darkens*, brightness 0.97) was intentionally left unchanged — it does not have this defect.

JS syntax validated with `node --check`.