### PR TITLE
fix(frontend): load taskmate-localize.js on the admin panel

### DIFF
--- a/custom_components/taskmate/frontend.py
+++ b/custom_components/taskmate/frontend.py
@@ -46,8 +46,15 @@ CARDS: Final = [
 ]
 
 # JS modules loaded on every HA frontend page (config flow sound preview).
+# taskmate-localize.js is ALSO listed in CARDS (Lovelace resources) so it loads
+# early on dashboards; it must be here too because the admin panel (panel.py) is
+# a panel_custom page, not a Lovelace dashboard, and never loads Lovelace
+# resources — without this the panel renders raw i18n keys. Double-loading is a
+# no-op: the module is keyed by URL (loaded once) and only assigns idempotent
+# window.__taskmate_localize globals.
 GLOBAL_MODULES: Final = [
     "taskmate-config-sounds.js",
+    "taskmate-localize.js",
 ]
 
 # Track if frontend is registered


### PR DESCRIPTION
## Summary
The TaskMate admin panel (`/taskmate-admin`) rendered raw i18n keys (`panel.tab_children`, `panel.child_title`, etc.) on a cold load. The panel localiser depends on `window.__taskmate_localize`, defined by `taskmate-localize.js` — but that file had been demoted from `GLOBAL_MODULES` to `CARDS` (Lovelace resources) in `d1d19d7`. Lovelace resources only load on dashboards, never on a `panel_custom` page, so the global was undefined and every string fell through to its key.

## Fix
Restore `taskmate-localize.js` to `GLOBAL_MODULES` so `add_extra_js_url` injects it on every frontend page, including the panel. Left in `CARDS` too (early in-order load on dashboards). The original load-order race that motivated `d1d19d7` is already handled by the `requestUpdate()` re-render added in that same commit, so this is safe.

## Verified on dev HA (4.0.0-beta.1)
- Before restart: frontend shell injected **0** references to `taskmate-localize.js`.
- After restart: `/` and `/taskmate-admin` both inject `taskmate-localize.js?v=4.0.0-beta.1`; `panel.tab_children` resolves to "Children".

Fixes #408