### PR TITLE
fix(tests): drop unused coord_rewards import (ruff F401)

### DIFF
--- a/tests/test_reward_restock.py
+++ b/tests/test_reward_restock.py
@@ -29,7 +29,6 @@ def _coord(rewards):
 
 
 def _run_on(coord, date_obj):
-    import custom_components.taskmate.coord_rewards as mod
     fake = MagicMock()
     fake.now.return_value = dt.datetime(date_obj.year, date_obj.month, date_obj.day, 0, 5)
     with patch.dict("sys.modules"):


### PR DESCRIPTION
The Lint workflow has been failing on main since #458.

ruff flags `tests/test_reward_restock.py:32` with **F401** — the `_run_on` helper imports `custom_components.taskmate.coord_rewards as mod` but never references `mod`. The helper drives restock through `patch("homeassistant.util.dt.now")` + `coord._async_restock_rewards()`, so the module import is dead.

Removed the unused import. `ruff check custom_components/taskmate tests` now passes and `tests/test_reward_restock.py` still passes (6 passed).