### PR TITLE
feat(panel): add wiki link to admin sidebar brand

### DIFF
--- a/custom_components/taskmate/www/locales/de.json
+++ b/custom_components/taskmate/www/locales/de.json
@@ -818,6 +818,7 @@
   "panel.tab_settings": "Einstellungen",
   "panel.tab_templates": "Vorlagen",
   "panel.tab_unknown": "Unbekannter Tab",
+  "panel.wiki_tooltip": "TaskMate-Wiki öffnen",
   "panel.notif_add_custom": "Benutzerdefinierte Benachrichtigung hinzufügen",
   "panel.notif_add_parent": "Elternteil hinzufügen",
   "panel.notif_custom_empty": "Noch keine benutzerdefinierten Benachrichtigungen.",

--- a/custom_components/taskmate/www/locales/en-GB.json
+++ b/custom_components/taskmate/www/locales/en-GB.json
@@ -868,6 +868,7 @@
   "panel.tab_settings": "Settings",
   "panel.tab_templates": "Templates",
   "panel.tab_unknown": "Unknown tab",
+  "panel.wiki_tooltip": "Open the TaskMate wiki",
   "panel.notif_add_custom": "Add custom notification",
   "panel.notif_add_parent": "Add parent",
   "panel.notif_custom_empty": "No custom notifications yet.",

--- a/custom_components/taskmate/www/locales/en.json
+++ b/custom_components/taskmate/www/locales/en.json
@@ -868,6 +868,7 @@
   "panel.tab_settings": "Settings",
   "panel.tab_templates": "Templates",
   "panel.tab_unknown": "Unknown tab",
+  "panel.wiki_tooltip": "Open the TaskMate wiki",
   "panel.notif_add_custom": "Add custom notification",
   "panel.notif_add_parent": "Add parent",
   "panel.notif_custom_empty": "No custom notifications yet.",

--- a/custom_components/taskmate/www/locales/fr.json
+++ b/custom_components/taskmate/www/locales/fr.json
@@ -818,6 +818,7 @@
   "panel.tab_settings": "Paramètres",
   "panel.tab_templates": "Modèles",
   "panel.tab_unknown": "Onglet inconnu",
+  "panel.wiki_tooltip": "Ouvrir le wiki TaskMate",
   "panel.notif_add_custom": "Ajouter une notification personnalisée",
   "panel.notif_add_parent": "Ajouter un parent",
   "panel.notif_custom_empty": "Aucune notification personnalisée pour l'instant.",

--- a/custom_components/taskmate/www/locales/nb.json
+++ b/custom_components/taskmate/www/locales/nb.json
@@ -818,6 +818,7 @@
   "panel.tab_settings": "Innstillinger",
   "panel.tab_templates": "Maler",
   "panel.tab_unknown": "Ukjent fane",
+  "panel.wiki_tooltip": "Åpne TaskMate-wikien",
   "panel.notif_add_custom": "Legg til egendefinert varsel",
   "panel.notif_add_parent": "Legg til foresatt",
   "panel.notif_custom_empty": "Ingen egendefinerte varsler ennå.",

--- a/custom_components/taskmate/www/locales/nn.json
+++ b/custom_components/taskmate/www/locales/nn.json
@@ -818,6 +818,7 @@
   "panel.tab_settings": "Innstillingar",
   "panel.tab_templates": "Malar",
   "panel.tab_unknown": "Ukjend fane",
+  "panel.wiki_tooltip": "Opne TaskMate-wikien",
   "panel.notif_add_custom": "Legg til eigendefinert varsel",
   "panel.notif_add_parent": "Legg til føresett",
   "panel.notif_custom_empty": "Ingen eigendefinerte varsel enno.",

--- a/custom_components/taskmate/www/locales/pt-BR.json
+++ b/custom_components/taskmate/www/locales/pt-BR.json
@@ -818,6 +818,7 @@
   "panel.tab_settings": "Configurações",
   "panel.tab_templates": "Modelos",
   "panel.tab_unknown": "Aba desconhecida",
+  "panel.wiki_tooltip": "Abrir a wiki do TaskMate",
   "panel.notif_add_custom": "Adicionar notificação personalizada",
   "panel.notif_add_parent": "Adicionar responsável",
   "panel.notif_custom_empty": "Nenhuma notificação personalizada ainda.",

--- a/custom_components/taskmate/www/locales/pt.json
+++ b/custom_components/taskmate/www/locales/pt.json
@@ -823,6 +823,7 @@
   "panel.tab_settings": "Definições",
   "panel.tab_templates": "Modelos",
   "panel.tab_unknown": "Separador desconhecido",
+  "panel.wiki_tooltip": "Abrir a wiki do TaskMate",
   "panel.notif_add_custom": "Adicionar notificação personalizada",
   "panel.notif_add_parent": "Adicionar encarregado",
   "panel.notif_custom_empty": "Ainda não há notificações personalizadas.",

--- a/custom_components/taskmate/www/taskmate-panel.js
+++ b/custom_components/taskmate/www/taskmate-panel.js
@@ -2169,6 +2169,9 @@ class TaskMatePanel extends HTMLElement {
             TaskMate
             <small>v${PANEL_VERSION}</small>
           </div>
+          <a class="tm-brand-wiki" href="https://github.com/tempus2016/taskmate/wiki" target="_blank" rel="noopener noreferrer" title="${this._esc(this._t("panel.wiki_tooltip"))}" aria-label="${this._esc(this._t("panel.wiki_tooltip"))}">
+            <ha-icon icon="mdi:book-open-variant"></ha-icon>
+          </a>
         </div>
         <nav class="tm-nav">
           ${groups.map(g => `
@@ -5034,6 +5037,21 @@ class TaskMatePanel extends HTMLElement {
         font-size: 11px;
         font-family: ui-monospace, "SF Mono", "JetBrains Mono", Menlo, monospace;
         margin-top: 1px;
+      }
+      .tm-brand-wiki {
+        flex-shrink: 0;
+        width: 28px; height: 28px;
+        border-radius: 7px;
+        display: grid; place-items: center;
+        color: var(--tm-text-faint);
+        text-decoration: none;
+        transition: color 0.15s ease, background 0.15s ease;
+      }
+      .tm-brand-wiki ha-icon { --mdc-icon-size: 18px; }
+      .tm-brand-wiki:hover, .tm-brand-wiki:focus-visible {
+        color: var(--tm-accent);
+        background: var(--tm-border-soft);
+        outline: none;
       }
       .tm-nav {
         padding: 10px 8px;


### PR DESCRIPTION
## What

Adds a small wiki icon button (`mdi:book-open-variant`) to the admin panel sidebar brand row, right next to the **TaskMate** brand text. Clicking it opens the [GitHub wiki home](https://github.com/tempus2016/taskmate/wiki) in a new tab so users can find documentation quickly.

## Details

- Markup added inside `.tm-brand` in `_sidebar()` (`taskmate-panel.js`); the brand text keeps `flex: 1`, so the icon sits flush at the right edge of the brand row.
- New `.tm-brand-wiki` style: 28×28 faint icon, accent colour + soft background on hover/focus, no underline, `flex-shrink: 0`.
- Opens with `target="_blank" rel="noopener noreferrer"`.
- New tooltip/aria-label string `panel.wiki_tooltip` shipped translated in **all** panel locales (de, en, en-GB, fr, nb, nn, pt, pt-BR).

## Verification

- `node --check` passes on `taskmate-panel.js`.
- Tested live on the ha-dev instance: served `taskmate-panel.js` and locale JSON confirmed to carry the change; rendered the authenticated panel via browserless and visually confirmed the book icon renders correctly beside "TaskMate v4.2.0" in the sidebar.

## Notes

- The link lives in the desktop sidebar brand block (the requested location). In the narrow/top-tab layout the brand block is not rendered, so the link is desktop-sidebar only.
- No version bump / release (additive UI only).