### PR TITLE
fix(complete): enforce admin on as_parent in the backend service

### DIFF
--- a/custom_components/taskmate/__init__.py
+++ b/custom_components/taskmate/__init__.py
@@ -261,22 +261,27 @@ def _async_update_service_descriptions(hass: HomeAssistant) -> None:
         async_set_service_schema(hass, DOMAIN, service_name, patched)
 
 
+async def _async_require_admin(hass: HomeAssistant, call: ServiceCall) -> None:
+    """Reject user-initiated service calls that aren't from an admin.
+
+    Calls without a user context (automations, scripts, schedules) pass
+    through; user-initiated calls must come from an admin, matching the
+    admin gate on the panel's WebSocket commands.
+    """
+    if call.context.user_id:
+        user = await hass.auth.async_get_user(call.context.user_id)
+        if user is None or not user.is_admin:
+            raise Unauthorized(context=call.context)
+
+
 async def _async_register_services(hass: HomeAssistant) -> None:
     """Register TaskMate services."""
 
     def _admin(handler):
-        """Require an admin user for parent-privileged services.
-
-        Calls without a user context (automations, scripts, schedules) pass
-        through; user-initiated calls must come from an admin, matching the
-        admin gate on the panel's WebSocket commands.
-        """
+        """Wrap a service handler so only admins (or context-less calls) run it."""
         @wraps(handler)
         async def wrapped(call: ServiceCall) -> None:
-            if call.context.user_id:
-                user = await hass.auth.async_get_user(call.context.user_id)
-                if user is None or not user.is_admin:
-                    raise Unauthorized(context=call.context)
+            await _async_require_admin(hass, call)
             await handler(call)
         return wrapped
 
@@ -289,6 +294,12 @@ async def _async_register_services(hass: HomeAssistant) -> None:
         chore_id = call.data[ATTR_CHORE_ID]
         child_id = call.data[ATTR_CHILD_ID]
         as_parent = call.data.get(ATTR_AS_PARENT, False)
+        if as_parent:
+            # Completing on behalf of a child (auto-approve + instant award) is a
+            # parent privilege. Enforce it on the backend, not just by hiding the
+            # control in the UI — the service is callable by any authenticated
+            # user. Normal child self-completion (as_parent omitted) stays open.
+            await _async_require_admin(hass, call)
         try:
             await coordinator.async_complete_chore(chore_id, child_id, as_parent=as_parent)
         except ValueError as err:

--- a/tests/test_service_admin_gate.py
+++ b/tests/test_service_admin_gate.py
@@ -1,0 +1,53 @@
+"""Backend admin gate for parent-privileged service calls (issue #410).
+
+The `complete_chore` service's `as_parent` path must enforce admin on the
+backend, not just hide the control in the UI. These cover the shared
+`_async_require_admin` helper that both the `_admin` wrapper and the
+as_parent branch use.
+"""
+from __future__ import annotations
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+import custom_components.taskmate as tm
+
+
+def _call(user_id):
+    call = MagicMock()
+    call.context.user_id = user_id
+    return call
+
+
+def _hass(user):
+    hass = MagicMock()
+    hass.auth.async_get_user = AsyncMock(return_value=user)
+    return hass
+
+
+@pytest.mark.asyncio
+async def test_passes_without_user_context():
+    """Automations/scripts/schedules (no user_id) pass through untouched."""
+    hass = _hass(None)
+    await tm._async_require_admin(hass, _call(None))
+    hass.auth.async_get_user.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_allows_admin_user():
+    admin = MagicMock(is_admin=True)
+    await tm._async_require_admin(_hass(admin), _call("uid-admin"))
+
+
+@pytest.mark.asyncio
+async def test_rejects_non_admin_user():
+    non_admin = MagicMock(is_admin=False)
+    with pytest.raises(tm.Unauthorized):
+        await tm._async_require_admin(_hass(non_admin), _call("uid-child"))
+
+
+@pytest.mark.asyncio
+async def test_rejects_unknown_user():
+    """A user_id that no longer resolves to a user is rejected, not allowed."""
+    with pytest.raises(tm.Unauthorized):
+        await tm._async_require_admin(_hass(None), _call("uid-ghost"))


### PR DESCRIPTION
## Summary
Closes the backend half of the complete-on-behalf admin gate, found during UI testing of #402 on the dev HA.

The `as_parent` action (auto-approve + instant award) was gated **only in the frontend** — cards hide the control via `hass.user.is_admin`, and the panel is `require_admin`/`@_admin_only`. But the cards complete via the `complete_chore` **service**, which passed `as_parent` straight through with **no admin check**, so any authenticated non-admin could call it directly (their own token / API) to self-approve an approval-required chore and award points — bypassing parent approval.

## Change
- Extract the admin check into a reusable module-level `_async_require_admin(hass, call)` (the existing `_admin` wrapper now uses it too).
- In `handle_complete_chore`, require admin on the `as_parent` branch only. Normal child self-completion stays open; context-less automation/script calls still pass.

## Testing
- New `tests/test_service_admin_gate.py` (4 tests): no-context passes, admin passes, non-admin -> Unauthorized, unknown user -> Unauthorized.
- Full suite: 489 passed (the 3 failures + 9 errors are the pre-existing suite-pollution baseline).
- UI render confirmed on dev HA (admin): the 👤✓ complete-on-behalf control and the "First come" badge render in the panel; panel is HA-enforced `require_admin`.

Fixes #410