### PR TITLE
chore: bump manifest to 3.9.8 for release

### DIFF
--- a/custom_components/taskmate/manifest.json
+++ b/custom_components/taskmate/manifest.json
@@ -17,5 +17,5 @@
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/tempus2016/taskmate/issues",
   "requirements": [],
-  "version": "3.9.7"
+  "version": "3.9.8"
 }


### PR DESCRIPTION
Bump manifest version to 3.9.8 for the v3.9.8 release.

Includes the time-of-day period editor fix (#397, PR #398).