### PR TITLE
fix(tests): split semicolon-joined statements (ruff E702)

### DIFF
--- a/tests/test_chore_swap.py
+++ b/tests/test_chore_swap.py
@@ -21,7 +21,9 @@ def run(coro):
 def _coord(chore, children):
     by_id = {c.id: c for c in children}
     coord = object.__new__(TaskMateCoordinator)
-    coord.hass = MagicMock(); coord.hass.bus = MagicMock(); coord.hass.bus.async_fire = MagicMock()
+    coord.hass = MagicMock()
+    coord.hass.bus = MagicMock()
+    coord.hass.bus.async_fire = MagicMock()
     reqs = []
     storage = MagicMock()
     storage.get_chore = MagicMock(return_value=chore)

--- a/tests/test_quests.py
+++ b/tests/test_quests.py
@@ -40,7 +40,8 @@ def _coord(quests, child):
     coord._progress = progress
     coord.get_child = MagicMock(return_value=child)
     coord.async_refresh = AsyncMock()
-    coord.notifications = MagicMock(); coord.notifications.fire = AsyncMock()
+    coord.notifications = MagicMock()
+    coord.notifications.fire = AsyncMock()
     # Stub level-up so _complete_quest's optional hook is a no-op
     coord._maybe_level_up = AsyncMock()
     return coord

--- a/tests/test_weekly_digest.py
+++ b/tests/test_weekly_digest.py
@@ -26,7 +26,8 @@ def _coord(children, completions):
     storage.get_completions = MagicMock(return_value=completions)
     storage.get_points_name = MagicMock(return_value="Stars")
     coord.storage = storage
-    coord.notifications = MagicMock(); coord.notifications.fire = AsyncMock()
+    coord.notifications = MagicMock()
+    coord.notifications.fire = AsyncMock()
     return coord
 
 


### PR DESCRIPTION
Lint is failing on main with 4 **E702** errors (semicolon-joined statements) introduced across recent feature merges:

- `tests/test_chore_swap.py:24` (#483)
- `tests/test_quests.py:43` (#489)
- `tests/test_weekly_digest.py:29` (#485)

Split each onto separate lines. `ruff check custom_components/taskmate tests` now passes; the three test files still pass (15 passed).