### PR TITLE
chore: community-health files, label automation, and README install buttons

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,95 @@
+# Contributing to TaskMate
+
+Thanks for your interest in improving TaskMate! This is a Home Assistant custom
+integration for family chore and points tracking. Contributions of all kinds are
+welcome — bug reports, feature ideas, translations, docs, and code.
+
+## Before you start
+
+- **Bugs and features:** please open an issue first using the
+  [issue templates](https://github.com/tempus2016/taskmate/issues/new/choose).
+  For features especially, it's worth agreeing on the approach before writing
+  code.
+- **Questions and ideas:** use
+  [Discussions](https://github.com/tempus2016/taskmate/discussions) rather than
+  an issue.
+- **Check the [Troubleshooting wiki](https://github.com/tempus2016/taskmate/wiki/Troubleshooting)**
+  first for common problems.
+
+## Project layout
+
+```
+custom_components/taskmate/
+├── __init__.py            # integration setup
+├── config_flow.py         # UI config & options flow
+├── coordinator.py         # core data coordinator
+├── coord_*.py             # per-domain coordinators (chores, points, badges, …)
+├── sensor.py              # sensors the cards read from
+├── services.yaml          # service definitions
+├── websocket.py           # WebSocket API commands
+├── translations/          # backend strings (de, en, en-GB, fr, nb, nn, pt, pt-BR)
+├── strings.json           # source strings
+└── www/                   # Lovelace cards (LitElement) + panel + locales
+```
+
+- **Backend** is Python. Follow the existing patterns — don't introduce new
+  frameworks or heavy dependencies without discussing it first.
+- **Cards** (`www/taskmate-*-card.js`) are **LitElement**-based. Other frontend
+  code is vanilla JS. Cards read chore/child data from the sensors, not by
+  calling services directly to fetch state.
+
+## Development setup
+
+The fastest loop is a real Home Assistant instance with the integration
+bind-mounted:
+
+1. Mount or copy `custom_components/taskmate` into your HA config's
+   `custom_components/` directory.
+2. Restart Home Assistant to pick up Python changes.
+3. For card (`.js`) changes, **hard-refresh** the browser — the cards are
+   cache-busted by the manifest version, so a hard refresh is needed after JS
+   edits.
+
+## Code quality
+
+Two checks gate every PR into `main`. Run them locally before pushing:
+
+```bash
+# Lint (matches the "Ruff" CI check)
+ruff check .
+
+# Tests (matches the "Run tests" CI check)
+pytest
+```
+
+`hassfest` and HACS validation also run in CI to keep the integration
+compliant.
+
+## Translations
+
+TaskMate ships in several languages. **Any new user-facing string must be added
+to every locale in the same PR** — `de`, `fr`, `nb`, `nn`, `pt`, and `pt-BR`
+(plus the English source). English-only PRs with a "translate later" note will
+be asked to include the translations.
+
+Backend strings live in `custom_components/taskmate/translations/` and
+`strings.json`; card strings live under `www/locales/`.
+
+## Submitting a pull request
+
+1. Fork and create a feature branch.
+2. Make your change, keeping the PR focused on one logical thing.
+3. Run `ruff` and `pytest` locally.
+4. Test the change on a real Home Assistant instance.
+5. Open a PR using the template. Link the issue it closes
+   (`Closes #123`) so it auto-closes on merge.
+6. If your change is release-bound and affects behaviour, bump the
+   `manifest.json` version.
+
+A maintainer will review, and may ask for changes. Once it's green and approved,
+it gets merged.
+
+## Code of Conduct
+
+By participating you agree to abide by our
+[Code of Conduct](../CODE_OF_CONDUCT.md).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,47 @@
+<!--
+Thanks for contributing to TaskMate! Please fill in the sections below.
+Keep PRs focused — one logical change per PR is easier to review and release.
+-->
+
+## Summary
+
+<!-- What does this PR do, and why? One or two sentences is fine. -->
+
+## Related issue
+
+<!-- Link the issue this closes so it auto-closes on merge, e.g. "Closes #123".
+     If there's no issue, say "N/A" and explain the motivation above. -->
+
+Closes #
+
+## Type of change
+
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (fix or feature that changes existing behaviour)
+- [ ] Documentation only
+- [ ] CI / tooling / chore
+
+## How has this been tested?
+
+<!-- Describe how you verified the change. Per the project's release gate,
+     new or changed behaviour must be exercised on a real Home Assistant
+     instance, not just unit tests. -->
+
+- [ ] Ran `ruff check .` locally (matches the `Ruff` CI check)
+- [ ] Ran `pytest` locally (matches the `Run tests` CI check)
+- [ ] Exercised the change on a live Home Assistant instance
+- [ ] For card changes: hard-refreshed the browser and checked the console for errors
+
+## Checklist
+
+- [ ] My code follows the existing patterns in the codebase
+- [ ] I bumped `manifest.json` `version` if this is a release-bound change
+- [ ] Any new user-facing strings are translated into **all** locales
+      (`de`, `fr`, `nb`, `nn`, `pt`, `pt-BR`) in this same PR — not English-only
+- [ ] I updated the `README` / docs where relevant
+- [ ] I did **not** add Claude / AI co-author attribution to commits or files
+
+## Screenshots / recordings
+
+<!-- For UI changes, drag in before/after screenshots or a short clip. -->

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,51 @@
+# Security Policy
+
+TaskMate is a Home Assistant custom integration. It stores all of its data —
+children, chores, points, reward claims and completion history — locally inside
+your Home Assistant instance using HA's native storage helpers. Nothing is sent
+to any external service.
+
+Because TaskMate runs inside Home Assistant, the most relevant security
+boundaries are the ones Home Assistant itself enforces (authenticated users,
+the HTTP/WebSocket API, and Lovelace). The most likely classes of issue in
+TaskMate specifically are:
+
+- A service or WebSocket command that performs an action without correctly
+  checking the caller, or that accepts unvalidated input.
+- A Lovelace card that renders attacker-controlled text without escaping it
+  (potential XSS in the dashboard).
+- Information disclosure through a sensor attribute or photo endpoint.
+
+## Supported versions
+
+Only the **latest released version** of TaskMate receives security fixes.
+Before reporting, please update to the newest release and confirm the issue
+still reproduces.
+
+## Reporting a vulnerability
+
+**Please do not open a public issue for security problems.**
+
+Report privately using GitHub's
+[private vulnerability reporting](https://github.com/tempus2016/taskmate/security/advisories/new)
+(the **Report a vulnerability** button under the repository's **Security** tab).
+This keeps the details private until a fix is available.
+
+When reporting, please include:
+
+- The TaskMate version and Home Assistant version.
+- A description of the issue and its impact.
+- Steps to reproduce, including any relevant card YAML, service calls, or
+  sensor state.
+
+## What to expect
+
+This is a community project maintained in spare time, so timelines are
+best-effort:
+
+- **Acknowledgement** of your report as soon as is practical.
+- An assessment of the issue and, if confirmed, a fix in a subsequent release.
+- Credit in the release notes for the fix, unless you'd prefer to stay
+  anonymous.
+
+Thank you for helping keep TaskMate and its users safe.

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,35 @@
+# Path-based PR labels, applied by .github/workflows/labeler.yml (actions/labeler v5).
+# Labels referenced here must exist — they're defined in .github/labels.yml.
+
+cards:
+  - changed-files:
+      - any-glob-to-any-file:
+          - custom_components/taskmate/www/**/*.js
+
+backend:
+  - changed-files:
+      - any-glob-to-any-file:
+          - custom_components/taskmate/**/*.py
+
+translations:
+  - changed-files:
+      - any-glob-to-any-file:
+          - custom_components/taskmate/translations/**
+          - custom_components/taskmate/www/locales/**
+          - custom_components/taskmate/strings.json
+
+tests:
+  - changed-files:
+      - any-glob-to-any-file:
+          - tests/**
+
+documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*.md"
+          - docs/**
+
+ci:
+  - changed-files:
+      - any-glob-to-any-file:
+          - .github/**

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,85 @@
+# Source of truth for repository labels, synced by .github/workflows/labels.yml.
+# Edit here and push to main to create/update labels. Deletion is disabled
+# (skip_delete: true) so existing labels not listed here are left untouched —
+# flip that in the workflow once this list is known-complete.
+
+# ── Type ─────────────────────────────────────────────────────────────────────
+- name: bug
+  color: d73a4a
+  description: Something isn't working
+- name: enhancement
+  color: a2eeef
+  description: New feature or request
+- name: documentation
+  color: 0075ca
+  description: Improvements or additions to documentation
+- name: question
+  color: d876e3
+  description: Further information is requested
+
+# ── Triage / workflow ────────────────────────────────────────────────────────
+- name: needs-triage
+  color: ededed
+  description: Awaiting maintainer triage
+- name: planned
+  color: 1d76db
+  description: Accepted and scheduled — triggers an auto-created branch
+- name: in-progress
+  color: fbca04
+  description: Actively being worked on
+- name: blocked
+  color: b60205
+  description: Blocked by another issue or external dependency
+- name: needs-info
+  color: e99695
+  description: More information needed from the reporter
+- name: stale
+  color: cccccc
+  description: No recent activity — may be closed if it stays inactive
+
+# ── Conversation state (set automatically on comment) ────────────────────────
+- name: Author Reply
+  color: 5319e7
+  description: Maintainer has replied — awaiting the reporter
+- name: User Reply
+  color: 0e8a16
+  description: Reporter has replied — awaiting the maintainer
+
+# ── Resolution ───────────────────────────────────────────────────────────────
+- name: duplicate
+  color: cfd3d7
+  description: This issue or PR already exists
+- name: wontfix
+  color: ffffff
+  description: This will not be worked on
+- name: invalid
+  color: e4e669
+  description: This doesn't seem right
+
+# ── Areas (also applied automatically by the path labeler) ───────────────────
+- name: cards
+  color: c5def5
+  description: Lovelace cards / frontend (www/*.js)
+- name: backend
+  color: bfd4f2
+  description: Python integration code
+- name: translations
+  color: fef2c0
+  description: i18n / locale strings
+- name: tests
+  color: c2e0c6
+  description: Test suite
+- name: ci
+  color: ededed
+  description: CI, workflows, and tooling
+- name: dependencies
+  color: 0366d6
+  description: Dependency updates
+
+# ── Community ────────────────────────────────────────────────────────────────
+- name: good first issue
+  color: 7057ff
+  description: Good for newcomers
+- name: help wanted
+  color: 008672
+  description: Extra attention is welcome

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,23 @@
+name: Label PRs by path
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply path labels
+        uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5 2026-06-23
+        with:
+          configuration-path: .github/labeler.yml
+          sync-labels: true

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,0 +1,32 @@
+name: Sync labels
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - .github/labels.yml
+      - .github/workflows/labels.yml
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6 2026-06-17
+
+      - name: Apply labels
+        uses: crazy-max/ghaction-github-labeler@24d110aa46a59976b8a7f35518cb7f14f434c916 # v5 2026-06-23
+        with:
+          yaml_file: .github/labels.yml
+          # Never delete labels not listed in labels.yml — create/update only.
+          # Set to false once the label list is confirmed complete.
+          skip_delete: true
+          dry_run: false

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,36 @@
+name: Close stale issues
+
+on:
+  schedule:
+    - cron: "30 1 * * *"
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9 2026-06-23
+        with:
+          # Only chase issues that are explicitly waiting on the reporter for
+          # information — never sweep the whole tracker.
+          only-labels: needs-info
+          days-before-stale: 21
+          days-before-close: 10
+          stale-issue-label: stale
+          stale-issue-message: >
+            This issue has been waiting on more information for a while and is
+            now marked stale. If it's still relevant, please reply with the
+            requested details and it'll be reopened/kept open. Otherwise it will
+            be closed in 10 days.
+          close-issue-message: >
+            Closing as stale because the requested information wasn't provided.
+            Comment any time and we'll happily reopen it.
+          exempt-issue-labels: planned,in-progress,blocked,help wanted,good first issue,pinned,security
+          # Issues only — leave pull requests alone.
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          remove-stale-when-updated: true
+          ascending: true

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, colour, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behaviour that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologising to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behaviour include:
+
+* The use of sexualised language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behaviour and will take appropriate and fair corrective action in
+response to any behaviour that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behaviour may be
+reported to the project maintainer,
+[@tempus2016](https://github.com/tempus2016). All complaints will be reviewed
+and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behaviour deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behaviour was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behaviour. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behaviour.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behaviour, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/README.md
+++ b/README.md
@@ -11,8 +11,17 @@
  
 <p align="center">
   <a href="https://github.com/tempus2016/taskmate/releases"><img src="https://img.shields.io/github/v/release/tempus2016/taskmate" alt="Latest Release"></a>
+  <a href="https://github.com/hacs/default"><img src="https://img.shields.io/badge/HACS-Default-41BDF5.svg" alt="HACS Default"></a>
   <a href="https://github.com/tempus2016/taskmate/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue" alt="License"></a>
   <img src="https://img.shields.io/badge/Home%20Assistant-2024.1+-blue" alt="HA Version">
+  <a href="https://github.com/tempus2016/taskmate/releases"><img src="https://img.shields.io/github/downloads/tempus2016/taskmate/total" alt="Downloads"></a>
+</p>
+
+<p align="center">
+  <a href="https://github.com/tempus2016/taskmate/actions/workflows/validate.yml"><img src="https://github.com/tempus2016/taskmate/actions/workflows/validate.yml/badge.svg" alt="HACS Validation"></a>
+  <a href="https://github.com/tempus2016/taskmate/actions/workflows/hassfest.yaml"><img src="https://github.com/tempus2016/taskmate/actions/workflows/hassfest.yaml/badge.svg" alt="hassfest"></a>
+  <a href="https://github.com/tempus2016/taskmate/actions/workflows/tests.yml"><img src="https://github.com/tempus2016/taskmate/actions/workflows/tests.yml/badge.svg" alt="Tests"></a>
+  <a href="https://github.com/tempus2016/taskmate/actions/workflows/lint.yml"><img src="https://github.com/tempus2016/taskmate/actions/workflows/lint.yml/badge.svg" alt="Lint"></a>
 </p>
  
 > Originally created by [vinnybad/choremander](https://github.com/vinnybad/choremander). This fork adds 15 Lovelace cards, a bonus points system, streak tracking, reward approval flow, a penalty system, and much more.
@@ -68,6 +77,13 @@ TaskMate is a **default HACS integration** — no custom repository needed:
 1. Open **HACS** → search **"TaskMate"**
 2. Click **Download**
 3. **Restart Home Assistant**
+4. Add the integration: **Settings → Devices & Services → Add Integration → TaskMate**
+ 
+Or use the one-click buttons:
+ 
+[![Open TaskMate in HACS](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=tempus2016&repository=taskmate&category=integration)
+&nbsp;
+[![Add TaskMate integration](https://my.home-assistant.io/badges/config_flow_start.svg)](https://my.home-assistant.io/redirect/config_flow_start/?domain=taskmate)
  
 > Already installed TaskMate as a custom repository from before it was accepted into HACS? It keeps working and keeps receiving updates — you can safely remove the custom repository entry, HACS now tracks it by default.
  


### PR DESCRIPTION
## What

Adds the GitHub community-health files, label automation, and repo-page polish requested in conversation.

### New files
- **`.github/PULL_REQUEST_TEMPLATE.md`** — checklist matching the actual release gates (ruff, pytest, test on live HA, translate all locales, version bump, no AI attribution).
- **`.github/SECURITY.md`** — private vulnerability reporting policy (unlocks the Security tab).
- **`.github/CONTRIBUTING.md`** — project layout, dev loop, ruff/pytest, translation requirement, PR flow.
- **`CODE_OF_CONDUCT.md`** — Contributor Covenant 2.1.
- **`.github/labels.yml`** + **`.github/workflows/labels.yml`** — committed label taxonomy as source of truth, synced on push. `skip_delete: true` so nothing existing is removed.
- **`.github/labeler.yml`** + **`.github/workflows/labeler.yml`** — path-based PR auto-labeling (cards / backend / translations / tests / documentation / ci).
- **`.github/workflows/stale.yml`** — conservative stale bot, scoped to `needs-info` issues only; never touches PRs.

### README
- Added HACS-default, total-downloads, and CI status badges (validate / hassfest / tests / lint).
- Added one-click **Open in HACS** and **Add Integration** My-Home-Assistant buttons to the install section.

All new GitHub Actions are pinned to commit SHAs to match the repo convention. New workflows only take effect once on `main`.

### Notes / manual follow-ups
- Repo **topics** and the **social preview image** could not be set via API (the fine-grained PAT lacks Administration permission) — these need John in the repo UI. Suggested topic set and steps are in the PR thread / chat.
- HA brands submission was intentionally skipped (no longer required).

No Python changed, so Ruff and Run tests should pass untouched.