### PR TITLE
fix(tests): remove unused asyncio import (fix red Lint on main)

### DIFF
--- a/tests/test_chore_difficulty.py
+++ b/tests/test_chore_difficulty.py
@@ -7,7 +7,6 @@ exact award value. The multiplier per tier is configurable via settings
 """
 from __future__ import annotations
 
-import asyncio
 from unittest.mock import AsyncMock, MagicMock
 
 from custom_components.taskmate.coordinator import TaskMateCoordinator


### PR DESCRIPTION
## Problem
The `Lint / Ruff` workflow went red on `main` after the #417 (chore difficulty tiers) merge:

```
F401 [*] `asyncio` imported but unused
  --> tests/test_chore_difficulty.py:10:8
Found 1 error.
```

## Fix
Remove the unused `import asyncio` from `tests/test_chore_difficulty.py`. It was never referenced anywhere in the file.

## Verification
- `ruff check custom_components/taskmate tests` → **All checks passed!** (ruff 0.15.12, same as CI)
- `pytest tests/test_chore_difficulty.py --collect-only` → 12 tests still collect cleanly

CI hotfix to restore a green `main`; no tracking issue.