### PR TITLE
fix: resolve CodeQL code-scanning alerts

### DIFF
--- a/.github/workflows/hassfest.yaml
+++ b/.github/workflows/hassfest.yaml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: "ubuntu-latest"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,6 +11,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   ruff:
     name: Ruff

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     name: Validate integration

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   hacs:
     runs-on: ubuntu-latest

--- a/custom_components/taskmate/www/taskmate-panel.js
+++ b/custom_components/taskmate/www/taskmate-panel.js
@@ -8,9 +8,14 @@
  */
 
 const PANEL_VERSION = (() => {
-  try { return new URL(import.meta.url).searchParams.get("v") || "?"; } catch (_) {}
+  // The version comes from the resource URL (?v=x.x.x), set by the integration
+  // itself — but it is still DOM-sourced text that we later splice into
+  // innerHTML, so clamp it to a version-safe charset to remove any chance of
+  // HTML injection (and silence CodeQL js/xss-through-dom).
+  const sanitize = (v) => ((v || "").replace(/[^\w.+-]/g, "") || "?");
+  try { return sanitize(new URL(import.meta.url).searchParams.get("v")); } catch (_) {}
   const el = document.querySelector('script[src*="/taskmate-panel.js"]');
-  return el ? new URLSearchParams(el.src.split("?")[1] || "").get("v") || "?" : "?";
+  return el ? sanitize(new URLSearchParams(el.src.split("?")[1] || "").get("v")) : "?";
 })();
 
 const TABS = [


### PR DESCRIPTION
Resolves all 6 open CodeQL code-scanning alerts.

## Alerts addressed

### High — `js/xss-through-dom` (alert #6)
`PANEL_VERSION` in `taskmate-panel.js` is parsed from the panel script's `?v=` URL query (DOM-sourced text) and later spliced into the shell `innerHTML` via `_sidebar()` (`<small>v${PANEL_VERSION}</small>`) without escaping.

In practice the `?v=` value is the manifest version string set by the integration itself, not user input — so it is not realistically exploitable (matches the existing audit's "no confirmed XSS" conclusion). But the unsanitized DOM->HTML pattern is real, so this clamps `PANEL_VERSION` to a version-safe charset (`[\w.+-]`) at the source. Valid versions (incl. `3.9.5-beta.1`) pass through unchanged; HTML meta-characters are stripped.

### Medium x5 — `actions/missing-workflow-permissions` (alerts #1–#5)
`hassfest.yaml`, `lint.yml`, `validate.yml` and `tests.yml` (both jobs) had no `permissions:` block, so `GITHUB_TOKEN` inherited the repo-default scope. Added an explicit top-level `permissions: contents: read` to each — all jobs are read-only (checkout / hassfest / HACS validate / ruff / pytest).

## Verification
- All four workflows parse and expose `permissions.contents == read`.
- Sanitizer: `3.9.6`->`3.9.6`, `3.9.5-beta.1`->`3.9.5-beta.1`, `null`->`?`, `"><img src=x onerror=alert(1)>`->`imgsrcxonerroralert1` (inert).

No Python logic changed, so Ruff + Run tests are unaffected.