### PR TITLE
fix(tests): clear ruff E702 + F401 lint failures

### DIFF
--- a/tests/test_photo_proof.py
+++ b/tests/test_photo_proof.py
@@ -19,7 +19,8 @@ def run(coro):
 def _coord(chore, child):
     coord = object.__new__(TaskMateCoordinator)
     coord.hass = MagicMock()
-    coord.hass.bus = MagicMock(); coord.hass.bus.async_fire = MagicMock()
+    coord.hass.bus = MagicMock()
+    coord.hass.bus.async_fire = MagicMock()
     added = []
     storage = MagicMock()
     storage.get_chore = MagicMock(return_value=chore)

--- a/tests/test_time_incentives.py
+++ b/tests/test_time_incentives.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import datetime as dt
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from custom_components.taskmate.coordinator import TaskMateCoordinator
 from custom_components.taskmate.models import Chore


### PR DESCRIPTION
The Lint workflow is failing on main with two ruff errors:

- **E702** `tests/test_photo_proof.py:22` — two statements joined by a semicolon (from #481). Split onto separate lines.
- **F401** `tests/test_time_incentives.py:5` — `MagicMock` imported but unused (from #479). Removed; only `patch` is needed.

`ruff check custom_components/taskmate tests` now passes; both test files still green (12 passed).