### PR TITLE
chore: bump version to 4.3.1

### DIFF
--- a/custom_components/taskmate/manifest.json
+++ b/custom_components/taskmate/manifest.json
@@ -17,5 +17,5 @@
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/tempus2016/taskmate/issues",
   "requirements": [],
-  "version": "4.3.1-beta.1"
+  "version": "4.3.1"
 }


### PR DESCRIPTION
Bumps manifest to `4.3.1` for the stable release. Promotes the contents of `v4.3.1-beta.1` (validated on ha-dev): #573 pending-approval count fix, #575 icon trim, and the first releases to carry a `taskmate.zip` asset. `hacs.json` zip_release flip follows in a separate PR after the v4.3.1 release is live with its asset (avoids breaking installs).