### PR TITLE
fix(rewards): jackpots are pool-mode so combined points can claim them (#552)

### DIFF
--- a/custom_components/taskmate/coord_rewards.py
+++ b/custom_components/taskmate/coord_rewards.py
@@ -56,7 +56,7 @@ class RewardsMixin:
             icon=icon,
             assigned_to=assigned_to or [],
             is_jackpot=is_jackpot,
-            pool_enabled=pool_enabled,
+            pool_enabled=pool_enabled,  # Reward.__post_init__ forces this on for jackpots (#552)
             quantity=quantity,
             expires_at=expires_at,
         )
@@ -75,6 +75,9 @@ class RewardsMixin:
         allocations on that reward are refunded in full.
         """
         old = self.get_reward(reward.id)
+        # Jackpots are always pool-mode (#552); keep stored data consistent.
+        if reward.is_jackpot:
+            reward.pool_enabled = True
         self.storage.update_reward(reward)
         if old and reward.cost < old.cost:
             self._refund_pool_excess(reward, "Pool refund (reward cost reduced)")

--- a/custom_components/taskmate/models.py
+++ b/custom_components/taskmate/models.py
@@ -415,6 +415,14 @@ class Reward:
     restock_last: str = ""  # ISO date this reward was last restocked
     id: str = field(default_factory=generate_id)
 
+    def __post_init__(self) -> None:
+        # Jackpots are inherently pooled (#552): everyone deposits into the shared
+        # jar, so pool mode is always on. Enforced here so every construction path
+        # — WS add, service add, and storage load (legacy migration) — stays
+        # consistent and never yields an unclaimable single-child jackpot.
+        if self.is_jackpot:
+            self.pool_enabled = True
+
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> Reward:
         """Create a Reward from a dictionary."""

--- a/custom_components/taskmate/www/taskmate-panel.js
+++ b/custom_components/taskmate/www/taskmate-panel.js
@@ -2655,7 +2655,7 @@ class TaskMatePanel extends HTMLElement {
 
   _renderRewardCard(r, pointsName) {
     const totalPooled = (this._state.pool_allocations || []).filter(a => a.reward_id === r.id).reduce((s, a) => s + (a.allocated_points || 0), 0);
-    const showProgress = r.pool_enabled && r.cost > 0;
+    const showProgress = (r.pool_enabled || r.is_jackpot) && r.cost > 0;
     const pct = showProgress ? Math.min(100, Math.round(totalPooled / r.cost * 100)) : 0;
     return `
       <article class="tm-card tm-reward-card">

--- a/custom_components/taskmate/www/taskmate-rewards-card.js
+++ b/custom_components/taskmate/www/taskmate-rewards-card.js
@@ -1122,7 +1122,7 @@ class TaskMateRewardsCard extends LitElement {
     const activeChild = activeChildId ? children.find((c) => c.id === activeChildId) : null;
     // Show the spendable banner when any visible reward is in pool mode
     const anyPoolReward = sortedRewards.some(
-      (r) => cardForcesPool || r.pool_enabled === true
+      (r) => cardForcesPool || r.pool_enabled === true || r.is_jackpot
     );
 
     return html`
@@ -1238,7 +1238,10 @@ class TaskMateRewardsCard extends LitElement {
     const isJackpot = reward.is_jackpot || false;
     // Pool mode is enabled per-reward (reward.pool_enabled) OR forced on via card config.
     const cardForcesPool = this.config.enable_pool_mode === true;
-    const enablePoolMode = cardForcesPool || reward.pool_enabled === true;
+    // Jackpot rewards are always pool-mode (#552): everyone deposits into the
+    // shared jar and it's redeemed when full. Combined points only work via the
+    // pool, so jackpots never show the single-child claim button.
+    const enablePoolMode = cardForcesPool || reward.pool_enabled === true || isJackpot;
     // All costs are static — just use reward.cost
     const displayCost = this._getDisplayCost(reward, children);
 
@@ -1668,7 +1671,10 @@ class TaskMateRewardsCard extends LitElement {
     const assignedTo = reward.assigned_to || [];
     const isJackpot = reward.is_jackpot || false;
     const cardForcesPool = this.config.enable_pool_mode === true;
-    const enablePoolMode = cardForcesPool || reward.pool_enabled === true;
+    // Jackpot rewards are always pool-mode (#552): everyone deposits into the
+    // shared jar and it's redeemed when full. Combined points only work via the
+    // pool, so jackpots never show the single-child claim button.
+    const enablePoolMode = cardForcesPool || reward.pool_enabled === true || isJackpot;
     const displayCost = this._getDisplayCost(reward, children);
 
     const relevantChildren = assignedTo.length === 0
@@ -1800,7 +1806,7 @@ class TaskMateRewardsCard extends LitElement {
     const cardForcesPool = this.config.enable_pool_mode === true;
     const activeChildId = this.config.child_id || this._selectedChildId;
     const activeChild = activeChildId ? children.find((c) => c.id === activeChildId) : null;
-    const anyPoolReward = sortedRewards.some((r) => cardForcesPool || r.pool_enabled === true);
+    const anyPoolReward = sortedRewards.some((r) => cardForcesPool || r.pool_enabled === true || r.is_jackpot);
 
     const header = this._designHeader(rewards.length, hd);
 

--- a/tests/test_coordinator_rewards.py
+++ b/tests/test_coordinator_rewards.py
@@ -641,3 +641,32 @@ class TestRewardStockAndExpiration:
 
         assert child.points == 80  # 50 + 30 refund
         coord.storage.remove_pool_allocation.assert_called_with("kid1", "reward1")
+
+
+class TestJackpotImpliesPoolMode:
+    """Jackpots are inherently pooled — pool mode is forced on (#552)."""
+
+    def test_add_jackpot_forces_pool_enabled(self):
+        coord = _make_coord()
+        reward = run(coord.async_add_reward(
+            name="Family Trip", cost=100, is_jackpot=True, pool_enabled=False
+        ))
+        assert reward.pool_enabled is True
+        assert coord.storage.add_reward.call_args.args[0].pool_enabled is True
+
+    def test_update_jackpot_forces_pool_enabled(self):
+        existing = Reward(name="Trip", cost=100, is_jackpot=True,
+                          pool_enabled=False, id="rwJ")
+        coord = _make_coord(rewards=[existing])
+        edited = Reward(name="Trip", cost=100, is_jackpot=True,
+                        pool_enabled=False, id="rwJ")
+        run(coord.async_update_reward(edited))
+        assert edited.pool_enabled is True
+        assert coord.storage.update_reward.call_args.args[0].pool_enabled is True
+
+    def test_non_jackpot_pool_flag_left_untouched(self):
+        coord = _make_coord()
+        reward = run(coord.async_add_reward(
+            name="Ice cream", cost=10, is_jackpot=False, pool_enabled=False
+        ))
+        assert reward.pool_enabled is False


### PR DESCRIPTION
Fixes #552 — Jackpot rewards could not be claimed with combined points.

**Root cause:** a jackpot with pool mode off rendered the single-child claim button, whose affordability check (`relevantChild.points − committed ≥ cost`) only looks at **one** child. When no single child could afford the cost but the kids **combined** could, the button stayed disabled and the jackpot was unclaimable. Jackpot/Pool were independent toggles in the panel, so this was an easy state to land in.

**Decision (chosen):** jackpots are **always pool-mode** — everyone deposits into the shared jar and it is redeemed when full.

**Fix — enforce the invariant at every layer:**
- `Reward.__post_init__` forces `pool_enabled=True` for jackpots → covers WS add, service add, and **storage load** (existing jackpots auto-migrate on load, no separate migration script).
- `async_update_reward` re-applies it after the edit path mutates fields via `setattr`.
- Rewards Card treats `is_jackpot` as pool mode in **both** the classic and designed render paths (and the spendable banner) → jackpots show deposit/redeem pool controls, never the dead claim button.
- Admin panel reward list shows pool progress for jackpots.

No new translatable strings (reuses the existing pool/deposit/redeem UI).

**Verified on ha-dev** (browserless, real `hass`):
- 100-pt jackpot that neither Malia (71) nor Vaiha (46) could afford alone → filled via Malia 71 + Vaiha 29 deposits → showed combined 100/100 with per-child contributions and a working **Redeem**.
- Existing jackpot stored `pool_enabled:false` auto-migrated to `true` on restart.
- Non-jackpot reward unchanged.
- 149 reward/model tests pass, incl. 3 new invariant tests. Full suite: no new failures vs the known baseline.

Builds on the #547 child-picker fix (both shipped on the same card).