### PR TITLE
fix(panel): pending-approval counts include swaps; stop banner doubling (#573)

### DIFF
--- a/custom_components/taskmate/www/locales/de.json
+++ b/custom_components/taskmate/www/locales/de.json
@@ -975,6 +975,7 @@
   "panel.topbar_pending": "{count} ausstehend",
   "panel.topbar_pending_title": "{count} ausstehend — klicke zum Überprüfen",
   "panel.topbar_reward_count": "{count} Belohnungseinlösung(en)",
+  "panel.topbar_swap_count": "{count} Tauschanfrage(n)",
   "panel.vis_equals": "Gleich — Zustand stimmt genau überein",
   "panel.vis_gt": "Größer als (>)",
   "panel.vis_gte": "Größer oder gleich (≥)",

--- a/custom_components/taskmate/www/locales/en-GB.json
+++ b/custom_components/taskmate/www/locales/en-GB.json
@@ -1028,6 +1028,7 @@
   "panel.topbar_pending": "{count} pending",
   "panel.topbar_pending_title": "{count} pending — click to review",
   "panel.topbar_reward_count": "{count} reward claim(s)",
+  "panel.topbar_swap_count": "{count} swap request(s)",
   "panel.vis_equals": "Equals — state matches exactly",
   "panel.vis_gt": "Greater than (>)",
   "panel.vis_gte": "Greater than or equal (≥)",

--- a/custom_components/taskmate/www/locales/en.json
+++ b/custom_components/taskmate/www/locales/en.json
@@ -1028,6 +1028,7 @@
   "panel.topbar_pending": "{count} pending",
   "panel.topbar_pending_title": "{count} pending — click to review",
   "panel.topbar_reward_count": "{count} reward claim(s)",
+  "panel.topbar_swap_count": "{count} swap request(s)",
   "panel.vis_equals": "Equals — state matches exactly",
   "panel.vis_gt": "Greater than (>)",
   "panel.vis_gte": "Greater than or equal (≥)",

--- a/custom_components/taskmate/www/locales/fr.json
+++ b/custom_components/taskmate/www/locales/fr.json
@@ -975,6 +975,7 @@
   "panel.topbar_pending": "{count} en attente",
   "panel.topbar_pending_title": "{count} en attente — cliquez pour vérifier",
   "panel.topbar_reward_count": "{count} réclamation(s) de récompense",
+  "panel.topbar_swap_count": "{count} demande(s) d'échange",
   "panel.vis_equals": "Égal — l'état correspond exactement",
   "panel.vis_gt": "Supérieur à (>)",
   "panel.vis_gte": "Supérieur ou égal (≥)",

--- a/custom_components/taskmate/www/locales/nb.json
+++ b/custom_components/taskmate/www/locales/nb.json
@@ -975,6 +975,7 @@
   "panel.topbar_pending": "{count} ventende",
   "panel.topbar_pending_title": "{count} ventende — klikk for å gjennomgå",
   "panel.topbar_reward_count": "{count} belønningsinnløsning(er)",
+  "panel.topbar_swap_count": "{count} bytteforespørsel(er)",
   "panel.vis_equals": "Er lik — tilstand samsvarer nøyaktig",
   "panel.vis_gt": "Større enn (>)",
   "panel.vis_gte": "Større enn eller lik (≥)",

--- a/custom_components/taskmate/www/locales/nn.json
+++ b/custom_components/taskmate/www/locales/nn.json
@@ -975,6 +975,7 @@
   "panel.topbar_pending": "{count} ventande",
   "panel.topbar_pending_title": "{count} ventande — klikk for å gjennomgå",
   "panel.topbar_reward_count": "{count} premiekrav",
+  "panel.topbar_swap_count": "{count} byteførespurnad(er)",
   "panel.vis_equals": "Lik — tilstand samsvarar nøyaktig",
   "panel.vis_gt": "Større enn (>)",
   "panel.vis_gte": "Større enn eller lik (≥)",

--- a/custom_components/taskmate/www/locales/pt-BR.json
+++ b/custom_components/taskmate/www/locales/pt-BR.json
@@ -975,6 +975,7 @@
   "panel.topbar_pending": "{count} pendente(s)",
   "panel.topbar_pending_title": "{count} pendente(s) — clique para revisar",
   "panel.topbar_reward_count": "{count} resgate(s) de recompensa",
+  "panel.topbar_swap_count": "{count} solicitação(ões) de troca",
   "panel.vis_equals": "Igual — estado corresponde exatamente",
   "panel.vis_gt": "Maior que (>)",
   "panel.vis_gte": "Maior ou igual (≥)",

--- a/custom_components/taskmate/www/locales/pt.json
+++ b/custom_components/taskmate/www/locales/pt.json
@@ -980,6 +980,7 @@
   "panel.topbar_pending": "{count} pendente(s)",
   "panel.topbar_pending_title": "{count} pendente(s) — clique para rever",
   "panel.topbar_reward_count": "{count} reclamação(ões) de recompensa",
+  "panel.topbar_swap_count": "{count} pedido(s) de troca",
   "panel.vis_equals": "Igual — estado corresponde exatamente",
   "panel.vis_gt": "Maior que (>)",
   "panel.vis_gte": "Maior ou igual (≥)",

--- a/custom_components/taskmate/www/taskmate-panel.js
+++ b/custom_components/taskmate/www/taskmate-panel.js
@@ -2131,7 +2131,7 @@ class TaskMatePanel extends HTMLElement {
   _sidebarGroups() {
     const counts = this._state ? {
       children:  (this._state.children || []).length,
-      activity:  (this._state.pending_completions || []).length + (this._state.pending_reward_claims || []).length,
+      activity:  (this._state.pending_completions || []).length + (this._state.pending_reward_claims || []).length + (this._state.swap_requests || []).length,
       chores:    (this._state.chores || []).length,
       rewards:   (this._state.rewards || []).length,
       penalties: (this._state.penalties || []).length,
@@ -2208,7 +2208,7 @@ class TaskMatePanel extends HTMLElement {
       .find(i => i.id === this._activeTab);
     const crumbLabel = crumb ? crumb.label : "";
     const pendingCount = this._state
-      ? (this._state.pending_completions || []).length + (this._state.pending_reward_claims || []).length
+      ? (this._state.pending_completions || []).length + (this._state.pending_reward_claims || []).length + (this._state.swap_requests || []).length
       : 0;
     return `
       <div class="tm-topbar">
@@ -2253,11 +2253,15 @@ class TaskMatePanel extends HTMLElement {
     if (this._activeTab === "activity") return "";
     const completionsP = (this._state.pending_completions || []).length;
     const rewardsP     = (this._state.pending_reward_claims || []).length;
-    const total = completionsP + rewardsP;
+    const swapsP       = (this._state.swap_requests || []).length;
+    const total = completionsP + rewardsP + swapsP;
     if (total === 0) return "";
     const parts = [];
-    if (completionsP) parts.push(`<strong>${completionsP}</strong> ${this._t("panel.topbar_chore_count", {count: completionsP})}`);
-    if (rewardsP)     parts.push(`<strong>${rewardsP}</strong> ${this._t("panel.topbar_reward_count", {count: rewardsP})}`);
+    // The count strings already include {count}; pass it bolded so the number
+    // renders once (not duplicated by a separate <strong> prefix — issue #573).
+    if (completionsP) parts.push(this._t("panel.topbar_chore_count", {count: `<strong>${completionsP}</strong>`}));
+    if (rewardsP)     parts.push(this._t("panel.topbar_reward_count", {count: `<strong>${rewardsP}</strong>`}));
+    if (swapsP)       parts.push(this._t("panel.topbar_swap_count", {count: `<strong>${swapsP}</strong>`}));
     return `
       <div class="tm-approval-banner">
         <ha-icon icon="mdi:bell-ring-outline"></ha-icon>


### PR DESCRIPTION
## Summary

Fixes #573 — the pending-approval counts in the admin panel were inconsistent, and the banner printed each number twice.

## Root cause

- **Sidebar "Activity" badge** and the **top-bar "X pending" pill** summed only `pending_completions + pending_reward_claims`, ignoring `swap_requests`. The **Pending approvals** list *does* count swaps, so the badge under-counted (e.g. badge **2** vs list **3** when a swap was waiting).
- The **"Awaiting your approval" banner** rendered `2 2 chore(s) · 1 1 reward claim(s)`: it prepended `<strong>{n}</strong>` *and* used the `topbar_chore_count` / `topbar_reward_count` strings which already contain `{count}`.

## Fix

- All three surfaces (sidebar badge, top-bar pill, banner total) now count **completions + reward claims + swap requests**, matching the Pending approvals list.
- The banner passes the count **bolded into** the translation (`{count}` → `<strong>n</strong>`) so the number renders once, and gains a swap-request part via a new `panel.topbar_swap_count` string — translated into all 8 locales (en, en-GB, de, fr, nb, nn, pt, pt-BR).

## Testing

Verified on the live ha-dev panel via browserless with a known state (2 completions + 1 reward claim + 1 swap):
- Sidebar badge → **4**
- Top-bar pill → **4 pending**
- Banner → `Awaiting your approval — 2 chore(s) · 1 reward claim(s) · 1 swap request(s)` (each number once, bolded)

Closes #573