### PR TITLE
feat(child-card): level + XP progress display

### DIFF
--- a/custom_components/taskmate/www/locales/en-GB.json
+++ b/custom_components/taskmate/www/locales/en-GB.json
@@ -1291,5 +1291,6 @@
   "panel.settings_level_step_hint": "Earned points needed to advance one level (XP = lifetime earned points).",
   "panel.child_stat_level": "Level",
   "notification.level_up.name": "Level up",
-  "notification.level_up.description": "Celebrates when a child reaches a new XP level (off by default)."
+  "notification.level_up.description": "Celebrates when a child reaches a new XP level (off by default).",
+  "child.level_label": "Lvl {level}"
 }

--- a/custom_components/taskmate/www/locales/en.json
+++ b/custom_components/taskmate/www/locales/en.json
@@ -1291,5 +1291,6 @@
   "panel.settings_level_step_hint": "Earned points needed to advance one level (XP = lifetime earned points).",
   "panel.child_stat_level": "Level",
   "notification.level_up.name": "Level up",
-  "notification.level_up.description": "Celebrates when a child reaches a new XP level (off by default)."
+  "notification.level_up.description": "Celebrates when a child reaches a new XP level (off by default).",
+  "child.level_label": "Lvl {level}"
 }

--- a/custom_components/taskmate/www/taskmate-child-card.js
+++ b/custom_components/taskmate/www/taskmate-child-card.js
@@ -561,6 +561,36 @@ class TaskMateChildCard extends LitElement {
         text-overflow: ellipsis;
         white-space: nowrap;
       }
+      .child-level {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        margin-top: 4px;
+      }
+      .level-badge {
+        font-size: 0.7rem;
+        font-weight: 800;
+        letter-spacing: .03em;
+        color: white;
+        background: rgba(255, 255, 255, 0.25);
+        padding: 1px 8px;
+        border-radius: 999px;
+        white-space: nowrap;
+      }
+      .level-xp-track {
+        flex: 1;
+        max-width: 90px;
+        height: 5px;
+        border-radius: 999px;
+        background: rgba(255, 255, 255, 0.25);
+        overflow: hidden;
+      }
+      .level-xp-fill {
+        height: 100%;
+        border-radius: 999px;
+        background: white;
+        transition: width 0.4s ease;
+      }
 
       /* Points pill — right side of header, compact like overview card */
       .points-display {
@@ -1628,6 +1658,14 @@ class TaskMateChildCard extends LitElement {
             </div>
             <div class="child-name-container">
               <div class="child-name">${child.name}</div>
+              ${child.level ? html`
+                <div class="child-level" title="${child.level_progress || 0} / ${child.level_target || 100} XP">
+                  <span class="level-badge">${this._t('child.level_label', { level: child.level })}</span>
+                  <div class="level-xp-track">
+                    <div class="level-xp-fill" style="width: ${Math.max(0, Math.min(100, Math.round(((child.level_progress || 0) / (child.level_target || 100)) * 100)))}%"></div>
+                  </div>
+                </div>
+              ` : ''}
             </div>
           </div>
           <div class="points-display">


### PR DESCRIPTION
Kid-facing level: Lvl N badge + XP progress bar on the child card header (data already on the overview sensor). See #470.