### PR TITLE
fix(tests): split semicolon-joined statement (ruff E702)

### DIFF
--- a/tests/test_challenges.py
+++ b/tests/test_challenges.py
@@ -44,7 +44,8 @@ def _coord(challenges, child, completions):
     coord._progress = progress
     coord.get_child = MagicMock(return_value=child)
     coord.async_refresh = AsyncMock()
-    coord.notifications = MagicMock(); coord.notifications.fire = AsyncMock()
+    coord.notifications = MagicMock()
+    coord.notifications.fire = AsyncMock()
     coord._maybe_level_up = AsyncMock()
     return coord
 


### PR DESCRIPTION
`tests/test_challenges.py:47` joined notifications setup with a semicolon, failing the Lint workflow (E702). This landed from #496, which slipped in during the ~27s window before the new branch ruleset took effect.

Split onto separate lines. `ruff check custom_components/taskmate tests` passes; test_challenges.py still green (7 passed). This PR also serves as the first live test of the Ruff required-status-check gate on main.