### PR TITLE
chore: bump version to 4.3.1-beta.1

### DIFF
--- a/custom_components/taskmate/manifest.json
+++ b/custom_components/taskmate/manifest.json
@@ -17,5 +17,5 @@
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/tempus2016/taskmate/issues",
   "requirements": [],
-  "version": "4.3.0"
+  "version": "4.3.1-beta.1"
 }


### PR DESCRIPTION
Bumps manifest to `4.3.1-beta.1` to cut the first pre-release. Pre-release exercises the new `release-zip.yml` (attaches `taskmate.zip`) and bundles the #573 pending-approval count fix + #575 icon trim for an end-to-end HACS install test on ha-dev before stable v4.3.1.