### PR TITLE
Fix first_come chores invisible on child cards and task lists (#540)

### DIFF
--- a/custom_components/taskmate/sensor.py
+++ b/custom_components/taskmate/sensor.py
@@ -1014,17 +1014,21 @@ class ChildStatsSensor(TaskMateBaseSensor):
         if not child:
             return {}
 
-        # Get chores assigned to this child. For alternating/random assignment,
-        # only include a chore when this child is the active one today — and
+        # Get chores assigned to this child. For alternating/random/balanced
+        # assignment, only include a chore when this child is the active one
+        # today. first_come is competitive: the whole pool sees it (no single
+        # active child) until one member fills the shared quota. Either way,
         # drop it once any pool member has completed it today (so a parent
         # crediting the off-rotation child clears the chore for everyone).
         chores = self.coordinator.data.get("chores", [])
         def _included(c):
             if not (child.id in c.assigned_to or not c.assigned_to):
                 return False
-            if getattr(c, "assignment_mode", "everyone") != "everyone":
+            mode = getattr(c, "assignment_mode", "everyone")
+            if mode not in ("everyone", "first_come"):
                 if getattr(c, "assignment_current_child_id", "") != child.id:
                     return False
+            if mode != "everyone":
                 if self.coordinator._is_rotation_done_today(c):
                     return False
             return True

--- a/custom_components/taskmate/www/taskmate-child-card.js
+++ b/custom_components/taskmate/www/taskmate-child-card.js
@@ -2566,21 +2566,27 @@ class TaskMateChildCard extends LitElement {
       const isAssignedToAll = assignedToStrings.length === 0;
       let isAssignedToChild = isAssignedToAll || assignedToStrings.includes(childId);
 
-      // Dynamic assignment (alternating / random): only the currently-active child
-      // sees the chore. The backend caches today's pick in assignment_current_child_id.
-      // Once any eligible pool member has completed the chore today (e.g. a parent
-      // credited the off-rotation child), the chore is done for the whole pool and
-      // should disappear for everyone — including today's active child.
+      // Dynamic assignment. Rotation modes (alternating / random / balanced):
+      // only the currently-active child sees the chore — the backend caches
+      // today's pick in assignment_current_child_id. first_come is competitive:
+      // the whole pool sees it (there is no single active child) until one
+      // member wins the race. Either way, once any eligible pool member has
+      // completed the chore today (e.g. a parent credited the off-rotation
+      // child), the chore is done for the whole pool and should disappear for
+      // everyone — including today's active child.
       const assignmentMode = chore.assignment_mode || 'everyone';
       if (assignmentMode !== 'everyone' && isAssignedToChild) {
         const activeId = chore.assignment_current_child_id ? String(chore.assignment_current_child_id) : '';
-        isAssignedToChild = activeId !== '' && activeId === String(childId);
+        if (assignmentMode !== 'first_come') {
+          isAssignedToChild = activeId !== '' && activeId === String(childId);
+        }
         if (isAssignedToChild) {
           const poolIds = assignedToStrings.length > 0
             ? assignedToStrings
             : (attrs.children || []).map(c => String(c.id));
           const poolSet = new Set(poolIds);
-          const dailyLimit = chore.daily_limit || 1;
+          // first_come is a single-winner race regardless of any configured limit.
+          const dailyLimit = assignmentMode === 'first_come' ? 1 : (chore.daily_limit || 1);
           const allTodayCompletions = attrs.todays_completions || [];
           const poolCompletionsToday = allTodayCompletions.filter(
             comp => comp.chore_id === chore.id && (poolSet.has(String(comp.child_id)) || comp.child_id === "__parent__") && !comp.bonus_subtask_id
@@ -2588,8 +2594,9 @@ class TaskMateChildCard extends LitElement {
           if (poolCompletionsToday >= dailyLimit) {
             // Bonus sub-tasks render inside the parent card; if the active
             // child still has any pending, keep the chore visible so they
-            // remain reachable.
-            const bonusSubtasks = chore.bonus_subtasks || [];
+            // remain reachable. Only applies to single-active-child rotation
+            // modes (mirrors the backend, which guards this on active_child_id).
+            const bonusSubtasks = activeId ? (chore.bonus_subtasks || []) : [];
             const completedBonusIds = new Set(
               allTodayCompletions
                 .filter(c => c.chore_id === chore.id && String(c.child_id) === activeId && c.bonus_subtask_id)

--- a/tests/test_sensor_attributes.py
+++ b/tests/test_sensor_attributes.py
@@ -31,7 +31,11 @@ from custom_components.taskmate.models import (
     Reward,
     RewardClaim,
 )
-from custom_components.taskmate.sensor import ChildBadgesSensor, PendingApprovalsSensor
+from custom_components.taskmate.sensor import (
+    ChildBadgesSensor,
+    ChildStatsSensor,
+    PendingApprovalsSensor,
+)
 
 
 MAX_ATTR_BYTES = 16384  # Home Assistant recorder limit
@@ -404,6 +408,56 @@ class TestChildBadgesSensor:
         attrs = sensor.extra_state_attributes
         assert attrs["total_badges"] == 1
         assert attrs["available"][0]["badge_id"] == "y"
+
+
+class TestChildStatsAssignedChores:
+    """`assigned_chores` drives which chores a child sees on their card.
+
+    Regression for #540: `first_come` ("First come, first served") chores were
+    invisible because the visibility filter treated every non-`everyone` mode as
+    a single-active-child rotation. first_come has no single active child, so the
+    chore was hidden from the whole pool. It must stay visible to every pool
+    member until one child fills the shared (single-winner) quota.
+    """
+
+    def _coord(self, child, chores, *, rotation_done=False):
+        coord = MagicMock()
+        coord.get_child = lambda cid: child if (child and child.id == cid) else None
+        coord.data = {"chores": chores}
+        coord._is_rotation_done_today = MagicMock(return_value=rotation_done)
+        return coord
+
+    def _assigned_names(self, child, chores, *, rotation_done=False):
+        coord = self._coord(child, chores, rotation_done=rotation_done)
+        sensor = ChildStatsSensor(coord, _MockEntry(), child)
+        return [c["name"] for c in sensor.extra_state_attributes["assigned_chores"]]
+
+    def test_first_come_chore_visible_to_pool_member(self, hass):
+        child = Child(name="Mia")
+        child.id = "c1"
+        chore = Chore(name="Race", assigned_to=["c1", "c2"], assignment_mode="first_come")
+        assert "Race" in self._assigned_names(child, [chore], rotation_done=False)
+
+    def test_first_come_chore_hidden_once_quota_filled(self, hass):
+        child = Child(name="Mia")
+        child.id = "c1"
+        chore = Chore(name="Race", assigned_to=["c1", "c2"], assignment_mode="first_come")
+        assert "Race" not in self._assigned_names(child, [chore], rotation_done=True)
+
+    def test_rotation_chore_still_hidden_from_off_rotation_child(self, hass):
+        # Guard: the fix must not over-expose single-assignee rotation modes.
+        child = Child(name="Mia")
+        child.id = "c1"
+        chore = Chore(name="Rotate", assigned_to=["c1", "c2"], assignment_mode="alternating")
+        chore.assignment_current_child_id = "c2"
+        assert "Rotate" not in self._assigned_names(child, [chore], rotation_done=False)
+
+    def test_rotation_chore_visible_to_active_child(self, hass):
+        child = Child(name="Mia")
+        child.id = "c1"
+        chore = Chore(name="Rotate", assigned_to=["c1", "c2"], assignment_mode="alternating")
+        chore.assignment_current_child_id = "c1"
+        assert "Rotate" in self._assigned_names(child, [chore], rotation_done=False)
 
 
 class TestPendingApprovalsSensor:


### PR DESCRIPTION
## Problem

Chores using the `first_come` ("First come, first served") assignment mode were **completely invisible** on Lovelace child cards (`custom:taskmate-child-card`) and in children's task lists. Switching the chore back to `everyone` made it reappear. Always reproducible.

## Root cause

The child-visibility filter exists in two layers and both treated *every* non-`everyone` assignment mode as a single-active-child rotation, gating the chore on `assignment_current_child_id` matching the viewing child:

- Backend: `ChildStatsSensor._included` in `sensor.py`
- Frontend: `taskmate-child-card.js` chore filter

`first_come` is skipped in `_compute_daily_assignments`, so it never gets a single active child — its `assignment_current_child_id` is always empty. Result: `activeId !== childId` for everyone, so the chore was hidden from the whole pool.

## Fix

`first_come` is competitive: the whole pool should see the chore until one member fills the shared single-winner quota, after which it disappears for everyone.

- Treat `first_come` like `everyone` for the *who-sees-it* decision (whole pool sees it), while still applying the rotation-done check so it vanishes once one child wins.
- Frontend clamps the `first_come` daily limit to 1 (single-winner race), mirroring the backend `_is_rotation_done_today`.
- Frontend bonus-keep-alive path is now guarded on `active_child_id` so it matches backend behaviour (no single active child for `first_come`).

Single-assignee rotation modes (alternating/random/balanced) and `unassigned` are unchanged.

## Tests

New `TestChildStatsAssignedChores` in `tests/test_sensor_attributes.py`:
- `first_come` chore visible to a pool member (the regression)
- `first_come` chore hidden once the shared quota is filled
- rotation chore still hidden from the off-rotation child (guard against over-exposure)
- rotation chore visible to the active child

All 79 tests in the affected files pass; Ruff clean.

## Verified on dev HA

Reproduced on the live `ha-dev` instance (HA 2026.6): created a `first_come` chore for two children.
- Before fix: absent from both children's stats sensors.
- After reload: visible to **both** children.
- After one child completes it: disappears for **both** (single-winner race).

Fixes #540