### PR TITLE
fix(frontend): deregister retired card Lovelace resources

### DIFF
--- a/custom_components/taskmate/frontend.py
+++ b/custom_components/taskmate/frontend.py
@@ -45,6 +45,17 @@ CARDS: Final = [
     "taskmate-calendar-card.js",
 ]
 
+# Cards that USED to ship but were removed. Their files no longer exist, so any
+# Lovelace resource still registered for them 404s on every dashboard load for
+# users upgrading from a version that had them. We deregister these by EXACT
+# URL only (never a heuristic diff — that once wiped every resource, which is
+# why blanket stale-cleanup was removed from async_register_cards).
+RETIRED_CARDS: Final = [
+    "taskmate-task-groups-card.js",  # removed #452
+    "taskmate-templates-card.js",    # removed #448
+    "taskmate-reminders-card.js",    # removed #450
+]
+
 # JS modules loaded on every HA frontend page (config flow sound preview).
 # taskmate-localize.js is ALSO listed in CARDS (Lovelace resources) so it loads
 # early on dashboards; it must be here too because the admin panel (panel.py) is
@@ -191,6 +202,27 @@ async def async_register_cards(hass: HomeAssistant) -> None:
                     )
                 else:
                     _LOGGER.debug("TaskMate: resource up to date: %s", versioned_url)
+
+        # Deregister retired cards by EXACT URL match only. This is the one
+        # delete we allow: each target is a specific /taskmate/<file>.js that no
+        # longer exists, looked up in the existing map we already built. No
+        # diffing of "unexpected" URLs, so it cannot cascade into deleting live
+        # resources the way the old blanket cleanup did.
+        if hasattr(resources, "async_delete_item"):
+            for retired in RETIRED_CARDS:
+                item = existing.get(f"{URL_BASE}/{retired}")
+                if item is None:
+                    continue
+                try:
+                    await resources.async_delete_item(item["id"])
+                    _LOGGER.info(
+                        "TaskMate: removed retired resource: %s", item.get("url")
+                    )
+                except (AttributeError, KeyError, TypeError, OSError) as err:
+                    _LOGGER.warning(
+                        "TaskMate: could not remove retired resource %s: %s",
+                        item.get("url"), err,
+                    )
 
     except (AttributeError, KeyError, TypeError, OSError) as err:
         _LOGGER.error("TaskMate: error managing Lovelace resources: %s", err)

--- a/tests/test_frontend_retired_cards.py
+++ b/tests/test_frontend_retired_cards.py
@@ -1,0 +1,85 @@
+"""Retired Lovelace card resources are deregistered on startup.
+
+Cards removed in v4 (templates / reminders / task-groups) left their Lovelace
+resource registrations behind, 404-ing on every dashboard load for upgraders.
+`async_register_cards` now deletes those by exact URL — and ONLY those, never a
+live card and never via heuristic diffing (which once wiped every resource).
+"""
+from __future__ import annotations
+
+import sys
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+# conftest stubs the whole `custom_components.taskmate.frontend` module (its HA
+# deps aren't stubbed suite-wide). To exercise the real cleanup logic, supply
+# the two HA submodules frontend.py imports, drop the stub, and import the real
+# module with its proper package context. Self-contained: nothing else imports
+# this module after package init, so no other test is affected.
+sys.modules.setdefault("homeassistant.components.http", MagicMock())
+sys.modules.setdefault("homeassistant.components.frontend", MagicMock())
+sys.modules.pop("custom_components.taskmate.frontend", None)
+
+from custom_components.taskmate import frontend as fe  # noqa: E402
+
+
+class FakeResources:
+    """Minimal stand-in for HA's Lovelace ResourceStorageCollection."""
+
+    def __init__(self, items):
+        self._items = list(items)
+        self.async_load = AsyncMock()
+        self.async_get_info = AsyncMock()
+
+    def async_items(self):
+        return list(self._items)
+
+    async def async_create_item(self, data):
+        self._items.append({"id": f"id-{len(self._items)}", **data})
+
+    async def async_update_item(self, item_id, data):
+        for it in self._items:
+            if it["id"] == item_id:
+                it.update(data)
+
+    async def async_delete_item(self, item_id):
+        self._items = [it for it in self._items if it["id"] != item_id]
+
+
+def _hass(resources):
+    hass = MagicMock()
+    lovelace = MagicMock()
+    lovelace.mode = "storage"
+    lovelace.resources = resources
+    hass.data = {"lovelace": lovelace}
+    # _async_get_version offloads manifest read to the executor — run inline.
+    async def _exec(func, *args):
+        return func(*args)
+    hass.async_add_executor_job = _exec
+    return hass
+
+
+@pytest.mark.asyncio
+async def test_retired_cards_deregistered_live_cards_kept():
+    live = f"{fe.URL_BASE}/{fe.CARDS[0]}"
+    retired = f"{fe.URL_BASE}/{fe.RETIRED_CARDS[0]}"
+    other = "/local/some-other-card.js"  # non-taskmate, must be untouched
+    res = FakeResources([
+        {"id": "a", "url": f"{live}?v=1.0.0", "res_type": "module"},
+        {"id": "b", "url": f"{retired}?v=1.0.0", "res_type": "module"},
+        {"id": "c", "url": other, "res_type": "module"},
+    ])
+    await fe.async_register_cards(_hass(res))
+    urls = [it["url"].split("?")[0] for it in res.async_items()]
+    assert retired not in urls            # retired removed
+    assert live in urls                   # live card preserved
+    assert other in urls                  # foreign resource untouched
+
+
+@pytest.mark.asyncio
+async def test_no_retired_present_is_a_noop():
+    """Nothing to clean up → live cards still present, no error."""
+    live = f"{fe.URL_BASE}/{fe.CARDS[0]}"
+    res = FakeResources([{"id": "a", "url": f"{live}?v=1.0.0", "res_type": "module"}])
+    await fe.async_register_cards(_hass(res))
+    assert any(it["url"].startswith(live) for it in res.async_items())


### PR DESCRIPTION
## Summary

The read-only cards removed in v4 — `taskmate-templates-card` (#448), `taskmate-reminders-card` (#450), `taskmate-task-groups-card` (#452) — were dropped from `CARDS`, but their **Lovelace resource registrations were never removed**. The files no longer exist, so anyone upgrading from a version that had them gets **3× `404 Not Found`** on every dashboard load. Fresh installs are unaffected.

**Root cause:** `async_register_cards` is add/update-only by design (its docstring notes blanket stale-cleanup was removed after a URL-mismatch bug once deleted *all* resources).

## Fix

Add a `RETIRED_CARDS` list and deregister those by **exact** `/taskmate/<file>.js` URL only — looked up in the existing-resources map, guarded per item. No heuristic diffing, so it cannot cascade into deleting live resources (the historical footgun).

## Verification

Driven on the **ha-dev** instance via browserless:
- `lovelace/resources` before: 23 taskmate resources incl. the 3 dead URLs → after entry reload: **20**, the 3 retired URLs gone.
- Dashboard load in-browser: **0 console errors** (was 3× 404).
- New regression test `tests/test_frontend_retired_cards.py`: retired card removed, live card kept, foreign (`/local/*`) resource untouched, empty-case no-op. `ruff` clean; full suite shows no new failures (only the pre-existing order-pollution cases).

Found while driving the v4 card flows end-to-end (the only issue surfaced so far).

Fixes #505