### PR TITLE
fix(rewards): refund pool allocations when a reward is deleted (#564)

### DIFF
--- a/custom_components/taskmate/coord_rewards.py
+++ b/custom_components/taskmate/coord_rewards.py
@@ -99,6 +99,12 @@ class RewardsMixin:
     async def async_remove_reward(self, reward_id: str) -> None:
         """Remove a reward and clean up any pending claims and pool allocations referencing it."""
         self.storage.remove_reward_claims_for_reward(reward_id)
+        # Refund any earmarked pool points back to their contributors before the
+        # allocations are dropped — otherwise the points deducted at allocation
+        # time would be silently lost (#564). Mirrors the expiry/sold-out paths.
+        reward = self.get_reward(reward_id)
+        if reward:
+            self._refund_all_pool_allocations(reward, "Pool refund (reward deleted)")
         self.storage.remove_pool_allocations_for_reward(reward_id)
         self.storage.remove_reward(reward_id)
         await self.storage.async_save()

--- a/custom_components/taskmate/www/locales/de.json
+++ b/custom_components/taskmate/www/locales/de.json
@@ -53,6 +53,7 @@
   "activity.reason_penalty": "Strafe: {name}",
   "activity.reason_perfect_week": "Perfekter Wochenbonus!",
   "activity.reason_pool_refund_cost_reduced": "Pool-Rückerstattung (Prämienkosten reduziert): {name}",
+  "activity.reason_pool_refund_deleted": "Poolrückerstattung (Prämie gelöscht): {name}",
   "activity.reason_pool_refund_expired": "Poolrückerstattung (Prämie abgelaufen): {name}",
   "activity.reason_pool_refund_sold_out": "Poolrückerstattung (Prämie ausverkauft): {name}",
   "activity.reason_streak_milestone": "Serie-Meilensteinbonus ({days} Tage Serie!)",

--- a/custom_components/taskmate/www/locales/en-GB.json
+++ b/custom_components/taskmate/www/locales/en-GB.json
@@ -53,6 +53,7 @@
   "activity.reason_penalty": "Penalty: {name}",
   "activity.reason_perfect_week": "Perfect week bonus!",
   "activity.reason_pool_refund_cost_reduced": "Pool refund (reward cost reduced): {name}",
+  "activity.reason_pool_refund_deleted": "Pool refund (reward deleted): {name}",
   "activity.reason_pool_refund_expired": "Pool refund (reward expired): {name}",
   "activity.reason_pool_refund_sold_out": "Pool refund (reward sold out): {name}",
   "activity.reason_streak_milestone": "Streak milestone bonus ({days} day streak!)",

--- a/custom_components/taskmate/www/locales/en.json
+++ b/custom_components/taskmate/www/locales/en.json
@@ -53,6 +53,7 @@
   "activity.reason_penalty": "Penalty: {name}",
   "activity.reason_perfect_week": "Perfect week bonus!",
   "activity.reason_pool_refund_cost_reduced": "Pool refund (reward cost reduced): {name}",
+  "activity.reason_pool_refund_deleted": "Pool refund (reward deleted): {name}",
   "activity.reason_pool_refund_expired": "Pool refund (reward expired): {name}",
   "activity.reason_pool_refund_sold_out": "Pool refund (reward sold out): {name}",
   "activity.reason_streak_milestone": "Streak milestone bonus ({days} day streak!)",

--- a/custom_components/taskmate/www/locales/fr.json
+++ b/custom_components/taskmate/www/locales/fr.json
@@ -53,6 +53,7 @@
   "activity.reason_penalty": "Pénalité : {name}",
   "activity.reason_perfect_week": "Bonus de semaine parfaite !",
   "activity.reason_pool_refund_cost_reduced": "Remboursement de cagnotte (coût réduit) : {name}",
+  "activity.reason_pool_refund_deleted": "Remboursement de cagnotte (récompense supprimée) : {name}",
   "activity.reason_pool_refund_expired": "Remboursement de cagnotte (récompense expirée) : {name}",
   "activity.reason_pool_refund_sold_out": "Remboursement de cagnotte (récompense épuisée) : {name}",
   "activity.reason_streak_milestone": "Bonus de palier de série ({days} jours de suite !)",

--- a/custom_components/taskmate/www/locales/nb.json
+++ b/custom_components/taskmate/www/locales/nb.json
@@ -53,6 +53,7 @@
   "activity.reason_penalty": "Straff: {name}",
   "activity.reason_perfect_week": "Perfekt uke-bonus!",
   "activity.reason_pool_refund_cost_reduced": "Refusjon fra sparegris (kostnad redusert): {name}",
+  "activity.reason_pool_refund_deleted": "Refusjon fra sparegris (belønning slettet): {name}",
   "activity.reason_pool_refund_expired": "Refusjon fra sparegris (belønning utløpt): {name}",
   "activity.reason_pool_refund_sold_out": "Refusjon fra sparegris (belønning utsolgt): {name}",
   "activity.reason_streak_milestone": "Milepælsbonus ({days} dagers strek!)",

--- a/custom_components/taskmate/www/locales/nn.json
+++ b/custom_components/taskmate/www/locales/nn.json
@@ -53,6 +53,7 @@
   "activity.reason_penalty": "Straff: {name}",
   "activity.reason_perfect_week": "Perfekt veke-bonus!",
   "activity.reason_pool_refund_cost_reduced": "Refusjon frå sparegris (kostnad redusert): {name}",
+  "activity.reason_pool_refund_deleted": "Refusjon frå sparegris (løning sletta): {name}",
   "activity.reason_pool_refund_expired": "Refusjon frå sparegris (løning utløpt): {name}",
   "activity.reason_pool_refund_sold_out": "Refusjon frå sparegris (løning utseld): {name}",
   "activity.reason_streak_milestone": "Milepælsbonus ({days} dagar på rad!)",

--- a/custom_components/taskmate/www/locales/pt-BR.json
+++ b/custom_components/taskmate/www/locales/pt-BR.json
@@ -53,6 +53,7 @@
   "activity.reason_penalty": "Penalidade: {name}",
   "activity.reason_perfect_week": "Bônus de semana perfeita!",
   "activity.reason_pool_refund_cost_reduced": "Reembolso do cofrinho (custo reduzido): {name}",
+  "activity.reason_pool_refund_deleted": "Reembolso do cofrinho (recompensa excluída): {name}",
   "activity.reason_pool_refund_expired": "Reembolso do cofrinho (recompensa expirada): {name}",
   "activity.reason_pool_refund_sold_out": "Reembolso do cofrinho (recompensa esgotada): {name}",
   "activity.reason_streak_milestone": "Bônus de marco de sequência ({days} dias seguidos!)",

--- a/custom_components/taskmate/www/locales/pt.json
+++ b/custom_components/taskmate/www/locales/pt.json
@@ -53,6 +53,7 @@
   "activity.reason_penalty": "Penalidade: {name}",
   "activity.reason_perfect_week": "Bónus de semana perfeita!",
   "activity.reason_pool_refund_cost_reduced": "Reembolso do mealheiro (custo reduzido): {name}",
+  "activity.reason_pool_refund_deleted": "Reembolso do mealheiro (recompensa eliminada): {name}",
   "activity.reason_pool_refund_expired": "Reembolso do mealheiro (recompensa expirada): {name}",
   "activity.reason_pool_refund_sold_out": "Reembolso do mealheiro (recompensa esgotada): {name}",
   "activity.reason_streak_milestone": "Bónus de marco de sequência ({days} dias seguidos!)",

--- a/custom_components/taskmate/www/taskmate-activity-card.js
+++ b/custom_components/taskmate/www/taskmate-activity-card.js
@@ -72,6 +72,7 @@ class TaskMateActivityCard extends LitElement {
       ['Pool refund (reward expired):', 'activity.reason_pool_refund_expired'],
       ['Pool refund (reward sold out):', 'activity.reason_pool_refund_sold_out'],
       ['Pool refund (reward cost reduced):', 'activity.reason_pool_refund_cost_reduced'],
+      ['Pool refund (reward deleted):', 'activity.reason_pool_refund_deleted'],
       ['Penalty:', 'activity.reason_penalty'],
       ['Bonus:', 'activity.reason_bonus'],
     ];

--- a/custom_components/taskmate/www/taskmate-panel.js
+++ b/custom_components/taskmate/www/taskmate-panel.js
@@ -292,6 +292,7 @@ class TaskMatePanel extends HTMLElement {
       ['Pool refund (reward expired):', 'activity.reason_pool_refund_expired'],
       ['Pool refund (reward sold out):', 'activity.reason_pool_refund_sold_out'],
       ['Pool refund (reward cost reduced):', 'activity.reason_pool_refund_cost_reduced'],
+      ['Pool refund (reward deleted):', 'activity.reason_pool_refund_deleted'],
       ['Penalty:', 'activity.reason_penalty'],
       ['Bonus:', 'activity.reason_bonus'],
     ];

--- a/tests/test_coordinator_rewards.py
+++ b/tests/test_coordinator_rewards.py
@@ -670,3 +670,35 @@ class TestJackpotImpliesPoolMode:
             name="Ice cream", cost=10, is_jackpot=False, pool_enabled=False
         ))
         assert reward.pool_enabled is False
+
+
+# ---------------------------------------------------------------------------
+# async_remove_reward — refund outstanding pool allocations (#564)
+# ---------------------------------------------------------------------------
+
+class TestRemoveRewardRefundsPool:
+    def test_delete_refunds_pool_allocations_to_wallets(self):
+        # Points were deducted at allocation time; deleting the reward must
+        # return each contributor's earmarked points to their wallet (#564).
+        child_a = Child(name="A", points=70, id="A")   # 30 earmarked earlier
+        child_b = Child(name="B", points=46, id="B")   # 25 earmarked earlier
+        reward = Reward(name="Family Trip", cost=800, is_jackpot=True, id="rewardJ")
+        coord = _make_coord(children=[child_a, child_b], rewards=[reward])
+        alloc_a = PoolAllocation(child_id="A", reward_id="rewardJ", allocated_points=30, id="pa1")
+        alloc_b = PoolAllocation(child_id="B", reward_id="rewardJ", allocated_points=25, id="pa2")
+        coord.storage.get_pool_allocations = MagicMock(return_value=[alloc_a, alloc_b])
+
+        run(coord.async_remove_reward("rewardJ"))
+
+        assert child_a.points == 100   # 70 + 30 refunded
+        assert child_b.points == 71    # 46 + 25 refunded
+        assert coord.storage.add_points_transaction.call_count == 2
+        coord.storage.remove_reward.assert_called_once_with("rewardJ")
+
+    def test_delete_with_no_allocations_still_removes(self):
+        reward = Reward(name="Ice cream", cost=10, id="reward1")
+        coord = _make_coord(rewards=[reward])
+        coord.storage.get_pool_allocations = MagicMock(return_value=[])
+        run(coord.async_remove_reward("reward1"))
+        coord.storage.remove_reward.assert_called_once_with("reward1")
+        assert coord.storage.add_points_transaction.call_count == 0


### PR DESCRIPTION
Fixes #564.

## Problem
Deleting a reward dropped its pool allocations **without refunding** the earmarked points. Because points are deducted from a child's wallet at allocation time, deleting the reward silently lost them.

Found while verifying #559 — a child deposited points into a jackpot pool, the reward was deleted, and the points never returned to the wallet.

## Fix
`async_remove_reward` now refunds every outstanding pool allocation via `_refund_all_pool_allocations` **before** the allocations are removed — exactly mirroring the existing **expiry** and **sold-out** refund paths. Each refund credits the contributor's wallet and writes a `Pool refund (reward deleted)` audit transaction.

Adds the `activity.reason_pool_refund_deleted` string in all 8 locales and the reason→key mapping in the activity card and admin panel so it renders localised.

## Testing
- **Unit (test-first):** `TestRemoveRewardRefundsPool` — deleting a jackpot with two contributors refunds both wallets and logs two transactions; the no-allocations case still removes cleanly. Full rewards suite (46 tests) green.
- **End-to-end on dev HA:** deposited into a jackpot pool (wallet `10 → 0`), deleted the reward, wallet returned to `10`. Before the fix those points were lost.