### PR TITLE
fix(cards): view cards default to sensor.taskmate_overview

### DIFF
--- a/custom_components/taskmate/www/taskmate-reminders-card.js
+++ b/custom_components/taskmate/www/taskmate-reminders-card.js
@@ -47,7 +47,7 @@ class TaskMateRemindersCard extends LitElement {
 
   getCardSize() { return 3; }
 
-  static getStubConfig() { return { entity: "sensor.taskmate_overall_stats" }; }
+  static getStubConfig() { return { entity: "sensor.taskmate_overview" }; }
 
   render() {
     if (!this.hass || !this.config) return html``;

--- a/custom_components/taskmate/www/taskmate-task-groups-card.js
+++ b/custom_components/taskmate/www/taskmate-task-groups-card.js
@@ -36,7 +36,7 @@ class TaskMateTaskGroupsCard extends LitElement {
 
   getCardSize() { return 3; }
 
-  static getStubConfig() { return { entity: "sensor.taskmate_overall_stats" }; }
+  static getStubConfig() { return { entity: "sensor.taskmate_overview" }; }
 
   render() {
     if (!this.hass || !this.config) return html``;

--- a/custom_components/taskmate/www/taskmate-templates-card.js
+++ b/custom_components/taskmate/www/taskmate-templates-card.js
@@ -36,7 +36,7 @@ class TaskMateTemplatesCard extends LitElement {
 
   getCardSize() { return 3; }
 
-  static getStubConfig() { return { entity: "sensor.taskmate_overall_stats" }; }
+  static getStubConfig() { return { entity: "sensor.taskmate_overview" }; }
 
   render() {
     if (!this.hass || !this.config) return html``;


### PR DESCRIPTION
View cards defaulted to non-existent sensor.taskmate_overall_stats; corrected to sensor.taskmate_overview. Verified on ha-dev. See #446.