### PR TITLE
feat(panel): custom unlimited time-of-day periods

### DIFF
--- a/README.md
+++ b/README.md
@@ -527,7 +527,7 @@ Kid-friendly chore completion. The entire row is tappable — no small targets. 
 type: custom:taskmate-child-card
 entity: sensor.taskmate_overview
 child_id: a8c8376a            # required — see Finding IDs
-time_category: anytime        # morning | afternoon | evening | night | anytime | all
+time_category: anytime        # any period id (built-in or custom) | anytime | all
 due_days_mode: hide           # hide | dim | show — chores not scheduled today
 recurrence_done_mode: dim     # dim | hide | show — recurring chores waiting to reset
 elapsed_time_mode: dim        # dim | hide | show — time-of-day chores whose period has passed
@@ -538,7 +538,9 @@ undo_sound: undo              # sound when undoing
 header_color: "#9b59b6"
 ```
 
-**`elapsed_time_mode`** — controls what happens to morning/afternoon/evening/night chores once that time window has passed without completion. Set to `dim` (default) to grey them out and make them non-interactive, `hide` to remove them entirely, or `show` to leave them active. Chores set to `Anytime` are never affected. Chores that were completed still show with their green done style regardless.
+**`elapsed_time_mode`** — controls what happens to time-of-day chores once that time window has passed without completion. Set to `dim` (default) to grey them out and make them non-interactive, `hide` to remove them entirely, or `show` to leave them active. Chores set to `Anytime` are never affected. Chores that were completed still show with their green done style regardless.
+
+Time-of-day periods are fully customisable in **Settings → Time-of-day boundaries** in the TaskMate admin panel: rename the built-in four, change their hours and icons, or add as many of your own (school run, bedtime, …) as you like. Periods can't overlap; gaps between them fall back to Anytime, and a period that still has chores assigned can't be deleted until they're reassigned. A chore's or card's `time_category` accepts any period id.
  
 ---
  

--- a/custom_components/taskmate/config_flow.py
+++ b/custom_components/taskmate/config_flow.py
@@ -29,7 +29,6 @@ from .const import (
     RECURRENCE_OPTIONS,
     REWARD_ICON_OPTIONS,
     TASK_GROUP_POLICIES,
-    TIME_CATEGORIES,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -129,6 +128,18 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
                 "TaskMate coordinator is not available for this config entry yet"
             )
         return domain_data[entry_id]
+
+    def _time_category_options(self) -> list[selector.SelectOptionDict]:
+        """Dropdown options built from the user-defined time periods."""
+        options = [
+            selector.SelectOptionDict(
+                value=p["id"],
+                label=p["label"] or p["id"].replace("_", " ").title(),
+            )
+            for p in self.coordinator.get_time_periods()
+        ]
+        options.append(selector.SelectOptionDict(value="anytime", label="Anytime"))
+        return options
 
     async def _async_get_user_language(self) -> str:
         """Get the current user's language from their HA profile."""
@@ -465,8 +476,7 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
             ),
             vol.Required("time_category", default="anytime"): selector.SelectSelector(
                 selector.SelectSelectorConfig(
-                    options=list(TIME_CATEGORIES),
-                    translation_key="time_category",
+                    options=self._time_category_options(),
                     mode=selector.SelectSelectorMode.DROPDOWN,
                 )
             ),
@@ -736,8 +746,7 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
             ),
             vol.Required("time_category", default="anytime"): selector.SelectSelector(
                 selector.SelectSelectorConfig(
-                    options=list(TIME_CATEGORIES),
-                    translation_key="time_category",
+                    options=self._time_category_options(),
                     mode=selector.SelectSelectorMode.DROPDOWN,
                 )
             ),
@@ -907,8 +916,7 @@ class TaskMateOptionsFlow(config_entries.OptionsFlow):
             ),
             vol.Required("time_category", default=chore.time_category): selector.SelectSelector(
                 selector.SelectSelectorConfig(
-                    options=list(TIME_CATEGORIES),
-                    translation_key="time_category",
+                    options=self._time_category_options(),
                     mode=selector.SelectSelectorMode.DROPDOWN,
                 )
             ),

--- a/custom_components/taskmate/const.py
+++ b/custom_components/taskmate/const.py
@@ -125,6 +125,18 @@ TIME_CATEGORY_ICONS: Final = {
     "anytime": "mdi:clock-outline",
 }
 
+# Default user-editable time-of-day periods. "anytime" is implicit (all-day,
+# always available) and never appears in this list. An empty label means
+# "use the translated built-in name for this id".
+DEFAULT_TIME_PERIODS: Final = [
+    {"id": "morning",   "label": "", "start": "06:00", "end": "12:00", "icon": "mdi:weather-sunny"},
+    {"id": "afternoon", "label": "", "start": "12:00", "end": "17:00", "icon": "mdi:white-balance-sunny"},
+    {"id": "evening",   "label": "", "start": "17:00", "end": "21:00", "icon": "mdi:weather-sunset"},
+    {"id": "night",     "label": "", "start": "21:00", "end": "23:59", "icon": "mdi:weather-night"},
+]
+
+MAX_TIME_PERIODS: Final = 24
+
 # Avatar options
 AVATAR_OPTIONS: Final = [
     # Basic faces

--- a/custom_components/taskmate/coord_calendar.py
+++ b/custom_components/taskmate/coord_calendar.py
@@ -10,8 +10,10 @@ from homeassistant.util import dt as dt_util
 
 from .const import (
     DEFAULT_CALENDAR_PROJECTION_DAYS,
+    DEFAULT_TIME_PERIODS,
     MAX_CALENDAR_PROJECTION_DAYS,
     MIN_CALENDAR_PROJECTION_DAYS,
+    TIME_CATEGORY_ICONS,
 )
 from .models import Chore
 
@@ -24,29 +26,70 @@ _LOGGER = logging.getLogger(__name__)
 class CalendarMixin:
     """Mixin providing calendar projection and event publishing logic."""
 
-    _DEFAULT_TIME_BOUNDARIES: dict[str, tuple[str, str]] = {
-        "morning":   ("06:00", "12:00"),
-        "afternoon": ("12:00", "17:00"),
-        "evening":   ("17:00", "21:00"),
-        "night":     ("21:00", "23:59"),
-    }
-
     _SCHEDULE_DOW = ("monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday")
 
+    @staticmethod
+    def _parse_hhmm(value: str) -> time | None:
+        """Parse an HH:MM string, returning None when invalid."""
+        try:
+            h, m = (int(x) for x in str(value).split(":"))
+            return time(h, m)
+        except (ValueError, TypeError):
+            return None
+
+    def get_time_periods(self) -> list[dict]:
+        """Resolve the user-defined time-of-day periods, ordered by start.
+
+        Fallback chain: `time_periods` setting → legacy `time_<cat>_start/end`
+        keys → DEFAULT_TIME_PERIODS. "anytime" is implicit and never listed.
+        """
+        raw = self.storage.get_setting("time_periods", None)
+        if isinstance(raw, list) and raw:
+            periods = []
+            for entry in raw:
+                if not isinstance(entry, dict):
+                    continue
+                start = self._parse_hhmm(entry.get("start"))
+                end = self._parse_hhmm(entry.get("end"))
+                pid = str(entry.get("id") or "").strip()
+                if not pid or pid == "anytime" or start is None or end is None:
+                    continue
+                periods.append({
+                    "id": pid,
+                    "label": str(entry.get("label") or "").strip(),
+                    "start": start.strftime("%H:%M"),
+                    "end": end.strftime("%H:%M"),
+                    "icon": str(entry.get("icon") or "") or TIME_CATEGORY_ICONS.get(pid, "mdi:clock-outline"),
+                })
+            if periods:
+                return sorted(periods, key=lambda p: p["start"])
+
+        # Legacy flat keys (pre-time_periods installs); these already default
+        # to the built-in boundaries, so this also covers fresh installs.
+        periods = []
+        for default in DEFAULT_TIME_PERIODS:
+            pid = default["id"]
+            start_str = self.storage.get_setting(f"time_{pid}_start", default["start"])
+            end_str = self.storage.get_setting(f"time_{pid}_end", default["end"])
+            start = self._parse_hhmm(start_str) or self._parse_hhmm(default["start"])
+            end = self._parse_hhmm(end_str) or self._parse_hhmm(default["end"])
+            periods.append({
+                "id": pid,
+                "label": "",
+                "start": start.strftime("%H:%M"),
+                "end": end.strftime("%H:%M"),
+                "icon": default["icon"],
+            })
+        return sorted(periods, key=lambda p: p["start"])
+
     def _get_time_boundaries(self) -> dict[str, tuple[time, time] | None]:
-        """Build time boundaries from storage settings with defaults."""
+        """Build time boundaries from the resolved periods."""
         result: dict[str, tuple[time, time] | None] = {"anytime": None}
-        for cat, (def_start, def_end) in self._DEFAULT_TIME_BOUNDARIES.items():
-            start_str = self.storage.get_setting(f"time_{cat}_start", def_start)
-            end_str = self.storage.get_setting(f"time_{cat}_end", def_end)
-            try:
-                sh, sm = (int(x) for x in start_str.split(":"))
-                eh, em = (int(x) for x in end_str.split(":"))
-                result[cat] = (time(sh, sm), time(eh, em))
-            except (ValueError, TypeError):
-                sh, sm = (int(x) for x in def_start.split(":"))
-                eh, em = (int(x) for x in def_end.split(":"))
-                result[cat] = (time(sh, sm), time(eh, em))
+        for period in self.get_time_periods():
+            result[period["id"]] = (
+                self._parse_hhmm(period["start"]),
+                self._parse_hhmm(period["end"]),
+            )
         return result
 
     def _time_category_window(self, category: str, today: date) -> tuple[datetime, datetime] | None:

--- a/custom_components/taskmate/sensor.py
+++ b/custom_components/taskmate/sensor.py
@@ -678,16 +678,19 @@ class TaskMateOverallStatsSensor(_CachedAttrsSensor):
         today_dow = dt_util.now().strftime("%A").lower()
         settings = data.get("settings", {})
 
-        time_boundaries = {
-            "morning_start": settings.get("time_morning_start", "06:00"),
-            "morning_end": settings.get("time_morning_end", "12:00"),
-            "afternoon_start": settings.get("time_afternoon_start", "12:00"),
-            "afternoon_end": settings.get("time_afternoon_end", "17:00"),
-            "evening_start": settings.get("time_evening_start", "17:00"),
-            "evening_end": settings.get("time_evening_end", "21:00"),
-            "night_start": settings.get("time_night_start", "21:00"),
-            "night_end": settings.get("time_night_end", "23:59"),
+        time_periods = self.coordinator.get_time_periods()
+        period_by_id = {p["id"]: p for p in time_periods}
+
+        # Legacy shape kept for cards that still read the four fixed keys.
+        legacy_defaults = {
+            "morning": ("06:00", "12:00"), "afternoon": ("12:00", "17:00"),
+            "evening": ("17:00", "21:00"), "night": ("21:00", "23:59"),
         }
+        time_boundaries = {}
+        for cat, (def_start, def_end) in legacy_defaults.items():
+            period = period_by_id.get(cat)
+            time_boundaries[f"{cat}_start"] = period["start"] if period else def_start
+            time_boundaries[f"{cat}_end"] = period["end"] if period else def_end
 
         return {
             "today_day_of_week": today_dow,
@@ -708,6 +711,7 @@ class TaskMateOverallStatsSensor(_CachedAttrsSensor):
             "points_icon": data.get("points_icon", "mdi:star"),
             "children": _build_children_summary(common),
             "time_boundaries": time_boundaries,
+            "time_periods": time_periods,
         }
 
 

--- a/custom_components/taskmate/websocket.py
+++ b/custom_components/taskmate/websocket.py
@@ -47,6 +47,7 @@ TaskMate's existing business logic (refunds, cleanup, recompute) runs.
 from __future__ import annotations
 
 import logging
+import re
 from functools import wraps
 from typing import Any, Final
 
@@ -54,7 +55,7 @@ import voluptuous as vol
 from homeassistant.components import websocket_api
 from homeassistant.core import HomeAssistant
 
-from .const import DOMAIN
+from .const import DEFAULT_TIME_PERIODS, DOMAIN, MAX_TIME_PERIODS, TIME_CATEGORY_ICONS
 from .coordinator import TaskMateCoordinator
 from .models import BonusSubTask, Reward
 
@@ -774,6 +775,89 @@ _SUBKEY_SETTINGS = {
     "time_night_start", "time_night_end",
 }
 
+
+def _slugify_period_id(label: str, taken: set[str]) -> str:
+    """Derive a stable, unique slug id from a period label."""
+    base = re.sub(r"[^a-z0-9]+", "_", label.lower()).strip("_") or "period"
+    if base == "anytime":
+        base = "period"
+    slug = base
+    n = 2
+    while slug in taken:
+        slug = f"{base}_{n}"
+        n += 1
+    return slug
+
+
+def _validate_time_periods(raw: list, coordinator) -> tuple[list[dict] | None, str | None]:
+    """Normalize and validate a time_periods payload.
+
+    Returns (periods, None) on success or (None, error_message) on failure.
+    Enforces: HH:MM times, start < end, non-empty labels for custom periods,
+    unique ids, non-overlapping when sorted by start, and block-on-delete for
+    periods still referenced by chores.
+    """
+    if not isinstance(raw, list) or not raw:
+        return None, "time_periods must be a non-empty list"
+    if len(raw) > MAX_TIME_PERIODS:
+        return None, f"too many periods (max {MAX_TIME_PERIODS})"
+
+    builtin_ids = {p["id"] for p in DEFAULT_TIME_PERIODS}
+    time_re = re.compile(r"^([01]\d|2[0-3]):[0-5]\d$")
+    periods: list[dict] = []
+    ids: set[str] = {"anytime"}
+
+    for entry in raw:
+        if not isinstance(entry, dict):
+            return None, "each period must be an object"
+        label = str(entry.get("label") or "").strip()[:60]
+        pid = str(entry.get("id") or "").strip()
+        if pid and pid != "anytime" and pid in ids:
+            return None, f"duplicate period id: {pid}"
+        if not pid or pid == "anytime":
+            pid = _slugify_period_id(label, ids)
+        if not label and pid not in builtin_ids:
+            return None, "every custom period needs a name"
+        start = str(entry.get("start") or "")
+        end = str(entry.get("end") or "")
+        if not time_re.match(start) or not time_re.match(end):
+            return None, f"invalid time for period '{label or pid}' (use HH:MM)"
+        if start >= end:
+            return None, f"period '{label or pid}' must start before it ends"
+        ids.add(pid)
+        periods.append({
+            "id": pid,
+            "label": label,
+            "start": start,
+            "end": end,
+            "icon": str(entry.get("icon") or "").strip()[:120]
+                    or TIME_CATEGORY_ICONS.get(pid, "mdi:clock-outline"),
+        })
+
+    periods.sort(key=lambda p: p["start"])
+    for prev, cur in zip(periods, periods[1:]):
+        if cur["start"] < prev["end"]:
+            return None, (
+                f"'{cur['label'] or cur['id']}' overlaps "
+                f"'{prev['label'] or prev['id']}' — periods cannot overlap"
+            )
+
+    removed = {p["id"] for p in coordinator.get_time_periods()} - {p["id"] for p in periods}
+    if removed:
+        in_use = sorted({
+            chore.name or chore.id
+            for chore in coordinator.storage.get_chores()
+            if chore.time_category in removed
+        })
+        if in_use:
+            return None, (
+                "cannot delete a period still used by chores: "
+                + ", ".join(in_use[:10])
+                + ("…" if len(in_use) > 10 else "")
+            )
+
+    return periods, None
+
 @websocket_api.websocket_command({
     vol.Required("type"): WS_UPDATE_SETTINGS,
     vol.Optional("points_name"): vol.All(str, vol.Length(min=1, max=120)),
@@ -796,14 +880,22 @@ _SUBKEY_SETTINGS = {
     vol.Optional("time_evening_end"): vol.Match(r"^\d{2}:\d{2}$"),
     vol.Optional("time_night_start"): vol.Match(r"^\d{2}:\d{2}$"),
     vol.Optional("time_night_end"): vol.Match(r"^\d{2}:\d{2}$"),
+    vol.Optional("time_periods"): list,
 })
 @websocket_api.async_response
 @_admin_only
 async def _ws_update_settings(hass, connection, msg, coordinator):
     storage = coordinator.storage
     changed = []
+    if "time_periods" in msg:
+        periods, err = _validate_time_periods(msg["time_periods"], coordinator)
+        if err:
+            connection.send_error(msg["id"], "invalid_time_periods", err)
+            return
+        storage.set_setting("time_periods", periods)
+        changed.append("time_periods")
     for k, v in msg.items():
-        if k in {"id", "type"}:
+        if k in {"id", "type", "time_periods"}:
             continue
         if k == "points_name":
             storage.set_points_name(v.strip())

--- a/custom_components/taskmate/www/locales/de.json
+++ b/custom_components/taskmate/www/locales/de.json
@@ -735,7 +735,7 @@
   "panel.settings_streak_milestones_label": "Serien-Meilensteine",
   "panel.settings_streak_reset_hint": "Was passiert, wenn ein Tag ausgelassen wird",
   "panel.settings_streak_reset_label": "Serien-Zurücksetzung",
-  "panel.settings_time_boundaries_hint": "Wann jede Tageszeit beginnt und endet (HH:MM, 24-Stunden-Format).",
+  "panel.settings_time_boundaries_hint": "Wann jeder Tagesabschnitt beginnt und endet (HH:MM, 24-Stunden). Eigene Abschnitte hinzufügen; Lücken fallen auf „Jederzeit“ zurück.",
   "panel.settings_time_boundaries_title": "Tageszeitgrenzen",
   "panel.settings_title": "Einstellungen",
   "panel.settings_weekend_multiplier_hint": "Bonus an Sa/So (1,0 = aus)",
@@ -1176,5 +1176,17 @@
   "notification.pending_reward_claim.description": "Wird an Eltern gesendet, wenn ein Kind eine Belohnung einlöst. Tippe auf Genehmigen oder Ablehnen in der Benachrichtigung.",
   "notification.pending_reward_claim.name": "Belohnung wartet auf Genehmigung",
   "notification.streak_at_risk.description": "Wird ausgelöst, wenn eine aktive Serie heute noch nicht verlängert wurde.",
-  "notification.streak_at_risk.name": "Serie in Gefahr"
+  "notification.streak_at_risk.name": "Serie in Gefahr",
+  "panel.tp_label_placeholder": "Name des Abschnitts",
+  "panel.tp_add_period": "Abschnitt hinzufügen",
+  "panel.tp_reset_defaults": "Auf Standard zurücksetzen",
+  "panel.tp_delete_title": "Abschnitt löschen",
+  "panel.tp_in_use_title": "Von {count} Aufgabe(n) verwendet — vor dem Löschen neu zuweisen",
+  "panel.tp_in_use_hint": "Von {count} Aufgabe(n) verwendet. Weise sie einem anderen Abschnitt zu, um diesen zu löschen.",
+  "panel.tp_anytime_hint": "Immer verfügbar, ganztägig. Integriert und nicht entfernbar.",
+  "panel.tp_err_label_required": "Jeder eigene Abschnitt braucht einen Namen.",
+  "panel.tp_err_time_required": "Lege Start- und Endzeit für „{name}“ fest.",
+  "panel.tp_err_order": "„{name}“ muss beginnen, bevor er endet.",
+  "panel.tp_err_empty": "Füge mindestens einen Tagesabschnitt hinzu.",
+  "panel.tp_err_overlap": "„{a}“ überschneidet sich mit „{b}“ — Abschnitte dürfen sich nicht überlappen."
 }

--- a/custom_components/taskmate/www/locales/en-GB.json
+++ b/custom_components/taskmate/www/locales/en-GB.json
@@ -735,7 +735,7 @@
   "panel.settings_streak_milestones_label": "Streak milestones",
   "panel.settings_streak_reset_hint": "What happens when a day is missed",
   "panel.settings_streak_reset_label": "Streak reset",
-  "panel.settings_time_boundaries_hint": "When each time period starts and ends (HH:MM, 24-hour).",
+  "panel.settings_time_boundaries_hint": "When each time period starts and ends (HH:MM, 24-hour). Add your own periods; gaps between periods fall back to Anytime.",
   "panel.settings_time_boundaries_title": "Time-of-day boundaries",
   "panel.settings_title": "Settings",
   "panel.settings_weekend_multiplier_hint": "Bonus on Sat/Sun (1.0 = off)",
@@ -1177,5 +1177,17 @@
   "notification.pending_reward_claim.description": "Sent to parents when a child redeems a reward. Tap Approve or Reject from the notification.",
   "notification.pending_reward_claim.name": "Pending reward claim",
   "notification.streak_at_risk.description": "Fires when an active streak hasn't been extended yet today.",
-  "notification.streak_at_risk.name": "Streak at risk"
+  "notification.streak_at_risk.name": "Streak at risk",
+  "panel.tp_label_placeholder": "Period name",
+  "panel.tp_add_period": "Add period",
+  "panel.tp_reset_defaults": "Reset to defaults",
+  "panel.tp_delete_title": "Delete period",
+  "panel.tp_in_use_title": "Used by {count} chore(s) — reassign them before deleting",
+  "panel.tp_in_use_hint": "Used by {count} chore(s). Reassign them to another period to delete this one.",
+  "panel.tp_anytime_hint": "Always available, all day. Built-in and cannot be removed.",
+  "panel.tp_err_label_required": "Every custom period needs a name.",
+  "panel.tp_err_time_required": "Set a start and end time for “{name}”.",
+  "panel.tp_err_order": "“{name}” must start before it ends.",
+  "panel.tp_err_empty": "Add at least one time period.",
+  "panel.tp_err_overlap": "“{a}” overlaps “{b}” — periods cannot overlap."
 }

--- a/custom_components/taskmate/www/locales/en.json
+++ b/custom_components/taskmate/www/locales/en.json
@@ -735,7 +735,7 @@
   "panel.settings_streak_milestones_label": "Streak milestones",
   "panel.settings_streak_reset_hint": "What happens when a day is missed",
   "panel.settings_streak_reset_label": "Streak reset",
-  "panel.settings_time_boundaries_hint": "When each time period starts and ends (HH:MM, 24-hour).",
+  "panel.settings_time_boundaries_hint": "When each time period starts and ends (HH:MM, 24-hour). Add your own periods; gaps between periods fall back to Anytime.",
   "panel.settings_time_boundaries_title": "Time-of-day boundaries",
   "panel.settings_title": "Settings",
   "panel.settings_weekend_multiplier_hint": "Bonus on Sat/Sun (1.0 = off)",
@@ -1177,5 +1177,17 @@
   "notification.pending_reward_claim.description": "Sent to parents when a child redeems a reward. Tap Approve or Reject from the notification.",
   "notification.pending_reward_claim.name": "Pending reward claim",
   "notification.streak_at_risk.description": "Fires when an active streak hasn't been extended yet today.",
-  "notification.streak_at_risk.name": "Streak at risk"
+  "notification.streak_at_risk.name": "Streak at risk",
+  "panel.tp_label_placeholder": "Period name",
+  "panel.tp_add_period": "Add period",
+  "panel.tp_reset_defaults": "Reset to defaults",
+  "panel.tp_delete_title": "Delete period",
+  "panel.tp_in_use_title": "Used by {count} chore(s) — reassign them before deleting",
+  "panel.tp_in_use_hint": "Used by {count} chore(s). Reassign them to another period to delete this one.",
+  "panel.tp_anytime_hint": "Always available, all day. Built-in and cannot be removed.",
+  "panel.tp_err_label_required": "Every custom period needs a name.",
+  "panel.tp_err_time_required": "Set a start and end time for “{name}”.",
+  "panel.tp_err_order": "“{name}” must start before it ends.",
+  "panel.tp_err_empty": "Add at least one time period.",
+  "panel.tp_err_overlap": "“{a}” overlaps “{b}” — periods cannot overlap."
 }

--- a/custom_components/taskmate/www/locales/fr.json
+++ b/custom_components/taskmate/www/locales/fr.json
@@ -735,7 +735,7 @@
   "panel.settings_streak_milestones_label": "Jalons de série",
   "panel.settings_streak_reset_hint": "Ce qui se passe quand un jour est manqué",
   "panel.settings_streak_reset_label": "Réinitialisation de série",
-  "panel.settings_time_boundaries_hint": "Quand chaque période commence et se termine (HH:MM, 24h).",
+  "panel.settings_time_boundaries_hint": "Quand chaque période de la journée commence et se termine (HH:MM, 24 h). Ajoutez vos propres périodes ; les trous retombent sur « À tout moment ».",
   "panel.settings_time_boundaries_title": "Limites horaires",
   "panel.settings_title": "Paramètres",
   "panel.settings_weekend_multiplier_hint": "Bonus le Sam/Dim (1.0 = désactivé)",
@@ -1176,5 +1176,17 @@
   "notification.pending_reward_claim.description": "Envoyé aux parents quand un enfant échange une récompense. Appuyez sur Approuver ou Rejeter depuis la notification.",
   "notification.pending_reward_claim.name": "Réclamation de récompense en attente",
   "notification.streak_at_risk.description": "Se déclenche quand une série active n'a pas encore été prolongée aujourd'hui.",
-  "notification.streak_at_risk.name": "Série en danger"
+  "notification.streak_at_risk.name": "Série en danger",
+  "panel.tp_label_placeholder": "Nom de la période",
+  "panel.tp_add_period": "Ajouter une période",
+  "panel.tp_reset_defaults": "Réinitialiser",
+  "panel.tp_delete_title": "Supprimer la période",
+  "panel.tp_in_use_title": "Utilisée par {count} corvée(s) — réassignez-les avant de supprimer",
+  "panel.tp_in_use_hint": "Utilisée par {count} corvée(s). Réassignez-les à une autre période pour pouvoir la supprimer.",
+  "panel.tp_anytime_hint": "Toujours disponible, toute la journée. Intégrée et non supprimable.",
+  "panel.tp_err_label_required": "Chaque période personnalisée doit avoir un nom.",
+  "panel.tp_err_time_required": "Définissez une heure de début et de fin pour « {name} ».",
+  "panel.tp_err_order": "« {name} » doit commencer avant de se terminer.",
+  "panel.tp_err_empty": "Ajoutez au moins une période.",
+  "panel.tp_err_overlap": "« {a} » chevauche « {b} » — les périodes ne peuvent pas se chevaucher."
 }

--- a/custom_components/taskmate/www/locales/nb.json
+++ b/custom_components/taskmate/www/locales/nb.json
@@ -735,7 +735,7 @@
   "panel.settings_streak_milestones_label": "Seriemilepæler",
   "panel.settings_streak_reset_hint": "Hva som skjer når en dag hoppes over",
   "panel.settings_streak_reset_label": "Serietilbakestilling",
-  "panel.settings_time_boundaries_hint": "Når hver tidsperiode starter og slutter (TT:MM, 24-timers).",
+  "panel.settings_time_boundaries_hint": "Når hver tidsperiode starter og slutter (HH:MM, 24-timers). Legg til egne perioder; hull faller tilbake til «Når som helst».",
   "panel.settings_time_boundaries_title": "Tidsgrenser for tid på døgnet",
   "panel.settings_title": "Innstillinger",
   "panel.settings_weekend_multiplier_hint": "Bonus lør/søn (1.0 = av)",
@@ -1176,5 +1176,17 @@
   "notification.pending_reward_claim.description": "Sendes til foresatte når et barn løser inn en belønning. Trykk Godkjenn eller Avvis fra varselet.",
   "notification.pending_reward_claim.name": "Belønningskrav venter",
   "notification.streak_at_risk.description": "Utløses når en aktiv rekke ikke er blitt forlenget ennå i dag.",
-  "notification.streak_at_risk.name": "Rekke i fare"
+  "notification.streak_at_risk.name": "Rekke i fare",
+  "panel.tp_label_placeholder": "Periodenavn",
+  "panel.tp_add_period": "Legg til periode",
+  "panel.tp_reset_defaults": "Tilbakestill til standard",
+  "panel.tp_delete_title": "Slett periode",
+  "panel.tp_in_use_title": "Brukes av {count} oppgave(r) — tilordne dem på nytt før sletting",
+  "panel.tp_in_use_hint": "Brukes av {count} oppgave(r). Tilordne dem til en annen periode for å slette denne.",
+  "panel.tp_anytime_hint": "Alltid tilgjengelig, hele dagen. Innebygd og kan ikke fjernes.",
+  "panel.tp_err_label_required": "Hver egendefinert periode trenger et navn.",
+  "panel.tp_err_time_required": "Angi start- og sluttid for «{name}».",
+  "panel.tp_err_order": "«{name}» må starte før den slutter.",
+  "panel.tp_err_empty": "Legg til minst én tidsperiode.",
+  "panel.tp_err_overlap": "«{a}» overlapper «{b}» — perioder kan ikke overlappe."
 }

--- a/custom_components/taskmate/www/locales/nn.json
+++ b/custom_components/taskmate/www/locales/nn.json
@@ -735,7 +735,7 @@
   "panel.settings_streak_milestones_label": "Rekkjemilepælar",
   "panel.settings_streak_reset_hint": "Kva som skjer når ein dag vert missa",
   "panel.settings_streak_reset_label": "Rekkjenullstilling",
-  "panel.settings_time_boundaries_hint": "Når kvar tidsperiode startar og sluttar (TT:MM, 24-timars).",
+  "panel.settings_time_boundaries_hint": "Når kvar tidsperiode startar og sluttar (HH:MM, 24-timars). Legg til eigne periodar; hol fell tilbake til «Når som helst».",
   "panel.settings_time_boundaries_title": "Tidspunkt-grenser",
   "panel.settings_title": "Innstillingar",
   "panel.settings_weekend_multiplier_hint": "Bonus på lau/sun (1.0 = av)",
@@ -1176,5 +1176,17 @@
   "notification.pending_reward_claim.description": "Vert sendt til føresette når eit born løyser inn ein premie. Trykk Godkjenn eller Avvis frå varselet.",
   "notification.pending_reward_claim.name": "Premiekrav ventar",
   "notification.streak_at_risk.description": "Vert utløyst når ei aktiv rekkje ikkje er vorte forlenga i dag enno.",
-  "notification.streak_at_risk.name": "Rekkje i fare"
+  "notification.streak_at_risk.name": "Rekkje i fare",
+  "panel.tp_label_placeholder": "Periodenamn",
+  "panel.tp_add_period": "Legg til periode",
+  "panel.tp_reset_defaults": "Tilbakestill til standard",
+  "panel.tp_delete_title": "Slett periode",
+  "panel.tp_in_use_title": "Brukt av {count} oppgåve(r) — tilordna dei på nytt før sletting",
+  "panel.tp_in_use_hint": "Brukt av {count} oppgåve(r). Tilordna dei til ein annan periode for å slette denne.",
+  "panel.tp_anytime_hint": "Alltid tilgjengeleg, heile dagen. Innebygd og kan ikkje fjernast.",
+  "panel.tp_err_label_required": "Kvar eigendefinert periode treng eit namn.",
+  "panel.tp_err_time_required": "Set start- og sluttid for «{name}».",
+  "panel.tp_err_order": "«{name}» må starte før han sluttar.",
+  "panel.tp_err_empty": "Legg til minst éin tidsperiode.",
+  "panel.tp_err_overlap": "«{a}» overlappar «{b}» — periodar kan ikkje overlappe."
 }

--- a/custom_components/taskmate/www/locales/pt-BR.json
+++ b/custom_components/taskmate/www/locales/pt-BR.json
@@ -735,7 +735,7 @@
   "panel.settings_streak_milestones_label": "Marcos de sequência",
   "panel.settings_streak_reset_hint": "O que acontece quando um dia é perdido",
   "panel.settings_streak_reset_label": "Reinício de sequência",
-  "panel.settings_time_boundaries_hint": "Quando cada período começa e termina (HH:MM, formato 24h).",
+  "panel.settings_time_boundaries_hint": "Quando cada período do dia começa e termina (HH:MM, 24 horas). Adicione seus próprios períodos; intervalos vazios caem em “A qualquer hora”.",
   "panel.settings_time_boundaries_title": "Limites de horário do dia",
   "panel.settings_title": "Configurações",
   "panel.settings_weekend_multiplier_hint": "Bônus no sáb/dom (1.0 = desligado)",
@@ -1176,5 +1176,17 @@
   "notification.pending_reward_claim.description": "Enviado aos responsáveis quando uma criança resgata uma recompensa. Toque em Aprovar ou Rejeitar na notificação.",
   "notification.pending_reward_claim.name": "Pedido de recompensa pendente",
   "notification.streak_at_risk.description": "Disparado quando uma sequência ativa ainda não foi prolongada hoje.",
-  "notification.streak_at_risk.name": "Sequência em risco"
+  "notification.streak_at_risk.name": "Sequência em risco",
+  "panel.tp_label_placeholder": "Nome do período",
+  "panel.tp_add_period": "Adicionar período",
+  "panel.tp_reset_defaults": "Restaurar padrões",
+  "panel.tp_delete_title": "Excluir período",
+  "panel.tp_in_use_title": "Usado por {count} tarefa(s) — reatribua-as antes de excluir",
+  "panel.tp_in_use_hint": "Usado por {count} tarefa(s). Reatribua-as a outro período para excluí-lo.",
+  "panel.tp_anytime_hint": "Sempre disponível, o dia todo. Integrado e não removível.",
+  "panel.tp_err_label_required": "Cada período personalizado precisa de um nome.",
+  "panel.tp_err_time_required": "Defina horário de início e fim para “{name}”.",
+  "panel.tp_err_order": "“{name}” deve começar antes de terminar.",
+  "panel.tp_err_empty": "Adicione pelo menos um período.",
+  "panel.tp_err_overlap": "“{a}” sobrepõe “{b}” — os períodos não podem se sobrepor."
 }

--- a/custom_components/taskmate/www/locales/pt.json
+++ b/custom_components/taskmate/www/locales/pt.json
@@ -735,7 +735,7 @@
   "panel.settings_streak_milestones_label": "Marcos de sequência",
   "panel.settings_streak_reset_hint": "O que acontece quando um dia é falhado",
   "panel.settings_streak_reset_label": "Reinício de sequência",
-  "panel.settings_time_boundaries_hint": "Quando cada período do dia começa e termina (HH:MM, 24 horas).",
+  "panel.settings_time_boundaries_hint": "Quando cada período do dia começa e termina (HH:MM, 24 horas). Adicione os seus próprios períodos; intervalos vazios passam para “A qualquer hora”.",
   "panel.settings_time_boundaries_title": "Limites dos períodos do dia",
   "panel.settings_title": "Definições",
   "panel.settings_weekend_multiplier_hint": "Bónus ao Sáb/Dom (1.0 = desligado)",
@@ -1176,5 +1176,17 @@
   "notification.pending_reward_claim.description": "Enviado aos encarregados quando uma criança resgata uma recompensa. Toque em Aprovar ou Rejeitar na notificação.",
   "notification.pending_reward_claim.name": "Pedido de recompensa pendente",
   "notification.streak_at_risk.description": "Disparado quando uma sequência ativa ainda não foi prolongada hoje.",
-  "notification.streak_at_risk.name": "Sequência em risco"
+  "notification.streak_at_risk.name": "Sequência em risco",
+  "panel.tp_label_placeholder": "Nome do período",
+  "panel.tp_add_period": "Adicionar período",
+  "panel.tp_reset_defaults": "Repor predefinições",
+  "panel.tp_delete_title": "Eliminar período",
+  "panel.tp_in_use_title": "Usado por {count} tarefa(s) — reatribua-as antes de eliminar",
+  "panel.tp_in_use_hint": "Usado por {count} tarefa(s). Reatribua-as a outro período para o eliminar.",
+  "panel.tp_anytime_hint": "Sempre disponível, o dia todo. Integrado e não removível.",
+  "panel.tp_err_label_required": "Cada período personalizado precisa de um nome.",
+  "panel.tp_err_time_required": "Defina hora de início e fim para “{name}”.",
+  "panel.tp_err_order": "“{name}” tem de começar antes de terminar.",
+  "panel.tp_err_empty": "Adicione pelo menos um período.",
+  "panel.tp_err_overlap": "“{a}” sobrepõe-se a “{b}” — os períodos não podem sobrepor-se."
 }

--- a/custom_components/taskmate/www/taskmate-approvals-card.js
+++ b/custom_components/taskmate/www/taskmate-approvals-card.js
@@ -626,7 +626,26 @@ class TaskMateApprovalsCard extends LitElement {
     }
   }
 
+  // User-defined periods from the overview sensor; legacy fixed four when
+  // the integration hasn't published time_periods yet.
+  _getTimePeriods() {
+    const entity = this.hass?.states?.[this.config?.entity];
+    const attrs = (window.__taskmate_attrs && window.__taskmate_attrs(this.hass, this.config?.entity))
+      || entity?.attributes || {};
+    if (Array.isArray(attrs.time_periods) && attrs.time_periods.length) {
+      return attrs.time_periods.filter(p => p && p.id);
+    }
+    return [
+      { id: "morning",   label: "", icon: "mdi:weather-sunset-up" },
+      { id: "afternoon", label: "", icon: "mdi:weather-sunny" },
+      { id: "evening",   label: "", icon: "mdi:weather-sunset-down" },
+      { id: "night",     label: "", icon: "mdi:weather-night" },
+    ];
+  }
+
   _getTimeCategoryIcon(category) {
+    const period = this._getTimePeriods().find(p => p.id === category);
+    if (period && period.icon) return period.icon;
     const icons = {
       morning: "mdi:weather-sunset-up",
       afternoon: "mdi:weather-sunny",
@@ -638,6 +657,8 @@ class TaskMateApprovalsCard extends LitElement {
   }
 
   _getTimeCategoryLabel(category) {
+    const period = this._getTimePeriods().find(p => p.id === category);
+    if (period && period.label) return period.label;
     const keyMap = {
       morning: 'common.morning',
       afternoon: 'common.afternoon',
@@ -649,14 +670,10 @@ class TaskMateApprovalsCard extends LitElement {
   }
 
   _getTimeCategoryOrder(category) {
-    const order = {
-      morning: 0,
-      afternoon: 1,
-      evening: 2,
-      night: 3,
-      anytime: 4,
-    };
-    return order[category] !== undefined ? order[category] : 5;
+    const ids = this._getTimePeriods().map(p => p.id);
+    const idx = ids.indexOf(category);
+    if (idx >= 0) return idx;
+    return category === "anytime" ? ids.length : ids.length + 1;
   }
 
   _renderEmptyState() {

--- a/custom_components/taskmate/www/taskmate-child-card.js
+++ b/custom_components/taskmate/www/taskmate-child-card.js
@@ -1893,6 +1893,8 @@ class TaskMateChildCard extends LitElement {
   }
 
   _getTimeCategoryIcon(category) {
+    const period = this._getTimePeriods().find(p => p.id === category);
+    if (period) return period.icon;
     const icons = {
       morning: "mdi:weather-sunset-up",
       afternoon: "mdi:weather-sunny",
@@ -1905,6 +1907,8 @@ class TaskMateChildCard extends LitElement {
   }
 
   _getTimeCategoryLabel(category) {
+    const period = this._getTimePeriods().find(p => p.id === category);
+    if (period && period.label) return period.label;
     const keyMap = {
       morning: 'common.morning',
       afternoon: 'common.afternoon',
@@ -1918,6 +1922,8 @@ class TaskMateChildCard extends LitElement {
 
   _getDynamicTitle() {
     const category = this.config.time_category;
+    const period = this._getTimePeriods().find(p => p.id === category);
+    if (period && period.label) return period.label;
     const keyMap = {
       morning: 'child.morning_chores',
       afternoon: 'child.afternoon_chores',
@@ -1934,16 +1940,37 @@ class TaskMateChildCard extends LitElement {
     return this.hass?.config?.time_zone || Intl.DateTimeFormat().resolvedOptions().timeZone;
   }
 
-  _getTimeBoundaries() {
+  // Ordered list of user-defined periods: [{id, label, icon, start, end}]
+  // with start/end as decimal hours. Falls back to the legacy fixed four
+  // when the integration hasn't published time_periods yet.
+  _getTimePeriods() {
     const attrs = (window.__taskmate_attrs && window.__taskmate_attrs(this.hass, this.config?.entity))
       || this.hass?.states?.[this.config?.entity]?.attributes || {};
+    if (Array.isArray(attrs.time_periods) && attrs.time_periods.length) {
+      return attrs.time_periods
+        .filter(p => p && p.id)
+        .map(p => ({
+          id: p.id,
+          label: p.label || "",
+          icon: p.icon || "mdi:clock-outline",
+          start: this._parseHHMM(p.start, 0, 0),
+          end: this._parseHHMM(p.end, 23, 59),
+        }))
+        .sort((a, b) => a.start - b.start);
+    }
     const tb = attrs.time_boundaries || {};
-    return {
-      morning:   [this._parseHHMM(tb.morning_start, 6, 0),   this._parseHHMM(tb.morning_end, 12, 0)],
-      afternoon: [this._parseHHMM(tb.afternoon_start, 12, 0), this._parseHHMM(tb.afternoon_end, 17, 0)],
-      evening:   [this._parseHHMM(tb.evening_start, 17, 0),   this._parseHHMM(tb.evening_end, 21, 0)],
-      night:     [this._parseHHMM(tb.night_start, 21, 0),     this._parseHHMM(tb.night_end, 23, 59)],
-    };
+    return [
+      { id: "morning",   label: "", icon: "mdi:weather-sunset-up",   start: this._parseHHMM(tb.morning_start, 6, 0),    end: this._parseHHMM(tb.morning_end, 12, 0) },
+      { id: "afternoon", label: "", icon: "mdi:weather-sunny",       start: this._parseHHMM(tb.afternoon_start, 12, 0), end: this._parseHHMM(tb.afternoon_end, 17, 0) },
+      { id: "evening",   label: "", icon: "mdi:weather-sunset-down", start: this._parseHHMM(tb.evening_start, 17, 0),   end: this._parseHHMM(tb.evening_end, 21, 0) },
+      { id: "night",     label: "", icon: "mdi:weather-night",       start: this._parseHHMM(tb.night_start, 21, 0),     end: this._parseHHMM(tb.night_end, 23, 59) },
+    ];
+  }
+
+  _getTimeBoundaries() {
+    const boundaries = {};
+    for (const p of this._getTimePeriods()) boundaries[p.id] = [p.start, p.end];
+    return boundaries;
   }
 
   _parseHHMM(str, defH, defM) {
@@ -1964,11 +1991,13 @@ class TaskMateChildCard extends LitElement {
     if (isNaN(hour)) hour = 0;
     if (hour === 24) hour = 0;
     const now = hour + minute / 60;
-    const b = this._getTimeBoundaries();
-    if (now >= b.night[0])     return 'night';
-    if (now >= b.evening[0])   return 'evening';
-    if (now >= b.afternoon[0]) return 'afternoon';
-    return 'morning';
+    const periods = this._getTimePeriods();
+    for (let i = periods.length - 1; i >= 0; i--) {
+      if (now >= periods[i].start) return periods[i].id;
+    }
+    // Before the first period starts (e.g. 02:00) we treat it as the first
+    // period of the day, matching the legacy pre-morning behaviour.
+    return periods[0]?.id || 'morning';
   }
 
   _getPeriodHours(period) {
@@ -2002,7 +2031,7 @@ class TaskMateChildCard extends LitElement {
   _isChorePreviewLocked(chore) {
     const cat = chore?.time_category;
     if (!cat || cat === 'anytime') return false;
-    const order = ['morning', 'afternoon', 'evening', 'night'];
+    const order = this._getTimePeriods().map(p => p.id);
     const choreIndex = order.indexOf(cat);
     const currentIndex = order.indexOf(this._getCurrentTimePeriod());
     if (choreIndex < 0 || currentIndex < 0) return false;
@@ -2035,11 +2064,12 @@ class TaskMateChildCard extends LitElement {
       ? choreOrCategory
       : choreOrCategory?.time_category;
     if (!cat || cat === 'anytime') return false;
-    const order = { morning: 0, afternoon: 1, evening: 2, night: 3 };
+    const order = {};
+    this._getTimePeriods().forEach((p, i) => { order[p.id] = i; });
     const choreIndex = order[cat];
     if (choreIndex === undefined) return false;
     const currentIndex = order[this._getCurrentTimePeriod()];
-    if (currentIndex <= choreIndex) return false;
+    if (currentIndex === undefined || currentIndex <= choreIndex) return false;
     if (typeof choreOrCategory === 'object' && this._isChoreInClaimWindow(choreOrCategory)) {
       return false;
     }
@@ -2875,6 +2905,27 @@ class TaskMateChildCardEditor extends LitElement {
     this.config = config;
   }
 
+  _timeCategoryEditorOptions(overviewEntity) {
+    const builtinLabels = {
+      morning: this._t('child.editor.time_category_morning'),
+      afternoon: this._t('child.editor.time_category_afternoon'),
+      evening: this._t('child.editor.time_category_evening'),
+      night: this._t('child.editor.time_category_night'),
+    };
+    const periods = overviewEntity?.attributes?.time_periods;
+    const periodOptions = Array.isArray(periods) && periods.length
+      ? periods.filter(p => p && p.id).map(p => ({
+          value: p.id,
+          label: p.label || builtinLabels[p.id] || p.id,
+        }))
+      : Object.entries(builtinLabels).map(([value, label]) => ({ value, label }));
+    return [
+      ...periodOptions,
+      { value: 'anytime', label: this._t('child.editor.time_category_anytime') },
+      { value: 'all', label: this._t('child.editor.time_category_all') },
+    ];
+  }
+
   _buildSchema() {
     const overviewEntity = this.config?.entity
       ? this.hass?.states?.[this.config.entity]
@@ -2899,14 +2950,7 @@ class TaskMateChildCardEditor extends LitElement {
         name: 'time_category',
         selector: {
           select: {
-            options: [
-              { value: 'morning', label: this._t('child.editor.time_category_morning') },
-              { value: 'afternoon', label: this._t('child.editor.time_category_afternoon') },
-              { value: 'evening', label: this._t('child.editor.time_category_evening') },
-              { value: 'night', label: this._t('child.editor.time_category_night') },
-              { value: 'anytime', label: this._t('child.editor.time_category_anytime') },
-              { value: 'all', label: this._t('child.editor.time_category_all') },
-            ],
+            options: this._timeCategoryEditorOptions(overviewEntity),
             mode: 'dropdown',
           },
         },

--- a/custom_components/taskmate/www/taskmate-panel.js
+++ b/custom_components/taskmate/www/taskmate-panel.js
@@ -45,14 +45,6 @@ const BADGE_TIERS = [
   { v: "platinum", lk: "badge.tier_platinum" },
 ];
 
-const TIME_CATEGORIES = [
-  { v: "anytime",   lk: "panel.time_anytime" },
-  { v: "morning",   lk: "panel.time_morning" },
-  { v: "afternoon", lk: "panel.time_afternoon" },
-  { v: "evening",   lk: "panel.time_evening" },
-  { v: "night",     lk: "panel.time_night" },
-];
-
 const SCHEDULE_MODES = [
   { v: "specific_days", lk: "panel.schedule_specific_days" },
   { v: "recurring",     lk: "panel.schedule_recurring" },
@@ -125,6 +117,7 @@ class TaskMatePanel extends HTMLElement {
     this._state = null;
     this._error = null;
     this._loading = false;
+    this._timePeriodsDraft = null;  // local edit state for the period editor
     this._activeTab = "children";
     this._dialog = null;
     this._dialogInitialHash = null;  // for confirm-on-leave
@@ -525,6 +518,25 @@ class TaskMatePanel extends HTMLElement {
     // Settings
     if (act === "save-settings") { this._doSaveSettings(); return; }
 
+    // Time-of-day period editor
+    if (act === "tp-add") {
+      this._syncTimePeriodInputs();
+      this._timePeriodsDraft.push({ id: "", label: "", start: "", end: "", icon: "mdi:clock-outline" });
+      this._render();
+      return;
+    }
+    if (act === "tp-remove") {
+      this._syncTimePeriodInputs();
+      this._timePeriodsDraft.splice(Number(t.dataset.idx), 1);
+      this._render();
+      return;
+    }
+    if (act === "tp-reset") {
+      this._timePeriodsDraft = this._defaultTimePeriods();
+      this._render();
+      return;
+    }
+
     // Activity / approvals
     if (act === "approve-chore")  { this._doApprove("chore", t.dataset.id); return; }
     if (act === "reject-chore")   { this._doReject("chore", t.dataset.id); return; }
@@ -568,6 +580,13 @@ class TaskMatePanel extends HTMLElement {
     // Inline rename input
     if (t.dataset.field === "_inlineRename") {
       this._inlineRename.value = t.value;
+      return;
+    }
+    // Time-of-day period editor field edits
+    const tpField = t.dataset?.tpField;
+    const tpIdx = t.dataset?.tpIdx;
+    if (tpField && tpIdx != null && this._timePeriodsDraft?.[Number(tpIdx)]) {
+      this._timePeriodsDraft[Number(tpIdx)][tpField] = t.value;
       return;
     }
     // Template preview chore field edits
@@ -627,6 +646,11 @@ class TaskMatePanel extends HTMLElement {
       this._showIds = t.checked;
       localStorage.setItem("taskmate-show-ids", this._showIds);
       this._render();
+      return;
+    }
+    // Time-of-day period editor (time inputs fire change on blur)
+    if (t.dataset?.tpField && t.dataset.tpIdx != null && this._timePeriodsDraft?.[Number(t.dataset.tpIdx)]) {
+      this._timePeriodsDraft[Number(t.dataset.tpIdx)][t.dataset.tpField] = t.value;
       return;
     }
     // Notifications tab change-driven actions
@@ -691,8 +715,14 @@ class TaskMatePanel extends HTMLElement {
   }
 
   _onValueChanged(e) {
-    if (!this._dialog) return;
     const t = e.target;
+    // Period editor icon pickers live outside any dialog
+    if (t.dataset?.tpField && t.dataset.tpIdx != null && this._timePeriodsDraft?.[Number(t.dataset.tpIdx)]) {
+      const val = e.detail && "value" in e.detail ? e.detail.value : t.value;
+      this._timePeriodsDraft[Number(t.dataset.tpIdx)][t.dataset.tpField] = val == null ? "" : val;
+      return;
+    }
+    if (!this._dialog) return;
     if (!t.dataset || !t.dataset.field) return;
     const v = e.detail && "value" in e.detail ? e.detail.value : t.value;
     this._dialog.data[t.dataset.field] = v == null ? "" : v;
@@ -1238,6 +1268,132 @@ class TaskMatePanel extends HTMLElement {
     this._showToast("ok", wasAdd ? this._t("panel.toast_group_added") : this._t("panel.toast_group_updated"));
   }
 
+  // ---- Time-of-day periods ----------------------------------------------
+  _defaultTimePeriods() {
+    return [
+      { id: "morning",   label: "", start: "06:00", end: "12:00", icon: "mdi:weather-sunny" },
+      { id: "afternoon", label: "", start: "12:00", end: "17:00", icon: "mdi:white-balance-sunny" },
+      { id: "evening",   label: "", start: "17:00", end: "21:00", icon: "mdi:weather-sunset" },
+      { id: "night",     label: "", start: "21:00", end: "23:59", icon: "mdi:weather-night" },
+    ];
+  }
+
+  // Saved periods, falling back to the legacy flat keys / built-in defaults
+  // for installs that haven't saved through the new editor yet.
+  _effectiveTimePeriods() {
+    const s = (this._state && this._state.settings) || {};
+    if (Array.isArray(s.time_periods) && s.time_periods.length) {
+      return s.time_periods.map(p => ({ ...p }));
+    }
+    return this._defaultTimePeriods().map(p => ({
+      ...p,
+      start: s[`time_${p.id}_start`] || p.start,
+      end: s[`time_${p.id}_end`] || p.end,
+    }));
+  }
+
+  _isBuiltinPeriod(id) {
+    return ["morning", "afternoon", "evening", "night"].includes(id);
+  }
+
+  _timePeriodLabel(p) {
+    if (p.label) return p.label;
+    return this._isBuiltinPeriod(p.id) ? this._t(`panel.time_${p.id}`) : (p.id || "");
+  }
+
+  _timeCategoryOptions() {
+    const opts = [{ v: "anytime", l: this._t("panel.time_anytime") }];
+    for (const p of this._effectiveTimePeriods()) opts.push({ v: p.id, l: this._timePeriodLabel(p) });
+    return opts;
+  }
+
+  _timeCategoryLabel(cat) {
+    const c = cat || "anytime";
+    if (c === "anytime") return this._t("panel.time_anytime");
+    const p = this._effectiveTimePeriods().find(x => x.id === c);
+    return p ? this._timePeriodLabel(p) : c;
+  }
+
+  _renderTimePeriodsSection() {
+    if (!this._timePeriodsDraft) this._timePeriodsDraft = this._effectiveTimePeriods();
+    const inUse = {};
+    (this._state.chores || []).forEach(c => {
+      const tc = c.time_category;
+      if (tc && tc !== "anytime") inUse[tc] = (inUse[tc] || 0) + 1;
+    });
+    const rows = this._timePeriodsDraft.map((p, i) => {
+      const used = p.id ? inUse[p.id] || 0 : 0;
+      const placeholder = this._isBuiltinPeriod(p.id) ? this._t(`panel.time_${p.id}`) : this._t("panel.tp_label_placeholder");
+      return `
+            <div class="tm-setting-row tm-period-row">
+              <ha-icon-picker data-tp-field="icon" data-tp-idx="${i}" data-current="${this._esc(p.icon || "mdi:clock-outline")}"></ha-icon-picker>
+              <ha-textfield data-tp-field="label" data-tp-idx="${i}" data-value="${this._esc(p.label || "")}" placeholder="${this._esc(placeholder)}"></ha-textfield>
+              <div class="tm-time-pair">
+                <ha-textfield type="time" data-tp-field="start" data-tp-idx="${i}" data-value="${this._esc(p.start || "")}"></ha-textfield>
+                <span>–</span>
+                <ha-textfield type="time" data-tp-field="end" data-tp-idx="${i}" data-value="${this._esc(p.end || "")}"></ha-textfield>
+              </div>
+              ${used
+                ? `<button type="button" class="tm-icon-btn tm-period-del" disabled title="${this._esc(this._t("panel.tp_in_use_title", { count: used }))}"><ha-icon icon="mdi:lock-outline"></ha-icon></button>`
+                : `<button type="button" class="tm-icon-btn tm-period-del" data-act="tp-remove" data-idx="${i}" title="${this._esc(this._t("panel.tp_delete_title"))}"><ha-icon icon="mdi:trash-can-outline"></ha-icon></button>`}
+              ${used ? `<div class="tm-period-inuse">${this._esc(this._t("panel.tp_in_use_hint", { count: used }))}</div>` : ""}
+            </div>`;
+    }).join("");
+    return `
+        <div class="tm-section">
+          <div class="tm-section-head"><div><h3>${this._t("panel.settings_time_boundaries_title")}</h3><p class="tm-meta">${this._t("panel.settings_time_boundaries_hint")}</p></div></div>
+          <div class="tm-section-body">
+            ${rows}
+            <div class="tm-setting-row tm-period-row tm-period-anytime">
+              <ha-icon icon="mdi:clock-outline"></ha-icon>
+              <div class="tm-setting-label">${this._t("panel.time_anytime")}<small>${this._t("panel.tp_anytime_hint")}</small></div>
+            </div>
+            <div class="tm-period-actions">
+              <button type="button" class="tm-btn" data-act="tp-add"><ha-icon icon="mdi:plus"></ha-icon> ${this._t("panel.tp_add_period")}</button>
+              <button type="button" class="tm-btn" data-act="tp-reset">${this._t("panel.tp_reset_defaults")}</button>
+            </div>
+          </div>
+        </div>`;
+  }
+
+  // Pull current editor input values into the draft. Inputs also stream into
+  // the draft via input/value-changed events; this is the safety net before
+  // any re-render or save.
+  _syncTimePeriodInputs() {
+    if (!this._timePeriodsDraft) return;
+    this.querySelectorAll("[data-tp-field]").forEach(el => {
+      const idx = Number(el.dataset.tpIdx);
+      const field = el.dataset.tpField;
+      if (this._timePeriodsDraft[idx] && el.value != null) {
+        this._timePeriodsDraft[idx][field] = el.value;
+      }
+    });
+  }
+
+  _validateTimePeriodsDraft() {
+    const periods = [];
+    for (const p of this._timePeriodsDraft) {
+      const label = (p.label || "").trim();
+      const id = (p.id || "").trim();
+      const name = label || (this._isBuiltinPeriod(id) ? this._t(`panel.time_${id}`) : id);
+      if (!label && !this._isBuiltinPeriod(id)) return { error: this._t("panel.tp_err_label_required") };
+      if (!/^\d{2}:\d{2}$/.test(p.start || "") || !/^\d{2}:\d{2}$/.test(p.end || "")) {
+        return { error: this._t("panel.tp_err_time_required", { name }) };
+      }
+      if (p.start >= p.end) return { error: this._t("panel.tp_err_order", { name }) };
+      periods.push({ id, label, start: p.start, end: p.end, icon: p.icon || "" });
+    }
+    if (!periods.length) return { error: this._t("panel.tp_err_empty") };
+    periods.sort((a, b) => (a.start < b.start ? -1 : 1));
+    for (let i = 1; i < periods.length; i++) {
+      if (periods[i].start < periods[i - 1].end) {
+        const nameOf = (q) => q.label || (this._isBuiltinPeriod(q.id) ? this._t(`panel.time_${q.id}`) : q.id);
+        return { error: this._t("panel.tp_err_overlap", { a: nameOf(periods[i]), b: nameOf(periods[i - 1]) }) };
+      }
+    }
+    return { periods };
+  }
+
   // ---- Settings --------------------------------------------------------
   async _doSaveSettings() {
     const root = this.querySelector(".tm-settings");
@@ -1256,8 +1412,15 @@ class TaskMatePanel extends HTMLElement {
     root.querySelectorAll("ha-icon-picker[data-setting]").forEach(el => {
       payload[el.dataset.setting] = el.value || "";
     });
+    if (this._timePeriodsDraft) {
+      this._syncTimePeriodInputs();
+      const { periods, error } = this._validateTimePeriodsDraft();
+      if (error) { this._showToast("err", error); return; }
+      payload.time_periods = periods;
+    }
     const { ok, err, res } = await this._callWS(payload);
     if (!ok) { this._showToast("err", this._t("panel.toast_save_failed", {error: err})); return; }
+    this._timePeriodsDraft = null;  // rebuild from saved state on next render
     await this._fetchState();
     this._showToast("ok", this._t("panel.toast_settings_saved", {count: (res && res.updated || []).length}));
   }
@@ -1948,7 +2111,7 @@ class TaskMatePanel extends HTMLElement {
       <tr class="tm-row ${c.enabled === false ? "tm-row-disabled" : ""}">
         <td>${nameCell}</td>
         <td><strong class="tm-numeric">${c.task_type === "timed" ? `${c.timed_rate_points || 0}/${c.timed_rate_minutes || 1} min` : c.points}</strong></td>
-        <td><span class="tm-pill">${this._t("panel.time_" + (c.time_category || "anytime"))}</span></td>
+        <td><span class="tm-pill">${this._esc(this._timeCategoryLabel(c.time_category))}</span></td>
         <td>${assignedNames} ${modeBadge}</td>
         <td>${currentName}</td>
         <td><span class="tm-pill ${schedClass} tm-pill-dot">${this._esc(schedLabel)}</span></td>
@@ -2569,7 +2732,7 @@ class TaskMatePanel extends HTMLElement {
           <span class="tm-tpl-preview-summary">
             <span>${this._t("panel.pts_display", {count: chore.points || 0})}</span>
             <span>${schedLabel}</span>
-            <span>${this._esc(chore.time_category || "anytime")}</span>
+            <span>${this._esc(this._timeCategoryLabel(chore.time_category))}</span>
           </span>
           <button type="button" class="tm-tpl-remove" data-act="tpl-remove-chore" data-idx="${idx}" title="${this._t("panel.tooltip_remove_batch")}">✕</button>
         </div>
@@ -2582,7 +2745,7 @@ class TaskMatePanel extends HTMLElement {
             <div class="tm-field-row">
               <div class="tm-field"><span class="tm-field-label">${this._t("panel.chore_time_category_label")}</span>
                 <select class="tm-select" data-tpl-field="time_category" data-tpl-idx="${idx}">
-                  ${TIME_CATEGORIES.map(t => `<option value="${t.v}" ${chore.time_category === t.v ? "selected" : ""}>${this._t(t.lk)}</option>`).join("")}
+                  ${this._timeCategoryOptions().map(t => `<option value="${this._esc(t.v)}" ${chore.time_category === t.v ? "selected" : ""}>${this._esc(t.l)}</option>`).join("")}
                 </select>
               </div>
               <div class="tm-field"><span class="tm-field-label">${this._t("panel.template_assignment_mode_label")}</span>
@@ -2799,43 +2962,7 @@ class TaskMatePanel extends HTMLElement {
           </div>
         </div>
 
-        <div class="tm-section">
-          <div class="tm-section-head"><div><h3>${this._t("panel.settings_time_boundaries_title")}</h3><p class="tm-meta">${this._t("panel.settings_time_boundaries_hint")}</p></div></div>
-          <div class="tm-section-body">
-            <div class="tm-setting-row">
-              <div class="tm-setting-label">${this._t("panel.settings_morning_label")}<small>${this._t("panel.settings_morning_hint")}</small></div>
-              <div class="tm-time-pair">
-                <ha-textfield type="time" data-setting="time_morning_start" data-value="${s.time_morning_start || "06:00"}"></ha-textfield>
-                <span>–</span>
-                <ha-textfield type="time" data-setting="time_morning_end" data-value="${s.time_morning_end || "12:00"}"></ha-textfield>
-              </div>
-            </div>
-            <div class="tm-setting-row">
-              <div class="tm-setting-label">${this._t("panel.settings_afternoon_label")}<small>${this._t("panel.settings_afternoon_hint")}</small></div>
-              <div class="tm-time-pair">
-                <ha-textfield type="time" data-setting="time_afternoon_start" data-value="${s.time_afternoon_start || "12:00"}"></ha-textfield>
-                <span>–</span>
-                <ha-textfield type="time" data-setting="time_afternoon_end" data-value="${s.time_afternoon_end || "17:00"}"></ha-textfield>
-              </div>
-            </div>
-            <div class="tm-setting-row">
-              <div class="tm-setting-label">${this._t("panel.settings_evening_label")}<small>${this._t("panel.settings_evening_hint")}</small></div>
-              <div class="tm-time-pair">
-                <ha-textfield type="time" data-setting="time_evening_start" data-value="${s.time_evening_start || "17:00"}"></ha-textfield>
-                <span>–</span>
-                <ha-textfield type="time" data-setting="time_evening_end" data-value="${s.time_evening_end || "21:00"}"></ha-textfield>
-              </div>
-            </div>
-            <div class="tm-setting-row">
-              <div class="tm-setting-label">${this._t("panel.settings_night_label")}<small>${this._t("panel.settings_night_hint")}</small></div>
-              <div class="tm-time-pair">
-                <ha-textfield type="time" data-setting="time_night_start" data-value="${s.time_night_start || "21:00"}"></ha-textfield>
-                <span>–</span>
-                <ha-textfield type="time" data-setting="time_night_end" data-value="${s.time_night_end || "23:59"}"></ha-textfield>
-              </div>
-            </div>
-          </div>
-        </div>
+        ${this._renderTimePeriodsSection()}
 
         <div class="tm-section">
           <div class="tm-section-head"><div><h3>${this._t("panel.settings_bonuses_title")}</h3></div></div>
@@ -3129,7 +3256,7 @@ class TaskMatePanel extends HTMLElement {
                   <div class="tm-field-row">
                     <div class="tm-field"><span class="tm-field-label">${this._t("panel.chore_time_category_label")}</span>
                       <select class="tm-select" data-tpl-dialog-field="time_category" data-tpl-dialog-idx="${i}">
-                        ${TIME_CATEGORIES.map(t => `<option value="${t.v}" ${c.time_category === t.v ? "selected" : ""}>${this._t(t.lk)}</option>`).join("")}
+                        ${this._timeCategoryOptions().map(t => `<option value="${this._esc(t.v)}" ${c.time_category === t.v ? "selected" : ""}>${this._esc(t.l)}</option>`).join("")}
                       </select>
                     </div>
                     <div class="tm-field"><span class="tm-field-label">${this._t("panel.template_schedule_label")}</span>
@@ -3225,7 +3352,7 @@ class TaskMatePanel extends HTMLElement {
           [{ v: "", l: this._t("panel.chore_rotation_no_override") }, ...children.map(c => ({ v: c.id, l: c.name }))],
           this._t("panel.chore_rotation_hint")
         ) : "",
-        this._select(this._t("panel.chore_time_category_label"), "time_category", d.time_category, TIME_CATEGORIES),
+        this._select(this._t("panel.chore_time_category_label"), "time_category", d.time_category, this._timeCategoryOptions()),
         this._field(this._t("panel.chore_claim_allowance_label"), "claim_allowance_minutes", d.claim_allowance_minutes, "number",
           this._t("panel.chore_claim_allowance_hint")),
         this._select(this._t("panel.chore_schedule_mode_label"), "schedule_mode", d.schedule_mode, SCHEDULE_MODES, "", true),
@@ -3453,7 +3580,7 @@ class TaskMatePanel extends HTMLElement {
             <span class="tm-field-hint">${this._t("panel.bulk_leave_empty_hint")}</span>
           </div>
         ` : "",
-        this._select(this._t("panel.chore_time_category_label"), "time_category", d.time_category, TIME_CATEGORIES),
+        this._select(this._t("panel.chore_time_category_label"), "time_category", d.time_category, this._timeCategoryOptions()),
         this._select(this._t("panel.chore_schedule_mode_label"), "schedule_mode", d.schedule_mode, SCHEDULE_MODES, "", true),
         d.schedule_mode === "specific_days" ? `
           <div class="tm-field">
@@ -4402,6 +4529,36 @@ class TaskMatePanel extends HTMLElement {
       }
       .tm-time-pair ha-textfield { max-width: 130px; }
       .tm-time-pair span { color: var(--tm-text-faint); }
+      .tm-period-row {
+        grid-template-columns: 56px minmax(140px, 1fr) auto 36px;
+        gap: 12px;
+      }
+      .tm-period-row ha-icon-picker { max-width: 56px; }
+      .tm-period-row > ha-textfield { max-width: none; }
+      .tm-period-del {
+        color: var(--tm-text-faint);
+      }
+      .tm-period-del:not([disabled]):hover { color: var(--error-color, #d9434f); }
+      .tm-period-del[disabled] { opacity: .5; cursor: not-allowed; }
+      .tm-period-inuse {
+        grid-column: 1 / -1;
+        font-size: 12px; color: var(--tm-text-faint);
+        margin-top: -6px;
+      }
+      .tm-period-anytime {
+        grid-template-columns: 56px 1fr;
+        color: var(--tm-text-faint);
+      }
+      .tm-period-anytime ha-icon { margin: 0 auto; }
+      .tm-period-actions {
+        display: flex; gap: 10px;
+        padding: 14px 20px;
+        border-top: 1px solid var(--tm-border-soft);
+      }
+      @media (max-width: 700px) {
+        .tm-period-row { grid-template-columns: 48px 1fr 36px; }
+        .tm-period-row .tm-time-pair { grid-column: 1 / -1; }
+      }
       .tm-settings-foot {
         display: flex; justify-content: flex-end;
         padding-top: 8px;

--- a/custom_components/taskmate/www/taskmate-reorder-card.js
+++ b/custom_components/taskmate/www/taskmate-reorder-card.js
@@ -488,7 +488,7 @@ class TaskMateReorderCard extends LitElement {
       const childChores = this._getChoresForChild(chores, child.id);
 
       const newLocalOrder = {};
-      const timeCategories = ["morning", "afternoon", "evening", "night", "anytime"];
+      const timeCategories = this._getTimeCategories();
 
       for (const category of timeCategories) {
         const categoryChores = childChores.filter(
@@ -544,7 +544,30 @@ class TaskMateReorderCard extends LitElement {
     });
   }
 
+  // User-defined periods from the overview sensor; legacy fixed four when
+  // the integration hasn't published time_periods yet.
+  _getTimePeriods() {
+    const entity = this.hass?.states?.[this.config?.entity];
+    const attrs = (window.__taskmate_attrs && window.__taskmate_attrs(this.hass, this.config?.entity))
+      || entity?.attributes || {};
+    if (Array.isArray(attrs.time_periods) && attrs.time_periods.length) {
+      return attrs.time_periods.filter(p => p && p.id);
+    }
+    return [
+      { id: "morning",   label: "", icon: "mdi:weather-sunset-up" },
+      { id: "afternoon", label: "", icon: "mdi:weather-sunny" },
+      { id: "evening",   label: "", icon: "mdi:weather-sunset-down" },
+      { id: "night",     label: "", icon: "mdi:weather-night" },
+    ];
+  }
+
+  _getTimeCategories() {
+    return [...this._getTimePeriods().map(p => p.id), "anytime"];
+  }
+
   _getTimeCategoryIcon(category) {
+    const period = this._getTimePeriods().find(p => p.id === category);
+    if (period && period.icon) return period.icon;
     const icons = {
       morning: "mdi:weather-sunset-up",
       afternoon: "mdi:weather-sunny",
@@ -556,6 +579,8 @@ class TaskMateReorderCard extends LitElement {
   }
 
   _getTimeCategoryLabel(category) {
+    const period = this._getTimePeriods().find(p => p.id === category);
+    if (period && period.label) return period.label;
     const keys = {
       morning: 'common.morning',
       afternoon: 'common.afternoon',
@@ -622,7 +647,7 @@ class TaskMateReorderCard extends LitElement {
       `;
     }
 
-    const timeCategories = ["morning", "afternoon", "evening", "night", "anytime"];
+    const timeCategories = this._getTimeCategories();
     const pointsIcon = attrs.points_icon || "mdi:star";
 
     const headerStyle = this.config.header_color
@@ -855,7 +880,7 @@ class TaskMateReorderCard extends LitElement {
 
     try {
       // Combine all category orders into a single flat array
-      const timeCategories = ["morning", "afternoon", "evening", "night", "anytime"];
+      const timeCategories = this._getTimeCategories();
       const fullOrder = [];
 
       for (const category of timeCategories) {

--- a/tests/test_time_periods.py
+++ b/tests/test_time_periods.py
@@ -1,0 +1,204 @@
+"""Tests for custom time-of-day periods (#391).
+
+Covers the coordinator resolver fallback chain (time_periods setting →
+legacy flat keys → defaults) and the websocket payload validation,
+including the block-on-delete rule for periods still used by chores.
+"""
+from __future__ import annotations
+
+from datetime import time
+from unittest.mock import MagicMock
+
+from custom_components.taskmate.models import Child, Chore
+from custom_components.taskmate.websocket import _validate_time_periods
+
+from .test_assignment_modes import _coord
+
+
+# ---------------------------------------------------------------------------
+# Resolver: coordinator.get_time_periods()
+# ---------------------------------------------------------------------------
+
+def test_resolver_defaults_when_no_settings():
+    coord = _coord([Child(name="A")])
+    periods = coord.get_time_periods()
+    assert [p["id"] for p in periods] == ["morning", "afternoon", "evening", "night"]
+    assert periods[0]["start"] == "06:00"
+    assert periods[-1]["end"] == "23:59"
+    assert periods[0]["icon"] == "mdi:weather-sunny"
+
+
+def test_resolver_legacy_flat_keys_preserved():
+    coord = _coord([Child(name="A")])
+    coord.storage.set_setting("time_morning_start", "05:30")
+    coord.storage.set_setting("time_morning_end", "11:00")
+    periods = coord.get_time_periods()
+    morning = next(p for p in periods if p["id"] == "morning")
+    assert morning["start"] == "05:30"
+    assert morning["end"] == "11:00"
+
+
+def test_resolver_time_periods_setting_wins_and_sorts():
+    coord = _coord([Child(name="A")])
+    coord.storage.set_setting("time_periods", [
+        {"id": "night", "label": "", "start": "21:00", "end": "23:59", "icon": "mdi:weather-night"},
+        {"id": "school_run", "label": "School run", "start": "08:00", "end": "09:00", "icon": "mdi:school"},
+    ])
+    periods = coord.get_time_periods()
+    assert [p["id"] for p in periods] == ["school_run", "night"]
+    assert periods[0]["label"] == "School run"
+
+
+def test_resolver_skips_garbage_entries():
+    coord = _coord([Child(name="A")])
+    coord.storage.set_setting("time_periods", [
+        "not-a-dict",
+        {"id": "anytime", "start": "01:00", "end": "02:00"},   # reserved id
+        {"id": "ok", "label": "OK", "start": "10:00", "end": "11:00", "icon": ""},
+        {"id": "bad_time", "label": "Bad", "start": "xx:yy", "end": "11:00"},
+    ])
+    periods = coord.get_time_periods()
+    assert [p["id"] for p in periods] == ["ok"]
+    assert periods[0]["icon"] == "mdi:clock-outline"  # empty icon falls back
+
+
+def test_boundaries_built_from_periods():
+    coord = _coord([Child(name="A")])
+    coord.storage.set_setting("time_periods", [
+        {"id": "school_run", "label": "School run", "start": "08:00", "end": "09:15", "icon": "mdi:school"},
+    ])
+    boundaries = coord._get_time_boundaries()
+    assert boundaries["anytime"] is None
+    assert boundaries["school_run"] == (time(8, 0), time(9, 15))
+
+
+def test_time_category_window_for_custom_period():
+    from datetime import date
+    coord = _coord([Child(name="A")])
+    coord.storage.set_setting("time_periods", [
+        {"id": "school_run", "label": "School run", "start": "08:00", "end": "09:15", "icon": "mdi:school"},
+    ])
+    window = coord._time_category_window("school_run", date(2026, 6, 11))
+    assert window is not None
+    start, end = window
+    assert (start.hour, start.minute) == (8, 0)
+    assert (end.hour, end.minute) == (9, 15)
+    assert coord._time_category_window("anytime", date(2026, 6, 11)) is None
+
+
+# ---------------------------------------------------------------------------
+# Validation: websocket._validate_time_periods()
+# ---------------------------------------------------------------------------
+
+def _valid_payload():
+    return [
+        {"id": "morning", "label": "", "start": "06:00", "end": "12:00", "icon": "mdi:weather-sunny"},
+        {"id": "afternoon", "label": "", "start": "12:00", "end": "17:00", "icon": ""},
+        {"label": "School run", "start": "05:00", "end": "06:00", "icon": "mdi:school"},
+    ]
+
+
+def test_validate_accepts_and_normalizes():
+    coord = _coord([Child(name="A")])
+    periods, err = _validate_time_periods(_valid_payload(), coord)
+    assert err is None
+    # Sorted by start: school_run first
+    assert [p["id"] for p in periods] == ["school_run", "morning", "afternoon"]
+    # Missing id generated from label
+    assert periods[0]["id"] == "school_run"
+    # Empty icon falls back to the built-in map
+    assert periods[2]["icon"] == "mdi:white-balance-sunny"
+
+
+def test_validate_rejects_overlap():
+    coord = _coord([Child(name="A")])
+    payload = [
+        {"id": "morning", "label": "", "start": "06:00", "end": "12:00"},
+        {"label": "Brunch", "start": "11:00", "end": "13:00"},
+    ]
+    periods, err = _validate_time_periods(payload, coord)
+    assert periods is None
+    assert "overlap" in err.lower()
+
+
+def test_validate_allows_gaps():
+    coord = _coord([Child(name="A")])
+    payload = [
+        {"id": "morning", "label": "", "start": "06:00", "end": "08:00"},
+        {"label": "Bedtime", "start": "20:00", "end": "21:00"},
+    ]
+    periods, err = _validate_time_periods(payload, coord)
+    assert err is None
+    assert len(periods) == 2
+
+
+def test_validate_rejects_start_after_end():
+    coord = _coord([Child(name="A")])
+    periods, err = _validate_time_periods(
+        [{"label": "Backwards", "start": "10:00", "end": "09:00"}], coord)
+    assert periods is None and "start before" in err
+
+
+def test_validate_rejects_bad_time_format():
+    coord = _coord([Child(name="A")])
+    periods, err = _validate_time_periods(
+        [{"label": "Bad", "start": "25:00", "end": "26:00"}], coord)
+    assert periods is None and "HH:MM" in err
+
+
+def test_validate_rejects_blank_custom_label():
+    coord = _coord([Child(name="A")])
+    periods, err = _validate_time_periods(
+        [{"label": "  ", "start": "10:00", "end": "11:00"}], coord)
+    assert periods is None and "name" in err
+
+
+def test_validate_rejects_duplicate_ids():
+    coord = _coord([Child(name="A")])
+    payload = [
+        {"id": "x", "label": "One", "start": "06:00", "end": "07:00"},
+        {"id": "x", "label": "Two", "start": "08:00", "end": "09:00"},
+    ]
+    periods, err = _validate_time_periods(payload, coord)
+    assert periods is None and "duplicate" in err
+
+
+def test_validate_rejects_empty_list():
+    coord = _coord([Child(name="A")])
+    periods, err = _validate_time_periods([], coord)
+    assert periods is None
+
+
+def test_validate_slug_collision_gets_suffix():
+    coord = _coord([Child(name="A")])
+    payload = [
+        {"label": "Quiet Time", "start": "06:00", "end": "07:00"},
+        {"label": "Quiet time!", "start": "08:00", "end": "09:00"},
+    ]
+    periods, err = _validate_time_periods(payload, coord)
+    assert err is None
+    ids = {p["id"] for p in periods}
+    assert ids == {"quiet_time", "quiet_time_2"}
+
+
+def test_validate_blocks_deleting_period_in_use():
+    coord = _coord([Child(name="A")])
+    coord.storage.get_chores = MagicMock(return_value=[
+        Chore(name="Brush teeth", time_category="night"),
+    ])
+    # Payload drops the built-in "night" period
+    payload = [{"id": "morning", "label": "", "start": "06:00", "end": "12:00"}]
+    periods, err = _validate_time_periods(payload, coord)
+    assert periods is None
+    assert "Brush teeth" in err
+
+
+def test_validate_allows_deleting_unused_period():
+    coord = _coord([Child(name="A")])
+    coord.storage.get_chores = MagicMock(return_value=[
+        Chore(name="Brush teeth", time_category="anytime"),
+    ])
+    payload = [{"id": "morning", "label": "", "start": "06:00", "end": "12:00"}]
+    periods, err = _validate_time_periods(payload, coord)
+    assert err is None
+    assert [p["id"] for p in periods] == ["morning"]


### PR DESCRIPTION
## Summary

Implements fully customizable, unlimited time-of-day periods (Closes #391).

The previous release made the four fixed periods' start/end times editable; this PR makes the **set of periods itself** editable. From **Settings → Time-of-day boundaries** in the admin panel you can now:

- **Add unlimited periods** (e.g. *School run*, *Bedtime*) with their own start/end times
- **Rename** any period, including the built-in four
- **Pick an icon per period** (full MDI icon picker)
- **Delete periods** — blocked with a clear message while chores still reference one, naming the chores to reassign first
- **Reset to defaults** with one click

### Rules
- Periods form a non-overlapping sequence sorted by start time; overlaps are rejected (client + server)
- Gaps between periods fall back to **Anytime**, which stays built-in, all-day and undeletable
- Validation is server-authoritative in the websocket layer; the editor mirrors it for instant feedback

### Implementation
- New `time_periods` list setting with a fallback chain (`time_periods` → legacy `time_<cat>_start/end` keys → defaults), so existing customized times survive the upgrade with no migration step
- Overview sensor exposes an ordered `time_periods` attribute; the legacy `time_boundaries` attribute is kept in sync for older cards
- Chore time-category dropdowns (HA config flow + panel dialogs + child-card editor) are built dynamically from the period list
- Child, reorder and approvals cards resolve period order, icons, labels, claim windows and preview locks from the dynamic list
- Editor strings translated for all 8 locales (en, en-GB, de, fr, pt, pt-BR, nb, nn)

### Testing
- 17 new backend tests (`tests/test_time_periods.py`) covering the resolver fallback chain, sorting, garbage tolerance, overlap/format/label/duplicate validation, slug generation and block-on-delete
- Full suite: 462 passed; the 3 failures + 9 errors also occur on unmodified `main` (pre-existing, unrelated)
- `ruff check` clean; all cards pass `node --check`; locale JSON validated

Closes #391