### PR TITLE
fix: resolve codebase audit findings (security, correctness, performance)

### DIFF
--- a/.github/workflows/hassfest.yaml
+++ b/.github/workflows/hassfest.yaml
@@ -15,4 +15,4 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - uses: "actions/checkout@v6"
-      - uses: home-assistant/actions/hassfest@master
+      - uses: home-assistant/actions/hassfest@e91ad1948e57189485b9c1ad608af0c303946f89 # master 2026-06-11

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install ruff
-        run: python -m pip install --upgrade pip ruff
+        run: python -m pip install --upgrade pip "ruff==0.15.12"
 
       - name: Run ruff
         run: ruff check custom_components/taskmate tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Hassfest validation
-        uses: home-assistant/actions/hassfest@master
+        uses: home-assistant/actions/hassfest@e91ad1948e57189485b9c1ad608af0c303946f89 # master 2026-06-11
 
   test:
     name: Run tests

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -14,8 +14,8 @@ jobs:
   hacs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: HACS validation
-        uses: hacs/action@main
+        uses: hacs/action@1ebf01c408f29afcb6406bd431bc98fd8cbb15aa # main 2026-06-08
         with:
           category: integration

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 __pycache__/
 *.pyc
 .pytest_cache/
+.ruff_cache/
+.tmp/
+.claude/
 
 # Dev environment - generated files
 dev/config/.storage/auth

--- a/custom_components/taskmate/__init__.py
+++ b/custom_components/taskmate/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import copy
 import logging
+from functools import wraps
 from pathlib import Path
 
 import yaml
@@ -10,6 +11,7 @@ import yaml
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, ServiceCall, callback
+from homeassistant.exceptions import Unauthorized
 import voluptuous as vol
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.service import async_set_service_schema
@@ -171,9 +173,11 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
         hass.data[DOMAIN].pop(entry.entry_id)
 
-        # If no more entries, unregister services
+        # If no more entries, unregister services. Count only coordinator
+        # instances — hass.data[DOMAIN] also holds bookkeeping flags.
         remaining_entries = [
-            key for key in hass.data[DOMAIN].keys() if key != SERVICES_REGISTERED
+            value for value in hass.data[DOMAIN].values()
+            if isinstance(value, TaskMateCoordinator)
         ]
         if not remaining_entries:
             _async_unregister_services(hass)
@@ -224,6 +228,14 @@ def _async_update_service_descriptions(hass: HomeAssistant) -> None:
         entities = getattr(coordinator.storage, getter)()
         options[field] = [{"label": e.name, "value": e.id} for e in entities]
 
+    # Re-registering schemas deep-copies every dynamic service description;
+    # skip the whole pass when the option sets haven't changed since last time.
+    fingerprint = repr(options)
+    domain_data = hass.data.setdefault(DOMAIN, {})
+    if domain_data.get("_service_desc_fingerprint") == fingerprint:
+        return
+    domain_data["_service_desc_fingerprint"] = fingerprint
+
     base = _load_base_descriptions()
 
     for service_name, service_desc in base.items():
@@ -246,6 +258,22 @@ def _async_update_service_descriptions(hass: HomeAssistant) -> None:
 
 async def _async_register_services(hass: HomeAssistant) -> None:
     """Register TaskMate services."""
+
+    def _admin(handler):
+        """Require an admin user for parent-privileged services.
+
+        Calls without a user context (automations, scripts, schedules) pass
+        through; user-initiated calls must come from an admin, matching the
+        admin gate on the panel's WebSocket commands.
+        """
+        @wraps(handler)
+        async def wrapped(call: ServiceCall) -> None:
+            if call.context.user_id:
+                user = await hass.auth.async_get_user(call.context.user_id)
+                if user is None or not user.is_admin:
+                    raise Unauthorized(context=call.context)
+            await handler(call)
+        return wrapped
 
     async def handle_complete_chore(call: ServiceCall) -> None:
         """Handle the complete_chore service call."""
@@ -753,7 +781,7 @@ async def _async_register_services(hass: HomeAssistant) -> None:
     hass.services.async_register(
         DOMAIN,
         SERVICE_APPROVE_CHORE,
-        handle_approve_chore,
+        _admin(handle_approve_chore),
         schema=vol.Schema(
             {
                 vol.Required("completion_id"): cv.string,
@@ -764,7 +792,7 @@ async def _async_register_services(hass: HomeAssistant) -> None:
     hass.services.async_register(
         DOMAIN,
         SERVICE_REJECT_CHORE,
-        handle_reject_chore,
+        _admin(handle_reject_chore),
         schema=vol.Schema(
             {
                 vol.Required("completion_id"): cv.string,
@@ -787,14 +815,14 @@ async def _async_register_services(hass: HomeAssistant) -> None:
     hass.services.async_register(
         DOMAIN,
         SERVICE_REJECT_REWARD,
-        handle_reject_reward,
+        _admin(handle_reject_reward),
         schema=vol.Schema({ vol.Required("claim_id"): cv.string }),
     )
 
     hass.services.async_register(
         DOMAIN,
         SERVICE_APPROVE_REWARD,
-        handle_approve_reward,
+        _admin(handle_approve_reward),
         schema=vol.Schema(
             {
                 vol.Required("claim_id"): cv.string,
@@ -818,7 +846,7 @@ async def _async_register_services(hass: HomeAssistant) -> None:
     hass.services.async_register(
         DOMAIN,
         SERVICE_ADD_POINTS,
-        handle_add_points,
+        _admin(handle_add_points),
         schema=vol.Schema(
             {
                 vol.Required(ATTR_CHILD_ID): cv.string,
@@ -831,7 +859,7 @@ async def _async_register_services(hass: HomeAssistant) -> None:
     hass.services.async_register(
         DOMAIN,
         SERVICE_REMOVE_POINTS,
-        handle_remove_points,
+        _admin(handle_remove_points),
         schema=vol.Schema(
             {
                 vol.Required(ATTR_CHILD_ID): cv.string,
@@ -859,7 +887,7 @@ async def _async_register_services(hass: HomeAssistant) -> None:
     hass.services.async_register(
         DOMAIN,
         SERVICE_SET_CHORE_ORDER,
-        handle_set_chore_order,
+        _admin(handle_set_chore_order),
         schema=vol.Schema(
             {
                 vol.Required(ATTR_CHILD_ID): cv.string,
@@ -872,7 +900,7 @@ async def _async_register_services(hass: HomeAssistant) -> None:
     hass.services.async_register(
         DOMAIN,
         SERVICE_ADD_PENALTY,
-        handle_add_penalty,
+        _admin(handle_add_penalty),
         schema=vol.Schema({
             vol.Required(ATTR_PENALTY_NAME): cv.string,
             vol.Required(ATTR_PENALTY_POINTS): cv.positive_int,
@@ -885,7 +913,7 @@ async def _async_register_services(hass: HomeAssistant) -> None:
     hass.services.async_register(
         DOMAIN,
         SERVICE_UPDATE_PENALTY,
-        handle_update_penalty,
+        _admin(handle_update_penalty),
         schema=vol.Schema({
             vol.Required(ATTR_PENALTY_ID): cv.string,
             vol.Optional(ATTR_PENALTY_NAME): cv.string,
@@ -899,14 +927,14 @@ async def _async_register_services(hass: HomeAssistant) -> None:
     hass.services.async_register(
         DOMAIN,
         SERVICE_REMOVE_PENALTY,
-        handle_remove_penalty,
+        _admin(handle_remove_penalty),
         schema=vol.Schema({vol.Required(ATTR_PENALTY_ID): cv.string}),
     )
 
     hass.services.async_register(
         DOMAIN,
         SERVICE_APPLY_PENALTY,
-        handle_apply_penalty,
+        _admin(handle_apply_penalty),
         schema=vol.Schema({
             vol.Required(ATTR_PENALTY_ID): cv.string,
             vol.Required(ATTR_CHILD_ID): cv.string,
@@ -916,7 +944,7 @@ async def _async_register_services(hass: HomeAssistant) -> None:
     hass.services.async_register(
         DOMAIN,
         SERVICE_ADD_BONUS,
-        handle_add_bonus,
+        _admin(handle_add_bonus),
         schema=vol.Schema({
             vol.Required(ATTR_BONUS_NAME): cv.string,
             vol.Required(ATTR_BONUS_POINTS): cv.positive_int,
@@ -929,7 +957,7 @@ async def _async_register_services(hass: HomeAssistant) -> None:
     hass.services.async_register(
         DOMAIN,
         SERVICE_UPDATE_BONUS,
-        handle_update_bonus,
+        _admin(handle_update_bonus),
         schema=vol.Schema({
             vol.Required(ATTR_BONUS_ID): cv.string,
             vol.Optional(ATTR_BONUS_NAME): cv.string,
@@ -943,14 +971,14 @@ async def _async_register_services(hass: HomeAssistant) -> None:
     hass.services.async_register(
         DOMAIN,
         SERVICE_REMOVE_BONUS,
-        handle_remove_bonus,
+        _admin(handle_remove_bonus),
         schema=vol.Schema({vol.Required(ATTR_BONUS_ID): cv.string}),
     )
 
     hass.services.async_register(
         DOMAIN,
         SERVICE_APPLY_BONUS,
-        handle_apply_bonus,
+        _admin(handle_apply_bonus),
         schema=vol.Schema({
             vol.Required(ATTR_BONUS_ID): cv.string,
             vol.Required(ATTR_CHILD_ID): cv.string,
@@ -960,7 +988,7 @@ async def _async_register_services(hass: HomeAssistant) -> None:
     hass.services.async_register(
         DOMAIN,
         SERVICE_ADD_CHORE,
-        handle_add_chore,
+        _admin(handle_add_chore),
         schema=vol.Schema({
             vol.Required(ATTR_CHORE_NAME): cv.string,
             vol.Optional(ATTR_CHORE_DESCRIPTION, default=""): cv.string,
@@ -975,14 +1003,14 @@ async def _async_register_services(hass: HomeAssistant) -> None:
     hass.services.async_register(
         DOMAIN,
         SERVICE_SKIP_CHORE,
-        handle_skip_chore,
+        _admin(handle_skip_chore),
         schema=vol.Schema({vol.Required(ATTR_CHORE_ID): cv.string}),
     )
 
     hass.services.async_register(
         DOMAIN,
         SERVICE_SET_CHORE_MANUAL_START,
-        handle_set_chore_manual_start,
+        _admin(handle_set_chore_manual_start),
         schema=vol.Schema({
             vol.Required(ATTR_CHORE_ID): cv.string,
             vol.Required(ATTR_CHILD_ID): cv.string,
@@ -992,7 +1020,7 @@ async def _async_register_services(hass: HomeAssistant) -> None:
     hass.services.async_register(
         DOMAIN,
         SERVICE_ADD_TASK_GROUP,
-        handle_add_task_group,
+        _admin(handle_add_task_group),
         schema=vol.Schema({
             vol.Required(CONF_TASK_GROUP_NAME): cv.string,
             vol.Required(CONF_TASK_GROUP_POLICY): vol.In(TASK_GROUP_POLICIES),
@@ -1003,7 +1031,7 @@ async def _async_register_services(hass: HomeAssistant) -> None:
     hass.services.async_register(
         DOMAIN,
         SERVICE_UPDATE_TASK_GROUP,
-        handle_update_task_group,
+        _admin(handle_update_task_group),
         schema=vol.Schema({
             vol.Required(CONF_TASK_GROUP_ID): cv.string,
             vol.Optional(CONF_TASK_GROUP_NAME): cv.string,
@@ -1015,14 +1043,14 @@ async def _async_register_services(hass: HomeAssistant) -> None:
     hass.services.async_register(
         DOMAIN,
         SERVICE_REMOVE_TASK_GROUP,
-        handle_remove_task_group,
+        _admin(handle_remove_task_group),
         schema=vol.Schema({vol.Required(CONF_TASK_GROUP_ID): cv.string}),
     )
 
     hass.services.async_register(
         DOMAIN,
         "add_badge",
-        handle_add_badge,
+        _admin(handle_add_badge),
         schema=vol.Schema({
             vol.Required(ATTR_BADGE_NAME): cv.string,
             vol.Optional(ATTR_BADGE_DESCRIPTION, default=""): cv.string,
@@ -1038,7 +1066,7 @@ async def _async_register_services(hass: HomeAssistant) -> None:
     hass.services.async_register(
         DOMAIN,
         "update_badge",
-        handle_update_badge,
+        _admin(handle_update_badge),
         schema=vol.Schema({
             vol.Required(ATTR_BADGE_ID): cv.string,
             vol.Optional(ATTR_BADGE_NAME): cv.string,
@@ -1056,14 +1084,14 @@ async def _async_register_services(hass: HomeAssistant) -> None:
     hass.services.async_register(
         DOMAIN,
         "remove_badge",
-        handle_remove_badge,
+        _admin(handle_remove_badge),
         schema=vol.Schema({vol.Required(ATTR_BADGE_ID): cv.string}),
     )
 
     hass.services.async_register(
         DOMAIN,
         "award_badge_manually",
-        handle_award_badge_manually,
+        _admin(handle_award_badge_manually),
         schema=vol.Schema({
             vol.Required(ATTR_BADGE_ID): cv.string,
             vol.Required(ATTR_CHILD_ID): cv.string,
@@ -1073,14 +1101,14 @@ async def _async_register_services(hass: HomeAssistant) -> None:
     hass.services.async_register(
         DOMAIN,
         "revoke_badge",
-        handle_revoke_badge,
+        _admin(handle_revoke_badge),
         schema=vol.Schema({vol.Required(ATTR_AWARDED_BADGE_ID): cv.string}),
     )
 
     hass.services.async_register(
         DOMAIN,
         "rebuild_badges",
-        handle_rebuild_badges,
+        _admin(handle_rebuild_badges),
         schema=vol.Schema({}),
     )
 

--- a/custom_components/taskmate/button.py
+++ b/custom_components/taskmate/button.py
@@ -52,6 +52,8 @@ async def async_setup_entry(
     tracked_combos: set[str] = set()
     for child in children:
         for chore in chores:
+            if getattr(chore, "assignment_mode", "everyone") == "unassigned":
+                continue
             if not chore.assigned_to or child.id in chore.assigned_to:
                 tracked_combos.add(f"{child.id}_{chore.id}_complete")
         for reward in rewards:
@@ -247,49 +249,3 @@ class ClaimRewardButton(TaskMateBaseButton):
             await self.coordinator.async_claim_reward(self.reward_id, self.child_id)
         except ValueError as err:
             _LOGGER.error("Failed to claim reward: %s", err)
-
-
-class ApproveChoreButton(TaskMateBaseButton):
-    """Button to approve a chore completion."""
-
-    def __init__(
-        self,
-        coordinator: TaskMateCoordinator,
-        entry: ConfigEntry,
-        completion_id: str,
-        child_name: str,
-        chore_name: str,
-    ) -> None:
-        """Initialize the button."""
-        super().__init__(coordinator, entry)
-        self.completion_id = completion_id
-        self._attr_unique_id = f"{entry.entry_id}_{completion_id}_approve"
-        self._attr_name = f"Approve: {child_name} - {chore_name}"
-        self._attr_icon = "mdi:check-circle"
-
-    async def async_press(self) -> None:
-        """Handle the button press."""
-        await self.coordinator.async_approve_chore(self.completion_id)
-
-
-class RejectChoreButton(TaskMateBaseButton):
-    """Button to reject a chore completion."""
-
-    def __init__(
-        self,
-        coordinator: TaskMateCoordinator,
-        entry: ConfigEntry,
-        completion_id: str,
-        child_name: str,
-        chore_name: str,
-    ) -> None:
-        """Initialize the button."""
-        super().__init__(coordinator, entry)
-        self.completion_id = completion_id
-        self._attr_unique_id = f"{entry.entry_id}_{completion_id}_reject"
-        self._attr_name = f"Reject: {child_name} - {chore_name}"
-        self._attr_icon = "mdi:close-circle"
-
-    async def async_press(self) -> None:
-        """Handle the button press."""
-        await self.coordinator.async_reject_chore(self.completion_id)

--- a/custom_components/taskmate/coord_assignments.py
+++ b/custom_components/taskmate/coord_assignments.py
@@ -477,7 +477,7 @@ class AssignmentsMixin:
         bonus_subtasks = getattr(chore, 'bonus_subtasks', None) or []
         if bonus_subtasks and active_child_id:
             for bst in bonus_subtasks:
-                bst_id = bst.get('id') if isinstance(bst, dict) else getattr(bst, 'id', None)
+                bst_id = getattr(bst, 'id', None)
                 if bst_id and bst_id not in completed_bonus_ids_today:
                     return False
         return True

--- a/custom_components/taskmate/coord_calendar.py
+++ b/custom_components/taskmate/coord_calendar.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from calendar import monthrange
 from datetime import date, datetime, time, timedelta
 from typing import TYPE_CHECKING
 
@@ -130,12 +131,18 @@ class CalendarMixin:
             except ValueError:
                 return False
 
-        if recurrence == "monthly" and recurrence_start:
+        month_steps = {"monthly": 1, "every_3_months": 3, "every_6_months": 6}.get(recurrence)
+        if month_steps and recurrence_start:
             try:
                 anchor = date.fromisoformat(recurrence_start)
                 if day < anchor:
                     return False
-                return day.day == anchor.day
+                months_diff = (day.year - anchor.year) * 12 + (day.month - anchor.month)
+                if months_diff % month_steps != 0:
+                    return False
+                # Clamp the anchor day for shorter months (e.g. 31st → Feb 28th)
+                target_day = min(anchor.day, monthrange(day.year, day.month)[1])
+                return day.day == target_day
             except ValueError:
                 return False
 

--- a/custom_components/taskmate/coord_chores.py
+++ b/custom_components/taskmate/coord_chores.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+from calendar import monthrange
 from datetime import date, datetime
 from typing import TYPE_CHECKING
 
@@ -13,6 +14,14 @@ if TYPE_CHECKING:
     pass
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _add_months(d: date, months: int) -> date:
+    """Step a date forward by calendar months, clamping to the month's last day."""
+    month_index = d.month - 1 + months
+    year = d.year + month_index // 12
+    month = month_index % 12 + 1
+    return date(year, month, min(d.day, monthrange(year, month)[1]))
 
 
 class ChoresMixin:
@@ -52,7 +61,11 @@ class ChoresMixin:
             if not created_date:
                 created_date = dt_util.as_local(dt_util.now()).date().isoformat()
 
-        resolved_mode = assignment_mode if assignment_mode in ("everyone", "alternating", "random", "balanced") else "everyone"
+        resolved_mode = (
+            assignment_mode
+            if assignment_mode in ("everyone", "alternating", "random", "balanced", "unassigned")
+            else "everyone"
+        )
         today = dt_util.as_local(dt_util.now()).date()
 
         # Apply manual start: for alternating, reorder pool + reset anchor so the
@@ -313,10 +326,7 @@ class ChoresMixin:
         chore.skip_date = ""
         chore.skip_count = 0
 
-        if mode in ("random", "balanced"):
-            chore.assignment_current_child_id = child_id
-        else:
-            chore.assignment_current_child_id = child_id
+        chore.assignment_current_child_id = child_id
 
         self.storage.update_chore(chore)
         await self.storage.async_save()
@@ -561,6 +571,12 @@ class ChoresMixin:
         completions = self.storage.get_completions()
         for completion in completions:
             if completion.id == completion_id:
+                if completion.approved:
+                    _LOGGER.debug(
+                        "Completion %s already approved, ignoring duplicate approval",
+                        completion_id,
+                    )
+                    return
                 chore = self.get_chore(completion.chore_id)
                 child = self.get_child(completion.child_id)
 
@@ -641,9 +657,31 @@ class ChoresMixin:
                         child.total_points_earned = max(0, child.total_points_earned - completion.points_awarded)
                         child.total_chores_completed = max(0, child.total_chores_completed - 1)
 
-                        # Only reverse streak for parent completions
+                        # Only reverse streak for parent completions, and only
+                        # when this was the child's sole completion that day —
+                        # streaks are day-based, not per-completion
                         if not completion.bonus_subtask_id:
-                            child.current_streak = max(0, child.current_streak - 1)
+                            reject_date = dt_util.as_local(completion.completed_at).date()
+                            other_same_day = any(
+                                c.id != completion.id
+                                and c.child_id == completion.child_id
+                                and not c.bonus_subtask_id
+                                and dt_util.as_local(c.completed_at).date() == reject_date
+                                for c in completions
+                            )
+                            if not other_same_day:
+                                child.current_streak = max(0, child.current_streak - 1)
+                                if getattr(child, "last_completion_date", None) == reject_date.isoformat():
+                                    remaining = [
+                                        dt_util.as_local(c.completed_at).date()
+                                        for c in completions
+                                        if c.id != completion.id
+                                        and c.child_id == completion.child_id
+                                        and not c.bonus_subtask_id
+                                    ]
+                                    child.last_completion_date = (
+                                        max(remaining).isoformat() if remaining else None
+                                    )
 
                         self.storage.update_child(child)
                 break
@@ -770,32 +808,28 @@ class ChoresMixin:
             'every_2_days': 2,
             'weekly': 7,
             'every_2_weeks': 14,
-            'monthly': 30,
-            'every_3_months': 90,
-            'every_6_months': 180,
         }.get(recurrence, 7)
 
         record = self.storage.get_last_completed(chore.id, child_id)
         current_iso = record.get('current')
 
         if not current_iso:
-            # Never completed — apply first_occurrence_mode
-            if first_occurrence_mode == 'wait_for_first_occurrence':
-                if recurrence == 'every_2_days' and recurrence_start:
-                    try:
-                        start_date = date.fromisoformat(recurrence_start)
-                        if start_date > today:
-                            return False
-                    except ValueError:
-                        pass
-                elif recurrence_day:
-                    day_map = {
-                        'monday': 0, 'tuesday': 1, 'wednesday': 2, 'thursday': 3,
-                        'friday': 4, 'saturday': 5, 'sunday': 6
-                    }
-                    target_dow = day_map.get(recurrence_day.lower())
-                    if target_dow is not None and today.weekday() != target_dow:
+            # Never completed — a future recurrence anchor always defers
+            # availability, regardless of first_occurrence_mode
+            if recurrence_start:
+                try:
+                    if date.fromisoformat(recurrence_start) > today:
                         return False
+                except ValueError:
+                    pass
+            if first_occurrence_mode == 'wait_for_first_occurrence' and recurrence_day:
+                day_map = {
+                    'monday': 0, 'tuesday': 1, 'wednesday': 2, 'thursday': 3,
+                    'friday': 4, 'saturday': 5, 'sunday': 6
+                }
+                target_dow = day_map.get(recurrence_day.lower())
+                if target_dow is not None and today.weekday() != target_dow:
+                    return False
             return True
 
         try:
@@ -825,6 +859,13 @@ class ChoresMixin:
             target_dow = day_map.get(recurrence_day.lower())
             if target_dow is not None and today.weekday() != target_dow:
                 return False
+
+        # Month-based recurrences use real calendar months so availability
+        # matches the calendar projection (a "monthly" chore re-opens on the
+        # same day next month, not after a fixed 30 days)
+        month_steps = {'monthly': 1, 'every_3_months': 3, 'every_6_months': 6}.get(recurrence)
+        if month_steps:
+            return today >= _add_months(last_dt, month_steps)
 
         days_since = (today - last_dt).days
         return days_since >= window_days

--- a/custom_components/taskmate/coord_notifications.py
+++ b/custom_components/taskmate/coord_notifications.py
@@ -118,7 +118,12 @@ class NotificationCoordinator:
             NOTIF_TYPE_PENDING_REWARD_CLAIM:   "{child_name} claimed '{reward_name}' ({cost} {points_name}) — awaiting approval.",
         }
         tpl = context.get("message_template") or templates.get(meta.id, "")
-        return tpl.format_map(_SafeDict(context))
+        try:
+            return tpl.format_map(_SafeDict(context))
+        except (ValueError, IndexError, KeyError):
+            # Malformed user template (e.g. stray '{') — fall back to raw text
+            _LOGGER.warning("Malformed notification template %r, sending raw", tpl)
+            return tpl
 
     async def _send_to(
         self, notify_service: str, message: str,
@@ -302,9 +307,18 @@ class NotificationCoordinator:
                 if recipient_id.startswith("child:"):
                     child = self.storage.get_child(recipient_id.split(":", 1)[1])
                     child_name = child.name if child else ""
-                message = n.message_template.format_map(
-                    _SafeDict({"child_name": child_name, "time": n.time}),
-                )
+                try:
+                    message = n.message_template.format_map(
+                        _SafeDict({"child_name": child_name, "time": n.time}),
+                    )
+                except (ValueError, IndexError, KeyError):
+                    # Malformed user template — send the raw text rather
+                    # than silently dropping the notification
+                    _LOGGER.warning(
+                        "Malformed custom notification template %r, sending raw",
+                        n.message_template,
+                    )
+                    message = n.message_template
                 service_name = notify_service.split(".", 1)[1] if "." in notify_service else notify_service
                 await self.hass.services.async_call(
                     "notify", service_name,

--- a/custom_components/taskmate/coord_points.py
+++ b/custom_components/taskmate/coord_points.py
@@ -41,7 +41,31 @@ class PointsMixin:
 
         all_completions = self.storage.get_completions()
         children = self.storage.get_children()
+        chores = [c for c in self.storage.get_chores() if getattr(c, "enabled", True)]
         changed = False
+
+        def _required_dates(child_id: str) -> set[str]:
+            """Days last week on which the child had at least one scheduled chore.
+
+            A perfect week shouldn't demand completions on days with nothing
+            due (e.g. weekends for weekday-only chores). Rotation-mode chores
+            are skipped — who was active on a past day can't be reconstructed.
+            """
+            req: set[str] = set()
+            for d_str in last_week_dates:
+                day = date.fromisoformat(d_str)
+                for chore in chores:
+                    assigned = chore.assigned_to or []
+                    if assigned and child_id not in assigned:
+                        continue
+                    if child_id in getattr(chore, "disabled_for", []):
+                        continue
+                    if getattr(chore, "assignment_mode", "everyone") not in ("", "everyone"):
+                        continue
+                    if self._is_chore_scheduled_for_date(chore, day):
+                        req.add(d_str)
+                        break
+            return req
 
         for child in children:
             awarded_weeks = list(getattr(child, 'awarded_perfect_weeks', None) or [])
@@ -64,7 +88,10 @@ class PointsMixin:
                 except (ValueError, TypeError, AttributeError):
                     continue
 
-            if completed_days == last_week_dates:
+            # If no scheduled days can be derived (e.g. rotation-only setups),
+            # fall back to requiring a completion on all 7 days as before
+            required_dates = _required_dates(child.id) or last_week_dates
+            if completed_days >= required_dates:
                 # Perfect week!
                 child.awarded_perfect_weeks = awarded_weeks + [week_key]
                 child.points += perfect_week_bonus

--- a/custom_components/taskmate/coord_timed.py
+++ b/custom_components/taskmate/coord_timed.py
@@ -174,10 +174,11 @@ class TimedMixin:
                 self.storage.remove_timed_session(session.id)
                 continue
 
-            # Close any open segment at midnight
+            # Close any open segment at midnight (tz-aware so it can be
+            # subtracted from the tz-aware segment start)
             if session.segments and session.segments[-1].get("end") is None:
-                midnight_str = f"{today}T00:00:00"
-                session.segments[-1]["end"] = midnight_str
+                midnight = dt_util.start_of_local_day()
+                session.segments[-1]["end"] = midnight.isoformat()
 
             total_seconds = self._calc_session_seconds(session)
             if chore.timed_max_daily_minutes > 0:

--- a/custom_components/taskmate/coordinator.py
+++ b/custom_components/taskmate/coordinator.py
@@ -9,7 +9,7 @@ from typing import Any
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.event import async_track_time_change
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
-from homeassistant.util import dt as dt_util  # noqa: F401 — used by tests as patch target
+from homeassistant.util import dt as dt_util
 
 from .const import DOMAIN
 from .coord_assignments import AssignmentsMixin
@@ -157,24 +157,36 @@ class TaskMateCoordinator(
 
     @callback
     def _async_midnight_streak_check(self, now: datetime) -> None:
-        """Scheduled callback at midnight to check and reset streaks if needed."""
-        self.hass.async_create_task(self._async_check_streaks())
-        self.hass.async_create_task(self._async_expire_one_shot_chores())
-        self.hass.async_create_task(self._async_expire_rewards())
-        self.hass.async_create_task(self._async_stop_stale_timed_sessions())
-        # Rotate assignment_current_child_id and publish today's events to every configured calendar
-        self.hass.async_create_task(self._async_refresh_assignments_and_publish())
+        """Scheduled callback at midnight to run all daily maintenance."""
+        self.hass.async_create_task(self._async_run_midnight_maintenance(now))
+
+    async def _async_run_midnight_maintenance(self, now: datetime) -> None:
+        """Run the midnight maintenance steps sequentially.
+
+        A single task (rather than one task per step) so the read-modify-write
+        steps on shared storage can't interleave and overwrite each other's
+        saves. One step failing must not stop the rest.
+        """
+        steps = [
+            self._async_check_streaks,
+            self._async_expire_one_shot_chores,
+            self._async_expire_rewards,
+            self._async_stop_stale_timed_sessions,
+            # Rotate assignment_current_child_id and publish today's events
+            # to every configured calendar
+            self._async_refresh_assignments_and_publish,
+        ]
         # Check for perfect week bonus every Monday at midnight
         if now.weekday() == 0:
-            self.hass.async_create_task(self._async_check_perfect_week())
+            steps.append(self._async_check_perfect_week)
+        for step in steps:
+            try:
+                await step()
+            except Exception:  # noqa: BLE001
+                _LOGGER.exception("Midnight maintenance step %s failed", step.__name__)
         # Prune all-chores-done daily flags older than today
-        today = dt_util.now().date().isoformat()
-        flags = self.storage._data.get("all_done_flags", {})
-        for key in list(flags.keys()):
-            # Keys are "all_done_<child_id>_<isodate>"
-            if not key.endswith(today):
-                flags.pop(key, None)
-        self.hass.async_create_task(self.storage.async_save())
+        self.storage.prune_all_done_flags(dt_util.now().date().isoformat())
+        await self.storage.async_save()
 
     @callback
     def _async_scheduled_prune(self, now: datetime) -> None:

--- a/custom_components/taskmate/manifest.json
+++ b/custom_components/taskmate/manifest.json
@@ -14,7 +14,7 @@
   ],
   "documentation": "https://github.com/tempus2016/taskmate",
   "integration_type": "service",
-  "iot_class": "local_polling",
+  "iot_class": "calculated",
   "issue_tracker": "https://github.com/tempus2016/taskmate/issues",
   "requirements": [],
   "version": "3.9.6"

--- a/custom_components/taskmate/models.py
+++ b/custom_components/taskmate/models.py
@@ -1,10 +1,13 @@
 """Data models for TaskMate integration."""
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any
 import uuid
+
+_LOGGER = logging.getLogger(__name__)
 
 
 def generate_id() -> str:
@@ -35,6 +38,7 @@ def parse_datetime(value: str | datetime | None) -> datetime | None:
         try:
             dt = datetime.fromisoformat(value)
         except (ValueError, TypeError):
+            _LOGGER.warning("Could not parse stored datetime %r", value)
             return None
         if dt.tzinfo is None:
             return dt.replace(tzinfo=timezone.utc)
@@ -529,7 +533,8 @@ class Penalty:
         return cls(
             id=data.get("id", generate_id()),
             name=data.get("name", ""),
-            points=data.get("points", 0),
+            # Always positive — a negative value would *grant* points on use
+            points=max(0, int(data.get("points", 0) or 0)),
             description=data.get("description", ""),
             icon=data.get("icon", "mdi:alert-circle-outline"),
             assigned_to=list(data.get("assigned_to", [])),
@@ -564,7 +569,8 @@ class Bonus:
         return cls(
             id=data.get("id", generate_id()),
             name=data.get("name", ""),
-            points=data.get("points", 0),
+            # Always positive — a negative value would *deduct* points on use
+            points=max(0, int(data.get("points", 0) or 0)),
             description=data.get("description", ""),
             icon=data.get("icon", "mdi:star-circle-outline"),
             assigned_to=list(data.get("assigned_to", [])),

--- a/custom_components/taskmate/storage.py
+++ b/custom_components/taskmate/storage.py
@@ -386,6 +386,10 @@ class TaskMateStorage:
             if c.get("id") == completion.id:
                 completions[i] = completion.to_dict()
                 return
+        _LOGGER.warning(
+            "update_completion: completion %s not found (possibly pruned mid-update)",
+            completion.id,
+        )
 
     def remove_completion(self, completion_id: str) -> None:
         """Remove a completion record."""
@@ -415,6 +419,10 @@ class TaskMateStorage:
             if c.get("id") == claim.id:
                 claims[i] = claim.to_dict()
                 return
+        _LOGGER.warning(
+            "update_reward_claim: claim %s not found (possibly removed mid-update)",
+            claim.id,
+        )
 
     def remove_reward_claim(self, claim_id: str) -> None:
         """Remove a reward claim."""
@@ -984,6 +992,16 @@ class TaskMateStorage:
         """Remove all career score history for a child."""
         history = self._data.get("career_score_history", {})
         history.pop(child_id, None)
+
+    def prune_all_done_flags(self, keep_date: str) -> None:
+        """Drop all-chores-done flags for dates other than keep_date.
+
+        Keys are "all_done_<child_id>_<isodate>".
+        """
+        flags = self._data.get("all_done_flags", {})
+        for key in list(flags):
+            if not key.endswith(keep_date):
+                flags.pop(key, None)
 
     # Template management
     def get_custom_templates(self) -> list[dict]:

--- a/custom_components/taskmate/strings.json
+++ b/custom_components/taskmate/strings.json
@@ -493,6 +493,24 @@
         }
       }
     },
+    "complete_bonus_subtask": {
+      "name": "Complete Bonus Sub-task",
+      "description": "Complete a bonus sub-task after the parent chore is done",
+      "fields": {
+        "chore_id": {
+          "name": "Chore ID",
+          "description": "The ID of the parent chore"
+        },
+        "bonus_subtask_id": {
+          "name": "Bonus Sub-task ID",
+          "description": "The ID of the bonus sub-task to complete"
+        },
+        "child_id": {
+          "name": "Child ID",
+          "description": "The ID of the child completing the bonus sub-task"
+        }
+      }
+    },
     "approve_chore": {
       "name": "Approve Chore",
       "description": "Approve a completed chore and award points",
@@ -534,6 +552,24 @@
         "claim_id": {
           "name": "Claim ID",
           "description": "The ID of the reward claim to approve"
+        }
+      }
+    },
+    "allocate_points_to_pool": {
+      "name": "Allocate Points to Pool",
+      "description": "Move points from a child's spendable balance into a reward's savings pool (locked).",
+      "fields": {
+        "child_id": {
+          "name": "Child ID",
+          "description": "The ID of the child making the allocation"
+        },
+        "reward_id": {
+          "name": "Reward ID",
+          "description": "The ID of the reward pool to deposit into"
+        },
+        "points": {
+          "name": "Points",
+          "description": "Number of points to allocate (capped at pool capacity and spendable balance)"
         }
       }
     },
@@ -873,6 +909,180 @@
           "name": "Group ID",
           "description": "The ID of the group to delete"
         }
+      }
+    },
+    "start_timed_task": {
+      "name": "Start Timed Task",
+      "description": "Start or resume the timer on a timed task",
+      "fields": {
+        "chore_id": {
+          "name": "Chore ID",
+          "description": "The ID of the timed chore"
+        },
+        "child_id": {
+          "name": "Child ID",
+          "description": "The ID of the child starting the timer"
+        }
+      }
+    },
+    "pause_timed_task": {
+      "name": "Pause Timed Task",
+      "description": "Pause a running timed task timer",
+      "fields": {
+        "chore_id": {
+          "name": "Chore ID",
+          "description": "The ID of the timed chore"
+        },
+        "child_id": {
+          "name": "Child ID",
+          "description": "The ID of the child pausing the timer"
+        }
+      }
+    },
+    "stop_timed_task": {
+      "name": "Stop Timed Task",
+      "description": "Stop a timed task timer and submit for approval",
+      "fields": {
+        "chore_id": {
+          "name": "Chore ID",
+          "description": "The ID of the timed chore"
+        },
+        "child_id": {
+          "name": "Child ID",
+          "description": "The ID of the child stopping the timer"
+        }
+      }
+    },
+    "add_badge": {
+      "name": "Add Badge",
+      "description": "Create a custom badge.",
+      "fields": {
+        "name": {
+          "name": "Name",
+          "description": "The display name of the badge"
+        },
+        "description": {
+          "name": "Description",
+          "description": "Description of how the badge is earned"
+        },
+        "icon": {
+          "name": "Icon",
+          "description": "Icon for the badge (e.g. mdi:beach)"
+        },
+        "tier": {
+          "name": "Tier",
+          "description": "Badge tier: bronze, silver, gold or platinum"
+        },
+        "point_bonus": {
+          "name": "Point bonus",
+          "description": "Points credited to the child when the badge is earned"
+        },
+        "criteria": {
+          "name": "Criteria",
+          "description": "List of {metric, operator, value} dicts. Empty = manual-award only."
+        },
+        "assigned_to": {
+          "name": "Assigned to",
+          "description": "List of child IDs (empty = all)"
+        },
+        "notify_on_earn": {
+          "name": "Notify on earn",
+          "description": "Send a notification when the badge is earned"
+        }
+      }
+    },
+    "update_badge": {
+      "name": "Update Badge",
+      "description": "Update an existing badge. For built-ins, only point_bonus, tier, assigned_to, enabled, notify_on_earn are editable.",
+      "fields": {
+        "badge_id": {
+          "name": "Badge ID",
+          "description": "The ID of the badge to update"
+        },
+        "name": {
+          "name": "Name",
+          "description": "New display name of the badge"
+        },
+        "description": {
+          "name": "Description",
+          "description": "New description of the badge"
+        },
+        "icon": {
+          "name": "Icon",
+          "description": "New icon for the badge"
+        },
+        "tier": {
+          "name": "Tier",
+          "description": "Badge tier: bronze, silver, gold or platinum"
+        },
+        "point_bonus": {
+          "name": "Point bonus",
+          "description": "Points credited to the child when the badge is earned"
+        },
+        "criteria": {
+          "name": "Criteria",
+          "description": "List of {metric, operator, value} dicts. Empty = manual-award only."
+        },
+        "assigned_to": {
+          "name": "Assigned to",
+          "description": "List of child IDs (empty = all)"
+        },
+        "enabled": {
+          "name": "Enabled",
+          "description": "Whether the badge is active"
+        },
+        "notify_on_earn": {
+          "name": "Notify on earn",
+          "description": "Send a notification when the badge is earned"
+        }
+      }
+    },
+    "remove_badge": {
+      "name": "Remove Badge",
+      "description": "Remove a custom badge. Built-ins cannot be removed.",
+      "fields": {
+        "badge_id": {
+          "name": "Badge ID",
+          "description": "The ID of the badge to remove"
+        }
+      }
+    },
+    "award_badge_manually": {
+      "name": "Award Badge Manually",
+      "description": "Manually award a badge to a child.",
+      "fields": {
+        "badge_id": {
+          "name": "Badge ID",
+          "description": "The ID of the badge to award"
+        },
+        "child_id": {
+          "name": "Child ID",
+          "description": "The ID of the child receiving the badge"
+        }
+      }
+    },
+    "revoke_badge": {
+      "name": "Revoke Badge",
+      "description": "Revoke an awarded badge. If a point bonus was credited, it is reversed.",
+      "fields": {
+        "awarded_badge_id": {
+          "name": "Awarded Badge ID",
+          "description": "The ID of the awarded badge record to revoke"
+        }
+      }
+    },
+    "rebuild_badges": {
+      "name": "Rebuild Badges",
+      "description": "Re-evaluate all badges across all children silently (no notifications, no point bonuses)."
+    }
+  },
+  "entity": {
+    "sensor": {
+      "child_stats": {
+        "unit_of_measurement": "chores"
+      },
+      "child_badges": {
+        "unit_of_measurement": "badges"
       }
     }
   }

--- a/custom_components/taskmate/translations/de.json
+++ b/custom_components/taskmate/translations/de.json
@@ -492,6 +492,24 @@
         }
       }
     },
+    "complete_bonus_subtask": {
+      "name": "Bonus-Unteraufgabe erledigen",
+      "description": "Erledigen Sie eine Bonus-Unteraufgabe, nachdem die übergeordnete Aufgabe abgeschlossen wurde",
+      "fields": {
+        "chore_id": {
+          "name": "Aufgaben-ID",
+          "description": "Die ID der übergeordneten Aufgabe"
+        },
+        "bonus_subtask_id": {
+          "name": "Bonus-Unteraufgaben-ID",
+          "description": "Die ID der zu erledigenden Bonus-Unteraufgabe"
+        },
+        "child_id": {
+          "name": "Kinder-ID",
+          "description": "Die ID des Kindes, das die Bonus-Unteraufgabe erledigt"
+        }
+      }
+    },
     "approve_chore": {
       "name": "Genehmigen Sie die Aufgabe",
       "description": "Genehmigen Sie eine erledigte Aufgabe und vergeben Sie Punkte",
@@ -533,6 +551,24 @@
         "claim_id": {
           "name": "Anspruchs-ID",
           "description": "Die ID des zu genehmigenden Prämienanspruchs"
+        }
+      }
+    },
+    "allocate_points_to_pool": {
+      "name": "Punkte dem Pool zuweisen",
+      "description": "Verschieben Sie Punkte vom ausgebbaren Guthaben eines Kindes in den Sparpool einer Belohnung (gesperrt).",
+      "fields": {
+        "child_id": {
+          "name": "Kinder-ID",
+          "description": "Die ID des Kindes, das die Zuweisung vornimmt"
+        },
+        "reward_id": {
+          "name": "Prämien-ID",
+          "description": "Die ID des Belohnungs-Pools, in den eingezahlt werden soll"
+        },
+        "points": {
+          "name": "Punkte",
+          "description": "Anzahl der zuzuweisenden Punkte (begrenzt durch Poolkapazität und ausgebbares Guthaben)"
         }
       }
     },
@@ -873,6 +909,170 @@
           "description": "Die ID der zu löschenden Gruppe"
         }
       }
+    },
+    "start_timed_task": {
+      "name": "Zeitbasierte Aufgabe starten",
+      "description": "Starten Sie den Timer einer zeitbasierten Aufgabe oder setzen Sie ihn fort",
+      "fields": {
+        "chore_id": {
+          "name": "Aufgaben-ID",
+          "description": "Die ID der zeitbasierten Aufgabe"
+        },
+        "child_id": {
+          "name": "Kinder-ID",
+          "description": "Die ID des Kindes, das den Timer startet"
+        }
+      }
+    },
+    "pause_timed_task": {
+      "name": "Zeitbasierte Aufgabe pausieren",
+      "description": "Pausieren Sie den laufenden Timer einer zeitbasierten Aufgabe",
+      "fields": {
+        "chore_id": {
+          "name": "Aufgaben-ID",
+          "description": "Die ID der zeitbasierten Aufgabe"
+        },
+        "child_id": {
+          "name": "Kinder-ID",
+          "description": "Die ID des Kindes, das den Timer pausiert"
+        }
+      }
+    },
+    "stop_timed_task": {
+      "name": "Zeitbasierte Aufgabe stoppen",
+      "description": "Stoppen Sie den Timer einer zeitbasierten Aufgabe und reichen Sie sie zur Genehmigung ein",
+      "fields": {
+        "chore_id": {
+          "name": "Aufgaben-ID",
+          "description": "Die ID der zeitbasierten Aufgabe"
+        },
+        "child_id": {
+          "name": "Kinder-ID",
+          "description": "Die ID des Kindes, das den Timer stoppt"
+        }
+      }
+    },
+    "add_badge": {
+      "name": "Abzeichen hinzufügen",
+      "description": "Erstellen Sie ein eigenes Abzeichen.",
+      "fields": {
+        "name": {
+          "name": "Name",
+          "description": "Der Anzeigename des Abzeichens"
+        },
+        "description": {
+          "name": "Beschreibung",
+          "description": "Beschreibung, wie das Abzeichen verdient wird"
+        },
+        "icon": {
+          "name": "Symbol",
+          "description": "Symbol für das Abzeichen (z. B. mdi:beach)"
+        },
+        "tier": {
+          "name": "Stufe",
+          "description": "Stufe des Abzeichens: Bronze, Silber, Gold oder Platin"
+        },
+        "point_bonus": {
+          "name": "Punktebonus",
+          "description": "Punkte, die dem Kind gutgeschrieben werden, wenn es das Abzeichen verdient"
+        },
+        "criteria": {
+          "name": "Kriterien",
+          "description": "Liste von {metric, operator, value}-Einträgen. Leer = nur manuelle Vergabe."
+        },
+        "assigned_to": {
+          "name": "Zugewiesen an",
+          "description": "Liste von Kinder-IDs (leer = alle)"
+        },
+        "notify_on_earn": {
+          "name": "Benachrichtigung beim Verdienen",
+          "description": "Senden Sie eine Benachrichtigung, wenn das Abzeichen verdient wird"
+        }
+      }
+    },
+    "update_badge": {
+      "name": "Abzeichen aktualisieren",
+      "description": "Aktualisieren Sie ein vorhandenes Abzeichen. Bei integrierten Abzeichen sind nur point_bonus, tier, assigned_to, enabled und notify_on_earn bearbeitbar.",
+      "fields": {
+        "badge_id": {
+          "name": "Abzeichen-ID",
+          "description": "Die ID des zu aktualisierenden Abzeichens"
+        },
+        "name": {
+          "name": "Name",
+          "description": "Neuer Anzeigename des Abzeichens"
+        },
+        "description": {
+          "name": "Beschreibung",
+          "description": "Neue Beschreibung des Abzeichens"
+        },
+        "icon": {
+          "name": "Symbol",
+          "description": "Neues Symbol für das Abzeichen"
+        },
+        "tier": {
+          "name": "Stufe",
+          "description": "Stufe des Abzeichens: Bronze, Silber, Gold oder Platin"
+        },
+        "point_bonus": {
+          "name": "Punktebonus",
+          "description": "Punkte, die dem Kind gutgeschrieben werden, wenn es das Abzeichen verdient"
+        },
+        "criteria": {
+          "name": "Kriterien",
+          "description": "Liste von {metric, operator, value}-Einträgen. Leer = nur manuelle Vergabe."
+        },
+        "assigned_to": {
+          "name": "Zugewiesen an",
+          "description": "Liste von Kinder-IDs (leer = alle)"
+        },
+        "enabled": {
+          "name": "Aktiviert",
+          "description": "Ob das Abzeichen aktiv ist"
+        },
+        "notify_on_earn": {
+          "name": "Benachrichtigung beim Verdienen",
+          "description": "Senden Sie eine Benachrichtigung, wenn das Abzeichen verdient wird"
+        }
+      }
+    },
+    "remove_badge": {
+      "name": "Abzeichen entfernen",
+      "description": "Entfernen Sie ein eigenes Abzeichen. Integrierte Abzeichen können nicht entfernt werden.",
+      "fields": {
+        "badge_id": {
+          "name": "Abzeichen-ID",
+          "description": "Die ID des zu entfernenden Abzeichens"
+        }
+      }
+    },
+    "award_badge_manually": {
+      "name": "Abzeichen manuell vergeben",
+      "description": "Vergeben Sie ein Abzeichen manuell an ein Kind.",
+      "fields": {
+        "badge_id": {
+          "name": "Abzeichen-ID",
+          "description": "Die ID des zu vergebenden Abzeichens"
+        },
+        "child_id": {
+          "name": "Kinder-ID",
+          "description": "Die ID des Kindes, das das Abzeichen erhält"
+        }
+      }
+    },
+    "revoke_badge": {
+      "name": "Abzeichen widerrufen",
+      "description": "Widerrufen Sie ein vergebenes Abzeichen. Wenn ein Punktebonus gutgeschrieben wurde, wird er rückgängig gemacht.",
+      "fields": {
+        "awarded_badge_id": {
+          "name": "ID des vergebenen Abzeichens",
+          "description": "Die ID des vergebenen Abzeichens, das widerrufen werden soll"
+        }
+      }
+    },
+    "rebuild_badges": {
+      "name": "Abzeichen neu berechnen",
+      "description": "Bewerten Sie alle Abzeichen für alle Kinder im Hintergrund neu (keine Benachrichtigungen, keine Punkteboni)."
     }
   },
   "entity": {

--- a/custom_components/taskmate/translations/en-GB.json
+++ b/custom_components/taskmate/translations/en-GB.json
@@ -492,6 +492,24 @@
         }
       }
     },
+    "complete_bonus_subtask": {
+      "name": "Complete Bonus Sub-task",
+      "description": "Complete a bonus sub-task after the parent chore is done",
+      "fields": {
+        "chore_id": {
+          "name": "Chore ID",
+          "description": "The ID of the parent chore"
+        },
+        "bonus_subtask_id": {
+          "name": "Bonus Sub-task ID",
+          "description": "The ID of the bonus sub-task to complete"
+        },
+        "child_id": {
+          "name": "Child ID",
+          "description": "The ID of the child completing the bonus sub-task"
+        }
+      }
+    },
     "approve_chore": {
       "name": "Approve Chore",
       "description": "Approve a completed chore and award points",
@@ -533,6 +551,24 @@
         "claim_id": {
           "name": "Claim ID",
           "description": "The ID of the reward claim to approve"
+        }
+      }
+    },
+    "allocate_points_to_pool": {
+      "name": "Allocate Points to Pool",
+      "description": "Move points from a child's spendable balance into a reward's savings pool (locked).",
+      "fields": {
+        "child_id": {
+          "name": "Child ID",
+          "description": "The ID of the child making the allocation"
+        },
+        "reward_id": {
+          "name": "Reward ID",
+          "description": "The ID of the reward pool to deposit into"
+        },
+        "points": {
+          "name": "Points",
+          "description": "Number of points to allocate (capped at pool capacity and spendable balance)"
         }
       }
     },
@@ -873,6 +909,170 @@
           "description": "The ID of the group to delete"
         }
       }
+    },
+    "start_timed_task": {
+      "name": "Start Timed Task",
+      "description": "Start or resume the timer on a timed task",
+      "fields": {
+        "chore_id": {
+          "name": "Chore ID",
+          "description": "The ID of the timed chore"
+        },
+        "child_id": {
+          "name": "Child ID",
+          "description": "The ID of the child starting the timer"
+        }
+      }
+    },
+    "pause_timed_task": {
+      "name": "Pause Timed Task",
+      "description": "Pause a running timed task timer",
+      "fields": {
+        "chore_id": {
+          "name": "Chore ID",
+          "description": "The ID of the timed chore"
+        },
+        "child_id": {
+          "name": "Child ID",
+          "description": "The ID of the child pausing the timer"
+        }
+      }
+    },
+    "stop_timed_task": {
+      "name": "Stop Timed Task",
+      "description": "Stop a timed task timer and submit for approval",
+      "fields": {
+        "chore_id": {
+          "name": "Chore ID",
+          "description": "The ID of the timed chore"
+        },
+        "child_id": {
+          "name": "Child ID",
+          "description": "The ID of the child stopping the timer"
+        }
+      }
+    },
+    "add_badge": {
+      "name": "Add Badge",
+      "description": "Create a custom badge.",
+      "fields": {
+        "name": {
+          "name": "Name",
+          "description": "The display name of the badge"
+        },
+        "description": {
+          "name": "Description",
+          "description": "Description of how the badge is earned"
+        },
+        "icon": {
+          "name": "Icon",
+          "description": "Icon for the badge (e.g. mdi:beach)"
+        },
+        "tier": {
+          "name": "Tier",
+          "description": "Badge tier: bronze, silver, gold or platinum"
+        },
+        "point_bonus": {
+          "name": "Point bonus",
+          "description": "Points credited to the child when the badge is earned"
+        },
+        "criteria": {
+          "name": "Criteria",
+          "description": "List of {metric, operator, value} dicts. Empty = manual-award only."
+        },
+        "assigned_to": {
+          "name": "Assigned to",
+          "description": "List of child IDs (empty = all)"
+        },
+        "notify_on_earn": {
+          "name": "Notify on earn",
+          "description": "Send a notification when the badge is earned"
+        }
+      }
+    },
+    "update_badge": {
+      "name": "Update Badge",
+      "description": "Update an existing badge. For built-ins, only point_bonus, tier, assigned_to, enabled, notify_on_earn are editable.",
+      "fields": {
+        "badge_id": {
+          "name": "Badge ID",
+          "description": "The ID of the badge to update"
+        },
+        "name": {
+          "name": "Name",
+          "description": "New display name of the badge"
+        },
+        "description": {
+          "name": "Description",
+          "description": "New description of the badge"
+        },
+        "icon": {
+          "name": "Icon",
+          "description": "New icon for the badge"
+        },
+        "tier": {
+          "name": "Tier",
+          "description": "Badge tier: bronze, silver, gold or platinum"
+        },
+        "point_bonus": {
+          "name": "Point bonus",
+          "description": "Points credited to the child when the badge is earned"
+        },
+        "criteria": {
+          "name": "Criteria",
+          "description": "List of {metric, operator, value} dicts. Empty = manual-award only."
+        },
+        "assigned_to": {
+          "name": "Assigned to",
+          "description": "List of child IDs (empty = all)"
+        },
+        "enabled": {
+          "name": "Enabled",
+          "description": "Whether the badge is active"
+        },
+        "notify_on_earn": {
+          "name": "Notify on earn",
+          "description": "Send a notification when the badge is earned"
+        }
+      }
+    },
+    "remove_badge": {
+      "name": "Remove Badge",
+      "description": "Remove a custom badge. Built-ins cannot be removed.",
+      "fields": {
+        "badge_id": {
+          "name": "Badge ID",
+          "description": "The ID of the badge to remove"
+        }
+      }
+    },
+    "award_badge_manually": {
+      "name": "Award Badge Manually",
+      "description": "Manually award a badge to a child.",
+      "fields": {
+        "badge_id": {
+          "name": "Badge ID",
+          "description": "The ID of the badge to award"
+        },
+        "child_id": {
+          "name": "Child ID",
+          "description": "The ID of the child receiving the badge"
+        }
+      }
+    },
+    "revoke_badge": {
+      "name": "Revoke Badge",
+      "description": "Revoke an awarded badge. If a point bonus was credited, it is reversed.",
+      "fields": {
+        "awarded_badge_id": {
+          "name": "Awarded Badge ID",
+          "description": "The ID of the awarded badge record to revoke"
+        }
+      }
+    },
+    "rebuild_badges": {
+      "name": "Rebuild Badges",
+      "description": "Re-evaluate all badges across all children silently (no notifications, no point bonuses)."
     }
   },
   "entity": {

--- a/custom_components/taskmate/translations/en.json
+++ b/custom_components/taskmate/translations/en.json
@@ -492,6 +492,24 @@
         }
       }
     },
+    "complete_bonus_subtask": {
+      "name": "Complete Bonus Sub-task",
+      "description": "Complete a bonus sub-task after the parent chore is done",
+      "fields": {
+        "chore_id": {
+          "name": "Chore ID",
+          "description": "The ID of the parent chore"
+        },
+        "bonus_subtask_id": {
+          "name": "Bonus Sub-task ID",
+          "description": "The ID of the bonus sub-task to complete"
+        },
+        "child_id": {
+          "name": "Child ID",
+          "description": "The ID of the child completing the bonus sub-task"
+        }
+      }
+    },
     "approve_chore": {
       "name": "Approve Chore",
       "description": "Approve a completed chore and award points",
@@ -533,6 +551,24 @@
         "claim_id": {
           "name": "Claim ID",
           "description": "The ID of the reward claim to approve"
+        }
+      }
+    },
+    "allocate_points_to_pool": {
+      "name": "Allocate Points to Pool",
+      "description": "Move points from a child's spendable balance into a reward's savings pool (locked).",
+      "fields": {
+        "child_id": {
+          "name": "Child ID",
+          "description": "The ID of the child making the allocation"
+        },
+        "reward_id": {
+          "name": "Reward ID",
+          "description": "The ID of the reward pool to deposit into"
+        },
+        "points": {
+          "name": "Points",
+          "description": "Number of points to allocate (capped at pool capacity and spendable balance)"
         }
       }
     },
@@ -873,6 +909,170 @@
           "description": "The ID of the group to delete"
         }
       }
+    },
+    "start_timed_task": {
+      "name": "Start Timed Task",
+      "description": "Start or resume the timer on a timed task",
+      "fields": {
+        "chore_id": {
+          "name": "Chore ID",
+          "description": "The ID of the timed chore"
+        },
+        "child_id": {
+          "name": "Child ID",
+          "description": "The ID of the child starting the timer"
+        }
+      }
+    },
+    "pause_timed_task": {
+      "name": "Pause Timed Task",
+      "description": "Pause a running timed task timer",
+      "fields": {
+        "chore_id": {
+          "name": "Chore ID",
+          "description": "The ID of the timed chore"
+        },
+        "child_id": {
+          "name": "Child ID",
+          "description": "The ID of the child pausing the timer"
+        }
+      }
+    },
+    "stop_timed_task": {
+      "name": "Stop Timed Task",
+      "description": "Stop a timed task timer and submit for approval",
+      "fields": {
+        "chore_id": {
+          "name": "Chore ID",
+          "description": "The ID of the timed chore"
+        },
+        "child_id": {
+          "name": "Child ID",
+          "description": "The ID of the child stopping the timer"
+        }
+      }
+    },
+    "add_badge": {
+      "name": "Add Badge",
+      "description": "Create a custom badge.",
+      "fields": {
+        "name": {
+          "name": "Name",
+          "description": "The display name of the badge"
+        },
+        "description": {
+          "name": "Description",
+          "description": "Description of how the badge is earned"
+        },
+        "icon": {
+          "name": "Icon",
+          "description": "Icon for the badge (e.g. mdi:beach)"
+        },
+        "tier": {
+          "name": "Tier",
+          "description": "Badge tier: bronze, silver, gold or platinum"
+        },
+        "point_bonus": {
+          "name": "Point bonus",
+          "description": "Points credited to the child when the badge is earned"
+        },
+        "criteria": {
+          "name": "Criteria",
+          "description": "List of {metric, operator, value} dicts. Empty = manual-award only."
+        },
+        "assigned_to": {
+          "name": "Assigned to",
+          "description": "List of child IDs (empty = all)"
+        },
+        "notify_on_earn": {
+          "name": "Notify on earn",
+          "description": "Send a notification when the badge is earned"
+        }
+      }
+    },
+    "update_badge": {
+      "name": "Update Badge",
+      "description": "Update an existing badge. For built-ins, only point_bonus, tier, assigned_to, enabled, notify_on_earn are editable.",
+      "fields": {
+        "badge_id": {
+          "name": "Badge ID",
+          "description": "The ID of the badge to update"
+        },
+        "name": {
+          "name": "Name",
+          "description": "New display name of the badge"
+        },
+        "description": {
+          "name": "Description",
+          "description": "New description of the badge"
+        },
+        "icon": {
+          "name": "Icon",
+          "description": "New icon for the badge"
+        },
+        "tier": {
+          "name": "Tier",
+          "description": "Badge tier: bronze, silver, gold or platinum"
+        },
+        "point_bonus": {
+          "name": "Point bonus",
+          "description": "Points credited to the child when the badge is earned"
+        },
+        "criteria": {
+          "name": "Criteria",
+          "description": "List of {metric, operator, value} dicts. Empty = manual-award only."
+        },
+        "assigned_to": {
+          "name": "Assigned to",
+          "description": "List of child IDs (empty = all)"
+        },
+        "enabled": {
+          "name": "Enabled",
+          "description": "Whether the badge is active"
+        },
+        "notify_on_earn": {
+          "name": "Notify on earn",
+          "description": "Send a notification when the badge is earned"
+        }
+      }
+    },
+    "remove_badge": {
+      "name": "Remove Badge",
+      "description": "Remove a custom badge. Built-ins cannot be removed.",
+      "fields": {
+        "badge_id": {
+          "name": "Badge ID",
+          "description": "The ID of the badge to remove"
+        }
+      }
+    },
+    "award_badge_manually": {
+      "name": "Award Badge Manually",
+      "description": "Manually award a badge to a child.",
+      "fields": {
+        "badge_id": {
+          "name": "Badge ID",
+          "description": "The ID of the badge to award"
+        },
+        "child_id": {
+          "name": "Child ID",
+          "description": "The ID of the child receiving the badge"
+        }
+      }
+    },
+    "revoke_badge": {
+      "name": "Revoke Badge",
+      "description": "Revoke an awarded badge. If a point bonus was credited, it is reversed.",
+      "fields": {
+        "awarded_badge_id": {
+          "name": "Awarded Badge ID",
+          "description": "The ID of the awarded badge record to revoke"
+        }
+      }
+    },
+    "rebuild_badges": {
+      "name": "Rebuild Badges",
+      "description": "Re-evaluate all badges across all children silently (no notifications, no point bonuses)."
     }
   },
   "entity": {

--- a/custom_components/taskmate/translations/fr.json
+++ b/custom_components/taskmate/translations/fr.json
@@ -492,6 +492,24 @@
         }
       }
     },
+    "complete_bonus_subtask": {
+      "name": "Terminer une sous-tâche bonus",
+      "description": "Terminer une sous-tâche bonus une fois la corvée parente terminée",
+      "fields": {
+        "chore_id": {
+          "name": "ID de la corvée",
+          "description": "L'identifiant de la corvée parente"
+        },
+        "bonus_subtask_id": {
+          "name": "ID de la sous-tâche bonus",
+          "description": "L'identifiant de la sous-tâche bonus à terminer"
+        },
+        "child_id": {
+          "name": "ID de l'enfant",
+          "description": "L'identifiant de l'enfant effectuant la sous-tâche bonus"
+        }
+      }
+    },
     "approve_chore": {
       "name": "Approuver une corvée",
       "description": "Approuver une corvée terminée et attribuer les points",
@@ -533,6 +551,24 @@
         "claim_id": {
           "name": "ID de la demande",
           "description": "L'identifiant de la demande de récompense à approuver"
+        }
+      }
+    },
+    "allocate_points_to_pool": {
+      "name": "Allouer des points à la cagnotte",
+      "description": "Déplacer des points du solde disponible d'un enfant vers la cagnotte d'une récompense (verrouillée).",
+      "fields": {
+        "child_id": {
+          "name": "ID de l'enfant",
+          "description": "L'identifiant de l'enfant effectuant l'allocation"
+        },
+        "reward_id": {
+          "name": "ID de la récompense",
+          "description": "L'identifiant de la cagnotte de récompense où déposer les points"
+        },
+        "points": {
+          "name": "Points",
+          "description": "Nombre de points à allouer (limité par la capacité de la cagnotte et le solde disponible)"
         }
       }
     },
@@ -873,6 +909,170 @@
           "description": "The ID of the group to delete"
         }
       }
+    },
+    "start_timed_task": {
+      "name": "Démarrer une tâche chronométrée",
+      "description": "Démarrer ou reprendre le minuteur d'une tâche chronométrée",
+      "fields": {
+        "chore_id": {
+          "name": "ID de la corvée",
+          "description": "L'identifiant de la corvée chronométrée"
+        },
+        "child_id": {
+          "name": "ID de l'enfant",
+          "description": "L'identifiant de l'enfant démarrant le minuteur"
+        }
+      }
+    },
+    "pause_timed_task": {
+      "name": "Mettre en pause une tâche chronométrée",
+      "description": "Mettre en pause le minuteur d'une tâche chronométrée en cours",
+      "fields": {
+        "chore_id": {
+          "name": "ID de la corvée",
+          "description": "L'identifiant de la corvée chronométrée"
+        },
+        "child_id": {
+          "name": "ID de l'enfant",
+          "description": "L'identifiant de l'enfant mettant le minuteur en pause"
+        }
+      }
+    },
+    "stop_timed_task": {
+      "name": "Arrêter une tâche chronométrée",
+      "description": "Arrêter le minuteur d'une tâche chronométrée et la soumettre pour approbation",
+      "fields": {
+        "chore_id": {
+          "name": "ID de la corvée",
+          "description": "L'identifiant de la corvée chronométrée"
+        },
+        "child_id": {
+          "name": "ID de l'enfant",
+          "description": "L'identifiant de l'enfant arrêtant le minuteur"
+        }
+      }
+    },
+    "add_badge": {
+      "name": "Ajouter un badge",
+      "description": "Créer un badge personnalisé.",
+      "fields": {
+        "name": {
+          "name": "Nom",
+          "description": "Le nom affiché du badge"
+        },
+        "description": {
+          "name": "Description",
+          "description": "Description de la façon d'obtenir le badge"
+        },
+        "icon": {
+          "name": "Icône",
+          "description": "Icône du badge (ex. mdi:beach)"
+        },
+        "tier": {
+          "name": "Niveau",
+          "description": "Niveau du badge : bronze, argent, or ou platine"
+        },
+        "point_bonus": {
+          "name": "Bonus de points",
+          "description": "Points crédités à l'enfant lorsque le badge est obtenu"
+        },
+        "criteria": {
+          "name": "Critères",
+          "description": "Liste de dictionnaires {metric, operator, value}. Vide = attribution manuelle uniquement."
+        },
+        "assigned_to": {
+          "name": "Attribué à",
+          "description": "Liste d'identifiants d'enfants (vide = tous)"
+        },
+        "notify_on_earn": {
+          "name": "Notifier à l'obtention",
+          "description": "Envoyer une notification lorsque le badge est obtenu"
+        }
+      }
+    },
+    "update_badge": {
+      "name": "Mettre à jour un badge",
+      "description": "Mettre à jour un badge existant. Pour les badges intégrés, seuls point_bonus, tier, assigned_to, enabled et notify_on_earn sont modifiables.",
+      "fields": {
+        "badge_id": {
+          "name": "ID du badge",
+          "description": "L'identifiant du badge à mettre à jour"
+        },
+        "name": {
+          "name": "Nom",
+          "description": "Nouveau nom affiché du badge"
+        },
+        "description": {
+          "name": "Description",
+          "description": "Nouvelle description du badge"
+        },
+        "icon": {
+          "name": "Icône",
+          "description": "Nouvelle icône du badge"
+        },
+        "tier": {
+          "name": "Niveau",
+          "description": "Niveau du badge : bronze, argent, or ou platine"
+        },
+        "point_bonus": {
+          "name": "Bonus de points",
+          "description": "Points crédités à l'enfant lorsque le badge est obtenu"
+        },
+        "criteria": {
+          "name": "Critères",
+          "description": "Liste de dictionnaires {metric, operator, value}. Vide = attribution manuelle uniquement."
+        },
+        "assigned_to": {
+          "name": "Attribué à",
+          "description": "Liste d'identifiants d'enfants (vide = tous)"
+        },
+        "enabled": {
+          "name": "Activé",
+          "description": "Indique si le badge est actif"
+        },
+        "notify_on_earn": {
+          "name": "Notifier à l'obtention",
+          "description": "Envoyer une notification lorsque le badge est obtenu"
+        }
+      }
+    },
+    "remove_badge": {
+      "name": "Supprimer un badge",
+      "description": "Supprimer un badge personnalisé. Les badges intégrés ne peuvent pas être supprimés.",
+      "fields": {
+        "badge_id": {
+          "name": "ID du badge",
+          "description": "L'identifiant du badge à supprimer"
+        }
+      }
+    },
+    "award_badge_manually": {
+      "name": "Attribuer un badge manuellement",
+      "description": "Attribuer manuellement un badge à un enfant.",
+      "fields": {
+        "badge_id": {
+          "name": "ID du badge",
+          "description": "L'identifiant du badge à attribuer"
+        },
+        "child_id": {
+          "name": "ID de l'enfant",
+          "description": "L'identifiant de l'enfant recevant le badge"
+        }
+      }
+    },
+    "revoke_badge": {
+      "name": "Révoquer un badge",
+      "description": "Révoquer un badge attribué. Si un bonus de points a été crédité, il est annulé.",
+      "fields": {
+        "awarded_badge_id": {
+          "name": "ID du badge attribué",
+          "description": "L'identifiant du badge attribué à révoquer"
+        }
+      }
+    },
+    "rebuild_badges": {
+      "name": "Recalculer les badges",
+      "description": "Réévaluer silencieusement tous les badges pour tous les enfants (sans notifications ni bonus de points)."
     }
   },
   "entity": {

--- a/custom_components/taskmate/translations/nb.json
+++ b/custom_components/taskmate/translations/nb.json
@@ -492,6 +492,24 @@
         }
       }
     },
+    "complete_bonus_subtask": {
+      "name": "Fullfør bonusdeloppgave",
+      "description": "Fullfør en bonusdeloppgave etter at hovedoppgaven er fullført",
+      "fields": {
+        "chore_id": {
+          "name": "Oppgave-ID",
+          "description": "ID-en til hovedoppgaven"
+        },
+        "bonus_subtask_id": {
+          "name": "Bonusdeloppgave-ID",
+          "description": "ID-en til bonusdeloppgaven som skal fullføres"
+        },
+        "child_id": {
+          "name": "Barn-ID",
+          "description": "ID-en til barnet som fullfører bonusdeloppgaven"
+        }
+      }
+    },
     "approve_chore": {
       "name": "Godkjenn oppgave",
       "description": "Godkjenn en fullført oppgave og tildel poeng",
@@ -533,6 +551,24 @@
         "claim_id": {
           "name": "Krav-ID",
           "description": "ID-en til belønningskravet som skal godkjennes"
+        }
+      }
+    },
+    "allocate_points_to_pool": {
+      "name": "Tildel poeng til sparegris",
+      "description": "Flytt poeng fra et barns disponible saldo til en belønnings sparegris (låst).",
+      "fields": {
+        "child_id": {
+          "name": "Barn-ID",
+          "description": "ID-en til barnet som gjør tildelingen"
+        },
+        "reward_id": {
+          "name": "Belønnings-ID",
+          "description": "ID-en til belønningens sparegris det skal settes inn i"
+        },
+        "points": {
+          "name": "Poeng",
+          "description": "Antall poeng å tildele (begrenset av sparegrisens kapasitet og disponibel saldo)"
         }
       }
     },
@@ -873,6 +909,170 @@
           "description": "The ID of the group to delete"
         }
       }
+    },
+    "start_timed_task": {
+      "name": "Start tidsbasert oppgave",
+      "description": "Start eller gjenoppta timeren på en tidsbasert oppgave",
+      "fields": {
+        "chore_id": {
+          "name": "Oppgave-ID",
+          "description": "ID-en til den tidsbaserte oppgaven"
+        },
+        "child_id": {
+          "name": "Barn-ID",
+          "description": "ID-en til barnet som starter timeren"
+        }
+      }
+    },
+    "pause_timed_task": {
+      "name": "Sett tidsbasert oppgave på pause",
+      "description": "Sett timeren på en tidsbasert oppgave på pause",
+      "fields": {
+        "chore_id": {
+          "name": "Oppgave-ID",
+          "description": "ID-en til den tidsbaserte oppgaven"
+        },
+        "child_id": {
+          "name": "Barn-ID",
+          "description": "ID-en til barnet som pauser timeren"
+        }
+      }
+    },
+    "stop_timed_task": {
+      "name": "Stopp tidsbasert oppgave",
+      "description": "Stopp timeren på en tidsbasert oppgave og send inn til godkjenning",
+      "fields": {
+        "chore_id": {
+          "name": "Oppgave-ID",
+          "description": "ID-en til den tidsbaserte oppgaven"
+        },
+        "child_id": {
+          "name": "Barn-ID",
+          "description": "ID-en til barnet som stopper timeren"
+        }
+      }
+    },
+    "add_badge": {
+      "name": "Legg til merke",
+      "description": "Opprett et egendefinert merke.",
+      "fields": {
+        "name": {
+          "name": "Navn",
+          "description": "Visningsnavnet til merket"
+        },
+        "description": {
+          "name": "Beskrivelse",
+          "description": "Beskrivelse av hvordan merket oppnås"
+        },
+        "icon": {
+          "name": "Ikon",
+          "description": "Ikon for merket (f.eks. mdi:beach)"
+        },
+        "tier": {
+          "name": "Nivå",
+          "description": "Merkets nivå: bronse, sølv, gull eller platina"
+        },
+        "point_bonus": {
+          "name": "Poengbonus",
+          "description": "Poeng som krediteres barnet når merket oppnås"
+        },
+        "criteria": {
+          "name": "Kriterier",
+          "description": "Liste med {metric, operator, value}-oppføringer. Tom = kun manuell tildeling."
+        },
+        "assigned_to": {
+          "name": "Tildelt til",
+          "description": "Liste med barn-ID-er (tom = alle)"
+        },
+        "notify_on_earn": {
+          "name": "Varsle ved oppnåelse",
+          "description": "Send et varsel når merket oppnås"
+        }
+      }
+    },
+    "update_badge": {
+      "name": "Oppdater merke",
+      "description": "Oppdater et eksisterende merke. For innebygde merker kan kun point_bonus, tier, assigned_to, enabled og notify_on_earn redigeres.",
+      "fields": {
+        "badge_id": {
+          "name": "Merke-ID",
+          "description": "ID-en til merket som skal oppdateres"
+        },
+        "name": {
+          "name": "Navn",
+          "description": "Nytt visningsnavn for merket"
+        },
+        "description": {
+          "name": "Beskrivelse",
+          "description": "Ny beskrivelse av merket"
+        },
+        "icon": {
+          "name": "Ikon",
+          "description": "Nytt ikon for merket"
+        },
+        "tier": {
+          "name": "Nivå",
+          "description": "Merkets nivå: bronse, sølv, gull eller platina"
+        },
+        "point_bonus": {
+          "name": "Poengbonus",
+          "description": "Poeng som krediteres barnet når merket oppnås"
+        },
+        "criteria": {
+          "name": "Kriterier",
+          "description": "Liste med {metric, operator, value}-oppføringer. Tom = kun manuell tildeling."
+        },
+        "assigned_to": {
+          "name": "Tildelt til",
+          "description": "Liste med barn-ID-er (tom = alle)"
+        },
+        "enabled": {
+          "name": "Aktivert",
+          "description": "Om merket er aktivt"
+        },
+        "notify_on_earn": {
+          "name": "Varsle ved oppnåelse",
+          "description": "Send et varsel når merket oppnås"
+        }
+      }
+    },
+    "remove_badge": {
+      "name": "Fjern merke",
+      "description": "Fjern et egendefinert merke. Innebygde merker kan ikke fjernes.",
+      "fields": {
+        "badge_id": {
+          "name": "Merke-ID",
+          "description": "ID-en til merket som skal fjernes"
+        }
+      }
+    },
+    "award_badge_manually": {
+      "name": "Tildel merke manuelt",
+      "description": "Tildel et merke manuelt til et barn.",
+      "fields": {
+        "badge_id": {
+          "name": "Merke-ID",
+          "description": "ID-en til merket som skal tildeles"
+        },
+        "child_id": {
+          "name": "Barn-ID",
+          "description": "ID-en til barnet som mottar merket"
+        }
+      }
+    },
+    "revoke_badge": {
+      "name": "Tilbakekall merke",
+      "description": "Tilbakekall et tildelt merke. Hvis en poengbonus ble kreditert, blir den reversert.",
+      "fields": {
+        "awarded_badge_id": {
+          "name": "Tildelt merke-ID",
+          "description": "ID-en til det tildelte merket som skal tilbakekalles"
+        }
+      }
+    },
+    "rebuild_badges": {
+      "name": "Gjenoppbygg merker",
+      "description": "Reevaluer alle merker for alle barn i stillhet (ingen varsler, ingen poengbonuser)."
     }
   },
   "entity": {

--- a/custom_components/taskmate/translations/nn.json
+++ b/custom_components/taskmate/translations/nn.json
@@ -492,6 +492,24 @@
         }
       }
     },
+    "complete_bonus_subtask": {
+      "name": "Fullfør bonus-deloppgåve",
+      "description": "Fullfør ei bonus-deloppgåve etter at hovudoppgåva er fullført",
+      "fields": {
+        "chore_id": {
+          "name": "Oppgåve-ID",
+          "description": "ID-en til hovudoppgåva"
+        },
+        "bonus_subtask_id": {
+          "name": "Bonus-deloppgåve-ID",
+          "description": "ID-en til bonus-deloppgåva som skal fullførast"
+        },
+        "child_id": {
+          "name": "Born-ID",
+          "description": "ID-en til bornet som fullfører bonus-deloppgåva"
+        }
+      }
+    },
     "approve_chore": {
       "name": "Godkjenn oppgåve",
       "description": "Godkjenn ei fullført oppgåve og tildel poeng",
@@ -533,6 +551,24 @@
         "claim_id": {
           "name": "Krav-ID",
           "description": "ID-en til løningskravet som skal godkjennast"
+        }
+      }
+    },
+    "allocate_points_to_pool": {
+      "name": "Tildel poeng til sparegris",
+      "description": "Flytt poeng frå den disponible saldoen til eit born inn i sparegrisen til ei løning (låst).",
+      "fields": {
+        "child_id": {
+          "name": "Born-ID",
+          "description": "ID-en til bornet som gjer tildelinga"
+        },
+        "reward_id": {
+          "name": "Lønings-ID",
+          "description": "ID-en til sparegrisen til løninga det skal setjast inn i"
+        },
+        "points": {
+          "name": "Poeng",
+          "description": "Tal poeng å tildele (avgrensa av kapasiteten til sparegrisen og disponibel saldo)"
         }
       }
     },
@@ -873,6 +909,170 @@
           "description": "The ID of the group to delete"
         }
       }
+    },
+    "start_timed_task": {
+      "name": "Start tidsstyrt oppgåve",
+      "description": "Start eller hald fram timeren på ei tidsstyrt oppgåve",
+      "fields": {
+        "chore_id": {
+          "name": "Oppgåve-ID",
+          "description": "ID-en til den tidsstyrte oppgåva"
+        },
+        "child_id": {
+          "name": "Born-ID",
+          "description": "ID-en til bornet som startar timeren"
+        }
+      }
+    },
+    "pause_timed_task": {
+      "name": "Set tidsstyrt oppgåve på pause",
+      "description": "Set timeren på ei tidsstyrt oppgåve på pause",
+      "fields": {
+        "chore_id": {
+          "name": "Oppgåve-ID",
+          "description": "ID-en til den tidsstyrte oppgåva"
+        },
+        "child_id": {
+          "name": "Born-ID",
+          "description": "ID-en til bornet som pausar timeren"
+        }
+      }
+    },
+    "stop_timed_task": {
+      "name": "Stopp tidsstyrt oppgåve",
+      "description": "Stopp timeren på ei tidsstyrt oppgåve og send inn til godkjenning",
+      "fields": {
+        "chore_id": {
+          "name": "Oppgåve-ID",
+          "description": "ID-en til den tidsstyrte oppgåva"
+        },
+        "child_id": {
+          "name": "Born-ID",
+          "description": "ID-en til bornet som stoppar timeren"
+        }
+      }
+    },
+    "add_badge": {
+      "name": "Legg til merke",
+      "description": "Opprett eit eigendefinert merke.",
+      "fields": {
+        "name": {
+          "name": "Namn",
+          "description": "Visingsnamnet til merket"
+        },
+        "description": {
+          "name": "Skildring",
+          "description": "Skildring av korleis merket vert oppnådd"
+        },
+        "icon": {
+          "name": "Ikon",
+          "description": "Ikon for merket (t.d. mdi:beach)"
+        },
+        "tier": {
+          "name": "Nivå",
+          "description": "Nivået til merket: bronse, sølv, gull eller platina"
+        },
+        "point_bonus": {
+          "name": "Poengbonus",
+          "description": "Poeng som vert krediterte bornet når merket vert oppnådd"
+        },
+        "criteria": {
+          "name": "Kriterium",
+          "description": "Liste med {metric, operator, value}-oppføringar. Tom = berre manuell tildeling."
+        },
+        "assigned_to": {
+          "name": "Tildelt til",
+          "description": "Liste med born-ID-ar (tom = alle)"
+        },
+        "notify_on_earn": {
+          "name": "Varsle ved oppnåing",
+          "description": "Send eit varsel når merket vert oppnådd"
+        }
+      }
+    },
+    "update_badge": {
+      "name": "Oppdater merke",
+      "description": "Oppdater eit eksisterande merke. For innebygde merke kan berre point_bonus, tier, assigned_to, enabled og notify_on_earn redigerast.",
+      "fields": {
+        "badge_id": {
+          "name": "Merke-ID",
+          "description": "ID-en til merket som skal oppdaterast"
+        },
+        "name": {
+          "name": "Namn",
+          "description": "Nytt visingsnamn for merket"
+        },
+        "description": {
+          "name": "Skildring",
+          "description": "Ny skildring av merket"
+        },
+        "icon": {
+          "name": "Ikon",
+          "description": "Nytt ikon for merket"
+        },
+        "tier": {
+          "name": "Nivå",
+          "description": "Nivået til merket: bronse, sølv, gull eller platina"
+        },
+        "point_bonus": {
+          "name": "Poengbonus",
+          "description": "Poeng som vert krediterte bornet når merket vert oppnådd"
+        },
+        "criteria": {
+          "name": "Kriterium",
+          "description": "Liste med {metric, operator, value}-oppføringar. Tom = berre manuell tildeling."
+        },
+        "assigned_to": {
+          "name": "Tildelt til",
+          "description": "Liste med born-ID-ar (tom = alle)"
+        },
+        "enabled": {
+          "name": "Aktivert",
+          "description": "Om merket er aktivt"
+        },
+        "notify_on_earn": {
+          "name": "Varsle ved oppnåing",
+          "description": "Send eit varsel når merket vert oppnådd"
+        }
+      }
+    },
+    "remove_badge": {
+      "name": "Fjern merke",
+      "description": "Fjern eit eigendefinert merke. Innebygde merke kan ikkje fjernast.",
+      "fields": {
+        "badge_id": {
+          "name": "Merke-ID",
+          "description": "ID-en til merket som skal fjernast"
+        }
+      }
+    },
+    "award_badge_manually": {
+      "name": "Tildel merke manuelt",
+      "description": "Tildel eit merke manuelt til eit born.",
+      "fields": {
+        "badge_id": {
+          "name": "Merke-ID",
+          "description": "ID-en til merket som skal tildelast"
+        },
+        "child_id": {
+          "name": "Born-ID",
+          "description": "ID-en til bornet som tek imot merket"
+        }
+      }
+    },
+    "revoke_badge": {
+      "name": "Tilbakekall merke",
+      "description": "Tilbakekall eit tildelt merke. Om ein poengbonus vart kreditert, vert han reversert.",
+      "fields": {
+        "awarded_badge_id": {
+          "name": "Tildelt merke-ID",
+          "description": "ID-en til det tildelte merket som skal tilbakekallast"
+        }
+      }
+    },
+    "rebuild_badges": {
+      "name": "Bygg opp att merke",
+      "description": "Reevaluer alle merke for alle born i det stille (ingen varsel, ingen poengbonusar)."
     }
   },
   "entity": {

--- a/custom_components/taskmate/translations/pt-BR.json
+++ b/custom_components/taskmate/translations/pt-BR.json
@@ -492,6 +492,24 @@
         }
       }
     },
+    "complete_bonus_subtask": {
+      "name": "Concluir subtarefa bônus",
+      "description": "Concluir uma subtarefa bônus depois que a tarefa principal for concluída",
+      "fields": {
+        "chore_id": {
+          "name": "ID da tarefa",
+          "description": "O ID da tarefa principal"
+        },
+        "bonus_subtask_id": {
+          "name": "ID da subtarefa bônus",
+          "description": "O ID da subtarefa bônus a concluir"
+        },
+        "child_id": {
+          "name": "ID da criança",
+          "description": "O ID da criança que conclui a subtarefa bônus"
+        }
+      }
+    },
     "approve_chore": {
       "name": "Aprovar tarefa",
       "description": "Aprovar uma tarefa concluída e atribuir pontos",
@@ -533,6 +551,24 @@
         "claim_id": {
           "name": "ID do pedido",
           "description": "O ID do pedido de recompensa a aprovar"
+        }
+      }
+    },
+    "allocate_points_to_pool": {
+      "name": "Alocar pontos ao cofrinho",
+      "description": "Mover pontos do saldo disponível de uma criança para o cofrinho de uma recompensa (bloqueado).",
+      "fields": {
+        "child_id": {
+          "name": "ID da criança",
+          "description": "O ID da criança que faz a alocação"
+        },
+        "reward_id": {
+          "name": "ID da recompensa",
+          "description": "O ID do cofrinho da recompensa onde depositar"
+        },
+        "points": {
+          "name": "Pontos",
+          "description": "Número de pontos a alocar (limitado pela capacidade do cofrinho e pelo saldo disponível)"
         }
       }
     },
@@ -873,6 +909,170 @@
           "description": "The ID of the group to delete"
         }
       }
+    },
+    "start_timed_task": {
+      "name": "Iniciar tarefa cronometrada",
+      "description": "Iniciar ou retomar o cronômetro de uma tarefa cronometrada",
+      "fields": {
+        "chore_id": {
+          "name": "ID da tarefa",
+          "description": "O ID da tarefa cronometrada"
+        },
+        "child_id": {
+          "name": "ID da criança",
+          "description": "O ID da criança que inicia o cronômetro"
+        }
+      }
+    },
+    "pause_timed_task": {
+      "name": "Pausar tarefa cronometrada",
+      "description": "Pausar o cronômetro de uma tarefa cronometrada em andamento",
+      "fields": {
+        "chore_id": {
+          "name": "ID da tarefa",
+          "description": "O ID da tarefa cronometrada"
+        },
+        "child_id": {
+          "name": "ID da criança",
+          "description": "O ID da criança que pausa o cronômetro"
+        }
+      }
+    },
+    "stop_timed_task": {
+      "name": "Parar tarefa cronometrada",
+      "description": "Parar o cronômetro de uma tarefa cronometrada e enviar para aprovação",
+      "fields": {
+        "chore_id": {
+          "name": "ID da tarefa",
+          "description": "O ID da tarefa cronometrada"
+        },
+        "child_id": {
+          "name": "ID da criança",
+          "description": "O ID da criança que para o cronômetro"
+        }
+      }
+    },
+    "add_badge": {
+      "name": "Adicionar conquista",
+      "description": "Criar uma conquista personalizada.",
+      "fields": {
+        "name": {
+          "name": "Nome",
+          "description": "O nome de exibição da conquista"
+        },
+        "description": {
+          "name": "Descrição",
+          "description": "Descrição de como a conquista é ganha"
+        },
+        "icon": {
+          "name": "Ícone",
+          "description": "Ícone da conquista (ex.: mdi:beach)"
+        },
+        "tier": {
+          "name": "Nível",
+          "description": "Nível da conquista: bronze, prata, ouro ou platina"
+        },
+        "point_bonus": {
+          "name": "Bônus de pontos",
+          "description": "Pontos creditados à criança quando a conquista é ganha"
+        },
+        "criteria": {
+          "name": "Critérios",
+          "description": "Lista de dicionários {metric, operator, value}. Vazio = apenas atribuição manual."
+        },
+        "assigned_to": {
+          "name": "Atribuída a",
+          "description": "Lista de IDs de crianças (vazio = todas)"
+        },
+        "notify_on_earn": {
+          "name": "Notificar ao ganhar",
+          "description": "Enviar uma notificação quando a conquista é ganha"
+        }
+      }
+    },
+    "update_badge": {
+      "name": "Atualizar conquista",
+      "description": "Atualizar uma conquista existente. Para as integradas, apenas point_bonus, tier, assigned_to, enabled e notify_on_earn são editáveis.",
+      "fields": {
+        "badge_id": {
+          "name": "ID da conquista",
+          "description": "O ID da conquista a atualizar"
+        },
+        "name": {
+          "name": "Nome",
+          "description": "Novo nome de exibição da conquista"
+        },
+        "description": {
+          "name": "Descrição",
+          "description": "Nova descrição da conquista"
+        },
+        "icon": {
+          "name": "Ícone",
+          "description": "Novo ícone da conquista"
+        },
+        "tier": {
+          "name": "Nível",
+          "description": "Nível da conquista: bronze, prata, ouro ou platina"
+        },
+        "point_bonus": {
+          "name": "Bônus de pontos",
+          "description": "Pontos creditados à criança quando a conquista é ganha"
+        },
+        "criteria": {
+          "name": "Critérios",
+          "description": "Lista de dicionários {metric, operator, value}. Vazio = apenas atribuição manual."
+        },
+        "assigned_to": {
+          "name": "Atribuída a",
+          "description": "Lista de IDs de crianças (vazio = todas)"
+        },
+        "enabled": {
+          "name": "Ativada",
+          "description": "Se a conquista está ativa"
+        },
+        "notify_on_earn": {
+          "name": "Notificar ao ganhar",
+          "description": "Enviar uma notificação quando a conquista é ganha"
+        }
+      }
+    },
+    "remove_badge": {
+      "name": "Remover conquista",
+      "description": "Remover uma conquista personalizada. As integradas não podem ser removidas.",
+      "fields": {
+        "badge_id": {
+          "name": "ID da conquista",
+          "description": "O ID da conquista a remover"
+        }
+      }
+    },
+    "award_badge_manually": {
+      "name": "Atribuir conquista manualmente",
+      "description": "Atribuir manualmente uma conquista a uma criança.",
+      "fields": {
+        "badge_id": {
+          "name": "ID da conquista",
+          "description": "O ID da conquista a atribuir"
+        },
+        "child_id": {
+          "name": "ID da criança",
+          "description": "O ID da criança que recebe a conquista"
+        }
+      }
+    },
+    "revoke_badge": {
+      "name": "Revogar conquista",
+      "description": "Revogar uma conquista atribuída. Se um bônus de pontos foi creditado, ele é revertido.",
+      "fields": {
+        "awarded_badge_id": {
+          "name": "ID da conquista atribuída",
+          "description": "O ID da conquista atribuída a revogar"
+        }
+      }
+    },
+    "rebuild_badges": {
+      "name": "Reconstruir conquistas",
+      "description": "Reavaliar todas as conquistas de todas as crianças silenciosamente (sem notificações nem bônus de pontos)."
     }
   },
   "entity": {

--- a/custom_components/taskmate/translations/pt.json
+++ b/custom_components/taskmate/translations/pt.json
@@ -492,6 +492,24 @@
         }
       }
     },
+    "complete_bonus_subtask": {
+      "name": "Concluir subtarefa bónus",
+      "description": "Concluir uma subtarefa bónus depois de a tarefa principal estar concluída",
+      "fields": {
+        "chore_id": {
+          "name": "ID da tarefa",
+          "description": "O ID da tarefa principal"
+        },
+        "bonus_subtask_id": {
+          "name": "ID da subtarefa bónus",
+          "description": "O ID da subtarefa bónus a concluir"
+        },
+        "child_id": {
+          "name": "ID da criança",
+          "description": "O ID da criança que conclui a subtarefa bónus"
+        }
+      }
+    },
     "approve_chore": {
       "name": "Aprovar tarefa",
       "description": "Aprovar uma tarefa concluída e atribuir pontos",
@@ -533,6 +551,24 @@
         "claim_id": {
           "name": "ID do pedido",
           "description": "O ID do pedido de recompensa a aprovar"
+        }
+      }
+    },
+    "allocate_points_to_pool": {
+      "name": "Alocar pontos ao mealheiro",
+      "description": "Mover pontos do saldo disponível de uma criança para o mealheiro de uma recompensa (bloqueado).",
+      "fields": {
+        "child_id": {
+          "name": "ID da criança",
+          "description": "O ID da criança que faz a alocação"
+        },
+        "reward_id": {
+          "name": "ID da recompensa",
+          "description": "O ID do mealheiro da recompensa onde depositar"
+        },
+        "points": {
+          "name": "Pontos",
+          "description": "Número de pontos a alocar (limitado pela capacidade do mealheiro e pelo saldo disponível)"
         }
       }
     },
@@ -873,6 +909,170 @@
           "description": "The ID of the group to delete"
         }
       }
+    },
+    "start_timed_task": {
+      "name": "Iniciar tarefa temporizada",
+      "description": "Iniciar ou retomar o temporizador de uma tarefa temporizada",
+      "fields": {
+        "chore_id": {
+          "name": "ID da tarefa",
+          "description": "O ID da tarefa temporizada"
+        },
+        "child_id": {
+          "name": "ID da criança",
+          "description": "O ID da criança que inicia o temporizador"
+        }
+      }
+    },
+    "pause_timed_task": {
+      "name": "Pausar tarefa temporizada",
+      "description": "Pausar o temporizador de uma tarefa temporizada em curso",
+      "fields": {
+        "chore_id": {
+          "name": "ID da tarefa",
+          "description": "O ID da tarefa temporizada"
+        },
+        "child_id": {
+          "name": "ID da criança",
+          "description": "O ID da criança que pausa o temporizador"
+        }
+      }
+    },
+    "stop_timed_task": {
+      "name": "Parar tarefa temporizada",
+      "description": "Parar o temporizador de uma tarefa temporizada e submeter para aprovação",
+      "fields": {
+        "chore_id": {
+          "name": "ID da tarefa",
+          "description": "O ID da tarefa temporizada"
+        },
+        "child_id": {
+          "name": "ID da criança",
+          "description": "O ID da criança que para o temporizador"
+        }
+      }
+    },
+    "add_badge": {
+      "name": "Adicionar conquista",
+      "description": "Criar uma conquista personalizada.",
+      "fields": {
+        "name": {
+          "name": "Nome",
+          "description": "O nome de apresentação da conquista"
+        },
+        "description": {
+          "name": "Descrição",
+          "description": "Descrição de como a conquista é ganha"
+        },
+        "icon": {
+          "name": "Ícone",
+          "description": "Ícone da conquista (ex.: mdi:beach)"
+        },
+        "tier": {
+          "name": "Nível",
+          "description": "Nível da conquista: bronze, prata, ouro ou platina"
+        },
+        "point_bonus": {
+          "name": "Bónus de pontos",
+          "description": "Pontos creditados à criança quando a conquista é ganha"
+        },
+        "criteria": {
+          "name": "Critérios",
+          "description": "Lista de dicionários {metric, operator, value}. Vazio = apenas atribuição manual."
+        },
+        "assigned_to": {
+          "name": "Atribuída a",
+          "description": "Lista de IDs de crianças (vazio = todas)"
+        },
+        "notify_on_earn": {
+          "name": "Notificar ao ganhar",
+          "description": "Enviar uma notificação quando a conquista é ganha"
+        }
+      }
+    },
+    "update_badge": {
+      "name": "Atualizar conquista",
+      "description": "Atualizar uma conquista existente. Para as integradas, apenas point_bonus, tier, assigned_to, enabled e notify_on_earn são editáveis.",
+      "fields": {
+        "badge_id": {
+          "name": "ID da conquista",
+          "description": "O ID da conquista a atualizar"
+        },
+        "name": {
+          "name": "Nome",
+          "description": "Novo nome de apresentação da conquista"
+        },
+        "description": {
+          "name": "Descrição",
+          "description": "Nova descrição da conquista"
+        },
+        "icon": {
+          "name": "Ícone",
+          "description": "Novo ícone da conquista"
+        },
+        "tier": {
+          "name": "Nível",
+          "description": "Nível da conquista: bronze, prata, ouro ou platina"
+        },
+        "point_bonus": {
+          "name": "Bónus de pontos",
+          "description": "Pontos creditados à criança quando a conquista é ganha"
+        },
+        "criteria": {
+          "name": "Critérios",
+          "description": "Lista de dicionários {metric, operator, value}. Vazio = apenas atribuição manual."
+        },
+        "assigned_to": {
+          "name": "Atribuída a",
+          "description": "Lista de IDs de crianças (vazio = todas)"
+        },
+        "enabled": {
+          "name": "Ativada",
+          "description": "Se a conquista está ativa"
+        },
+        "notify_on_earn": {
+          "name": "Notificar ao ganhar",
+          "description": "Enviar uma notificação quando a conquista é ganha"
+        }
+      }
+    },
+    "remove_badge": {
+      "name": "Remover conquista",
+      "description": "Remover uma conquista personalizada. As integradas não podem ser removidas.",
+      "fields": {
+        "badge_id": {
+          "name": "ID da conquista",
+          "description": "O ID da conquista a remover"
+        }
+      }
+    },
+    "award_badge_manually": {
+      "name": "Atribuir conquista manualmente",
+      "description": "Atribuir manualmente uma conquista a uma criança.",
+      "fields": {
+        "badge_id": {
+          "name": "ID da conquista",
+          "description": "O ID da conquista a atribuir"
+        },
+        "child_id": {
+          "name": "ID da criança",
+          "description": "O ID da criança que recebe a conquista"
+        }
+      }
+    },
+    "revoke_badge": {
+      "name": "Revogar conquista",
+      "description": "Revogar uma conquista atribuída. Se um bónus de pontos foi creditado, é revertido.",
+      "fields": {
+        "awarded_badge_id": {
+          "name": "ID da conquista atribuída",
+          "description": "O ID da conquista atribuída a revogar"
+        }
+      }
+    },
+    "rebuild_badges": {
+      "name": "Reconstruir conquistas",
+      "description": "Reavaliar todas as conquistas de todas as crianças silenciosamente (sem notificações nem bónus de pontos)."
     }
   },
   "entity": {

--- a/custom_components/taskmate/websocket.py
+++ b/custom_components/taskmate/websocket.py
@@ -160,20 +160,11 @@ def _admin_only(handler):
 # Validators / coercers
 # ---------------------------------------------------------------------------
 
-_str_list = vol.All(vol.Any([str], None), lambda v: list(v or []))
-
-
 def _opt_str(v: Any) -> str:
     """Coerce optional string field to stripped str (or empty)."""
     if v is None:
         return ""
     return str(v).strip()
-
-
-def _opt_int(v: Any) -> int | None:
-    if v is None or v == "":
-        return None
-    return int(v)
 
 
 # ---------------------------------------------------------------------------
@@ -188,12 +179,12 @@ def _build_state_snapshot(coordinator: TaskMateCoordinator) -> dict[str, Any]:
 
     parent_completable = {}
     for chore_dict in data.get("chores", []):
-        chore = coordinator.get_chore(chore_dict.get("id", ""))
-        if not chore or not getattr(chore, "enabled", True):
+        chore_id = chore_dict.get("id")
+        if not chore_id or not chore_dict.get("enabled", True):
             continue
-        if getattr(chore, "schedule_mode", "specific_days") == "one_shot":
+        if chore_dict.get("schedule_mode", "specific_days") == "one_shot":
             continue
-        parent_completable[chore.id] = True
+        parent_completable[chore_id] = True
 
     return {
         "version": "2",
@@ -1080,12 +1071,10 @@ async def _ws_templates_delete(hass, connection, msg, coordinator):
 
 @websocket_api.websocket_command({vol.Required("type"): WS_NOTIF_GET_STATE})
 @websocket_api.async_response
-async def ws_notif_get_state(hass, connection, msg):
+@_admin_only
+async def ws_notif_get_state(hass, connection, msg, coordinator):
     from .coord_notifications import NOTIFICATION_TYPES
-    c = _get_coordinator(hass)
-    if c is None:
-        connection.send_error(msg["id"], "no_coordinator", "TaskMate not loaded")
-        return
+    c = coordinator
     state = {
         "recipients": {
             "children": [
@@ -1127,9 +1116,9 @@ async def ws_notif_get_state(hass, connection, msg):
     vol.Required("enabled"): bool,
 })
 @websocket_api.async_response
-async def ws_notif_set_master(hass, connection, msg):
-    c = _get_coordinator(hass)
-    await c.notifications.set_master_enabled(msg["type_id"], msg["enabled"])
+@_admin_only
+async def ws_notif_set_master(hass, connection, msg, coordinator):
+    await coordinator.notifications.set_master_enabled(msg["type_id"], msg["enabled"])
     connection.send_result(msg["id"], {"ok": True})
 
 
@@ -1141,11 +1130,11 @@ async def ws_notif_set_master(hass, connection, msg):
     vol.Optional("time"): vol.Any(str, None),
 })
 @websocket_api.async_response
-async def ws_notif_set_route(hass, connection, msg):
+@_admin_only
+async def ws_notif_set_route(hass, connection, msg, coordinator):
     from .models import NotificationRoute
-    c = _get_coordinator(hass)
     route = NotificationRoute(enabled=msg["enabled"], time=msg.get("time"))
-    await c.notifications.set_route(msg["type_id"], msg["recipient_id"], route)
+    await coordinator.notifications.set_route(msg["type_id"], msg["recipient_id"], route)
     connection.send_result(msg["id"], {"ok": True})
 
 
@@ -1155,8 +1144,9 @@ async def ws_notif_set_route(hass, connection, msg):
     vol.Required("notify_service"): vol.Any(str, None),
 })
 @websocket_api.async_response
-async def ws_notif_set_child_notify(hass, connection, msg):
-    c = _get_coordinator(hass)
+@_admin_only
+async def ws_notif_set_child_notify(hass, connection, msg, coordinator):
+    c = coordinator
     child = c.storage.get_child(msg["child_id"])
     if child is None:
         connection.send_error(msg["id"], "not_found", "Child not found")
@@ -1176,9 +1166,10 @@ async def ws_notif_set_child_notify(hass, connection, msg):
     vol.Optional("enabled", default=True): bool,
 })
 @websocket_api.async_response
-async def ws_notif_upsert_parent(hass, connection, msg):
+@_admin_only
+async def ws_notif_upsert_parent(hass, connection, msg, coordinator):
     from .models import ParentRecipient
-    c = _get_coordinator(hass)
+    c = coordinator
     p_id = msg.get("parent_id")
     if p_id:
         existing = next(
@@ -1207,9 +1198,9 @@ async def ws_notif_upsert_parent(hass, connection, msg):
     vol.Required("parent_id"): str,
 })
 @websocket_api.async_response
-async def ws_notif_delete_parent(hass, connection, msg):
-    c = _get_coordinator(hass)
-    await c.notifications.delete_parent(msg["parent_id"])
+@_admin_only
+async def ws_notif_delete_parent(hass, connection, msg, coordinator):
+    await coordinator.notifications.delete_parent(msg["parent_id"])
     connection.send_result(msg["id"], {"ok": True})
 
 
@@ -1224,9 +1215,10 @@ async def ws_notif_delete_parent(hass, connection, msg):
     vol.Optional("enabled", default=True): bool,
 })
 @websocket_api.async_response
-async def ws_notif_upsert_custom(hass, connection, msg):
+@_admin_only
+async def ws_notif_upsert_custom(hass, connection, msg, coordinator):
     from .models import CustomNotification
-    c = _get_coordinator(hass)
+    c = coordinator
     n = CustomNotification.from_dict({
         "id": msg.get("custom_id"),
         "name": msg["name"],
@@ -1245,15 +1237,16 @@ async def ws_notif_upsert_custom(hass, connection, msg):
     vol.Required("custom_id"): str,
 })
 @websocket_api.async_response
-async def ws_notif_delete_custom(hass, connection, msg):
-    c = _get_coordinator(hass)
-    await c.notifications.delete_custom(msg["custom_id"])
+@_admin_only
+async def ws_notif_delete_custom(hass, connection, msg, coordinator):
+    await coordinator.notifications.delete_custom(msg["custom_id"])
     connection.send_result(msg["id"], {"ok": True})
 
 
 @websocket_api.websocket_command({vol.Required("type"): WS_NOTIF_LIST_NOTIFY})
 @websocket_api.async_response
-async def ws_notif_list_notify(hass, connection, msg):
+@_admin_only
+async def ws_notif_list_notify(hass, connection, msg, coordinator):
     services = [
         f"notify.{name}"
         for name in hass.services.async_services().get("notify", {})
@@ -1267,9 +1260,9 @@ async def ws_notif_list_notify(hass, connection, msg):
     vol.Required("time"): str,
 })
 @websocket_api.async_response
-async def ws_notif_set_streak_cutoff(hass, connection, msg):
-    c = _get_coordinator(hass)
-    await c.notifications.set_streak_cutoff(msg["time"])
+@_admin_only
+async def ws_notif_set_streak_cutoff(hass, connection, msg, coordinator):
+    await coordinator.notifications.set_streak_cutoff(msg["time"])
     connection.send_result(msg["id"], {"ok": True})
 
 

--- a/custom_components/taskmate/www/locales/de.json
+++ b/custom_components/taskmate/www/locales/de.json
@@ -779,6 +779,7 @@
   "panel.notif_recipients_parents": "Eltern",
   "panel.notif_remove_parent": "Entfernen",
   "panel.notif_section_custom": "Benutzerdefinierte geplante Benachrichtigungen",
+  "panel.notif_unnamed_recipient": "(unbenannt)",
   "panel.notif_section_custom_desc": "Füge eigene zeitgesteuerte Erinnerungen hinzu. Für ereignisgesteuerte Benachrichtigungen höre auf die taskmate_*-Ereignisse auf dem Home Assistant Bus.",
   "panel.notif_section_matrix": "Integrierte Benachrichtigungen",
   "panel.notif_section_matrix_desc": "Pro Empfänger umschalten. Der Schalter links deaktiviert die gesamte Zeile global. Mit — markierte Zellen sind für diesen Empfänger nicht gültig.",

--- a/custom_components/taskmate/www/locales/fr.json
+++ b/custom_components/taskmate/www/locales/fr.json
@@ -779,6 +779,7 @@
   "panel.notif_recipients_parents": "Parents",
   "panel.notif_remove_parent": "Supprimer",
   "panel.notif_section_custom": "Notifications planifiées personnalisées",
+  "panel.notif_unnamed_recipient": "(sans nom)",
   "panel.notif_section_custom_desc": "Ajoutez vos propres rappels minutés. Pour les notifications déclenchées par des événements, écoutez les événements taskmate_* sur le bus Home Assistant.",
   "panel.notif_section_matrix": "Notifications intégrées",
   "panel.notif_section_matrix_desc": "Basculer par destinataire. Le commutateur à gauche désactive toute la ligne globalement. Les cellules marquées — ne sont pas valides pour ce destinataire.",

--- a/custom_components/taskmate/www/locales/nb.json
+++ b/custom_components/taskmate/www/locales/nb.json
@@ -779,6 +779,7 @@
   "panel.notif_recipients_parents": "Foresatte",
   "panel.notif_remove_parent": "Fjern",
   "panel.notif_section_custom": "Egendefinerte planlagte varsler",
+  "panel.notif_unnamed_recipient": "(uten navn)",
   "panel.notif_section_custom_desc": "Legg til egne tidsstyrte påminnelser. For hendelsesdrevne varsler, lytt til taskmate_*-hendelsene på Home Assistant-bussen.",
   "panel.notif_section_matrix": "Innebygde varsler",
   "panel.notif_section_matrix_desc": "Slå av/på per mottaker. Bryteren til venstre deaktiverer hele raden globalt. Celler merket med — er ikke gyldige for den mottakeren.",

--- a/custom_components/taskmate/www/locales/nn.json
+++ b/custom_components/taskmate/www/locales/nn.json
@@ -779,6 +779,7 @@
   "panel.notif_recipients_parents": "Føresette",
   "panel.notif_remove_parent": "Fjern",
   "panel.notif_section_custom": "Eigendefinerte planlagde varsel",
+  "panel.notif_unnamed_recipient": "(utan namn)",
   "panel.notif_section_custom_desc": "Legg til eigne tidsstyrte påminningar. For hendingsdrivne varsel, lytt til taskmate_*-hendingane på Home Assistant-bussen.",
   "panel.notif_section_matrix": "Innebygde varsel",
   "panel.notif_section_matrix_desc": "Slå av/på per mottakar. Bryteren til venstre deaktiverer heile rada globalt. Celler merkte med — er ikkje gyldige for den mottakaren.",

--- a/custom_components/taskmate/www/locales/pt-BR.json
+++ b/custom_components/taskmate/www/locales/pt-BR.json
@@ -779,6 +779,7 @@
   "panel.notif_recipients_parents": "Responsáveis",
   "panel.notif_remove_parent": "Remover",
   "panel.notif_section_custom": "Notificações agendadas personalizadas",
+  "panel.notif_unnamed_recipient": "(sem nome)",
   "panel.notif_section_custom_desc": "Adicione seus próprios lembretes temporizados. Para notificações por eventos, escute os eventos taskmate_* no barramento do Home Assistant.",
   "panel.notif_section_matrix": "Notificações integradas",
   "panel.notif_section_matrix_desc": "Ativar/desativar por destinatário. O interruptor à esquerda desativa toda a linha globalmente. Células marcadas com — não são válidas para esse destinatário.",

--- a/custom_components/taskmate/www/locales/pt.json
+++ b/custom_components/taskmate/www/locales/pt.json
@@ -779,6 +779,7 @@
   "panel.notif_recipients_parents": "Encarregados",
   "panel.notif_remove_parent": "Remover",
   "panel.notif_section_custom": "Notificações agendadas personalizadas",
+  "panel.notif_unnamed_recipient": "(sem nome)",
   "panel.notif_section_custom_desc": "Adicione os seus próprios lembretes temporizados. Para notificações por eventos, escute os eventos taskmate_* no barramento do Home Assistant.",
   "panel.notif_section_matrix": "Notificações incorporadas",
   "panel.notif_section_matrix_desc": "Ativar/desativar por destinatário. O interruptor à esquerda desativa toda a linha globalmente. Células marcadas com — não são válidas para esse destinatário.",

--- a/custom_components/taskmate/www/taskmate-activity-card.js
+++ b/custom_components/taskmate/www/taskmate-activity-card.js
@@ -13,6 +13,8 @@ const LitElement = customElements.get("hui-masonry-view")
 const html = LitElement.prototype.html;
 const css = LitElement.prototype.css;
 
+const _safeColor = (c, d) => (typeof c === "string" && /^#[0-9a-fA-F]{3,8}$/.test(c) ? c : d);
+
 class TaskMateActivityCard extends LitElement {
   static get properties() {
     return {
@@ -478,7 +480,7 @@ class TaskMateActivityCard extends LitElement {
       : unfiltered.filter(e => this._eventBucket(e) === this._filter);
 
     const title = this.config.title || this._t('activity.default_title');
-    const headerColor = this.config.header_color || '#2471a3';
+    const headerColor = _safeColor(this.config.header_color, '#2471a3');
 
     if (unfiltered.length === 0) {
       return html`

--- a/custom_components/taskmate/www/taskmate-approvals-card.js
+++ b/custom_components/taskmate/www/taskmate-approvals-card.js
@@ -501,6 +501,7 @@ class TaskMateApprovalsCard extends LitElement {
   }
 
   async _callClaimService(service, claimId) {
+    if (this._loading[claimId]) return;
     this._loading = { ...this._loading, [claimId]: true };
     this.requestUpdate();
     try {
@@ -759,6 +760,7 @@ class TaskMateApprovalsCard extends LitElement {
   }
 
   async _callService(service, completionId) {
+    if (this._loading[completionId]) return;
     this._loading = { ...this._loading, [completionId]: true };
     this.requestUpdate();
 

--- a/custom_components/taskmate/www/taskmate-badges-card.js
+++ b/custom_components/taskmate/www/taskmate-badges-card.js
@@ -33,6 +33,8 @@ class TaskMateBadgesCard extends LitElement {
     this._filterTier = "all";
     this._justEarned = null;
     this._unsubscribeEvents = null;
+    this._subscribing = false;
+    this._justEarnedTimeout = null;
   }
 
   connectedCallback() {
@@ -44,24 +46,37 @@ class TaskMateBadgesCard extends LitElement {
     super.disconnectedCallback();
     this._unsubscribeEvents?.();
     this._unsubscribeEvents = null;
+    if (this._justEarnedTimeout) {
+      clearTimeout(this._justEarnedTimeout);
+      this._justEarnedTimeout = null;
+    }
   }
 
   _subscribeEvents() {
     if (!this.hass) return;
+    if (this._unsubscribeEvents || this._subscribing) return;
+    this._subscribing = true;
     this.hass.connection.subscribeEvents((event) => {
       const data = event.data || {};
       if (data.child_id && this.config?.child_id && String(data.child_id) !== String(this.config.child_id)) return;
       if (data.badge_id) {
         this._justEarned = String(data.badge_id);
         this.requestUpdate();
-        setTimeout(() => {
+        this._justEarnedTimeout = setTimeout(() => {
           this._justEarned = null;
           this.requestUpdate();
         }, 1800);
       }
     }, "taskmate_badge_earned").then(unsub => {
+      this._subscribing = false;
+      if (!this.isConnected) {
+        unsub();
+        return;
+      }
       this._unsubscribeEvents = unsub;
-    }).catch(() => {});
+    }).catch(() => {
+      this._subscribing = false;
+    });
   }
 
   shouldUpdate(changedProps) {

--- a/custom_components/taskmate/www/taskmate-bonuses-card.js
+++ b/custom_components/taskmate/www/taskmate-bonuses-card.js
@@ -13,6 +13,8 @@ const LitElement = customElements.get("hui-masonry-view")
 const html = LitElement.prototype.html;
 const css = LitElement.prototype.css;
 
+const _safeColor = (c, d) => (typeof c === "string" && /^#[0-9a-fA-F]{3,8}$/.test(c) ? c : d);
+
 class TaskMateBonusesCard extends LitElement {
   static get properties() {
     return {
@@ -425,11 +427,17 @@ class TaskMateBonusesCard extends LitElement {
 
   _showToast(msg) {
     this._toast = null;
+    clearTimeout(this._toastTimer);
     // Force re-render with new toast
-    setTimeout(() => {
+    this._toastTimer = setTimeout(() => {
       this._toast = msg;
-      setTimeout(() => { this._toast = null; }, 2700);
+      this._toastTimer = setTimeout(() => { this._toast = null; }, 2700);
     }, 10);
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    clearTimeout(this._toastTimer);
   }
 
   _startEdit(bonus) {
@@ -633,7 +641,7 @@ class TaskMateBonusesCard extends LitElement {
 
     return html`
       <ha-card>
-        <style>:host { --taskmate-header-bg: ${this.config.header_color || '#2e7d32'}; }</style>
+        <style>:host { --taskmate-header-bg: ${_safeColor(this.config.header_color, '#2e7d32')}; }</style>
         <div class="card-header">
           <div class="header-left">
             <ha-icon class="header-icon" icon="mdi:star-circle"></ha-icon>

--- a/custom_components/taskmate/www/taskmate-calendar-card.js
+++ b/custom_components/taskmate/www/taskmate-calendar-card.js
@@ -12,6 +12,8 @@ const LitElement = customElements.get("hui-masonry-view")
 const html = LitElement.prototype.html;
 const css = LitElement.prototype.css;
 
+const _safeColor = (c, d) => (typeof c === "string" && /^#[0-9a-fA-F]{3,8}$/.test(c) ? c : d);
+
 const DAY_NAMES = [
   "monday", "tuesday", "wednesday", "thursday",
   "friday", "saturday", "sunday",
@@ -323,11 +325,18 @@ class TaskMateCalendarCard extends LitElement {
         } catch (e) { return false; }
       }
 
-      if (recurrence === "monthly" && recurrenceStart) {
+      const monthSteps = { monthly: 1, every_3_months: 3, every_6_months: 6 }[recurrence];
+      if (monthSteps && recurrenceStart) {
         try {
           const anchor = new Date(recurrenceStart + "T00:00:00");
           if (dayDate < anchor) return false;
-          return dayDate.getDate() === anchor.getDate();
+          const monthsDiff =
+            (dayDate.getFullYear() - anchor.getFullYear()) * 12 +
+            (dayDate.getMonth() - anchor.getMonth());
+          if (monthsDiff % monthSteps !== 0) return false;
+          // Clamp the anchor day for shorter months (e.g. 31st -> Feb 28th)
+          const lastDay = new Date(dayDate.getFullYear(), dayDate.getMonth() + 1, 0).getDate();
+          return dayDate.getDate() === Math.min(anchor.getDate(), lastDay);
         } catch (e) { return false; }
       }
 
@@ -425,7 +434,7 @@ class TaskMateCalendarCard extends LitElement {
 
     return html`
       <ha-card>
-        <style>:host { --taskmate-header-bg: ${this.config.header_color || "#3498db"}; }</style>
+        <style>:host { --taskmate-header-bg: ${_safeColor(this.config.header_color, "#3498db")}; }</style>
         <div class="card-header">
           <div class="header-content">
             <ha-icon class="header-icon" icon="mdi:calendar-account"></ha-icon>

--- a/custom_components/taskmate/www/taskmate-child-card.js
+++ b/custom_components/taskmate/www/taskmate-child-card.js
@@ -75,6 +75,10 @@ class TaskMateChildCard extends LitElement {
     this._stopTimerTick();
     this._badgeEventUnsub?.();
     this._badgeEventUnsub = null;
+    if (this._audioContext) {
+      this._audioContext.close().catch(() => {});
+      this._audioContext = null;
+    }
   }
 
   updated(changedProperties) {
@@ -103,6 +107,7 @@ class TaskMateChildCard extends LitElement {
   }
 
   _subscribeBadgeEvents() {
+    if (this._badgeEventUnsub) return;
     if (!this.hass?.connection) return;
     this.hass.connection.subscribeEvents((event) => {
       const data = event.data || {};
@@ -114,6 +119,10 @@ class TaskMateChildCard extends LitElement {
         setTimeout(() => { this._justEarnedBadge = null; this.requestUpdate(); }, 1800);
       }
     }, "taskmate_badge_earned").then(unsub => {
+      if (!this.isConnected) {
+        unsub();
+        return;
+      }
       this._badgeEventUnsub = unsub;
     }).catch(() => {});
   }

--- a/custom_components/taskmate/www/taskmate-config-sounds.js
+++ b/custom_components/taskmate/www/taskmate-config-sounds.js
@@ -599,8 +599,9 @@
     findAndEnhanceSoundSelectors();
     startObserver();
 
-    // Periodic scan to catch dynamically loaded content
-    window._taskmateConfigSoundsPoll = setInterval(findAndEnhanceSoundSelectors, 2000);
+    // Slow periodic scan as a safety net for dynamically loaded content the
+    // MutationObserver doesn't catch (e.g. dialogs rendered outside body's light DOM)
+    window._taskmateConfigSoundsPoll = setInterval(findAndEnhanceSoundSelectors, 10000);
 
     const cleanup = () => {
       if (window._taskmateConfigSoundsPoll) {

--- a/custom_components/taskmate/www/taskmate-graph-card.js
+++ b/custom_components/taskmate/www/taskmate-graph-card.js
@@ -14,6 +14,8 @@ const LitElement = customElements.get("hui-masonry-view")
 const html = LitElement.prototype.html;
 const css = LitElement.prototype.css;
 
+const _safeColor = (c, d) => (typeof c === "string" && /^#[0-9a-fA-F]{3,8}$/.test(c) ? c : d);
+
 // Child colors — matches the streak/jackpot palette
 const CHILD_COLORS = [
   { line: "#9b59b6", fill: "rgba(155,89,182,0.15)" },
@@ -302,7 +304,7 @@ class TaskMateGraphCard extends LitElement {
 
     return html`
       <ha-card>
-        <style>:host { --taskmate-header-bg: ${this.config.header_color || '#d35400'}; }</style>
+        <style>:host { --taskmate-header-bg: ${_safeColor(this.config.header_color, '#d35400')}; }</style>
         <div class="card-header">
           <div class="header-left">
             <ha-icon class="header-icon" icon="mdi:chart-line"></ha-icon>
@@ -381,8 +383,14 @@ class TaskMateGraphCard extends LitElement {
     `;
   }
 
-  updated() {
-    this._drawCanvas();
+  updated(changedProps) {
+    if (
+      changedProps.has("hass")
+      || changedProps.has("config")
+      || changedProps.has("_mode")
+    ) {
+      this._drawCanvas();
+    }
   }
 
   _drawCanvas() {
@@ -584,11 +592,12 @@ class TaskMateGraphCard extends LitElement {
 
   _buildDateRange(days, tz) {
     const range = [];
-    const today = new Date();
+    const todayKey = new Date().toLocaleDateString("en-CA", { timeZone: tz });
+    const today = new Date(todayKey + "T12:00:00"); // noon avoids DST edge cases
     for (let i = days - 1; i >= 0; i--) {
       const d = new Date(today);
       d.setDate(d.getDate() - i);
-      range.push(d.toLocaleDateString("en-CA", { timeZone: tz }));
+      range.push(d.toLocaleDateString("en-CA"));
     }
     return range;
   }

--- a/custom_components/taskmate/www/taskmate-leaderboard-card.js
+++ b/custom_components/taskmate/www/taskmate-leaderboard-card.js
@@ -12,6 +12,8 @@ const LitElement = customElements.get("hui-masonry-view")
 const html = LitElement.prototype.html;
 const css = LitElement.prototype.css;
 
+const _safeColor = (c, d) => (typeof c === "string" && /^#[0-9a-fA-F]{3,8}$/.test(c) ? c : d);
+
 const RANK_COLOURS = ["#f1c40f", "#bdc3c7", "#cd7f32", "#9b59b6", "#3498db"];
 const RANK_LABELS = ["🥇", "🥈", "🥉"];
 
@@ -280,7 +282,7 @@ class TaskMateLeaderboardCard extends LitElement {
 
     return html`
       <ha-card>
-        <style>:host { --taskmate-header-bg: ${this.config.header_color || '#b7950b'}; }</style>
+        <style>:host { --taskmate-header-bg: ${_safeColor(this.config.header_color, '#b7950b')}; }</style>
         <div class="card-header">
           <div class="header-content">
             <ha-icon class="header-icon" icon="mdi:trophy"></ha-icon>
@@ -291,7 +293,7 @@ class TaskMateLeaderboardCard extends LitElement {
         <div class="card-content">
           ${sorted.map((child, idx) => {
             const prevChild = idx > 0 ? sorted[idx - 1] : null;
-            const isTie = prevChild && this._getScore(child, prevChild, sortBy, weeklyPoints);
+            const isTie = prevChild && this._isTie(child, prevChild, sortBy, weeklyPoints);
             return html`
               ${isTie ? html`<div class="tie-line"><span class="tie-label">${this._t('leaderboard.tie')}</span></div>` : ''}
               ${this._renderRankRow(child, idx, sortBy, weeklyPoints, pointsIcon, pointsName)}
@@ -305,7 +307,7 @@ class TaskMateLeaderboardCard extends LitElement {
     `;
   }
 
-  _getScore(a, b, sortBy, weeklyPoints) {
+  _isTie(a, b, sortBy, weeklyPoints) {
     if (sortBy === "streak") return (a.current_streak || 0) === (b.current_streak || 0);
     if (sortBy === "weekly") return (weeklyPoints[a.id] || 0) === (weeklyPoints[b.id] || 0);
     if (sortBy === "career") return (a.career_score || 0) === (b.career_score || 0);
@@ -389,7 +391,7 @@ class TaskMateLeaderboardCard extends LitElement {
 
     return html`
       <ha-card>
-        <style>:host { --taskmate-header-bg: ${this.config.header_color || '#b7950b'}; }</style>
+        <style>:host { --taskmate-header-bg: ${_safeColor(this.config.header_color, '#b7950b')}; }</style>
         <div class="card-header">
           <div class="header-content">
             <ha-icon class="header-icon" icon="mdi:trophy"></ha-icon>

--- a/custom_components/taskmate/www/taskmate-overview-card.js
+++ b/custom_components/taskmate/www/taskmate-overview-card.js
@@ -14,6 +14,8 @@ const LitElement = customElements.get("hui-masonry-view")
 const html = LitElement.prototype.html;
 const css = LitElement.prototype.css;
 
+const _safeColor = (c, d) => (typeof c === "string" && /^#[0-9a-fA-F]{3,8}$/.test(c) ? c : d);
+
 class TaskMateOverviewCard extends LitElement {
   static get properties() {
     return {
@@ -341,7 +343,7 @@ class TaskMateOverviewCard extends LitElement {
 
     return html`
       <ha-card>
-        <style>:host { --taskmate-header-bg: ${this.config.header_color || '#8e44ad'}; }</style>
+        <style>:host { --taskmate-header-bg: ${_safeColor(this.config.header_color, '#8e44ad')}; }</style>
         <div class="card-header">
           <div class="header-content">
             <ha-icon class="header-icon" icon="mdi:home-heart"></ha-icon>

--- a/custom_components/taskmate/www/taskmate-parent-dashboard-card.js
+++ b/custom_components/taskmate/www/taskmate-parent-dashboard-card.js
@@ -754,6 +754,7 @@ class TaskMateParentDashboardCard extends LitElement {
   }
 
   async _handleApprove(completionId) {
+    if (this._loading[completionId]) return;
     this._loading = { ...this._loading, [completionId]: true };
     this.requestUpdate();
     try {
@@ -767,6 +768,7 @@ class TaskMateParentDashboardCard extends LitElement {
   }
 
   async _handleReject(completionId) {
+    if (this._loading[completionId]) return;
     this._loading = { ...this._loading, [completionId]: true };
     this.requestUpdate();
     try {
@@ -780,6 +782,7 @@ class TaskMateParentDashboardCard extends LitElement {
   }
 
   async _handleApproveReward(claimId) {
+    if (this._loading[claimId]) return;
     this._loading = { ...this._loading, [claimId]: true };
     this.requestUpdate();
     try {
@@ -793,6 +796,7 @@ class TaskMateParentDashboardCard extends LitElement {
   }
 
   async _handleRejectReward(claimId) {
+    if (this._loading[claimId]) return;
     this._loading = { ...this._loading, [claimId]: true };
     this.requestUpdate();
     try {

--- a/custom_components/taskmate/www/taskmate-penalties-card.js
+++ b/custom_components/taskmate/www/taskmate-penalties-card.js
@@ -13,6 +13,8 @@ const LitElement = customElements.get("hui-masonry-view")
 const html = LitElement.prototype.html;
 const css = LitElement.prototype.css;
 
+const _safeColor = (c, d) => (typeof c === "string" && /^#[0-9a-fA-F]{3,8}$/.test(c) ? c : d);
+
 class TaskMatePenaltiesCard extends LitElement {
   static get properties() {
     return {
@@ -425,11 +427,17 @@ class TaskMatePenaltiesCard extends LitElement {
 
   _showToast(msg) {
     this._toast = null;
+    clearTimeout(this._toastTimer);
     // Force re-render with new toast
-    setTimeout(() => {
+    this._toastTimer = setTimeout(() => {
       this._toast = msg;
-      setTimeout(() => { this._toast = null; }, 2700);
+      this._toastTimer = setTimeout(() => { this._toast = null; }, 2700);
     }, 10);
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    clearTimeout(this._toastTimer);
   }
 
   _startEdit(penalty) {
@@ -631,7 +639,7 @@ class TaskMatePenaltiesCard extends LitElement {
 
     return html`
       <ha-card>
-        <style>:host { --taskmate-header-bg: ${this.config.header_color || '#e74c3c'}; }</style>
+        <style>:host { --taskmate-header-bg: ${_safeColor(this.config.header_color, '#e74c3c')}; }</style>
         <div class="card-header">
           <div class="header-left">
             <ha-icon class="header-icon" icon="mdi:alert-circle-outline"></ha-icon>

--- a/custom_components/taskmate/www/taskmate-points-card.js
+++ b/custom_components/taskmate/www/taskmate-points-card.js
@@ -859,6 +859,9 @@ class TaskMatePointsCard extends LitElement {
   }
 
   _openDialog(child, action, pointsIcon, pointsName) {
+    if (this._dialogKeyHandler) {
+      document.removeEventListener("keydown", this._dialogKeyHandler);
+    }
     this._dialog = { child, action, pointsIcon, pointsName };
     this._dialogKeyHandler = (e) => {
       if (e.key === "Escape") this._closeDialog();

--- a/custom_components/taskmate/www/taskmate-points-display-card.js
+++ b/custom_components/taskmate/www/taskmate-points-display-card.js
@@ -44,15 +44,17 @@ function getChildren(state) {
   return state.attributes.children || [];
 }
 
-function weeklyPoints(child) {
-  const today = new Date();
+function weeklyPoints(child, tz) {
+  const todayKey = new Date().toLocaleDateString("en-CA", { timeZone: tz });
+  const today = new Date(todayKey + "T12:00:00"); // noon avoids DST edge cases
   const monday = new Date(today);
   monday.setDate(today.getDate() - ((today.getDay() + 6) % 7));
-  monday.setHours(0, 0, 0, 0);
+  const mondayKey = monday.toLocaleDateString("en-CA");
 
   const history = child.history || [];
   return history
-    .filter(e => e.approved && new Date(e.timestamp) >= monday)
+    .filter(e => e.approved
+      && new Date(e.timestamp).toLocaleDateString("en-CA", { timeZone: tz }) >= mondayKey)
     .reduce((s, e) => s + (e.points || 0), 0);
 }
 
@@ -601,7 +603,8 @@ class TaskMatePointsDisplayCard extends LitElement {
     const colour   = CHILD_COLOURS[children.indexOf(child) % CHILD_COLOURS.length];
     const primary  = this._primaryValue(child);
     const secondary = this._secondaryValue(child);
-    const weekly   = weeklyPoints(child);
+    const tz       = this.hass?.config?.time_zone || Intl.DateTimeFormat().resolvedOptions().timeZone;
+    const weekly   = weeklyPoints(child, tz);
     const streak   = child.streak || 0;
     const rank     = this._rankedChildren().findIndex(c => c.id === child.id) + 1;
 
@@ -664,13 +667,15 @@ class TaskMatePointsDisplayCard extends LitElement {
       </div>`;
     }
 
+    const tz = this.hass?.config?.time_zone || Intl.DateTimeFormat().resolvedOptions().timeZone;
+
     return html`
       <div class="multi-grid">
         ${ranked.map((child, idx) => {
           const colour    = CHILD_COLOURS[this._allChildren().indexOf(child) % CHILD_COLOURS.length];
           const primary   = this._primaryValue(child);
           const secondary = this._secondaryValue(child);
-          const weekly    = weeklyPoints(child);
+          const weekly    = weeklyPoints(child, tz);
           const streak    = child.streak || 0;
           const isTop     = idx === 0;
           return html`

--- a/custom_components/taskmate/www/taskmate-reorder-card.js
+++ b/custom_components/taskmate/www/taskmate-reorder-card.js
@@ -14,6 +14,8 @@ const LitElement = customElements.get("hui-masonry-view")
 const html = LitElement.prototype.html;
 const css = LitElement.prototype.css;
 
+const _safeColor = (c, d) => (typeof c === "string" && /^#[0-9a-fA-F]{3,8}$/.test(c) ? c : d);
+
 class TaskMateReorderCard extends LitElement {
   static get properties() {
     return {
@@ -464,14 +466,7 @@ class TaskMateReorderCard extends LitElement {
     if (!entity) return;
 
     if (entity.state === "unavailable" || entity.state === "unknown") {
-      return html`
-        <ha-card>
-          <div class="error-state">
-            <ha-icon icon="mdi:alert-circle"></ha-icon>
-            <div>${this._t('common.unavailable')}</div>
-          </div>
-        </ha-card>
-      `;
+      return;
     }
 
     const attrs = (window.__taskmate_attrs && window.__taskmate_attrs(this.hass, this.config.entity)) || entity.attributes || {};
@@ -625,8 +620,9 @@ class TaskMateReorderCard extends LitElement {
     const timeCategories = ["morning", "afternoon", "evening", "night", "anytime"];
     const pointsIcon = attrs.points_icon || "mdi:star";
 
-    const headerStyle = this.config.header_color
-      ? `--taskmate-header-bg: ${this.config.header_color};`
+    const headerColor = _safeColor(this.config.header_color, '');
+    const headerStyle = headerColor
+      ? `--taskmate-header-bg: ${headerColor};`
       : '';
 
     return html`
@@ -806,7 +802,7 @@ class TaskMateReorderCard extends LitElement {
     this.shadowRoot?.querySelectorAll(".chore-item").forEach(i => i.classList.remove("drag-over"));
     const item = el ? el.closest(".chore-item") : null;
     if (item) {
-      const toIndex = parseInt(item.dataset.index);
+      const toIndex = parseInt(item.dataset.index, 10);
       const { index: fromIndex } = this._touchState;
       if (!isNaN(toIndex) && fromIndex !== toIndex) {
         this._swapChores(category, fromIndex, toIndex);

--- a/custom_components/taskmate/www/taskmate-reward-progress-card.js
+++ b/custom_components/taskmate/www/taskmate-reward-progress-card.js
@@ -12,6 +12,8 @@ const LitElement = customElements.get("hui-masonry-view")
 const html = LitElement.prototype.html;
 const css = LitElement.prototype.css;
 
+const _safeColor = (c, d) => (typeof c === "string" && /^#[0-9a-fA-F]{3,8}$/.test(c) ? c : d);
+
 class TaskMateRewardProgressCard extends LitElement {
   static get properties() {
     return { hass: { type: Object }, config: { type: Object } };
@@ -461,8 +463,9 @@ class TaskMateRewardProgressCard extends LitElement {
       availabilityClass = 'badge-expiring-soon';
     }
 
-    const headerStyle = this.config.header_color
-      ? `--taskmate-header-bg: ${this.config.header_color};`
+    const headerColor = _safeColor(this.config.header_color, '');
+    const headerStyle = headerColor
+      ? `--taskmate-header-bg: ${headerColor};`
       : '';
 
     return html`

--- a/custom_components/taskmate/www/taskmate-rewards-card.js
+++ b/custom_components/taskmate/www/taskmate-rewards-card.js
@@ -1354,6 +1354,7 @@ class TaskMateRewardsCard extends LitElement {
 
   async _handleClaim(reward, child) {
     if (!child || !reward) return;
+    if (this._loading[reward.id]) return;
     this._loading = { ...this._loading, [reward.id]: true };
     this.requestUpdate();
     try {
@@ -1391,6 +1392,7 @@ class TaskMateRewardsCard extends LitElement {
   async _handleAllocate(reward, child, points) {
     if (!child || !reward) return;
     const key = `${reward.id}_alloc`;
+    if (this._loading[key]) return;
     this._loading = { ...this._loading, [key]: true };
     this.requestUpdate();
     try {

--- a/custom_components/taskmate/www/taskmate-streak-card.js
+++ b/custom_components/taskmate/www/taskmate-streak-card.js
@@ -14,6 +14,8 @@ const LitElement = customElements.get("hui-masonry-view")
 const html = LitElement.prototype.html;
 const css = LitElement.prototype.css;
 
+const _safeColor = (c, d) => (typeof c === "string" && /^#[0-9a-fA-F]{3,8}$/.test(c) ? c : d);
+
 class TaskMateStreakCard extends LitElement {
   static get properties() {
     return {
@@ -260,7 +262,7 @@ class TaskMateStreakCard extends LitElement {
 
     return html`
       <ha-card>
-        <style>:host { --taskmate-header-bg: ${this.config.header_color || '#e74c3c'}; }</style>
+        <style>:host { --taskmate-header-bg: ${_safeColor(this.config.header_color, '#e74c3c')}; }</style>
         <div class="card-header">
           <div class="header-content">
             <ha-icon class="header-icon" icon="mdi:fire"></ha-icon>
@@ -340,11 +342,12 @@ class TaskMateStreakCard extends LitElement {
 
     // Walk backwards from today counting consecutive days
     let streak = 0;
-    const today = new Date();
+    const todayKey = new Date().toLocaleDateString("en-CA", { timeZone: tz });
+    const today = new Date(todayKey + "T12:00:00"); // noon avoids DST edge cases
     for (let i = 0; i < 365; i++) {
       const d = new Date(today);
       d.setDate(d.getDate() - i);
-      const key = d.toLocaleDateString("en-CA", { timeZone: tz });
+      const key = d.toLocaleDateString("en-CA");
       if (daysWithCompletion.has(key)) {
         streak++;
       } else {
@@ -364,13 +367,13 @@ class TaskMateStreakCard extends LitElement {
     });
 
     const dots = [];
-    const today = new Date();
-    const todayKey = today.toLocaleDateString("en-CA", { timeZone: tz });
+    const todayKey = new Date().toLocaleDateString("en-CA", { timeZone: tz });
+    const today = new Date(todayKey + "T12:00:00"); // noon avoids DST edge cases
 
     for (let i = days - 1; i >= 0; i--) {
       const d = new Date(today);
       d.setDate(d.getDate() - i);
-      const key = d.toLocaleDateString("en-CA", { timeZone: tz });
+      const key = d.toLocaleDateString("en-CA");
       const active = daysWithCompletion.has(key);
       const isToday = key === todayKey;
       dots.push({

--- a/custom_components/taskmate/www/taskmate-weekly-card.js
+++ b/custom_components/taskmate/www/taskmate-weekly-card.js
@@ -14,6 +14,8 @@ const LitElement = customElements.get("hui-masonry-view")
 const html = LitElement.prototype.html;
 const css = LitElement.prototype.css;
 
+const _safeColor = (c, d) => (typeof c === "string" && /^#[0-9a-fA-F]{3,8}$/.test(c) ? c : d);
+
 class TaskMateWeeklyCard extends LitElement {
   static get properties() {
     return {
@@ -356,7 +358,7 @@ class TaskMateWeeklyCard extends LitElement {
 
     return html`
       <ha-card>
-        <style>:host { --taskmate-header-bg: ${this.config.header_color || '#27ae60'}; }</style>
+        <style>:host { --taskmate-header-bg: ${_safeColor(this.config.header_color, '#27ae60')}; }</style>
         <div class="card-header">
           <div class="header-content">
             <ha-icon class="header-icon" icon="mdi:calendar-week"></ha-icon>
@@ -447,7 +449,8 @@ class TaskMateWeeklyCard extends LitElement {
   }
 
   _getWeekDays(tz) {
-    const today = new Date();
+    const todayKey = new Date().toLocaleDateString("en-CA", { timeZone: tz });
+    const today = new Date(todayKey + "T12:00:00"); // noon avoids DST edge cases
     const todayDay = today.getDay(); // 0=Sun
     // Start week on Monday
     const mondayOffset = (todayDay === 0 ? -6 : 1 - todayDay);
@@ -464,7 +467,7 @@ class TaskMateWeeklyCard extends LitElement {
       const d = new Date(monday);
       d.setDate(monday.getDate() + i);
       days.push({
-        key: d.toLocaleDateString("en-CA", { timeZone: tz }),
+        key: d.toLocaleDateString("en-CA"),
         short: shortNames[i],
         date: d,
       });

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -111,6 +111,19 @@ _ha_websocket_api_const.ERR_UNAUTHORIZED = "unauthorized"
 _ha_websocket_api.const = _ha_websocket_api_const
 
 
+# ── homeassistant.exceptions ────────────────────────────────────────────────
+
+class FakeUnauthorized(Exception):
+    """Stand-in for homeassistant.exceptions.Unauthorized."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args)
+
+
+_ha_exceptions = MagicMock()
+_ha_exceptions.Unauthorized = FakeUnauthorized
+
+
 # ── homeassistant.helpers.event ─────────────────────────────────────────────
 
 _ha_event = MagicMock()
@@ -172,6 +185,9 @@ class _DtUtilMock:
     def now(self) -> _dt.datetime:
         return self._now
 
+    def start_of_local_day(self) -> _dt.datetime:
+        return self._now.replace(hour=0, minute=0, second=0, microsecond=0)
+
     @staticmethod
     def as_local(dt: _dt.datetime) -> _dt.datetime:
         return dt  # treat everything as UTC in tests
@@ -197,6 +213,7 @@ sys.modules.update(
         "homeassistant.core": _ha_core,
         "homeassistant.config_entries": MagicMock(),
         "homeassistant.const": MagicMock(),
+        "homeassistant.exceptions": _ha_exceptions,
         "homeassistant.helpers": MagicMock(),
         "homeassistant.helpers.service": MagicMock(),
         "homeassistant.helpers.storage": _ha_storage_mod,

--- a/tests/test_websocket_admin.py
+++ b/tests/test_websocket_admin.py
@@ -1,0 +1,96 @@
+"""Admin gating on TaskMate WebSocket commands.
+
+Every panel command — including the notification handlers — must reject
+non-admin users with ERR_UNAUTHORIZED before touching any data.
+"""
+from __future__ import annotations
+
+import pytest
+from unittest.mock import MagicMock
+
+from custom_components.taskmate.const import DOMAIN
+from custom_components.taskmate.coordinator import TaskMateCoordinator
+from custom_components.taskmate import websocket as ws
+
+
+@pytest.fixture
+async def setup(hass):
+    coord = object.__new__(TaskMateCoordinator)
+    coord.hass = hass
+    coord.entry_id = "ws_admin_test"
+    from custom_components.taskmate.storage import TaskMateStorage
+    coord.storage = TaskMateStorage(hass, "ws_admin_test")
+    await coord.storage.async_load()
+    from custom_components.taskmate.coord_notifications import NotificationCoordinator
+    coord.notifications = NotificationCoordinator(hass, coord.storage)
+    coord.notifications.coordinator = coord
+    hass.data = {DOMAIN: {"ws_admin_test": coord}}
+    return coord
+
+
+def _non_admin_connection() -> MagicMock:
+    connection = MagicMock()
+    connection.user.is_admin = False
+    return connection
+
+
+def _admin_connection() -> MagicMock:
+    connection = MagicMock()
+    connection.user.is_admin = True
+    return connection
+
+
+NOTIF_HANDLERS = [
+    ws.ws_notif_get_state,
+    ws.ws_notif_set_master,
+    ws.ws_notif_set_route,
+    ws.ws_notif_set_child_notify,
+    ws.ws_notif_upsert_parent,
+    ws.ws_notif_delete_parent,
+    ws.ws_notif_upsert_custom,
+    ws.ws_notif_delete_custom,
+    ws.ws_notif_list_notify,
+    ws.ws_notif_set_streak_cutoff,
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("handler", NOTIF_HANDLERS, ids=lambda h: h.__name__)
+async def test_notification_handlers_reject_non_admin(setup, hass, handler):
+    connection = _non_admin_connection()
+    msg = {"id": 1, "type": "test"}
+    await handler(hass, connection, msg)
+
+    connection.send_error.assert_called_once()
+    args, _ = connection.send_error.call_args
+    assert args[0] == 1
+    assert args[1] == ws.websocket_api.const.ERR_UNAUTHORIZED
+    connection.send_result.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_crud_handler_rejects_non_admin(setup, hass):
+    connection = _non_admin_connection()
+    msg = {"id": 2, "type": "taskmate/add_child", "name": "Intruder"}
+    await ws._ws_add_child(hass, connection, msg)
+
+    connection.send_error.assert_called_once()
+    args, _ = connection.send_error.call_args
+    assert args[1] == ws.websocket_api.const.ERR_UNAUTHORIZED
+    connection.send_result.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_notification_handler_allows_admin(setup, hass):
+    coord = setup
+    connection = _admin_connection()
+    msg = {
+        "id": 3, "type": "test",
+        "type_id": "bedtime_reminder", "enabled": True,
+    }
+    await ws.ws_notif_set_master(hass, connection, msg)
+
+    args, _ = connection.send_result.call_args
+    assert args[0] == 3
+    assert args[1] == {"ok": True}
+    assert coord.storage.get_notification_config("bedtime_reminder").master_enabled is True


### PR DESCRIPTION
Full sweep of fixes from the read-only codebase audit (no behaviour-neutral refactors, fixes only).

## Security
- **Broken access control:** all ten `ws_notif_*` WebSocket handlers were missing the `@_admin_only` decorator used by every other panel command — any authenticated non-admin user could read notification/recipient config, enumerate `notify.*` services and rewrite routing. All ten are now admin-gated (which also fixes their missing coordinator `None` checks).
- **Service privilege asymmetry:** parent-privileged services (`approve_chore`, `reject_chore`, `approve/reject_reward`, `add/remove_points`, penalties, bonuses, chore/task-group/badge management, `set_chore_order`, `skip_chore`, `set_chore_manual_start`) now require an admin user when invoked with a user context. Calls without a user context (automations, scripts, schedules) pass through unchanged, and child-flow services (`complete_chore`, `claim_reward`, timed-task start/pause/stop, `allocate_points_to_pool`, `complete_bonus_subtask`) remain open.
- `header_color` is validated as a hex colour before being interpolated into card `<style>` blocks (CSS injection hardening).
- `Penalty`/`Bonus` points are clamped non-negative in `from_dict` (a negative penalty would have *granted* points).
- CI: `home-assistant/actions/hassfest` and `hacs/action` pinned to commit SHAs; `actions/checkout` standardised to v6; ruff pinned to 0.15.12.

## Correctness
- **Timed tasks:** the midnight stale-session cleanup wrote a tz-naive segment end against a tz-aware start; the resulting `TypeError` was swallowed and the overnight segment scored 0 points. Now uses `dt_util.start_of_local_day()`.
- **Double awards:** `async_approve_chore` now ignores a second approval of the same completion (mobile-action double-tap previously awarded points twice). The reward path already had this guard.
- **Rejection reversal:** streak is only decremented when the rejected completion was the child's sole completion that day, and `last_completion_date` rolls back to the previous completion when applicable.
- **Recurrence:** monthly / every-3-months / every-6-months now use real calendar months (with end-of-month clamping) in both availability and calendar projection, and the 3/6-month branches missing from the calendar (HA + JS card mirror) were added — quarterly/biannual chores previously never appeared on calendars.
- A future `recurrence_start` now defers availability regardless of `first_occurrence_mode`.
- **Midnight race:** the six concurrent midnight maintenance tasks (each mutating storage and saving) now run sequentially in one task with per-step exception logging and a single save.
- **Perfect week:** the bonus now compares against days the child actually had scheduled chores (weekday-only households could never earn it); falls back to the old all-7-days rule when no schedule can be derived.
- Malformed notification templates fall back to raw text instead of silently killing the notification.
- **Front-end double-submit:** approve/reject/claim/allocate handlers across the approvals, parent-dashboard and rewards cards now early-return while a call is in flight (double-click = double points/spend before).
- Badge event subscriptions no longer leak when a card disconnects before the subscribe promise resolves (badges + child cards); dialog keydown listener and toast timers are cleaned up; AudioContext is closed on disconnect.
- Week/streak/graph day-anchors are derived from the HA-configured timezone instead of the browser's (off-by-one-day around midnight for mismatched timezones).

## Performance
- Dynamic service descriptions are only re-registered when the selector option sets actually change (previously a full deepcopy + re-register of every dynamic service on every 30s coordinator refresh).
- WS state snapshot no longer does an O(n²) per-chore linear re-scan.
- Graph card only redraws the canvas when `hass`/`config`/`_mode` change; config-sounds DOM polling slowed 2s → 10s.

## Cleanup
- Removed dead `ApproveChoreButton`/`RejectChoreButton` classes, unused `_str_list`/`_opt_int` validators, an identical if/else, and a dead `isinstance(bst, dict)` branch.
- `update_completion`/`update_reward_claim` and unparseable stored datetimes now log warnings instead of silently no-opping.
- Service unregistration now counts only coordinator instances (the WS-registered flag previously made the "no entries left" branch unreachable).
- `async_add_chore` accepts `unassigned` to match `ASSIGNMENT_MODES`; `iot_class` corrected to `calculated`; `.ruff_cache/`, `.tmp/`, `.claude/` gitignored.

## i18n
- Backfilled the 11 missing service translation blocks (timed tasks, badges, pool allocation, bonus subtasks) in `strings.json` and all 8 locales; added `panel.notif_unnamed_recipient` to the 6 panel locales missing it; added the `entity` block to `strings.json`.

## Tests
- New `tests/test_websocket_admin.py`: all ten notification handlers reject non-admins with `ERR_UNAUTHORIZED`, a representative CRUD command does too, and an admin call still succeeds (12 tests).
- Full suite: **457 passed**; the 3 failures/9 errors that remain occur only in full-suite runs, are byte-identical on `main` (pre-existing test-order pollution) and pass individually.

Deliberately **not** changed (audit items needing their own discussion/PRs): the 30s coordinator poll (it drives timed-task auto-stop and time-category transitions), bonuses/penalties card de-duplication, the shared colour-picker extraction, storage save debouncing, and the O(chores×children×completions) availability precompute.