### PR TITLE
fix(services): surface coordinator ValueErrors as clean validation errors

### DIFF
--- a/custom_components/taskmate/__init__.py
+++ b/custom_components/taskmate/__init__.py
@@ -280,6 +280,27 @@ async def _async_require_admin(hass: HomeAssistant, call: ServiceCall) -> None:
             raise Unauthorized(context=call.context)
 
 
+def _safe(handler):
+    """Surface coordinator validation errors as clean service errors.
+
+    Coordinator methods raise ``ValueError`` for bad or rejected input (unknown
+    id, locked avatar, insufficient balance, swap not allowed, ...). Left
+    unhandled those reach the caller as an unhandled error + a full traceback in
+    the log. Re-raise as ``ServiceValidationError`` so a frontend/WebSocket
+    caller (the cards, the admin panel, Dev Tools) gets a clean failure result
+    with the human-readable message and no traceback is logged.
+    ``ServiceValidationError`` is not a ``ValueError``, so a handler that already
+    raises it (e.g. complete_chore) passes through untouched.
+    """
+    @wraps(handler)
+    async def wrapped(call: ServiceCall) -> None:
+        try:
+            await handler(call)
+        except ValueError as err:
+            raise ServiceValidationError(str(err)) from err
+    return wrapped
+
+
 async def _async_require_linked_child(
     hass: HomeAssistant, call: ServiceCall, coordinator, child_id: str
 ) -> None:
@@ -311,7 +332,10 @@ async def _async_register_services(hass: HomeAssistant) -> None:
         async def wrapped(call: ServiceCall) -> None:
             await _async_require_admin(hass, call)
             await handler(call)
-        return wrapped
+        # Compose with _safe so admin handlers also convert coordinator
+        # ValueErrors into clean validation errors. The admin gate raises
+        # Unauthorized (not ValueError), so it is unaffected and still 401s.
+        return _safe(wrapped)
 
     async def handle_complete_chore(call: ServiceCall) -> None:
         """Handle the complete_chore service call."""
@@ -847,7 +871,7 @@ async def _async_register_services(hass: HomeAssistant) -> None:
     hass.services.async_register(
         DOMAIN,
         SERVICE_COMPLETE_BONUS_SUBTASK,
-        handle_complete_bonus_subtask,
+        _safe(handle_complete_bonus_subtask),
         schema=vol.Schema(
             {
                 vol.Required(ATTR_CHORE_ID): cv.string,
@@ -860,7 +884,7 @@ async def _async_register_services(hass: HomeAssistant) -> None:
     hass.services.async_register(
         DOMAIN,
         SERVICE_START_TIMED_TASK,
-        handle_start_timed_task,
+        _safe(handle_start_timed_task),
         schema=vol.Schema(
             {
                 vol.Required(ATTR_CHORE_ID): cv.string,
@@ -872,7 +896,7 @@ async def _async_register_services(hass: HomeAssistant) -> None:
     hass.services.async_register(
         DOMAIN,
         SERVICE_PAUSE_TIMED_TASK,
-        handle_pause_timed_task,
+        _safe(handle_pause_timed_task),
         schema=vol.Schema(
             {
                 vol.Required(ATTR_CHORE_ID): cv.string,
@@ -884,7 +908,7 @@ async def _async_register_services(hass: HomeAssistant) -> None:
     hass.services.async_register(
         DOMAIN,
         SERVICE_STOP_TIMED_TASK,
-        handle_stop_timed_task,
+        _safe(handle_stop_timed_task),
         schema=vol.Schema(
             {
                 vol.Required(ATTR_CHORE_ID): cv.string,
@@ -953,7 +977,7 @@ async def _async_register_services(hass: HomeAssistant) -> None:
     hass.services.async_register(
         DOMAIN,
         SERVICE_REQUEST_SWAP,
-        handle_request_swap,
+        _safe(handle_request_swap),
         schema=vol.Schema(
             {
                 vol.Required("chore_id"): cv.string,
@@ -965,7 +989,7 @@ async def _async_register_services(hass: HomeAssistant) -> None:
     hass.services.async_register(
         DOMAIN,
         SERVICE_CHOOSE_AVATAR,
-        handle_choose_avatar,
+        _safe(handle_choose_avatar),
         schema=vol.Schema(
             {
                 vol.Required(ATTR_CHILD_ID): cv.string,
@@ -977,7 +1001,7 @@ async def _async_register_services(hass: HomeAssistant) -> None:
     hass.services.async_register(
         DOMAIN,
         SERVICE_CLAIM_REWARD,
-        handle_claim_reward,
+        _safe(handle_claim_reward),
         schema=vol.Schema(
             {
                 vol.Required(ATTR_REWARD_ID): cv.string,
@@ -1007,7 +1031,7 @@ async def _async_register_services(hass: HomeAssistant) -> None:
     hass.services.async_register(
         DOMAIN,
         SERVICE_ALLOCATE_POINTS_TO_POOL,
-        handle_allocate_points_to_pool,
+        _safe(handle_allocate_points_to_pool),
         schema=vol.Schema(
             {
                 vol.Required(ATTR_CHILD_ID): cv.string,
@@ -1046,7 +1070,7 @@ async def _async_register_services(hass: HomeAssistant) -> None:
     hass.services.async_register(
         DOMAIN,
         SERVICE_PREVIEW_SOUND,
-        handle_preview_sound,
+        _safe(handle_preview_sound),
         schema=vol.Schema(
             {
                 vol.Required(ATTR_SOUND): vol.In([

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -120,8 +120,16 @@ class FakeUnauthorized(Exception):
         super().__init__(*args)
 
 
+class FakeServiceValidationError(Exception):
+    """Stand-in for homeassistant.exceptions.ServiceValidationError."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args)
+
+
 _ha_exceptions = MagicMock()
 _ha_exceptions.Unauthorized = FakeUnauthorized
+_ha_exceptions.ServiceValidationError = FakeServiceValidationError
 
 
 # ── homeassistant.helpers.event ─────────────────────────────────────────────

--- a/tests/test_service_validation_errors.py
+++ b/tests/test_service_validation_errors.py
@@ -1,0 +1,40 @@
+"""Coordinator ValueErrors surface as clean ServiceValidationErrors.
+
+Coordinator methods raise ``ValueError`` for bad/rejected input (locked
+avatar, insufficient gift balance, unknown id, ...). The service layer wraps
+handlers in ``_safe`` so the frontend/WebSocket caller gets a clean failure
+result with the message instead of an unhandled error + traceback. A handler
+that already raises ``ServiceValidationError`` must pass through untouched.
+"""
+from __future__ import annotations
+
+import pytest
+from unittest.mock import AsyncMock
+
+import custom_components.taskmate as tm
+
+
+@pytest.mark.asyncio
+async def test_value_error_becomes_service_validation_error():
+    handler = AsyncMock(side_effect=ValueError("That avatar is not unlocked yet"))
+    wrapped = tm._safe(handler)
+    with pytest.raises(tm.ServiceValidationError, match="not unlocked yet"):
+        await wrapped(object())
+
+
+@pytest.mark.asyncio
+async def test_clean_call_passes_through():
+    handler = AsyncMock(return_value=None)
+    call = object()
+    await tm._safe(handler)(call)
+    handler.assert_awaited_once_with(call)
+
+
+@pytest.mark.asyncio
+async def test_service_validation_error_not_double_wrapped():
+    """A handler that already raises ServiceValidationError is left as-is."""
+    original = tm.ServiceValidationError("already clean")
+    handler = AsyncMock(side_effect=original)
+    with pytest.raises(tm.ServiceValidationError) as excinfo:
+        await tm._safe(handler)(object())
+    assert excinfo.value is original


### PR DESCRIPTION
## Summary

Routine validation rejections from coordinator methods (bare `ValueError`) reached the frontend WebSocket path unhandled — the service call failed with no clean message and **logged a full traceback** on every rejection (locked-avatar `choose_avatar`, over-balance / self / unknown-child `gift_points`, unknown-id `undo_transaction` / `request_swap`, task-group ops, ...).

This wraps the service handlers so `ValueError` is re-raised as `ServiceValidationError` — the same pattern `complete_chore` already uses. Over the WebSocket API (what the cards, the admin panel, and Dev Tools use) the caller now gets a clean `service_validation_error` result with the human-readable message, and the log gets a single line instead of a traceback.

## Implementation

- New reusable `_safe` decorator (module-level, so it is unit-testable).
- Composed into the existing `_admin` wrapper, so all admin-gated handlers are covered with no per-site change. The admin gate raises `Unauthorized` (not `ValueError`), so it is unaffected.
- Applied to the 9 remaining bare handlers (`complete_bonus_subtask`, timed-task start/pause/stop, `request_swap`, `choose_avatar`, `claim_reward`, `allocate_points_to_pool`, `preview_sound`). `complete_chore` already self-converts and is left as-is.

## Verification

Exercised on the **ha-dev** instance (HA 2026.6.3) over the real WebSocket `call_service` path:

| Probe | Before | After |
|---|---|---|
| `choose_avatar` locked | unhandled + traceback | `success:false` — "That avatar is not unlocked yet" |
| `gift_points` > balance | unhandled + traceback | "Not enough points: Malia has 1, gift 9999" |
| `gift_points` to self | unhandled + traceback | "Cannot gift to the same child" |
| `undo_transaction` bad id | unhandled + traceback | "Transaction nope not found" |
| `request_swap` bad chore | unhandled + traceback | "Chore nope not found" |
| happy paths | ok | ok (`success:true`) |

Log now shows a single clean line per rejection, no traceback. State was never corrupted in any case.

- New regression test `tests/test_service_validation_errors.py` (3 tests) + a `FakeServiceValidationError` conftest stub.
- `ruff check` clean. Full suite: 684 passed; the only failures (3 + 9 errors) are the pre-existing test-order-pollution cases on `main`, unchanged by this PR.

Fixes #501