### PR TITLE
fix(panel,cards): photo evidence on approval cards + scrollable tables on mobile

### DIFF
--- a/custom_components/taskmate/sensor.py
+++ b/custom_components/taskmate/sensor.py
@@ -17,6 +17,7 @@ from homeassistant.util import dt as dt_util
 
 import logging
 
+from . import photos
 from .const import DOMAIN
 from .coordinator import TaskMateCoordinator
 from .models import Child
@@ -115,6 +116,7 @@ def _compute_common(coordinator: TaskMateCoordinator) -> dict:
 
     common = {
         "data_id": data_id,
+        "hass": coordinator.hass,
         "data": data,
         "children": children,
         "chores": chores,
@@ -330,6 +332,11 @@ def _build_todays_completions(common: dict) -> list[dict]:
         }
         if timed_secs > 0:
             rec["timed_duration_seconds"] = timed_secs
+        # Sign the evidence photo so a card's <img> (which carries no bearer
+        # token) can load it from the auth-gated serve view.
+        photo = getattr(comp, "photo_url", "") or ""
+        if photo:
+            rec["photo_url"] = photos.sign_photo_url(common["hass"], photo)
         out.append(rec)
     return out
 
@@ -1184,6 +1191,11 @@ class PendingApprovalsSensor(TaskMateBaseSensor):
                 }
                 if timed_secs > 0:
                     detail["timed_duration_seconds"] = timed_secs
+                photo = getattr(comp, "photo_url", "") or ""
+                if photo:
+                    detail["photo_url"] = photos.sign_photo_url(
+                        self.coordinator.hass, photo
+                    )
                 completion_details.append(detail)
 
         reward_details = []

--- a/custom_components/taskmate/www/taskmate-approvals-card.js
+++ b/custom_components/taskmate/www/taskmate-approvals-card.js
@@ -161,6 +161,19 @@ class TaskMateApprovalsCard extends LitElement {
         text-overflow: ellipsis;
       }
 
+      .approval-photo {
+        display: inline-block;
+        margin-top: 4px;
+        line-height: 0;
+      }
+      .approval-photo img {
+        width: 48px;
+        height: 48px;
+        object-fit: cover;
+        border-radius: 8px;
+        border: 1px solid var(--divider-color, #e0e0e0);
+      }
+
       .item-details {
         display: flex;
         align-items: center;
@@ -753,6 +766,12 @@ class TaskMateApprovalsCard extends LitElement {
               ${completion.points}
             </span>
           </div>
+          ${completion.photo_url ? html`
+            <a class="approval-photo" href="${completion.photo_url}" target="_blank" rel="noopener"
+               title="${this._t('approvals.view_photo') || 'View photo'}">
+              <img src="${completion.photo_url}" alt="" loading="lazy">
+            </a>
+          ` : ''}
         </div>
         <div class="action-buttons right">
           <button

--- a/custom_components/taskmate/www/taskmate-panel.js
+++ b/custom_components/taskmate/www/taskmate-panel.js
@@ -5280,7 +5280,12 @@ class TaskMatePanel extends HTMLElement {
         background: var(--tm-surface-0);
         border: 1px solid var(--tm-border);
         border-radius: var(--tm-radius-lg);
-        overflow: hidden;
+        /* Scroll horizontally on narrow screens so wide tables (e.g. Chores)
+           stay usable and the action buttons remain reachable, instead of being
+           clipped by the rounded container. */
+        overflow-x: auto;
+        overflow-y: hidden;
+        -webkit-overflow-scrolling: touch;
         box-shadow: var(--tm-shadow-xs);
       }
       .tm-table { width: 100%; border-collapse: collapse; font-size: 13px; }
@@ -5289,6 +5294,9 @@ class TaskMatePanel extends HTMLElement {
         padding: 11px 16px;
         border-bottom: 1px solid var(--tm-border-soft);
         vertical-align: middle;
+        /* Keep columns at their natural width so the table overflows (and the
+           wrap scrolls) on small devices rather than squashing cells. */
+        white-space: nowrap;
       }
       .tm-table th {
         color: var(--tm-text-faint);

--- a/custom_components/taskmate/www/taskmate-parent-dashboard-card.js
+++ b/custom_components/taskmate/www/taskmate-parent-dashboard-card.js
@@ -199,6 +199,8 @@ class TaskMateParentDashboardCard extends LitElement {
       .approval-child-avatar ha-icon { --mdc-icon-size: 22px; color: white; }
 
       .approval-info { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 2px; }
+      .approval-photo { display: inline-block; margin-top: 4px; line-height: 0; }
+      .approval-photo img { width: 48px; height: 48px; object-fit: cover; border-radius: 8px; border: 1px solid var(--divider-color, #e0e0e0); }
 
       .approval-chore {
         font-size: 0.9rem; font-weight: 600;
@@ -707,6 +709,12 @@ class TaskMateParentDashboardCard extends LitElement {
                   +${comp.points || chore?.points || 0}
                 </span>
               </div>
+              ${comp.photo_url ? html`
+                <a class="approval-photo" href="${comp.photo_url}" target="_blank" rel="noopener"
+                   title="${this._t('approvals.view_photo') || 'View photo'}">
+                  <img src="${comp.photo_url}" alt="" loading="lazy">
+                </a>
+              ` : ''}
             </div>
             <div class="approval-actions">
               <button class="btn-approve" @click="${() => this._handleApprove(comp.completion_id)}" title="${this._t('common.approve')}" aria-label="${this._t('common.approve')}">


### PR DESCRIPTION
## Summary
Two mobile/display follow-ups to v4.0.0.

### Photo evidence on approval cards (Fixes #515)
v4.0.0 shipped photo capture + backend + **admin-panel** display, but the Lovelace approval cards never showed the photo — they didn't render `photo_url`, and the sensor handed them an **unsigned** URL a plain `<img>` can't load.
- `sensor.py` now signs `photo_url` (via `photos.sign_photo_url`) on both the pending-approvals `chore_completions` list and `todays_completions`, mirroring the panel WebSocket snapshot.
- `approvals-card` and `parent-dashboard-card` render a 48px evidence thumbnail (links to full image) when a completion has a photo.

### Scrollable tables on small devices (Fixes #516)
`.tm-table-wrap` used `overflow: hidden`, so on a phone the Chores table (and other wide tables) were clipped and the action buttons unreachable. Now `overflow-x: auto` (+ touch scrolling) on the wrap and `white-space: nowrap` on cells, so tables keep natural width and scroll instead of squashing. Shared `.tm-table-wrap`/`.tm-table` → applies to **all** panel tables.

## Verification
- `ruff` clean; full suite green at the known baseline (3 pre-existing order-pollution failures only); sensor-attribute tests pass; no import regression from the new `photos` import in `sensor.py`.
- ⚠️ **Live browser verification of the table-scroll fix was blocked this session** by repeated harness write-permission timeouts when overlaying the built `panel.js` onto the ha-dev bind-mount (the fix is a standard `overflow:hidden`→`overflow-x:auto` + `nowrap` change; the clipping bug was reproduced in earlier panel screenshots). Recommend a quick on-device check after merge, or via a tagged build.

Fixes #515
Fixes #516