### PR TITLE
ci(tests): run Validate & Test on pull requests targeting main

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,6 +3,8 @@ name: Validate & Test
 on:
   push:
     branches: [main]
+  pull_request:
+    branches: [main]
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Companion to #494 (which added the same for Ruff/Lint).

The **Validate & Test** workflow (hassfest + `pytest -v`) only triggered on `push` to main, so the test suite never ran on PRs and could not gate them. PR #496 merged a 679-line feature without its tests ever running pre-merge.

Adds a `pull_request` trigger (branches: [main]) so both the **Validate integration** and **Run tests** jobs run on every PR into main. This PR self-validates the change. Once merged, **Run tests** can be added as a required status check alongside **Ruff**.