### PR TITLE
fix(panel): render time-of-day period inputs as native fields

### DIFF
--- a/custom_components/taskmate/www/taskmate-panel.js
+++ b/custom_components/taskmate/www/taskmate-panel.js
@@ -1327,11 +1327,11 @@ class TaskMatePanel extends HTMLElement {
       return `
             <div class="tm-setting-row tm-period-row">
               <ha-icon-picker data-tp-field="icon" data-tp-idx="${i}" data-current="${this._esc(p.icon || "mdi:clock-outline")}"></ha-icon-picker>
-              <ha-textfield data-tp-field="label" data-tp-idx="${i}" data-value="${this._esc(p.label || "")}" placeholder="${this._esc(placeholder)}"></ha-textfield>
+              <input type="text" class="tm-input" data-tp-field="label" data-tp-idx="${i}" value="${this._esc(p.label || "")}" placeholder="${this._esc(placeholder)}">
               <div class="tm-time-pair">
-                <ha-textfield type="time" data-tp-field="start" data-tp-idx="${i}" data-value="${this._esc(p.start || "")}"></ha-textfield>
+                <input type="time" class="tm-input" data-tp-field="start" data-tp-idx="${i}" value="${this._esc(p.start || "")}">
                 <span>–</span>
-                <ha-textfield type="time" data-tp-field="end" data-tp-idx="${i}" data-value="${this._esc(p.end || "")}"></ha-textfield>
+                <input type="time" class="tm-input" data-tp-field="end" data-tp-idx="${i}" value="${this._esc(p.end || "")}">
               </div>
               ${used
                 ? `<button type="button" class="tm-icon-btn tm-period-del" disabled title="${this._esc(this._t("panel.tp_in_use_title", { count: used }))}"><ha-icon icon="mdi:lock-outline"></ha-icon></button>`
@@ -4527,14 +4527,14 @@ class TaskMatePanel extends HTMLElement {
       .tm-time-pair {
         display: flex; align-items: center; gap: 8px;
       }
-      .tm-time-pair ha-textfield { max-width: 130px; }
+      .tm-time-pair .tm-input { max-width: 130px; }
       .tm-time-pair span { color: var(--tm-text-faint); }
       .tm-period-row {
         grid-template-columns: 56px minmax(140px, 1fr) auto 36px;
         gap: 12px;
       }
       .tm-period-row ha-icon-picker { max-width: 56px; }
-      .tm-period-row > ha-textfield { max-width: none; }
+      .tm-period-row > .tm-input { max-width: none; }
       .tm-period-del {
         color: var(--tm-text-faint);
       }


### PR DESCRIPTION
## Summary

The custom time-of-day period editor (Settings → Time-of-day boundaries) showed no input fields for the period **name** or **start/end times** — only the icon and the delete/lock button rendered. Users could not create or edit period boundaries.

Fixes #397

## Root cause

The label and time inputs were rendered as `<ha-textfield>` elements. In the reporter's environment (HAOS, HA 2026.6.3) these did not render at all, while the sibling `<ha-icon-picker>` in the same row did. The result was a blank middle column with only the `–` separator visible (see the screenshot on the issue).

The failure is specific to this section — the reporter clearly uses the rest of the app (multiple chores assigned to periods), so `ha-textfield` works for them in dialogs. Rather than depend on HA web-component load timing here, the editor now uses native inputs.

## Fix

- Replace the period **label** field and the **start/end time** fields with native `<input>` elements styled with the existing `.tm-input` class (text + `type="time"`).
- Native inputs reflect their value via the `value` attribute, so they render immediately with no picker hydration step.
- The icon column keeps using `ha-icon-picker` (it rendered correctly in the report).
- Repointed two CSS rules (`.tm-time-pair`, `.tm-period-row`) from `ha-textfield` to `.tm-input`.

No new translation strings; no behaviour change to validation, saving, or the draft model.

## Verification

Loaded the panel module in jsdom and rendered `_renderTimePeriodsSection()`:
- 12 native `<input>` elements produced (4 periods × label/start/end), **0** `ha-textfield`, 4 `ha-icon-picker` retained.
- Inputs carry correct default values (`06:00`–`12:00`, etc.).
- Editing through the real `_onInput`/`_onChange` handlers updates `_timePeriodsDraft` (label and start time), and `_validateTimePeriodsDraft()` returns 4 valid periods.