### PR TITLE
fix(rewards-card): show pool total in jackpot claim dialog (#557)

### DIFF
--- a/custom_components/taskmate/www/locales/de.json
+++ b/custom_components/taskmate/www/locales/de.json
@@ -1132,6 +1132,7 @@
   "rewards.confirm_body": "Einlösen: {name}?",
   "rewards.confirm_claim_btn": "Einlösen!",
   "rewards.confirm_cost": "Kosten",
+  "rewards.confirm_pool_total": "Pool gesamt",
   "rewards.confirm_remaining": "Verbleibend",
   "rewards.confirm_title": "Belohnung einlösen?",
   "rewards.confirm_your_points": "Deine {name}",

--- a/custom_components/taskmate/www/locales/en-GB.json
+++ b/custom_components/taskmate/www/locales/en-GB.json
@@ -1185,6 +1185,7 @@
   "rewards.confirm_body": "Claim {name}?",
   "rewards.confirm_claim_btn": "Claim!",
   "rewards.confirm_cost": "Cost",
+  "rewards.confirm_pool_total": "Pool total",
   "rewards.confirm_remaining": "Remaining",
   "rewards.confirm_title": "Claim Reward?",
   "rewards.confirm_your_points": "Your {name}",

--- a/custom_components/taskmate/www/locales/en.json
+++ b/custom_components/taskmate/www/locales/en.json
@@ -1185,6 +1185,7 @@
   "rewards.confirm_body": "Claim {name}?",
   "rewards.confirm_claim_btn": "Claim!",
   "rewards.confirm_cost": "Cost",
+  "rewards.confirm_pool_total": "Pool total",
   "rewards.confirm_remaining": "Remaining",
   "rewards.confirm_title": "Claim Reward?",
   "rewards.confirm_your_points": "Your {name}",

--- a/custom_components/taskmate/www/locales/fr.json
+++ b/custom_components/taskmate/www/locales/fr.json
@@ -1132,6 +1132,7 @@
   "rewards.confirm_body": "Réclamer {name} ?",
   "rewards.confirm_claim_btn": "Réclamer !",
   "rewards.confirm_cost": "Coût",
+  "rewards.confirm_pool_total": "Total de la cagnotte",
   "rewards.confirm_remaining": "Restant",
   "rewards.confirm_title": "Réclamer la récompense ?",
   "rewards.confirm_your_points": "Vos {name}",

--- a/custom_components/taskmate/www/locales/nb.json
+++ b/custom_components/taskmate/www/locales/nb.json
@@ -1132,6 +1132,7 @@
   "rewards.confirm_body": "Innløs {name}?",
   "rewards.confirm_claim_btn": "Innløs!",
   "rewards.confirm_cost": "Kostnad",
+  "rewards.confirm_pool_total": "Sparegris totalt",
   "rewards.confirm_remaining": "Gjenstående",
   "rewards.confirm_title": "Innløs belønning?",
   "rewards.confirm_your_points": "Dine {name}",

--- a/custom_components/taskmate/www/locales/nn.json
+++ b/custom_components/taskmate/www/locales/nn.json
@@ -1132,6 +1132,7 @@
   "rewards.confirm_body": "Løys inn {name}?",
   "rewards.confirm_claim_btn": "Løys inn!",
   "rewards.confirm_cost": "Kostnad",
+  "rewards.confirm_pool_total": "Sparegris totalt",
   "rewards.confirm_remaining": "Attståande",
   "rewards.confirm_title": "Løys inn belønning?",
   "rewards.confirm_your_points": "Dine {name}",

--- a/custom_components/taskmate/www/locales/pt-BR.json
+++ b/custom_components/taskmate/www/locales/pt-BR.json
@@ -1132,6 +1132,7 @@
   "rewards.confirm_body": "Resgatar {name}?",
   "rewards.confirm_claim_btn": "Resgatar!",
   "rewards.confirm_cost": "Custo",
+  "rewards.confirm_pool_total": "Total do cofrinho",
   "rewards.confirm_remaining": "Restante",
   "rewards.confirm_title": "Resgatar recompensa?",
   "rewards.confirm_your_points": "Seus {name}",

--- a/custom_components/taskmate/www/locales/pt.json
+++ b/custom_components/taskmate/www/locales/pt.json
@@ -1137,6 +1137,7 @@
   "rewards.confirm_body": "Resgatar {name}?",
   "rewards.confirm_claim_btn": "Resgatar!",
   "rewards.confirm_cost": "Custo",
+  "rewards.confirm_pool_total": "Total do mealheiro",
   "rewards.confirm_remaining": "Restante",
   "rewards.confirm_title": "Resgatar recompensa?",
   "rewards.confirm_your_points": "Seus {name}",

--- a/custom_components/taskmate/www/taskmate-rewards-card.js
+++ b/custom_components/taskmate/www/taskmate-rewards-card.js
@@ -1158,15 +1158,33 @@ class TaskMateRewardsCard extends LitElement {
               ${(() => {
                 const r = this._pendingClaim;
                 const child = r._child;
-                const currentPoints = child ? (typeof child.spendable_balance === 'number' ? child.spendable_balance : (child.points || 0)) : null;
                 const cost = r.cost;
+                // Pool/jackpot redemptions spend POOLED points, not the claiming
+                // child's wallet. Showing the child's balance vs the full cost
+                // produced a nonsensical negative "Remaining" (#557). Use the pool
+                // total (jackpot: summed across all children; savings-jar: this
+                // child's allocation) so the calculation reflects the pooled points.
+                const isJackpot = r.is_jackpot === true;
+                const isPoolRedeem = isJackpot || r.pool_enabled === true || this.config.enable_pool_mode === true;
+                let currentPoints;
+                let availableLabel;
+                if (isPoolRedeem) {
+                  const poolAllocations = r.pool_allocations || {};
+                  currentPoints = isJackpot
+                    ? (typeof r.jackpot_pool_total === 'number' ? r.jackpot_pool_total : 0)
+                    : (child ? (poolAllocations[child.id] || 0) : 0);
+                  availableLabel = this._t('rewards.confirm_pool_total');
+                } else {
+                  currentPoints = child ? (typeof child.spendable_balance === 'number' ? child.spendable_balance : (child.points || 0)) : null;
+                  availableLabel = this._t('rewards.confirm_your_points', { name: pointsName });
+                }
                 const remaining = currentPoints !== null ? currentPoints - cost : null;
                 return html`
                   <div style="margin-bottom: 12px;">${this._t('rewards.confirm_body', { name: r.name })}</div>
                   ${currentPoints !== null ? html`
                     <div class="dialog-points-summary">
                       <div class="dialog-points-row">
-                        <span>${this._t('rewards.confirm_your_points', { name: pointsName })}</span>
+                        <span>${availableLabel}</span>
                         <span class="points-val">
                           <ha-icon icon="${pointsIcon}" style="--mdc-icon-size:14px;"></ha-icon>
                           ${currentPoints}


### PR DESCRIPTION
Fixes #557.

## Problem
When claiming a **Jackpot** reward, the claim confirmation dialog showed an incorrect calculation. It read **Your Stars** from the claiming child's wallet balance and computed **Remaining** as `balance − cost`. Because jackpot (and savings-jar pool) points are pooled — already deducted from each contributor at deposit time — this produced nonsensical figures.

Example from the report: a child with **21** spendable points redeeming a **full 50-point pool** showed `Your Stars 21 / Cost −50 / Remaining −29`.

The actual deduction was always correct — only the displayed calculation was wrong.

## Fix
Pool/jackpot redemptions now display the **pool total** instead of the single child's wallet:
- **Jackpot:** `jackpot_pool_total` (summed across all contributors)
- **Savings-jar pool:** the child's own allocation

Regular (wallet) claims are unchanged.

## Verification
Verified end-to-end on the dev HA instance with the real Rewards Card and live data (jackpot reward, full 50-point pool, contributing child with 21 spendable). The dialog now reads **Pool total 50 / Cost −50 / Remaining 0**.

## i18n
Adds `rewards.confirm_pool_total` to all locales (en, en-GB, de, fr, nb, nn, pt, pt-BR); key parity maintained (1467 keys each).