### PR TITLE
chore: bump manifest to 3.9.7 for release

### DIFF
--- a/custom_components/taskmate/manifest.json
+++ b/custom_components/taskmate/manifest.json
@@ -17,5 +17,5 @@
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/tempus2016/taskmate/issues",
   "requirements": [],
-  "version": "3.9.6"
+  "version": "3.9.7"
 }


### PR DESCRIPTION
Bump manifest version to 3.9.7 for the v3.9.7 release.

Bundles the changes merged since v3.9.6:
- Codebase audit fixes — security, correctness, performance (#392)
- Custom unlimited time-of-day periods (#393, Closes #391)
- Hassfest translation placeholder fix (#394)