### PR TITLE
chore: bump manifest to 3.9.6 for release

### DIFF
--- a/custom_components/taskmate/manifest.json
+++ b/custom_components/taskmate/manifest.json
@@ -17,5 +17,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/tempus2016/taskmate/issues",
   "requirements": [],
-  "version": "3.9.5"
+  "version": "3.9.6"
 }


### PR DESCRIPTION
Bump manifest version to 3.9.6 for the v3.9.6 release.

Includes fixes: #383, #384, #386.