### PR TITLE
fix(services): whitelist difficulty on add_chore, document photo_url, fix interest label

### DIFF
--- a/custom_components/taskmate/__init__.py
+++ b/custom_components/taskmate/__init__.py
@@ -99,6 +99,8 @@ from .const import (
     CONF_TASK_GROUP_CHORE_IDS,
     TASK_GROUP_POLICIES,
     TIME_CATEGORIES,
+    DIFFICULTY_TIERS,
+    DEFAULT_DIFFICULTY,
 )
 from .coordinator import TaskMateCoordinator
 from .frontend import async_register_cards, async_register_frontend
@@ -1193,6 +1195,7 @@ async def _async_register_services(hass: HomeAssistant) -> None:
             vol.Optional(ATTR_CHORE_POINTS, default=10): cv.positive_int,
             vol.Optional(ATTR_CHORE_ASSIGNED_TO, default=[]): vol.All(cv.ensure_list, [cv.string]),
             vol.Optional(ATTR_CHORE_TIME_CATEGORY, default="anytime"): vol.In(TIME_CATEGORIES),
+            vol.Optional("difficulty", default=DEFAULT_DIFFICULTY): vol.In(DIFFICULTY_TIERS),
             vol.Optional(ATTR_CHORE_ONE_SHOT, default=False): cv.boolean,
             vol.Optional(ATTR_CHORE_REQUIRES_APPROVAL, default=True): cv.boolean,
         }),

--- a/custom_components/taskmate/services.yaml
+++ b/custom_components/taskmate/services.yaml
@@ -21,6 +21,12 @@ complete_chore:
       default: false
       selector:
         boolean:
+    photo_url:
+      name: Photo URL
+      description: Optional URL or path to a photo submitted as evidence for the completion (e.g. a camera snapshot). Shown to the parent during approval.
+      required: false
+      selector:
+        text:
 
 complete_bonus_subtask:
   name: Complete Bonus Sub-task

--- a/custom_components/taskmate/www/locales/de.json
+++ b/custom_components/taskmate/www/locales/de.json
@@ -1301,6 +1301,7 @@
   "panel.settings_interest_enabled_label": "Sparzinsen",
   "panel.settings_interest_enabled_hint": "Zahlt jedem Kind regelmäßig Zinsen auf sein verfügbares Guthaben (belohnt Sparen).",
   "panel.settings_interest_params_label": "Einstellungen für Sparzinsen",
+  "panel.settings_interest_percent": "Zinsen %",
   "panel.settings_interest_params_hint": "Zinssatz auf das Guthaben und wie oft.",
   "panel.chore_due_time_label": "Fälligkeitszeit (optional)",
   "panel.chore_due_time_hint": "Erledigungen bis zu dieser Zeit erhalten den Frühbonus; danach den Verspätungsabzug.",

--- a/custom_components/taskmate/www/locales/en-GB.json
+++ b/custom_components/taskmate/www/locales/en-GB.json
@@ -1301,6 +1301,7 @@
   "panel.settings_interest_enabled_label": "Savings interest",
   "panel.settings_interest_enabled_hint": "Periodically pay each child interest on their spendable balance (rewards saving).",
   "panel.settings_interest_params_label": "Savings interest settings",
+  "panel.settings_interest_percent": "Interest %",
   "panel.settings_interest_params_hint": "Interest rate applied to the balance, and how often.",
   "panel.chore_due_time_label": "Due time (optional)",
   "panel.chore_due_time_hint": "Completions at/before this time earn the early bonus; after it lose the late penalty.",

--- a/custom_components/taskmate/www/locales/en.json
+++ b/custom_components/taskmate/www/locales/en.json
@@ -1301,6 +1301,7 @@
   "panel.settings_interest_enabled_label": "Savings interest",
   "panel.settings_interest_enabled_hint": "Periodically pay each child interest on their spendable balance (rewards saving).",
   "panel.settings_interest_params_label": "Savings interest settings",
+  "panel.settings_interest_percent": "Interest %",
   "panel.settings_interest_params_hint": "Interest rate applied to the balance, and how often.",
   "panel.chore_due_time_label": "Due time (optional)",
   "panel.chore_due_time_hint": "Completions at/before this time earn the early bonus; after it lose the late penalty.",

--- a/custom_components/taskmate/www/locales/fr.json
+++ b/custom_components/taskmate/www/locales/fr.json
@@ -1301,6 +1301,7 @@
   "panel.settings_interest_enabled_label": "Intérêts d'épargne",
   "panel.settings_interest_enabled_hint": "Verse régulièrement des intérêts à chaque enfant sur son solde disponible (récompense l'épargne).",
   "panel.settings_interest_params_label": "Réglages des intérêts d'épargne",
+  "panel.settings_interest_percent": "Intérêts %",
   "panel.settings_interest_params_hint": "Taux d'intérêt appliqué au solde et fréquence.",
   "panel.chore_due_time_label": "Heure limite (facultatif)",
   "panel.chore_due_time_hint": "Les réalisations avant cette heure obtiennent le bonus d'avance ; après, la pénalité de retard.",

--- a/custom_components/taskmate/www/locales/nb.json
+++ b/custom_components/taskmate/www/locales/nb.json
@@ -1301,6 +1301,7 @@
   "panel.settings_interest_enabled_label": "Sparerente",
   "panel.settings_interest_enabled_hint": "Betal jevnlig hvert barn rente på den disponible saldoen (belønner sparing).",
   "panel.settings_interest_params_label": "Innstillinger for sparerente",
+  "panel.settings_interest_percent": "Rente %",
   "panel.settings_interest_params_hint": "Rentesats på saldoen, og hvor ofte.",
   "panel.chore_due_time_label": "Forfallstid (valgfritt)",
   "panel.chore_due_time_hint": "Fullføringer ved/før dette tidspunktet får tidligbonusen; etterpå mister de forsinkelsesstraffen.",

--- a/custom_components/taskmate/www/locales/nn.json
+++ b/custom_components/taskmate/www/locales/nn.json
@@ -1301,6 +1301,7 @@
   "panel.settings_interest_enabled_label": "Sparerente",
   "panel.settings_interest_enabled_hint": "Betal jamleg kvart barn rente på den disponible saldoen (belønnar sparing).",
   "panel.settings_interest_params_label": "Innstillingar for sparerente",
+  "panel.settings_interest_percent": "Rente %",
   "panel.settings_interest_params_hint": "Rentesats på saldoen, og kor ofte.",
   "panel.chore_due_time_label": "Forfallstid (valfritt)",
   "panel.chore_due_time_hint": "Fullføringar ved/før dette tidspunktet får tidlegbonusen; etterpå misser dei forseinkingsstraffa.",

--- a/custom_components/taskmate/www/locales/pt-BR.json
+++ b/custom_components/taskmate/www/locales/pt-BR.json
@@ -1301,6 +1301,7 @@
   "panel.settings_interest_enabled_label": "Juros de poupança",
   "panel.settings_interest_enabled_hint": "Paga periodicamente juros a cada criança sobre o saldo disponível (recompensa a poupança).",
   "panel.settings_interest_params_label": "Configurações dos juros de poupança",
+  "panel.settings_interest_percent": "Juros %",
   "panel.settings_interest_params_hint": "Taxa de juros aplicada ao saldo e com que frequência.",
   "panel.chore_due_time_label": "Hora limite (opcional)",
   "panel.chore_due_time_hint": "Conclusões até este horário ganham o bônus de antecipação; depois, a penalidade por atraso.",

--- a/custom_components/taskmate/www/locales/pt.json
+++ b/custom_components/taskmate/www/locales/pt.json
@@ -1301,6 +1301,7 @@
   "panel.settings_interest_enabled_label": "Juros de poupança",
   "panel.settings_interest_enabled_hint": "Paga periodicamente juros a cada criança sobre o saldo disponível (recompensa a poupança).",
   "panel.settings_interest_params_label": "Configurações dos juros de poupança",
+  "panel.settings_interest_percent": "Juros %",
   "panel.settings_interest_params_hint": "Taxa de juros aplicada ao saldo e com que frequência.",
   "panel.chore_due_time_label": "Hora limite (opcional)",
   "panel.chore_due_time_hint": "Conclusões até esta hora ganham o bónus de antecipação; depois, a penalização por atraso.",

--- a/custom_components/taskmate/www/taskmate-panel.js
+++ b/custom_components/taskmate/www/taskmate-panel.js
@@ -3666,7 +3666,7 @@ class TaskMatePanel extends HTMLElement {
             <div class="tm-setting-row">
               <div class="tm-setting-label">${this._t("panel.settings_interest_params_label")}<small>${this._t("panel.settings_interest_params_hint")}</small></div>
               <div class="tm-difficulty-mults">
-                <label>${this._t("panel.settings_decay_percent")}<input type="number" class="tm-input" step="1" min="0" max="100" data-setting="interest_percent" value="${s.interest_percent ?? 5}"></label>
+                <label>${this._t("panel.settings_interest_percent")}<input type="number" class="tm-input" step="1" min="0" max="100" data-setting="interest_percent" value="${s.interest_percent ?? 5}"></label>
                 <label>${this._t("panel.settings_decay_period")}
                   <select class="tm-select" data-setting="interest_period">
                     <option value="weekly" ${(s.interest_period || "weekly") === "weekly" ? "selected" : ""}>${this._t("panel.reward_restock_weekly")}</option>

--- a/tests/test_service_validation_errors.py
+++ b/tests/test_service_validation_errors.py
@@ -8,10 +8,29 @@ that already raises ``ServiceValidationError`` must pass through untouched.
 """
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
+import voluptuous as vol
 from unittest.mock import AsyncMock
 
 import custom_components.taskmate as tm
+
+
+async def _registered_schemas() -> dict:
+    """Register services against a fake hass and capture each service's schema.
+
+    Registration only stores closures; it does not touch the coordinator, so a
+    minimal fake hass is enough to inspect the real ``vol.Schema`` objects.
+    """
+    schemas: dict = {}
+
+    class _Services:
+        def async_register(self, domain, name, handler, schema=None):
+            schemas[name] = schema
+
+    await tm._async_register_services(SimpleNamespace(services=_Services()))
+    return schemas
 
 
 @pytest.mark.asyncio
@@ -38,3 +57,40 @@ async def test_service_validation_error_not_double_wrapped():
     with pytest.raises(tm.ServiceValidationError) as excinfo:
         await tm._safe(handler)(object())
     assert excinfo.value is original
+
+
+def _schema_entry(schema, key):
+    """Return (marker, validator) for `key` in a vol.Schema, or (None, None).
+
+    Inspecting the schema avoids running the cv.* validators, which are mocked
+    out in the test harness; voluptuous itself is real.
+    """
+    for marker, validator in schema.schema.items():
+        if getattr(marker, "schema", marker) == key:
+            return marker, validator
+    return None, None
+
+
+@pytest.mark.asyncio
+async def test_add_chore_schema_accepts_difficulty():
+    """The add_chore schema must whitelist `difficulty`. vol.Schema rejects
+    unknown keys by default, so without the key the whole call would 400."""
+    schema = (await _registered_schemas())[tm.SERVICE_ADD_CHORE]
+    marker, validator = _schema_entry(schema, "difficulty")
+
+    assert marker is not None, "add_chore schema is missing the 'difficulty' key"
+    assert isinstance(marker, vol.Optional)
+    assert marker.default() == tm.DEFAULT_DIFFICULTY
+    # Constrained to the known tiers.
+    assert isinstance(validator, vol.In)
+    assert validator.container == tm.DIFFICULTY_TIERS
+
+
+@pytest.mark.asyncio
+async def test_complete_chore_schema_accepts_photo_url():
+    """The complete_chore schema must accept the optional photo_url evidence."""
+    schema = (await _registered_schemas())[tm.SERVICE_COMPLETE_CHORE]
+    marker, _ = _schema_entry(schema, "photo_url")
+
+    assert marker is not None, "complete_chore schema is missing 'photo_url'"
+    assert isinstance(marker, vol.Optional)


### PR DESCRIPTION
Fixes three issues surfaced while documenting the v4.0.0 feature batch for the wiki.

## Changes

**1. `add_chore` rejected the documented `difficulty` field**
`services.yaml` documents a `difficulty` selector and `handle_add_chore` reads `call.data.get("difficulty", ...)`, but the registered `vol.Schema` omitted the key. Voluptuous defaults to `PREVENT_EXTRA`, so any `add_chore` call passing `difficulty` failed validation before the handler ran. Added `vol.Optional("difficulty", default=DEFAULT_DIFFICULTY): vol.In(DIFFICULTY_TIERS)`.

**2. `complete_chore` `photo_url` undocumented**
The schema already accepts `photo_url` (photo/evidence proof), but it was missing from `services.yaml`, so it did not appear in the Developer Tools / UI service picker. Documented it.

**3. Savings-interest input mislabelled "Decay %"**
The interest percent input in the admin panel reused the `panel.settings_decay_percent` string, showing "Decay %" for the savings-interest rate. Added a dedicated `panel.settings_interest_percent` string across all 8 locales (en, en-GB, de, fr, nb, nn, pt, pt-BR) and pointed the input at it.

## Tests
Added schema-level regression tests (`tests/test_service_validation_errors.py`) that inspect the registered schemas for the `difficulty` and `photo_url` keys — verified red without the fix, green with it. Full relevant suite passes; `ruff check` clean.