### PR TITLE
feat(rewards): auto-restock automation

### DIFF
--- a/custom_components/taskmate/coord_rewards.py
+++ b/custom_components/taskmate/coord_rewards.py
@@ -467,6 +467,40 @@ class RewardsMixin:
         await self.async_refresh()
         return allocation
 
+    async def _async_restock_rewards(self) -> None:
+        """Refill `quantity` to restock_amount on the period boundary.
+
+        daily → every day; weekly → Mondays; monthly → the 1st. A
+        ``restock_last`` stamp guards against restocking twice in a day.
+        """
+        from homeassistant.util import dt as dt_util
+        today = dt_util.now().date()
+        today_iso = today.isoformat()
+        changed = False
+        for reward in self.storage.get_rewards():
+            if not getattr(reward, "restock_enabled", False):
+                continue
+            if int(getattr(reward, "restock_amount", 0) or 0) <= 0:
+                continue
+            if getattr(reward, "restock_last", "") == today_iso:
+                continue
+            period = getattr(reward, "restock_period", "weekly")
+            due = (
+                period == "daily"
+                or (period == "weekly" and today.weekday() == 0)
+                or (period == "monthly" and today.day == 1)
+            )
+            if not due:
+                continue
+            reward.quantity = int(reward.restock_amount)
+            reward.restock_last = today_iso
+            self.storage.update_reward(reward)
+            changed = True
+            _LOGGER.info("Restocked reward '%s' to %d", reward.name, reward.quantity)
+        if changed:
+            await self.storage.async_save()
+            await self.async_refresh()
+
     async def _async_expire_rewards(self) -> None:
         """Refund pool allocations on any reward whose expires_at is past.
 

--- a/custom_components/taskmate/coordinator.py
+++ b/custom_components/taskmate/coordinator.py
@@ -326,6 +326,7 @@ class TaskMateCoordinator(
         steps = [
             self._async_check_streaks,
             self._async_expire_one_shot_chores,
+            self._async_restock_rewards,
             self._async_expire_rewards,
             self._async_stop_stale_timed_sessions,
             # Rotate assignment_current_child_id and publish today's events

--- a/custom_components/taskmate/models.py
+++ b/custom_components/taskmate/models.py
@@ -370,6 +370,11 @@ class Reward:
     pool_enabled: bool = False  # If True, this reward uses pool-mode (savings jar) semantics
     quantity: int | None = None  # Remaining stock; None means unlimited
     expires_at: str | None = None  # ISO "YYYY-MM-DD"; None means no deadline
+    # Auto-restock: periodically reset `quantity` back to restock_amount.
+    restock_enabled: bool = False
+    restock_amount: int = 0
+    restock_period: str = "weekly"  # daily | weekly (Mon) | monthly (1st)
+    restock_last: str = ""  # ISO date this reward was last restocked
     id: str = field(default_factory=generate_id)
 
     @classmethod
@@ -389,6 +394,10 @@ class Reward:
             pool_enabled=data.get("pool_enabled", False),
             quantity=quantity,
             expires_at=expires_at,
+            restock_enabled=data.get("restock_enabled", False),
+            restock_amount=int(data.get("restock_amount", 0) or 0),
+            restock_period=data.get("restock_period", "weekly"),
+            restock_last=data.get("restock_last", ""),
             id=data.get("id", generate_id()),
         )
 
@@ -404,6 +413,10 @@ class Reward:
             "pool_enabled": self.pool_enabled,
             "quantity": self.quantity,
             "expires_at": self.expires_at,
+            "restock_enabled": self.restock_enabled,
+            "restock_amount": self.restock_amount,
+            "restock_period": self.restock_period,
+            "restock_last": self.restock_last,
             "id": self.id,
         }
 

--- a/custom_components/taskmate/websocket.py
+++ b/custom_components/taskmate/websocket.py
@@ -545,7 +545,8 @@ async def _ws_remove_chore(hass, connection, msg, coordinator):
 # ---------------------------------------------------------------------------
 
 _REWARD_FIELDS = {"name", "cost", "description", "icon", "assigned_to",
-                  "is_jackpot", "pool_enabled", "quantity", "expires_at"}
+                  "is_jackpot", "pool_enabled", "quantity", "expires_at",
+                  "restock_enabled", "restock_amount", "restock_period"}
 
 
 def _reward_payload_schema(*, require_name: bool):
@@ -561,6 +562,9 @@ def _reward_payload_schema(*, require_name: bool):
         vol.Optional("pool_enabled"): bool,
         vol.Optional("quantity"): vol.Any(None, vol.All(int, vol.Range(min=0))),
         vol.Optional("expires_at"): vol.Any(None, str),
+        vol.Optional("restock_enabled"): bool,
+        vol.Optional("restock_amount"): vol.All(int, vol.Range(min=0, max=10000)),
+        vol.Optional("restock_period"): vol.In(["daily", "weekly", "monthly"]),
     }
 
 
@@ -583,6 +587,9 @@ async def _ws_add_reward(hass, connection, msg, coordinator):
         pool_enabled=msg.get("pool_enabled", False),
         quantity=msg.get("quantity"),
         expires_at=msg.get("expires_at") or None,
+        restock_enabled=msg.get("restock_enabled", False),
+        restock_amount=msg.get("restock_amount", 0),
+        restock_period=msg.get("restock_period", "weekly"),
     )
     coordinator.storage.add_reward(reward)
     await coordinator.storage.async_save()

--- a/custom_components/taskmate/www/locales/en-GB.json
+++ b/custom_components/taskmate/www/locales/en-GB.json
@@ -1251,5 +1251,12 @@
   "panel.settings_surprise_params_hint": "Daily chance per child, and the random points range awarded on a hit.",
   "panel.settings_surprise_chance": "Chance %",
   "panel.settings_surprise_min": "Min pts",
-  "panel.settings_surprise_max": "Max pts"
+  "panel.settings_surprise_max": "Max pts",
+  "panel.reward_restock_label": "Auto-restock",
+  "panel.reward_restock_hint": "Periodically reset this reward's stock back to a set amount.",
+  "panel.reward_restock_amount": "Restock to",
+  "panel.reward_restock_period": "Restock every",
+  "panel.reward_restock_daily": "Day",
+  "panel.reward_restock_weekly": "Week (Mon)",
+  "panel.reward_restock_monthly": "Month (1st)"
 }

--- a/custom_components/taskmate/www/locales/en.json
+++ b/custom_components/taskmate/www/locales/en.json
@@ -1251,5 +1251,12 @@
   "panel.settings_surprise_params_hint": "Daily chance per child, and the random points range awarded on a hit.",
   "panel.settings_surprise_chance": "Chance %",
   "panel.settings_surprise_min": "Min pts",
-  "panel.settings_surprise_max": "Max pts"
+  "panel.settings_surprise_max": "Max pts",
+  "panel.reward_restock_label": "Auto-restock",
+  "panel.reward_restock_hint": "Periodically reset this reward's stock back to a set amount.",
+  "panel.reward_restock_amount": "Restock to",
+  "panel.reward_restock_period": "Restock every",
+  "panel.reward_restock_daily": "Day",
+  "panel.reward_restock_weekly": "Week (Mon)",
+  "panel.reward_restock_monthly": "Month (1st)"
 }

--- a/custom_components/taskmate/www/taskmate-panel.js
+++ b/custom_components/taskmate/www/taskmate-panel.js
@@ -1215,7 +1215,8 @@ class TaskMatePanel extends HTMLElement {
   _openRewardDialog(id) {
     const blank = { name: "", description: "", cost: 50, icon: "mdi:gift",
       assigned_to: [], is_jackpot: false, pool_enabled: false,
-      quantity_str: "", expires_at: "" };
+      quantity_str: "", expires_at: "",
+      restock_enabled: false, restock_amount: 0, restock_period: "weekly" };
     if (id) {
       const r = (this._state.rewards || []).find(x => x.id === id);
       if (!r) return;
@@ -1246,6 +1247,9 @@ class TaskMatePanel extends HTMLElement {
       pool_enabled: !!d.pool_enabled,
       quantity: qty,
       expires_at: (d.expires_at || "").trim() || null,
+      restock_enabled: !!d.restock_enabled,
+      restock_amount: Math.max(0, Number(d.restock_amount) || 0),
+      restock_period: d.restock_period || "weekly",
     };
     const payload = wasAdd ? { type: "taskmate/add_reward", ...base } : { type: "taskmate/update_reward", reward_id: d.id, ...base };
     const { ok, err } = await this._callWS(payload);
@@ -3738,6 +3742,16 @@ class TaskMatePanel extends HTMLElement {
         `<div class="tm-field-row">
           ${this._field(this._t("panel.reward_quantity_label"), "quantity_str", d.quantity_str, "text", this._t("panel.reward_quantity_hint"))}
           ${this._dateField(this._t("panel.reward_expires_label"), "expires_at", d.expires_at, this._t("panel.reward_expires_hint"))}
+        </div>`,
+        this._switch(this._t("panel.reward_restock_label"), "restock_enabled", d.restock_enabled,
+          this._t("panel.reward_restock_hint")),
+        `<div class="tm-field-row">
+          ${this._field(this._t("panel.reward_restock_amount"), "restock_amount", d.restock_amount, "number")}
+          ${this._select(this._t("panel.reward_restock_period"), "restock_period", d.restock_period || "weekly", [
+            { v: "daily", l: this._t("panel.reward_restock_daily") },
+            { v: "weekly", l: this._t("panel.reward_restock_weekly") },
+            { v: "monthly", l: this._t("panel.reward_restock_monthly") },
+          ])}
         </div>`,
       ].join(""),
       `<button type="button" class="tm-btn" data-act="close-dialog">${this._t("panel.btn_cancel")}</button>

--- a/tests/test_reward_restock.py
+++ b/tests/test_reward_restock.py
@@ -1,0 +1,93 @@
+"""Tests for reward auto-restock."""
+from __future__ import annotations
+
+import asyncio
+import datetime as dt
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from custom_components.taskmate.coordinator import TaskMateCoordinator
+from custom_components.taskmate.models import Reward
+
+
+def run(coro):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+def _coord(rewards):
+    coord = object.__new__(TaskMateCoordinator)
+    storage = MagicMock()
+    storage.get_rewards = MagicMock(return_value=rewards)
+    storage.update_reward = MagicMock()
+    storage.async_save = AsyncMock()
+    coord.storage = storage
+    coord.async_refresh = AsyncMock()
+    return coord
+
+
+def _run_on(coord, date_obj):
+    import custom_components.taskmate.coord_rewards as mod
+    fake = MagicMock()
+    fake.now.return_value = dt.datetime(date_obj.year, date_obj.month, date_obj.day, 0, 5)
+    with patch.dict("sys.modules"):
+        with patch("homeassistant.util.dt.now", return_value=fake.now.return_value):
+            run(coord._async_restock_rewards())
+
+
+def test_daily_restocks_every_day():
+    r = Reward(name="Snack", quantity=0, restock_enabled=True, restock_amount=3,
+               restock_period="daily", restock_last="", id="r1")
+    coord = _coord([r])
+    _run_on(coord, dt.date(2026, 6, 17))  # any day
+    assert r.quantity == 3 and r.restock_last == "2026-06-17"
+
+
+def test_weekly_only_on_monday():
+    r = Reward(name="Movie", quantity=0, restock_enabled=True, restock_amount=1,
+               restock_period="weekly", restock_last="", id="r1")
+    coord = _coord([r])
+    _run_on(coord, dt.date(2026, 6, 17))  # Wednesday -> no restock
+    assert r.quantity == 0
+    _run_on(coord, dt.date(2026, 6, 15))  # Monday -> restock
+    assert r.quantity == 1
+
+
+def test_monthly_only_on_first():
+    r = Reward(name="Outing", quantity=0, restock_enabled=True, restock_amount=2,
+               restock_period="monthly", restock_last="", id="r1")
+    coord = _coord([r])
+    _run_on(coord, dt.date(2026, 6, 17))  # not the 1st
+    assert r.quantity == 0
+    _run_on(coord, dt.date(2026, 7, 1))   # 1st -> restock
+    assert r.quantity == 2
+
+
+def test_no_double_restock_same_day():
+    r = Reward(name="Snack", quantity=5, restock_enabled=True, restock_amount=3,
+               restock_period="daily", restock_last="2026-06-17", id="r1")
+    coord = _coord([r])
+    _run_on(coord, dt.date(2026, 6, 17))  # already restocked today
+    assert r.quantity == 5  # untouched
+    coord.storage.update_reward.assert_not_called()
+
+
+def test_disabled_or_zero_amount_skipped():
+    r1 = Reward(name="Off", quantity=0, restock_enabled=False, restock_amount=3,
+                restock_period="daily", id="r1")
+    r2 = Reward(name="ZeroAmt", quantity=0, restock_enabled=True, restock_amount=0,
+                restock_period="daily", id="r2")
+    coord = _coord([r1, r2])
+    _run_on(coord, dt.date(2026, 6, 17))
+    assert r1.quantity == 0 and r2.quantity == 0
+    coord.storage.update_reward.assert_not_called()
+
+
+def test_restock_round_trips_serialization():
+    r = Reward(name="X", restock_enabled=True, restock_amount=4, restock_period="monthly",
+               restock_last="2026-06-01")
+    r2 = Reward.from_dict(r.to_dict())
+    assert r2.restock_enabled and r2.restock_amount == 4
+    assert r2.restock_period == "monthly" and r2.restock_last == "2026-06-01"


### PR DESCRIPTION
Auto-restock rewards (daily/weekly/monthly) via a midnight step + reward fields + panel dialog. See #457. 594 passed.