### PR TITLE
fix(translations): reword badge criteria descriptions for hassfest

### DIFF
--- a/custom_components/taskmate/services.yaml
+++ b/custom_components/taskmate/services.yaml
@@ -694,7 +694,7 @@ add_badge:
           mode: box
     criteria:
       name: Criteria
-      description: "List of {metric, operator, value} dicts. Empty = manual-award only."
+      description: "List of metric / operator / value dicts. Empty = manual-award only."
       selector:
         object:
     assigned_to:

--- a/custom_components/taskmate/strings.json
+++ b/custom_components/taskmate/strings.json
@@ -979,7 +979,7 @@
         },
         "criteria": {
           "name": "Criteria",
-          "description": "List of {metric, operator, value} dicts. Empty = manual-award only."
+          "description": "List of metric / operator / value dicts. Empty = manual-award only."
         },
         "assigned_to": {
           "name": "Assigned to",
@@ -1021,7 +1021,7 @@
         },
         "criteria": {
           "name": "Criteria",
-          "description": "List of {metric, operator, value} dicts. Empty = manual-award only."
+          "description": "List of metric / operator / value dicts. Empty = manual-award only."
         },
         "assigned_to": {
           "name": "Assigned to",

--- a/custom_components/taskmate/translations/de.json
+++ b/custom_components/taskmate/translations/de.json
@@ -978,7 +978,7 @@
         },
         "criteria": {
           "name": "Kriterien",
-          "description": "Liste von {metric, operator, value}-Einträgen. Leer = nur manuelle Vergabe."
+          "description": "Liste von metric / operator / value-Einträgen. Leer = nur manuelle Vergabe."
         },
         "assigned_to": {
           "name": "Zugewiesen an",
@@ -1020,7 +1020,7 @@
         },
         "criteria": {
           "name": "Kriterien",
-          "description": "Liste von {metric, operator, value}-Einträgen. Leer = nur manuelle Vergabe."
+          "description": "Liste von metric / operator / value-Einträgen. Leer = nur manuelle Vergabe."
         },
         "assigned_to": {
           "name": "Zugewiesen an",

--- a/custom_components/taskmate/translations/en-GB.json
+++ b/custom_components/taskmate/translations/en-GB.json
@@ -978,7 +978,7 @@
         },
         "criteria": {
           "name": "Criteria",
-          "description": "List of {metric, operator, value} dicts. Empty = manual-award only."
+          "description": "List of metric / operator / value dicts. Empty = manual-award only."
         },
         "assigned_to": {
           "name": "Assigned to",
@@ -1020,7 +1020,7 @@
         },
         "criteria": {
           "name": "Criteria",
-          "description": "List of {metric, operator, value} dicts. Empty = manual-award only."
+          "description": "List of metric / operator / value dicts. Empty = manual-award only."
         },
         "assigned_to": {
           "name": "Assigned to",

--- a/custom_components/taskmate/translations/en.json
+++ b/custom_components/taskmate/translations/en.json
@@ -978,7 +978,7 @@
         },
         "criteria": {
           "name": "Criteria",
-          "description": "List of {metric, operator, value} dicts. Empty = manual-award only."
+          "description": "List of metric / operator / value dicts. Empty = manual-award only."
         },
         "assigned_to": {
           "name": "Assigned to",
@@ -1020,7 +1020,7 @@
         },
         "criteria": {
           "name": "Criteria",
-          "description": "List of {metric, operator, value} dicts. Empty = manual-award only."
+          "description": "List of metric / operator / value dicts. Empty = manual-award only."
         },
         "assigned_to": {
           "name": "Assigned to",

--- a/custom_components/taskmate/translations/fr.json
+++ b/custom_components/taskmate/translations/fr.json
@@ -978,7 +978,7 @@
         },
         "criteria": {
           "name": "Critères",
-          "description": "Liste de dictionnaires {metric, operator, value}. Vide = attribution manuelle uniquement."
+          "description": "Liste de dictionnaires metric / operator / value. Vide = attribution manuelle uniquement."
         },
         "assigned_to": {
           "name": "Attribué à",
@@ -1020,7 +1020,7 @@
         },
         "criteria": {
           "name": "Critères",
-          "description": "Liste de dictionnaires {metric, operator, value}. Vide = attribution manuelle uniquement."
+          "description": "Liste de dictionnaires metric / operator / value. Vide = attribution manuelle uniquement."
         },
         "assigned_to": {
           "name": "Attribué à",

--- a/custom_components/taskmate/translations/nb.json
+++ b/custom_components/taskmate/translations/nb.json
@@ -978,7 +978,7 @@
         },
         "criteria": {
           "name": "Kriterier",
-          "description": "Liste med {metric, operator, value}-oppføringer. Tom = kun manuell tildeling."
+          "description": "Liste med metric / operator / value-oppføringer. Tom = kun manuell tildeling."
         },
         "assigned_to": {
           "name": "Tildelt til",
@@ -1020,7 +1020,7 @@
         },
         "criteria": {
           "name": "Kriterier",
-          "description": "Liste med {metric, operator, value}-oppføringer. Tom = kun manuell tildeling."
+          "description": "Liste med metric / operator / value-oppføringer. Tom = kun manuell tildeling."
         },
         "assigned_to": {
           "name": "Tildelt til",

--- a/custom_components/taskmate/translations/nn.json
+++ b/custom_components/taskmate/translations/nn.json
@@ -978,7 +978,7 @@
         },
         "criteria": {
           "name": "Kriterium",
-          "description": "Liste med {metric, operator, value}-oppføringar. Tom = berre manuell tildeling."
+          "description": "Liste med metric / operator / value-oppføringar. Tom = berre manuell tildeling."
         },
         "assigned_to": {
           "name": "Tildelt til",
@@ -1020,7 +1020,7 @@
         },
         "criteria": {
           "name": "Kriterium",
-          "description": "Liste med {metric, operator, value}-oppføringar. Tom = berre manuell tildeling."
+          "description": "Liste med metric / operator / value-oppføringar. Tom = berre manuell tildeling."
         },
         "assigned_to": {
           "name": "Tildelt til",

--- a/custom_components/taskmate/translations/pt-BR.json
+++ b/custom_components/taskmate/translations/pt-BR.json
@@ -978,7 +978,7 @@
         },
         "criteria": {
           "name": "Critérios",
-          "description": "Lista de dicionários {metric, operator, value}. Vazio = apenas atribuição manual."
+          "description": "Lista de dicionários metric / operator / value. Vazio = apenas atribuição manual."
         },
         "assigned_to": {
           "name": "Atribuída a",
@@ -1020,7 +1020,7 @@
         },
         "criteria": {
           "name": "Critérios",
-          "description": "Lista de dicionários {metric, operator, value}. Vazio = apenas atribuição manual."
+          "description": "Lista de dicionários metric / operator / value. Vazio = apenas atribuição manual."
         },
         "assigned_to": {
           "name": "Atribuída a",

--- a/custom_components/taskmate/translations/pt.json
+++ b/custom_components/taskmate/translations/pt.json
@@ -978,7 +978,7 @@
         },
         "criteria": {
           "name": "Critérios",
-          "description": "Lista de dicionários {metric, operator, value}. Vazio = apenas atribuição manual."
+          "description": "Lista de dicionários metric / operator / value. Vazio = apenas atribuição manual."
         },
         "assigned_to": {
           "name": "Atribuída a",
@@ -1020,7 +1020,7 @@
         },
         "criteria": {
           "name": "Critérios",
-          "description": "Lista de dicionários {metric, operator, value}. Vazio = apenas atribuição manual."
+          "description": "Lista de dicionários metric / operator / value. Vazio = apenas atribuição manual."
         },
         "assigned_to": {
           "name": "Atribuída a",


### PR DESCRIPTION
## Summary

Fixes the hassfest failures blocking CI on `main` ([Validate with hassfest](https://github.com/tempus2016/taskmate/actions/runs/27360134727), [Validate & Test](https://github.com/tempus2016/taskmate/actions/runs/27360134822)).

A newer hassfest build began enforcing that `{…}` sequences in translation strings are valid placeholder identifiers. The `add_badge` / `update_badge` services described their `criteria` field as `List of {metric, operator, value} dicts`, which now fails on every run — the same SHA passed hassfest earlier in the day and failed later, confirming the rule change is upstream, not a repo regression.

### Changes
- Reword to `List of metric / operator / value dicts` in `strings.json`, all 8 `translations/*.json`, and `services.yaml` (19 occurrences)
- Scanned every translation string for other non-identifier `{…}` placeholders: none remain