### PR TITLE
fix(approvals): keep approve button after a recurring chore resets

### DIFF
--- a/custom_components/taskmate/sensor.py
+++ b/custom_components/taskmate/sensor.py
@@ -1122,7 +1122,19 @@ class PendingApprovalsSensor(TaskMateBaseSensor):
             child = self.coordinator.get_child(comp.child_id)
             chore = self.coordinator.get_chore(comp.chore_id)
             if child and chore:
-                pts = chore.points
+                # Bonus sub-task completions carry the sub-task's own name and
+                # points; mirror _build_todays_completions so cards reading this
+                # list render them identically.
+                bonus_subtask_id = getattr(comp, "bonus_subtask_id", "") or ""
+                if bonus_subtask_id:
+                    subtask = next(
+                        (b for b in chore.bonus_subtasks if b.id == bonus_subtask_id), None
+                    )
+                    chore_name = f"{chore.name} › {subtask.name}" if subtask else chore.name
+                    pts = subtask.points if subtask else 0
+                else:
+                    chore_name = chore.name
+                    pts = chore.points
                 timed_secs = getattr(comp, "timed_duration_seconds", 0) or 0
                 if timed_secs > 0 and getattr(chore, "task_type", "") == "timed":
                     rate_seconds = chore.timed_rate_minutes * 60
@@ -1133,11 +1145,12 @@ class PendingApprovalsSensor(TaskMateBaseSensor):
                     "type": "chore",
                     "child_name": child.name,
                     "child_id": child.id,
-                    "chore_name": chore.name,
+                    "chore_name": chore_name,
                     "chore_id": chore.id,
                     "points": pts,
                     "time_category": chore.time_category,
                     "completed_at": comp.completed_at.isoformat(),
+                    "bonus_subtask_id": bonus_subtask_id,
                 }
                 if timed_secs > 0:
                     detail["timed_duration_seconds"] = timed_secs

--- a/custom_components/taskmate/www/taskmate-approvals-card.js
+++ b/custom_components/taskmate/www/taskmate-approvals-card.js
@@ -372,7 +372,12 @@ class TaskMateApprovalsCard extends LitElement {
     // resolve from their new companion sensors when the card is pointed at
     // the overview entity.
     const attrs = (window.__taskmate_attrs && window.__taskmate_attrs(this.hass, this.config.entity)) || entity.attributes || {};
-    let completions = entity.attributes.chore_completions;
+    // Prefer the full pending list (chore_completions, resolved from the
+    // pending_approvals companion sensor) so approvals left pending from a
+    // previous day still appear after a recurring chore resets at midnight.
+    // Fall back to today's completions only on older backends that don't
+    // expose chore_completions via the resolver.
+    let completions = attrs.chore_completions;
     if (!completions) {
       completions = (attrs.todays_completions || []).filter(c => !c.approved);
     }

--- a/custom_components/taskmate/www/taskmate-attr-resolver.js
+++ b/custom_components/taskmate/www/taskmate-attr-resolver.js
@@ -27,6 +27,10 @@
     "sensor.taskmate_rewards",
     "sensor.taskmate_activity",
     "sensor.taskmate_incentives",
+    // Full pending-approvals lists (chore_completions / reward_claims). These
+    // are NOT filtered to today, so approval cards pointed at the overview
+    // entity can still surface a completion left pending from a previous day.
+    "sensor.pending_approvals",
   ];
 
   function mergedAttributes(hass, primaryEntityId) {

--- a/custom_components/taskmate/www/taskmate-overview-card.js
+++ b/custom_components/taskmate/www/taskmate-overview-card.js
@@ -318,13 +318,16 @@ class TaskMateOverviewCard extends LitElement {
     const pointsIcon = attrs.points_icon || "mdi:star";
     const pointsName = attrs.points_name || this._t("common.stars");
 
-    // Pending approvals — from approvals entity if configured, else from completions
+    // Pending approvals — from approvals entity if configured, else from the
+    // full pending list (resolved via companion) so the count keeps including
+    // completions left pending from a previous day; fall back to today's
+    // completions only on older backends.
     let pendingApprovals = 0;
     if (this.config.approvals_entity) {
       const appEntity = this.hass.states[this.config.approvals_entity];
       pendingApprovals = appEntity?.attributes?.chore_completions?.length || 0;
     } else {
-      pendingApprovals = completions.filter(c => !c.approved).length;
+      pendingApprovals = (attrs.chore_completions || completions.filter(c => !c.approved)).length;
     }
 
     // Total points across all children

--- a/custom_components/taskmate/www/taskmate-parent-dashboard-card.js
+++ b/custom_components/taskmate/www/taskmate-parent-dashboard-card.js
@@ -399,7 +399,11 @@ class TaskMateParentDashboardCard extends LitElement {
     const children = attrs.children || [];
     const chores = attrs.chores || [];
     const completions = attrs.todays_completions || [];
-    const pendingCompletions = completions.filter(c => !c.approved);
+    // Pending approvals come from the full pending list (not filtered to
+    // today) so a completion left pending from a previous day still shows an
+    // approve button after a recurring chore resets. `completions` stays
+    // today-only for the overview tab's activity display.
+    const pendingCompletions = attrs.chore_completions || completions.filter(c => !c.approved);
     const pendingRewardClaims = attrs.pending_reward_claims || [];
     const pointsIcon = attrs.points_icon || "mdi:star";
     const pointsName = attrs.points_name || this._t('common.points');

--- a/tests/test_sensor_attributes.py
+++ b/tests/test_sensor_attributes.py
@@ -21,6 +21,7 @@ from custom_components.taskmate.models import (
     Badge,
     BadgeCriterion,
     Bonus,
+    BonusSubTask,
     Child,
     Chore,
     ChoreCompletion,
@@ -30,7 +31,7 @@ from custom_components.taskmate.models import (
     Reward,
     RewardClaim,
 )
-from custom_components.taskmate.sensor import ChildBadgesSensor
+from custom_components.taskmate.sensor import ChildBadgesSensor, PendingApprovalsSensor
 
 
 MAX_ATTR_BYTES = 16384  # Home Assistant recorder limit
@@ -397,3 +398,64 @@ class TestChildBadgesSensor:
         attrs = sensor.extra_state_attributes
         assert attrs["total_badges"] == 1
         assert attrs["available"][0]["badge_id"] == "y"
+
+
+class TestPendingApprovalsSensor:
+    """The pending-approvals list is the single source of truth for parent
+    approval surfaces. It must NOT be filtered to today (a completion from a
+    previous day stays pending until approved), and it must describe bonus
+    sub-task completions correctly so cards can render them."""
+
+    def _coord(self, children, chores, pending):
+        coord = MagicMock()
+        coord.data = {
+            "pending_completions": pending,
+            "pending_reward_claims": [],
+        }
+        by_child = {c.id: c for c in children}
+        by_chore = {c.id: c for c in chores}
+        coord.get_child = lambda cid: by_child.get(cid)
+        coord.get_chore = lambda cid: by_chore.get(cid)
+        coord.get_reward = lambda rid: None
+        return coord
+
+    def test_includes_pending_completion_from_previous_day(self, hass):
+        # Daughter completed a daily chore yesterday; today it reset. The
+        # still-unapproved completion must remain in the approvals list so the
+        # parent can still approve it.
+        dt_util_mock._now = dt.datetime(2026, 6, 7, 9, 0, 0, tzinfo=UTC)
+        child = Child(name="Mia")
+        child.id = "c1"
+        chore = Chore(name="Make bed", points=10, requires_approval=True)
+        chore.id = "ch1"
+        yesterday = dt.datetime(2026, 6, 6, 18, 0, 0, tzinfo=UTC)
+        comp = ChoreCompletion(
+            chore_id="ch1", child_id="c1", completed_at=yesterday,
+            approved=False, points_awarded=0, id="comp-yesterday",
+        )
+        coord = self._coord([child], [chore], [comp])
+        sensor = PendingApprovalsSensor(coord, _MockEntry())
+        attrs = sensor.extra_state_attributes
+        ids = [d["completion_id"] for d in attrs["chore_completions"]]
+        assert "comp-yesterday" in ids
+
+    def test_bonus_subtask_completion_named_and_priced_correctly(self, hass):
+        dt_util_mock._now = dt.datetime(2026, 6, 7, 9, 0, 0, tzinfo=UTC)
+        child = Child(name="Mia")
+        child.id = "c1"
+        sub = BonusSubTask(name="Tidy toys", points=3)
+        sub.id = "sub1"
+        chore = Chore(name="Make bed", points=10, bonus_subtasks=[sub])
+        chore.id = "ch1"
+        comp = ChoreCompletion(
+            chore_id="ch1", child_id="c1",
+            completed_at=dt.datetime(2026, 6, 7, 8, 0, 0, tzinfo=UTC),
+            approved=False, points_awarded=0, bonus_subtask_id="sub1",
+            id="comp-bonus",
+        )
+        coord = self._coord([child], [chore], [comp])
+        sensor = PendingApprovalsSensor(coord, _MockEntry())
+        detail = sensor.extra_state_attributes["chore_completions"][0]
+        assert detail["chore_name"] == "Make bed › Tidy toys"
+        assert detail["points"] == 3
+        assert detail["bonus_subtask_id"] == "sub1"


### PR DESCRIPTION
## Summary

A completion left **pending overnight** lost its Approve button once the chore reset the next day. Most visible with **daily recurring chores**: the child completes it, the day rolls over, and yesterday's still-pending completion becomes unapproveable from the dashboard cards.

## Root cause

The completion is never lost — `sensor.pending_approvals` (`chore_completions`) retains it. But the cards sourced their pending list from `todays_completions`, which the backend filters to `completed_at == today`. After midnight the completion dropped out of that list, hiding the button. The correct un-filtered source wasn't reachable: cards point at `sensor.taskmate_overview`, and the attribute resolver didn't include `sensor.pending_approvals` as a companion, so cards silently fell back to the date-filtered list.

## Changes

- **`taskmate-attr-resolver.js`** — add `sensor.pending_approvals` to the companion list so `chore_completions` resolves from the overview entity.
- **`taskmate-approvals-card.js`** — prefer the resolved `chore_completions` (full pending list); fall back to `todays_completions` only on older backends.
- **`taskmate-parent-dashboard-card.js`** — Approvals tab uses the full pending list; `todays_completions` stays today-only for the Overview tab activity display.
- **`taskmate-overview-card.js`** — pending-approvals count badge uses the full list (it had the same midnight undercount).
- **`sensor.py`** — enrich `pending_approvals` `chore_completions` with bonus sub-task name/points + `bonus_subtask_id`, so cards now reading it render bonus approvals identically to `todays_completions` (prevents a display regression).

The admin Panel (Activity tab) was already correct — it reads the full `pending_completions` list.

## Testing

- New `TestPendingApprovalsSensor` tests: a previous-day pending completion still surfaces; bonus sub-task naming/points/id are correct.
- Verified the resolver + card selection flow against the real resolver source with a mock `hass` where `todays_completions` holds only today and `chore_completions` holds a yesterday item — both cards now surface the yesterday completion.

Fixes #386