### PR TITLE
feat(hacs): distribute via taskmate.zip release asset

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,7 @@
 {
   "name": "TaskMate",
   "homeassistant": "2024.1.0",
-  "render_readme": true
+  "render_readme": true,
+  "zip_release": true,
+  "filename": "taskmate.zip"
 }


### PR DESCRIPTION
Flips `hacs.json` to `"zip_release": true` + `"filename": "taskmate.zip"`.

Now that **v4.3.1** (latest release) carries a `taskmate.zip` asset, HACS will install via the asset and surface its `download_count` — the download counter starts moving instead of being stuck at 0.

This is deliberately a **separate PR after** the v4.3.1 release: HACS reads `hacs.json` from the default branch and `zip_release` governs install of every version, so flipping it before a live release had the asset would have broken installs for everyone. The latest release now has the asset, so there is no breakage window.

Verified the published `v4.3.1` asset: `manifest.json` at zip root, version `4.3.1`, `www/` + `translations/` + `brand/` present, no `__pycache__`/`.pyc`, zip integrity OK.