### PR TITLE
fix(panel): save ha-switch toggles via input event

### DIFF
--- a/custom_components/taskmate/www/taskmate-panel.js
+++ b/custom_components/taskmate/www/taskmate-panel.js
@@ -601,7 +601,12 @@ class TaskMatePanel extends HTMLElement {
     // Dialog field
     if (this._dialog && t.dataset.field) {
       const field = t.dataset.field;
-      const value = (t.type === "number") ? (t.value === "" ? null : Number(t.value)) : t.value;
+      // ha-switch / checkbox elements fire `input` on toggle in newer HA; their
+      // `value` is the constant string "on", so read `.checked` instead — otherwise
+      // a switch can never be set false (it always stores a truthy string). Mirrors _onChange.
+      let value;
+      if (t.type === "checkbox" || t.tagName === "HA-SWITCH") value = t.checked;
+      else value = (t.type === "number") ? (t.value === "" ? null : Number(t.value)) : t.value;
       const arrMatch = field.match(/^(\w+)\[(\d+)\]\.(\w+)$/);
       if (arrMatch) {
         const [, arr, idx, prop] = arrMatch;


### PR DESCRIPTION
## Summary
Fixes the **Requires parent approval** toggle in the Sidebar admin panel (Edit chore) not saving when switched from YES to NO.

## Root cause
In newer Home Assistant frontends, `ha-switch` fires an `input` event on toggle (not just `change`). The panels `_onInput` generic dialog-field branch stored `t.value`, and a switchs `.value` is the constant string `"on"` — always truthy. So the switch could only ever produce a truthy value:

- **YES → NO**: stored `"on"` → saved as `true` → reverts to YES (the reported bug).
- **NO → YES**: stored `"on"` → saved as `true` → appears to work.

`_onChange` already handled switches correctly via `.checked`, but the `input` event reached `_onInput` first/instead.

## Fix
Read `.checked` for `checkbox` / `HA-SWITCH` elements in `_onInput`, mirroring `_onChange`. This makes every boolean switch in the panel (approval, skip-unavailable, etc.) toggle correctly regardless of whether HA emits `input`, `change`, or both.

## Verification
Reproduced the exact event flow in isolation: the old branch stores `"on"` (saved as `true`), the fixed branch stores `false`. Matches the reported asymmetry.

Fixes #384