### PR TITLE
feat(activity-card): add show_undo toggle for kid-friendly dashboards (#565)

### DIFF
--- a/custom_components/taskmate/www/locales/de.json
+++ b/custom_components/taskmate/www/locales/de.json
@@ -34,6 +34,8 @@
   "activity.editor.show_relative_time": "Relative time labels",
   "activity.editor.show_filter_chips_helper": "Show the All / Chores / Rewards / Adjustments chip bar below the header",
   "activity.editor.show_filter_chips": "Show filter chips",
+  "activity.editor.show_undo": "Rückgängig-Schaltflächen anzeigen",
+  "activity.editor.show_undo_helper": "Zeigt die Rückgängig-Schaltfläche in jeder Zeile. Für ein kindgerechtes Dashboard deaktivieren, damit Kinder ihre eigene Aktivität nicht rückgängig machen können.",
   "activity.events_count": "{count} Ereignisse",
   "activity.just_now": "just now",
   "activity.hours_ago": "{count}h ago",

--- a/custom_components/taskmate/www/locales/en-GB.json
+++ b/custom_components/taskmate/www/locales/en-GB.json
@@ -34,6 +34,8 @@
   "activity.editor.show_relative_time": "Relative time labels",
   "activity.editor.show_filter_chips_helper": "Show the All / Chores / Rewards / Adjustments chip bar below the header",
   "activity.editor.show_filter_chips": "Show filter chips",
+  "activity.editor.show_undo": "Show undo buttons",
+  "activity.editor.show_undo_helper": "Show the undo button on each row. Turn off for a kid-friendly dashboard so children can't reverse their own activity.",
   "activity.events_count": "{count} events",
   "activity.just_now": "just now",
   "activity.hours_ago": "{count}h ago",

--- a/custom_components/taskmate/www/locales/en.json
+++ b/custom_components/taskmate/www/locales/en.json
@@ -34,6 +34,8 @@
   "activity.editor.show_relative_time": "Relative time labels",
   "activity.editor.show_filter_chips_helper": "Show the All / Chores / Rewards / Adjustments chip bar below the header",
   "activity.editor.show_filter_chips": "Show filter chips",
+  "activity.editor.show_undo": "Show undo buttons",
+  "activity.editor.show_undo_helper": "Show the undo button on each row. Turn off for a kid-friendly dashboard so children can't reverse their own activity.",
   "activity.events_count": "{count} events",
   "activity.just_now": "just now",
   "activity.hours_ago": "{count}h ago",

--- a/custom_components/taskmate/www/locales/fr.json
+++ b/custom_components/taskmate/www/locales/fr.json
@@ -34,6 +34,8 @@
   "activity.editor.show_relative_time": "Relative time labels",
   "activity.editor.show_filter_chips_helper": "Show the All / Chores / Rewards / Adjustments chip bar below the header",
   "activity.editor.show_filter_chips": "Show filter chips",
+  "activity.editor.show_undo": "Afficher les boutons d'annulation",
+  "activity.editor.show_undo_helper": "Affiche le bouton d'annulation sur chaque ligne. Désactivez-le pour un tableau de bord adapté aux enfants, afin qu'ils ne puissent pas annuler leur propre activité.",
   "activity.events_count": "{count} événements",
   "activity.just_now": "just now",
   "activity.hours_ago": "{count}h ago",

--- a/custom_components/taskmate/www/locales/nb.json
+++ b/custom_components/taskmate/www/locales/nb.json
@@ -34,6 +34,8 @@
   "activity.editor.show_relative_time": "Relative time labels",
   "activity.editor.show_filter_chips_helper": "Show the All / Chores / Rewards / Adjustments chip bar below the header",
   "activity.editor.show_filter_chips": "Show filter chips",
+  "activity.editor.show_undo": "Vis angre-knapper",
+  "activity.editor.show_undo_helper": "Viser angre-knappen på hver rad. Slå av for et barnevennlig dashbord slik at barn ikke kan angre sin egen aktivitet.",
   "activity.events_count": "{count} hendelser",
   "activity.just_now": "just now",
   "activity.hours_ago": "{count}h ago",

--- a/custom_components/taskmate/www/locales/nn.json
+++ b/custom_components/taskmate/www/locales/nn.json
@@ -34,6 +34,8 @@
   "activity.editor.show_relative_time": "Relative time labels",
   "activity.editor.show_filter_chips_helper": "Show the All / Chores / Rewards / Adjustments chip bar below the header",
   "activity.editor.show_filter_chips": "Show filter chips",
+  "activity.editor.show_undo": "Vis angre-knappar",
+  "activity.editor.show_undo_helper": "Viser angre-knappen på kvar rad. Slå av for eit barnevenleg dashbord slik at barn ikkje kan angre sin eigen aktivitet.",
   "activity.events_count": "{count} hendingar",
   "activity.just_now": "just now",
   "activity.hours_ago": "{count}h ago",

--- a/custom_components/taskmate/www/locales/pt-BR.json
+++ b/custom_components/taskmate/www/locales/pt-BR.json
@@ -34,6 +34,8 @@
   "activity.editor.show_relative_time": "Relative time labels",
   "activity.editor.show_filter_chips_helper": "Show the All / Chores / Rewards / Adjustments chip bar below the header",
   "activity.editor.show_filter_chips": "Show filter chips",
+  "activity.editor.show_undo": "Mostrar botões de desfazer",
+  "activity.editor.show_undo_helper": "Mostra o botão de desfazer em cada linha. Desative para um painel adequado para crianças, para que elas não possam desfazer a própria atividade.",
   "activity.events_count": "{count} eventos",
   "activity.just_now": "just now",
   "activity.hours_ago": "{count}h ago",

--- a/custom_components/taskmate/www/locales/pt.json
+++ b/custom_components/taskmate/www/locales/pt.json
@@ -34,6 +34,8 @@
   "activity.editor.show_relative_time": "Relative time labels",
   "activity.editor.show_filter_chips_helper": "Show the All / Chores / Rewards / Adjustments chip bar below the header",
   "activity.editor.show_filter_chips": "Show filter chips",
+  "activity.editor.show_undo": "Mostrar botões de desfazer",
+  "activity.editor.show_undo_helper": "Mostra o botão de desfazer em cada linha. Desative para um painel adequado a crianças, para que não possam desfazer a própria atividade.",
   "activity.events_count": "{count} eventos",
   "activity.just_now": "just now",
   "activity.hours_ago": "{count}h ago",

--- a/custom_components/taskmate/www/taskmate-activity-card.js
+++ b/custom_components/taskmate/www/taskmate-activity-card.js
@@ -489,6 +489,7 @@ class TaskMateActivityCard extends LitElement {
       show_filter_chips: true,
       accent_stripes: true,
       show_relative_time: true,
+      show_undo: true,
       ...config,
     };
   }
@@ -812,7 +813,7 @@ class TaskMateActivityCard extends LitElement {
   // ── Undo affordance ──────────────────────────────────────
   // kind: 'chore' (undo an approval → pending) or 'txn' (reverse a points txn).
   _renderUndoButton(kind, id, detail, child, points) {
-    if (!id) return '';
+    if (!id || this.config.show_undo === false) return '';
     const loading = !!this._loading[id];
     const message = kind === 'chore'
       ? this._t('activity.undo_confirm_chore', { detail, child, points })
@@ -951,7 +952,7 @@ class TaskMateActivityCard extends LitElement {
   }
 
   _designUndoBtn(undo, label) {
-    if (!undo || !undo.id) return '';
+    if (!undo || !undo.id || this.config.show_undo === false) return '';
     const loading = !!this._loading[undo.id];
     const message = undo.kind === 'chore'
       ? this._t('activity.undo_confirm_chore', { detail: undo.detail, child: undo.child, points: undo.points })
@@ -1209,6 +1210,7 @@ class TaskMateActivityCardEditor extends LitElement {
       { name: 'show_filter_chips', selector: { boolean: {} } },
       { name: 'accent_stripes', selector: { boolean: {} } },
       { name: 'show_relative_time', selector: { boolean: {} } },
+      { name: 'show_undo', selector: { boolean: {} } },
     ];
   }
 
@@ -1222,6 +1224,7 @@ class TaskMateActivityCardEditor extends LitElement {
       show_filter_chips: this._t('activity.editor.show_filter_chips'),
       accent_stripes: this._t('activity.editor.accent_stripes'),
       show_relative_time: this._t('activity.editor.show_relative_time'),
+      show_undo: this._t('activity.editor.show_undo'),
     };
     return labels[entry.name] ?? entry.name;
   };
@@ -1234,6 +1237,7 @@ class TaskMateActivityCardEditor extends LitElement {
       show_filter_chips: this._t('activity.editor.show_filter_chips_helper'),
       accent_stripes: this._t('activity.editor.accent_stripes_helper'),
       show_relative_time: this._t('activity.editor.show_relative_time_helper'),
+      show_undo: this._t('activity.editor.show_undo_helper'),
     };
     return helpers[entry.name] ?? '';
   };
@@ -1249,6 +1253,7 @@ class TaskMateActivityCardEditor extends LitElement {
       show_filter_chips: this.config.show_filter_chips !== false,
       accent_stripes: this.config.accent_stripes !== false,
       show_relative_time: this.config.show_relative_time !== false,
+      show_undo: this.config.show_undo !== false,
     };
     return html`
       <ha-form


### PR DESCRIPTION
## Summary

Implements #565 — adds a **Show undo buttons** toggle to the activity card so the undo affordance can be hidden on a children's dashboard. The activity card shows kids what they earned, but the undo button let them reverse their own activity; this option removes it while keeping the event history visible.

## Behaviour

- New config option `show_undo` (**boolean, defaults to `true`** — existing dashboards are unchanged).
- When `show_undo: false`, the undo button is hidden from **every** row, across both the classic and design-styled (`playroom`/`console`/`cleanpro`) render paths.
- Events are still listed in full; only the undo control is removed.
- The undo **service** and confirmation dialog are untouched — this purely controls whether the button renders. The backend already guards what is reversible.

## Editor

- Adds a `show_undo` boolean to the card editor with a translated label (“Show undo buttons”) and helper (“Show the undo button on each row. Turn off for a kid-friendly dashboard so children can’t reverse their own activity.”).

## i18n

- New `activity.editor.show_undo` / `_helper` strings added to **all** locales: en, en-GB, de, fr, nb, nn, pt, pt-BR.

## Scope

Activity card only. No backend / service changes.

## Testing

Verified on the live ha-dev instance via browserless:
- Default card → undo ↩ shown on each approved row (pending rows correctly have none).
- `show_undo: false` card → 0 undo buttons, events still listed (asserted programmatically: 2 → 0 undo buttons).
- Card editor → new toggle renders with the localized label + helper.

Closes #565