### PR TITLE
chore: bump manifest to 3.9.5 for release

### DIFF
--- a/custom_components/taskmate/manifest.json
+++ b/custom_components/taskmate/manifest.json
@@ -17,5 +17,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/tempus2016/taskmate/issues",
   "requirements": [],
-  "version": "3.9.5-beta.2"
+  "version": "3.9.5"
 }


### PR DESCRIPTION
Manifest version bump 3.9.5-beta.2 -> 3.9.5 for the stable v3.9.5 release. No code changes.