### PR TITLE
chore(release): bump manifest to 4.0.0

### DIFF
--- a/custom_components/taskmate/manifest.json
+++ b/custom_components/taskmate/manifest.json
@@ -17,5 +17,5 @@
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/tempus2016/taskmate/issues",
   "requirements": [],
-  "version": "4.0.0-beta.1"
+  "version": "4.0.0"
 }


### PR DESCRIPTION
Release v4.0.0. Manifest bumped from 4.0.0-beta.1 to 4.0.0. Tagged release follows on merge.