### PR TITLE
fix: graceful first_come race-loser error + non-blocking services.yaml load

### DIFF
--- a/custom_components/taskmate/__init__.py
+++ b/custom_components/taskmate/__init__.py
@@ -11,7 +11,7 @@ import yaml
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, ServiceCall, callback
-from homeassistant.exceptions import Unauthorized
+from homeassistant.exceptions import ServiceValidationError, Unauthorized
 import voluptuous as vol
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.service import async_set_service_schema
@@ -289,7 +289,13 @@ async def _async_register_services(hass: HomeAssistant) -> None:
         chore_id = call.data[ATTR_CHORE_ID]
         child_id = call.data[ATTR_CHILD_ID]
         as_parent = call.data.get(ATTR_AS_PARENT, False)
-        await coordinator.async_complete_chore(chore_id, child_id, as_parent=as_parent)
+        try:
+            await coordinator.async_complete_chore(chore_id, child_id, as_parent=as_parent)
+        except ValueError as err:
+            # Expected, user-facing conditions (e.g. a first_come race loser:
+            # "already completed by another child") must surface as a clean
+            # validation error, not an unhandled 500 + traceback.
+            raise ServiceValidationError(str(err)) from err
 
     async def handle_complete_bonus_subtask(call: ServiceCall) -> None:
         """Handle the complete_bonus_subtask service call."""

--- a/custom_components/taskmate/__init__.py
+++ b/custom_components/taskmate/__init__.py
@@ -155,6 +155,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         await _async_register_services(hass)
         hass.data[DOMAIN][SERVICES_REGISTERED] = True
 
+    # Pre-load services.yaml off the event loop so the @callback below
+    # never has to do blocking disk I/O.
+    await hass.async_add_executor_job(_load_base_descriptions)
+
     _async_update_service_descriptions(hass)
     coordinator.async_add_listener(
         lambda: _async_update_service_descriptions(hass)


### PR DESCRIPTION
## Summary
Fixes two bugs found while testing the 4.0.0-beta.1 features (#401 first-come, #402 complete-on-behalf) on the dev HA instance.

### 1. first_come race-loser returned HTTP 500 (#405)
When a child completes a `first_come` chore another child already won, `coord_chores.py` raises `ValueError("...already completed by another child")`. The `complete_chore` **service** had no handler for it, so it surfaced as an HTTP 500 + traceback. Losing a race is a *normal* outcome, so the service now translates the `ValueError` into a `ServiceValidationError` → the losing child gets a clean validation message over `hass.callService()`, no points, no log traceback.

### 2. services.yaml read blocked the event loop (#406)
`_load_base_descriptions()` did a blocking `open()` on the event loop during setup (HA `Detected blocking call to open` warning). Now pre-warmed off-loop via `async_add_executor_job` before the `@callback` runs.

## Testing
- Verified live on the dev HA instance (2-child pool):
  - Race loser over WS `call_service` → `success: false`, `code: service_validation_error`, message `"...already completed by another child."`, no points, no traceback.
  - Blocking-call warning no longer present in the error log after restart.
- `pytest`: 485 passed; the 3 failures + 9 errors are the pre-existing suite-order-pollution baseline (unchanged on main).

Fixes #405
Fixes #406