### PR TITLE
fix(child-card): friendly message when a child tries to undo a chore

### DIFF
--- a/custom_components/taskmate/www/locales/de.json
+++ b/custom_components/taskmate/www/locales/de.json
@@ -211,6 +211,7 @@
   "child.error_complete": "Etwas ist schief gelaufen: {message}",
   "child.error_title": "Hoppla!",
   "child.error_undo": "Konnte nicht rückgängig gemacht werden: {message}",
+  "child.undo_not_allowed": "Nur Eltern können eine erledigte Aufgabe rückgängig machen.",
   "child.evening_chores": "Abendliche Aufgaben",
   "child.morning_chores": "Morgenaufgaben",
   "child.night_chores": "Nachtaufgaben",

--- a/custom_components/taskmate/www/locales/en-GB.json
+++ b/custom_components/taskmate/www/locales/en-GB.json
@@ -224,6 +224,7 @@
   "child.error_complete": "Something went wrong: {message}",
   "child.error_title": "Oops!",
   "child.error_undo": "Couldn't undo: {message}",
+  "child.undo_not_allowed": "Only a parent can undo a completed chore.",
   "child.evening_chores": "Evening Chores",
   "child.morning_chores": "Morning Chores",
   "child.night_chores": "Night Chores",

--- a/custom_components/taskmate/www/locales/en.json
+++ b/custom_components/taskmate/www/locales/en.json
@@ -224,6 +224,7 @@
   "child.error_complete": "Something went wrong: {message}",
   "child.error_title": "Oops!",
   "child.error_undo": "Couldn't undo: {message}",
+  "child.undo_not_allowed": "Only a parent can undo a completed chore.",
   "child.evening_chores": "Evening Chores",
   "child.morning_chores": "Morning Chores",
   "child.night_chores": "Night Chores",

--- a/custom_components/taskmate/www/locales/fr.json
+++ b/custom_components/taskmate/www/locales/fr.json
@@ -211,6 +211,7 @@
   "child.error_complete": "Un problème est survenu : {message}",
   "child.error_title": "Oups !",
   "child.error_undo": "Impossible d'annuler : {message}",
+  "child.undo_not_allowed": "Seul un parent peut annuler une tâche terminée.",
   "child.evening_chores": "Tâches du soir",
   "child.morning_chores": "Tâches du matin",
   "child.night_chores": "Tâches de la nuit",

--- a/custom_components/taskmate/www/locales/nb.json
+++ b/custom_components/taskmate/www/locales/nb.json
@@ -211,6 +211,7 @@
   "child.error_complete": "Noe gikk galt: {message}",
   "child.error_title": "Oops!",
   "child.error_undo": "Kunne ikke angre: {message}",
+  "child.undo_not_allowed": "Bare en forelder kan angre en fullført oppgave.",
   "child.evening_chores": "Kveldsoppgaver",
   "child.morning_chores": "Morgenoppgaver",
   "child.night_chores": "Nattoppgaver",

--- a/custom_components/taskmate/www/locales/nn.json
+++ b/custom_components/taskmate/www/locales/nn.json
@@ -211,6 +211,7 @@
   "child.error_complete": "Noko gjekk gale: {message}",
   "child.error_title": "Oops!",
   "child.error_undo": "Kunne ikkje angre: {message}",
+  "child.undo_not_allowed": "Berre ein forelder kan angra ei fullført oppgåve.",
   "child.evening_chores": "Kveldsoppgåver",
   "child.morning_chores": "Morgonoppgåver",
   "child.night_chores": "Nattoppgåver",

--- a/custom_components/taskmate/www/locales/pt-BR.json
+++ b/custom_components/taskmate/www/locales/pt-BR.json
@@ -211,6 +211,7 @@
   "child.error_complete": "Algo correu mal: {message}",
   "child.error_title": "Oops!",
   "child.error_undo": "Não foi possível desfazer: {message}",
+  "child.undo_not_allowed": "Somente os pais podem desfazer uma tarefa concluída.",
   "child.evening_chores": "Tarefas da Noite",
   "child.morning_chores": "Tarefas da Manhã",
   "child.night_chores": "Tarefas da Madrugada",

--- a/custom_components/taskmate/www/locales/pt.json
+++ b/custom_components/taskmate/www/locales/pt.json
@@ -211,6 +211,7 @@
   "child.error_complete": "Algo correu mal: {message}",
   "child.error_title": "Oops!",
   "child.error_undo": "Não foi possível desfazer: {message}",
+  "child.undo_not_allowed": "Só os pais podem desfazer uma tarefa concluída.",
   "child.evening_chores": "Tarefas da Noite",
   "child.morning_chores": "Tarefas da Manhã",
   "child.night_chores": "Tarefas da Madrugada",

--- a/custom_components/taskmate/www/taskmate-child-card.js
+++ b/custom_components/taskmate/www/taskmate-child-card.js
@@ -3122,9 +3122,34 @@ class TaskMateChildCard extends LitElement {
     `;
   }
 
+  /** Show a brief, friendly popup (HA snackbar) instead of a raw error. */
+  _notifyUndo(message) {
+    this.dispatchEvent(new CustomEvent("hass-notification", {
+      detail: { message },
+      bubbles: true,
+      composed: true,
+    }));
+  }
+
+  /** True if an error from reject_chore is an authorization/admin rejection. */
+  _isUnauthorized(error) {
+    const text = `${error?.message || ""} ${error?.code || ""}`.toLowerCase();
+    return text.includes("unauthorized") || text.includes("not authorized");
+  }
+
   async _handleUndo(chore, child, childCompletionsToday) {
     // Check if already loading for this chore (prevent double-clicks during loading)
     if (this._loading[chore.id]) {
+      return;
+    }
+
+    // Undoing a completion removes already-awarded points, so it is parent-only
+    // (this mirrors the admin gate on the reject_chore service). For a non-admin
+    // user the call always fails with a raw "Unauthorized" — HA shows its own
+    // snackbar and we used to add an error notification on top. Short-circuit
+    // with one clear, friendly message and never fire the doomed call.
+    if (this.hass.user && !this.hass.user.is_admin) {
+      this._notifyUndo(this._t("child.undo_not_allowed"));
       return;
     }
 
@@ -3171,14 +3196,14 @@ class TaskMateChildCard extends LitElement {
     } catch (error) {
       console.error("Failed to undo chore completion:", error);
 
-      // Show error notification
-      if (this.hass.callService) {
-        this.hass.callService("persistent_notification", "create", {
-          title: this._t('child.error_title'),
-          message: this._t('child.error_undo', { message: error.message }),
-          notification_id: `taskmate_undo_error_${chore.id}`,
-        });
-      }
+      // Fallback for the rare case an undo still fails (e.g. a parent hit a
+      // genuine error). Show a single transient popup, not a sticky bell
+      // notification. An auth rejection gets the same friendly wording as the
+      // pre-check above.
+      const message = this._isUnauthorized(error)
+        ? this._t("child.undo_not_allowed")
+        : this._t("child.error_undo", { message: error?.message || "" });
+      this._notifyUndo(message);
     } finally {
       this._loading = { ...this._loading, [chore.id]: false };
       this.requestUpdate();


### PR DESCRIPTION
Children are non-admin Home Assistant users, but the child card lets them tap a completed chore to "undo" it. That calls the admin-gated `reject_chore` service, which always rejects with `Unauthorized` for a child — surfacing as **two** raw errors:

- HA's own snackbar: "Failed to perform the action taskmate/reject_chore. Unauthorized"
- A sticky bell notification from the card's catch block: "Oops! / Couldn't undo: Unauthorized"

## Fix
In `_handleUndo`, short-circuit for non-admin users (`hass.user.is_admin === false`, mirroring the server-side admin gate) and show **one** friendly, transient HA snackbar instead of firing the doomed service call. This removes both errors at once. The `catch` block is hardened as a fallback: it now shows a transient popup (not a persistent notification), and auth errors reuse the same friendly wording.

Adds `child.undo_not_allowed` ("Only a parent can undo a completed chore.") across all 8 locales.

## Verification
Confirmed on the ha-dev instance as the non-admin test user: driving `_handleUndo` now dispatches exactly one `hass-notification` (`child.undo_not_allowed`) and makes **zero** service calls — so neither the HA snackbar nor the bell notification appears. ESM syntax checked; all 8 locale JSONs validate; served content confirmed live on ha-dev.