### PR TITLE
Show mandatory badge on child card (chores sensor field)

### DIFF
--- a/custom_components/taskmate/sensor.py
+++ b/custom_components/taskmate/sensor.py
@@ -231,6 +231,13 @@ def _build_chores_list(coordinator: TaskMateCoordinator, common: dict) -> list[d
         requires_approval = getattr(c, 'requires_approval', True)
         if not requires_approval:
             record["requires_approval"] = False
+        # Mandatory chores (#532): emit only when set so the child card can
+        # show the mandatory styling/badge. penalty rides along when non-zero.
+        if getattr(c, 'mandatory', False):
+            record["mandatory"] = True
+            penalty = getattr(c, 'mandatory_penalty_points', 0) or 0
+            if penalty:
+                record["mandatory_penalty_points"] = penalty
         if getattr(c, 'require_photo', False):
             record["require_photo"] = True
         recurrence = getattr(c, 'recurrence', 'weekly')

--- a/tests/test_mandatory_chores_sensor.py
+++ b/tests/test_mandatory_chores_sensor.py
@@ -1,0 +1,38 @@
+"""The chores sensor list must carry the mandatory flag so the child card
+can render the badge/styling (#532 regression guard)."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from custom_components.taskmate.sensor import _build_chores_list
+from custom_components.taskmate.models import Chore
+
+
+def _coord():
+    c = MagicMock()
+    c.effective_chore_points = MagicMock(side_effect=lambda ch: ch.points)
+    return c
+
+
+def test_mandatory_chore_emits_flag_and_penalty():
+    chore = Chore(name="Homework", points=8, mandatory=True,
+                  mandatory_penalty_points=10, id="c1")
+    out = _build_chores_list(_coord(), {"chores": [chore]})
+    rec = out[0]
+    assert rec["mandatory"] is True
+    assert rec["mandatory_penalty_points"] == 10
+
+
+def test_non_mandatory_chore_omits_flag():
+    chore = Chore(name="Tidy", points=5, mandatory=False, id="c2")
+    rec = _build_chores_list(_coord(), {"chores": [chore]})[0]
+    assert "mandatory" not in rec
+    assert "mandatory_penalty_points" not in rec
+
+
+def test_mandatory_with_zero_penalty_omits_penalty_key():
+    chore = Chore(name="Brush teeth", points=3, mandatory=True,
+                  mandatory_penalty_points=0, id="c3")
+    rec = _build_chores_list(_coord(), {"chores": [chore]})[0]
+    assert rec["mandatory"] is True
+    assert "mandatory_penalty_points" not in rec


### PR DESCRIPTION
## Summary

Follow-up fix for #532. Mandatory chores saved correctly but the **child card showed no badge/styling**, because the chores sensor list (`_build_chores_list`) — which the child card reads — omitted the `mandatory` field. The card's CSS/JS were correct; they just never received the flag.

## Fix
- Emit `mandatory: true` (and `mandatory_penalty_points` when non-zero) in each chore record from `_build_chores_list`, following the sensor's compact "only when non-default" convention.

## Testing
- New regression test `test_mandatory_chores_sensor.py` asserts the flag is emitted for mandatory chores and omitted otherwise (3 tests, green); Ruff clean.
- Verified live on ha-dev by rendering the actual child card via browser: mandatory chores now show the red border + tint + left spine + "⚠ Mandatory" badge, matching the approved wireframe.

Relates to #532