### PR TITLE
feat: native per-child calendar platform (#529)

### DIFF
--- a/custom_components/taskmate/__init__.py
+++ b/custom_components/taskmate/__init__.py
@@ -110,7 +110,7 @@ from .websocket import async_register_websocket_commands
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.BUTTON, Platform.BINARY_SENSOR]
+PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.BUTTON, Platform.BINARY_SENSOR, Platform.CALENDAR]
 
 # Track if services are registered
 SERVICES_REGISTERED = "services_registered"

--- a/custom_components/taskmate/calendar.py
+++ b/custom_components/taskmate/calendar.py
@@ -1,0 +1,232 @@
+"""Calendar platform for TaskMate.
+
+Exposes one read-only ``calendar.taskmate_<child>`` entity per child. Events are
+derived live from existing TaskMate data — there is no second store and nothing
+to keep in sync:
+
+  * chore occurrences come from the recurrence/assignment engine
+    (``_is_chore_scheduled_for_date`` + ``_compute_active_children``), rendered
+    as timed events inside the configured time-of-day window or as all-day
+    events when the chore is "anytime";
+  * away / unavailable blocks come from ``_is_child_on_vacation`` (#525),
+    coalesced into multi-day all-day events. On an away day the child's chores
+    are hidden, mirroring the rest of the integration.
+
+Read-only for now: completing a chore from the calendar is intentionally not
+supported.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import date, datetime, timedelta
+
+from homeassistant.components.calendar import CalendarEntity, CalendarEvent
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.util import dt as dt_util
+
+from .const import DOMAIN
+from .coordinator import TaskMateCoordinator
+from .models import Chore, Child
+
+_LOGGER = logging.getLogger(__name__)
+
+# How far ahead the `event` (next-up) property scans for the soonest event.
+_NEXT_EVENT_HORIZON_DAYS = 60
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up one calendar entity per child, adding more as children are created."""
+    coordinator: TaskMateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    tracked: set[str] = set()
+
+    def _new_entities() -> list[TaskMateCalendar]:
+        out: list[TaskMateCalendar] = []
+        for child in coordinator.data.get("children", []):
+            if child.id in tracked:
+                continue
+            tracked.add(child.id)
+            out.append(TaskMateCalendar(coordinator, entry, child))
+        return out
+
+    async_add_entities(_new_entities())
+
+    @callback
+    def _async_add_new() -> None:
+        new = _new_entities()
+        if new:
+            async_add_entities(new)
+
+    coordinator.async_add_listener(_async_add_new)
+
+
+def _chore_applies_to_child(
+    coordinator: TaskMateCoordinator, chore: Chore, child_id: str, day: date
+) -> bool:
+    """True if ``chore`` is scheduled for ``child_id`` on ``day``.
+
+    Combines the recurrence schedule with the assignment engine so the calendar
+    matches who would actually see the chore — without consulting completion
+    state (the calendar projects the schedule, not today's done/not-done).
+    """
+    if not getattr(chore, "enabled", True):
+        return False
+    if getattr(chore, "assignment_mode", "everyone") == "unassigned":
+        return False
+    if not coordinator._is_chore_scheduled_for_date(chore, day):
+        return False
+    active = coordinator._compute_active_children(chore, day)
+    if active:
+        return child_id in active
+    # Empty active set means an unrestricted "everyone" chore (no assigned_to).
+    return not chore.assigned_to
+
+
+def _chore_description(chore: Chore) -> str:
+    """Compact one-line description for a chore event."""
+    parts = ["TaskMate chore"]
+    pts = getattr(chore, "points", 0) or 0
+    parts.append(f"{pts} pts")
+    cat = getattr(chore, "time_category", "anytime") or "anytime"
+    if cat != "anytime":
+        parts.append(cat)
+    return " · ".join(parts)
+
+
+def _as_local_dt(value: date | datetime) -> datetime:
+    """Normalise a CalendarEvent start/end to an aware local datetime for sorting."""
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            return value.replace(tzinfo=dt_util.DEFAULT_TIME_ZONE)
+        return value
+    return datetime(value.year, value.month, value.day, tzinfo=dt_util.DEFAULT_TIME_ZONE)
+
+
+class TaskMateCalendar(CoordinatorEntity, CalendarEntity):
+    """A read-only calendar of one child's chores and away periods."""
+
+    _attr_icon = "mdi:calendar-account"
+
+    def __init__(
+        self,
+        coordinator: TaskMateCoordinator,
+        entry: ConfigEntry,
+        child: Child,
+    ) -> None:
+        super().__init__(coordinator)
+        self._entry = entry
+        self._child_id = child.id
+        self._attr_unique_id = f"{entry.entry_id}_{child.id}_calendar"
+        self._attr_name = f"TaskMate {child.name}"
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._entry.entry_id)},
+            name="TaskMate",
+            manufacturer="TaskMate",
+            model="Family Chore Manager",
+        )
+
+    @property
+    def _child(self) -> Child | None:
+        return self.coordinator.storage.get_child(self._child_id)
+
+    @property
+    def available(self) -> bool:
+        return self._child is not None and super().available
+
+    @property
+    def event(self) -> CalendarEvent | None:
+        """The current or next upcoming event (HA shows this as the entity state)."""
+        child = self._child
+        if not child:
+            return None
+        now = dt_util.now()
+        today = now.date()
+        events = self._build_events(child, today, today + timedelta(days=_NEXT_EVENT_HORIZON_DAYS))
+        upcoming = [e for e in events if _as_local_dt(e.end) > now]
+        upcoming.sort(key=lambda e: _as_local_dt(e.start))
+        return upcoming[0] if upcoming else None
+
+    async def async_get_events(
+        self, hass: HomeAssistant, start_date: datetime, end_date: datetime
+    ) -> list[CalendarEvent]:
+        """Return all events overlapping the requested range."""
+        child = self._child
+        if not child:
+            return []
+        return self._build_events(child, start_date.date(), end_date.date())
+
+    def _build_events(
+        self, child: Child, start_day: date, end_day: date
+    ) -> list[CalendarEvent]:
+        coord = self.coordinator
+        events: list[CalendarEvent] = []
+
+        # ---- away blocks: coalesce consecutive away days into one all-day event ----
+        run_start: date | None = None
+        run_label: str | None = None
+        day = start_day
+        while day <= end_day:
+            if coord._is_child_on_vacation(child, day):
+                if run_start is None:
+                    period = coord.active_vacation(day)
+                    run_label = (period or {}).get("name") or ""
+                    run_start = day
+            elif run_start is not None:
+                events.append(_away_event(run_start, day, run_label))
+                run_start = None
+            day += timedelta(days=1)
+        if run_start is not None:
+            events.append(_away_event(run_start, end_day + timedelta(days=1), run_label))
+
+        # ---- chore occurrences (skipped on away days) ----
+        chores = coord.storage.get_chores()
+        tz = dt_util.DEFAULT_TIME_ZONE
+        day = start_day
+        while day <= end_day:
+            if not coord._is_child_on_vacation(child, day):
+                for chore in chores:
+                    if not _chore_applies_to_child(coord, chore, child.id, day):
+                        continue
+                    window = coord._time_category_window(
+                        getattr(chore, "time_category", "anytime"), day
+                    )
+                    desc = _chore_description(chore)
+                    if window is None:
+                        events.append(CalendarEvent(
+                            start=day,
+                            end=day + timedelta(days=1),
+                            summary=chore.name,
+                            description=desc,
+                        ))
+                    else:
+                        start_dt, end_dt = window
+                        events.append(CalendarEvent(
+                            start=start_dt.replace(tzinfo=tz),
+                            end=end_dt.replace(tzinfo=tz),
+                            summary=chore.name,
+                            description=desc,
+                        ))
+            day += timedelta(days=1)
+
+        return events
+
+
+def _away_event(start_day: date, end_day_exclusive: date, label: str | None) -> CalendarEvent:
+    """Build a coalesced all-day 'away' event over [start, end)."""
+    summary = f"Away — {label}" if label else "Away"
+    return CalendarEvent(
+        start=start_day,
+        end=end_day_exclusive,
+        summary=summary,
+        description="Unavailable — streak paused and chores hidden.",
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -172,6 +172,27 @@ class _FakeDeviceInfo(dict):
         super().__init__(**kwargs)
 
 
+class _FakeCalendarEntity:
+    pass
+
+
+class _FakeCalendarEvent:
+    """Minimal stand-in storing the fields calendar.py sets / tests read."""
+
+    def __init__(self, start, end, summary, description=None, **kwargs):
+        self.start = start
+        self.end = end
+        self.summary = summary
+        self.description = description
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+
+_ha_components_calendar = MagicMock()
+_ha_components_calendar.CalendarEntity = _FakeCalendarEntity
+_ha_components_calendar.CalendarEvent = _FakeCalendarEvent
+
+
 _ha_helpers_entity = MagicMock()
 _ha_helpers_entity.DeviceInfo = _FakeDeviceInfo
 
@@ -189,6 +210,7 @@ class _DtUtilMock:
     """Controllable drop-in for homeassistant.util.dt."""
 
     _now: _dt.datetime = _DEFAULT_NOW
+    DEFAULT_TIME_ZONE = _UTC
 
     def now(self) -> _dt.datetime:
         return self._now
@@ -214,6 +236,7 @@ _ha_util.dt = dt_util_mock  # `from homeassistant.util import dt` resolves here
 # auto-generates a new MagicMock instead of returning our stub.
 _ha_components = MagicMock()
 _ha_components.websocket_api = _ha_websocket_api
+_ha_components.calendar = _ha_components_calendar
 
 sys.modules.update(
     {
@@ -233,6 +256,7 @@ sys.modules.update(
         "homeassistant.components": _ha_components,
         "homeassistant.components.sensor": _ha_components_sensor,
         "homeassistant.components.binary_sensor": _ha_components_binary_sensor,
+        "homeassistant.components.calendar": _ha_components_calendar,
         "homeassistant.components.websocket_api": _ha_websocket_api,
         "homeassistant.util": _ha_util,
         "homeassistant.util.dt": dt_util_mock,

--- a/tests/test_calendar_platform.py
+++ b/tests/test_calendar_platform.py
@@ -1,0 +1,130 @@
+"""Tests for the native per-child calendar platform (#529).
+
+Each ``calendar.taskmate_<child>`` entity derives events live from the chore
+recurrence/assignment engine + ``_is_child_on_vacation``. These tests drive a
+real coordinator (mocked storage) so the actual scheduling logic runs, and
+exercise the calendar's event builder directly.
+"""
+from __future__ import annotations
+
+from datetime import date, datetime
+from unittest.mock import MagicMock
+
+from custom_components.taskmate.calendar import (
+    TaskMateCalendar,
+    _chore_applies_to_child,
+)
+from custom_components.taskmate.coordinator import TaskMateCoordinator
+from custom_components.taskmate.models import Child, Chore
+
+
+def _coord(children, chores, settings=None) -> TaskMateCoordinator:
+    coord = object.__new__(TaskMateCoordinator)
+    coord.hass = MagicMock()
+    _settings = settings or {}
+    by_id = {c.id: c for c in children}
+    storage = MagicMock()
+    storage.get_setting = MagicMock(side_effect=lambda k, d="": _settings.get(k, d))
+    storage.get_children = MagicMock(return_value=children)
+    storage.get_child = MagicMock(side_effect=lambda cid: by_id.get(cid))
+    storage.get_chores = MagicMock(return_value=chores)
+    coord.storage = storage
+    return coord
+
+
+def _cal(coord, child) -> TaskMateCalendar:
+    cal = object.__new__(TaskMateCalendar)
+    cal.coordinator = coord
+    cal._child_id = child.id
+    cal._entry = MagicMock()
+    return cal
+
+
+# A Monday in June 2026 (2026-06-22 is a Monday).
+MON = date(2026, 6, 22)
+TUE = date(2026, 6, 23)
+
+
+class TestChoreApplies:
+    def test_specific_day_match(self):
+        c = Child(name="A")
+        chore = Chore(name="Bins", schedule_mode="specific_days", due_days=["monday"])
+        coord = _coord([c], [chore])
+        assert _chore_applies_to_child(coord, chore, c.id, MON) is True
+        assert _chore_applies_to_child(coord, chore, c.id, TUE) is False
+
+    def test_empty_due_days_is_every_day(self):
+        c = Child(name="A")
+        chore = Chore(name="Daily", schedule_mode="specific_days", due_days=[])
+        coord = _coord([c], [chore])
+        assert _chore_applies_to_child(coord, chore, c.id, MON) is True
+        assert _chore_applies_to_child(coord, chore, c.id, TUE) is True
+
+    def test_assigned_to_restricts(self):
+        a, b = Child(name="A"), Child(name="B")
+        chore = Chore(name="Dishes", due_days=[], assigned_to=[a.id])
+        coord = _coord([a, b], [chore])
+        assert _chore_applies_to_child(coord, chore, a.id, MON) is True
+        assert _chore_applies_to_child(coord, chore, b.id, MON) is False
+
+    def test_disabled_and_unassigned_excluded(self):
+        c = Child(name="A")
+        off = Chore(name="Off", due_days=[], enabled=False)
+        un = Chore(name="Un", due_days=[], assignment_mode="unassigned")
+        coord = _coord([c], [off, un])
+        assert _chore_applies_to_child(coord, off, c.id, MON) is False
+        assert _chore_applies_to_child(coord, un, c.id, MON) is False
+
+
+class TestBuildEvents:
+    def test_timed_vs_all_day(self):
+        c = Child(name="A")
+        timed = Chore(name="Make bed", due_days=[], time_category="morning")
+        anytime = Chore(name="Tidy", due_days=[], time_category="anytime")
+        coord = _coord([c], [timed, anytime])
+        cal = _cal(coord, c)
+        evs = cal._build_events(c, MON, MON)
+        by_summary = {e.summary: e for e in evs}
+        assert isinstance(by_summary["Make bed"].start, datetime)  # timed
+        assert by_summary["Make bed"].start.tzinfo is not None
+        assert isinstance(by_summary["Tidy"].start, date)
+        assert not isinstance(by_summary["Tidy"].start, datetime)  # all-day
+
+    def test_per_child_isolation(self):
+        a, b = Child(name="A"), Child(name="B")
+        chore_b = Chore(name="B chore", due_days=[], assigned_to=[b.id])
+        coord = _coord([a, b], [chore_b])
+        cal_a = _cal(coord, a)
+        assert cal_a._build_events(a, MON, MON) == []
+        cal_b = _cal(coord, b)
+        assert [e.summary for e in cal_b._build_events(b, MON, MON)] == ["B chore"]
+
+    def test_away_coalesced_and_hides_chores(self):
+        c = Child(name="A")
+        daily = Chore(name="Daily", due_days=[])
+        vac = [{"id": "v1", "name": "Summer", "start": "2026-06-24", "end": "2026-06-26"}]
+        coord = _coord([c], [daily], {"vacation_periods": vac})
+        cal = _cal(coord, c)
+        evs = cal._build_events(c, date(2026, 6, 22), date(2026, 6, 28))
+
+        away = [e for e in evs if e.summary.startswith("Away")]
+        assert len(away) == 1  # three away days coalesced into one block
+        assert away[0].summary == "Away — Summer"
+        assert away[0].start == date(2026, 6, 24)
+        assert away[0].end == date(2026, 6, 27)  # exclusive end
+
+        chore_days = {e.start for e in evs if e.summary == "Daily"}
+        # present outside the vacation, absent inside it
+        assert date(2026, 6, 23) in chore_days
+        assert date(2026, 6, 27) in chore_days
+        assert date(2026, 6, 24) not in chore_days
+        assert date(2026, 6, 25) not in chore_days
+
+    def test_away_without_name_falls_back(self):
+        c = Child(name="A")
+        vac = [{"id": "v1", "name": "", "start": "2026-06-24", "end": "2026-06-24"}]
+        coord = _coord([c], [], {"vacation_periods": vac})
+        cal = _cal(coord, c)
+        evs = cal._build_events(c, date(2026, 6, 24), date(2026, 6, 24))
+        assert len(evs) == 1
+        assert evs[0].summary == "Away"


### PR DESCRIPTION
## Summary
Implements [#529](https://github.com/tempus2016/taskmate/issues/529) — a native TaskMate **calendar platform**. Adds `Platform.CALENDAR` with one **read-only** `calendar.taskmate_<child>` entity per child, surfaced in HA's Calendar dashboard and the calendar card.

Approved via an HTML wireframe before implementation.

## How it works
Events are **derived live** from existing TaskMate data — there is no second store and nothing to sync:
- **Chore occurrences** from the recurrence + assignment engine (`_is_chore_scheduled_for_date` + `_compute_active_children`), rendered as **timezone-aware timed events** inside the configured time-of-day window, or **all-day** when the chore is "anytime".
- **Away / unavailable blocks** from `_is_child_on_vacation` (#525), **coalesced** into multi-day all-day events. Chores are hidden on away days, mirroring the rest of the integration.

Per-child entities are created **dynamically** as children are added, matching the button platform pattern.

## Design decisions (settled via the wireframe)
- **Per-child entities** (not one combined) so each toggles independently in dashboards.
- **Read-only** for v1 — completing a chore from the calendar is intentionally out of scope.
- **Away rendered as coalesced all-day blocks** that suppress chores.

## Changes
- `calendar.py` — new platform (`TaskMateCalendar` + event builder/helpers)
- `__init__.py` — register `Platform.CALENDAR`
- `tests/test_calendar_platform.py` — schedule/assignment filter, away coalescing, timed-vs-all-day, per-child isolation
- `tests/conftest.py` — calendar component stub + `dt_util.DEFAULT_TIME_ZONE`

## Note on i18n
Calendar event text is emitted by the backend, which has no per-user locale context (HA does not pass a locale to `async_get_events`), so the fixed strings `Away` / the away description stay in English — chore names are user data and already localized. Flagging in case you want these handled differently; everything user-facing in the panel is unaffected.

## Verification
- `pytest` green (+8 new; only the documented pre-existing order-pollution failures + template-setup errors remain); `ruff` clean.
- **Live ha-dev:** both `calendar.taskmate_malia` / `calendar.taskmate_vaiha` load with no errors; HA's calendar REST API returns correctly-typed, timezone-aware (`+01:00`), **per-child** events (89 vs 78, distinct chores). A static test trip rendered as a single coalesced `Away — Test Trip` block (25th→28th exclusive) and hid that child's chores on those days (7 → 0). ha-dev settings restored.

Fixes #529