### PR TITLE
ci(lint): run Ruff on pull requests targeting main

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,6 +3,8 @@ name: Lint
 on:
   push:
     branches: [main]
+  pull_request:
+    branches: [main]
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
The Lint workflow only triggered on `push` to main, so it never ran on PRs and could not gate them — ruff failures kept landing on main and only surfaced post-merge (4 consecutive cleanup PRs: #461, #482, #491).

Adds a `pull_request` trigger (branches: [main]) so the **Ruff** check runs on every PR into main. This PR self-validates the change. Once merged, Ruff can be set as a required status check on `main`.