### PR TITLE
ci: attach taskmate.zip asset to releases for HACS zip_release

### DIFF
--- a/.github/workflows/release-zip.yml
+++ b/.github/workflows/release-zip.yml
@@ -1,0 +1,38 @@
+name: Attach HACS zip to release
+
+# Builds taskmate.zip from custom_components/taskmate/ and attaches it to the
+# GitHub release. HACS uses this asset when hacs.json has "zip_release": true
+# and "filename": "taskmate.zip" — and the asset's download_count is what HACS
+# shows as the integration's download number.
+#
+# The zip's root must contain manifest.json directly: HACS extracts the archive
+# straight into custom_components/taskmate/.
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  attach-zip:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6 2026-06-17
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Build taskmate.zip
+        run: |
+          cd custom_components/taskmate
+          zip -r -X "$GITHUB_WORKSPACE/taskmate.zip" . \
+            -x '*/__pycache__/*' '__pycache__/*' '*.pyc'
+          cd "$GITHUB_WORKSPACE"
+          echo "--- zip contents (top level) ---"
+          unzip -l taskmate.zip | grep -E 'manifest.json' || (echo "manifest.json missing from zip root" && exit 1)
+
+      - name: Upload taskmate.zip to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload "${{ github.event.release.tag_name }}" taskmate.zip --clobber --repo "${{ github.repository }}"


### PR DESCRIPTION
## What

Adds a CI workflow (`release-zip.yml`) that builds `taskmate.zip` from `custom_components/taskmate/` and attaches it to every published GitHub release.

The zip is rooted at the integration files (manifest.json at the archive root), with `__pycache__/` and `*.pyc` excluded — the exact layout HACS expects to extract into `custom_components/taskmate/`.

## Why

The README downloads badge and the HACS store both read **release asset `download_count`** from the GitHub API. TaskMate ships source-only releases (0 attached assets), so both show **0** and always will — HACS installs via file-by-file fetch, which never increments any counter.

This workflow is **step 1** of switching to asset-based distribution so installs become countable.

## Rollout (do NOT flip hacs.json yet)

`hacs.json` `zip_release` is read from the **default branch** and governs how HACS installs **every** version. Flipping it before a release carries the asset would make HACS try to download `taskmate.zip` from the current latest (v4.3.0, no asset) and **break installs for everyone**.

Safe order:
1. Merge this (additive, no behavior change).
2. Cut a pre-release → this workflow attaches `taskmate.zip` → test the HACS install path on ha-dev.
3. Only then flip `hacs.json` to `zip_release: true` + `filename: taskmate.zip`.

## Verified

Built the zip locally with the same exclusions: 84 files, `manifest.json` at root, `www/taskmate-panel.js` present, no `__pycache__`/`.pyc`, ~1 MB.