### PR TITLE
fix(security): reject foreign photo_url in complete_chore

### DIFF
--- a/custom_components/taskmate/coord_chores.py
+++ b/custom_components/taskmate/coord_chores.py
@@ -499,6 +499,19 @@ class ChoresMixin:
         if not child:
             raise ValueError(f"Child {child_id} not found")
 
+        # Security: photo_url must be one of OUR upload URLs
+        # (/api/taskmate/photo/<uuid>.<ext>). The service accepts it as a free
+        # string, so reject foreign/crafted values (e.g. "javascript:..." or an
+        # external https URL) before they are stored and later rendered into an
+        # href/src in the parent's approval views. An invalid value is dropped to
+        # "" — which also means it can't satisfy a require_photo chore below.
+        if photo_url and not photos.is_taskmate_photo_url(photo_url):
+            _LOGGER.warning(
+                "Ignoring invalid photo_url for chore %s (not a TaskMate photo URL)",
+                chore_id,
+            )
+            photo_url = ""
+
         now = dt_util.now()
         today = dt_util.as_local(now).date()
 

--- a/custom_components/taskmate/photos.py
+++ b/custom_components/taskmate/photos.py
@@ -67,6 +67,22 @@ def photos_path(hass) -> Path:
     return Path(hass.config.path(PHOTOS_DIR))
 
 
+def is_taskmate_photo_url(photo_url: str) -> bool:
+    """True only for a well-formed ``/api/taskmate/photo/<name>`` URL of ours.
+
+    Pure (no hass / no filesystem) so it can guard untrusted ``photo_url`` input
+    at the service/coordinator boundary. Rejects blanks, foreign URLs and any
+    dangerous scheme (``javascript:``, external ``http(s):``) and anything whose
+    name fails the strict filename pattern.
+    """
+    if not photo_url:
+        return False
+    prefix = URL_PREFIX + "/"
+    if not photo_url.startswith(prefix):
+        return False
+    return bool(FILENAME_RE.match(photo_url[len(prefix):]))
+
+
 def photo_file_for_url(hass, photo_url: str) -> Path | None:
     """Map a ``/api/taskmate/photo/<name>`` URL to its file path.
 

--- a/custom_components/taskmate/www/taskmate-approvals-card.js
+++ b/custom_components/taskmate/www/taskmate-approvals-card.js
@@ -10,6 +10,13 @@ const LitElement = customElements.get("hui-masonry-view")
 const html = LitElement.prototype.html;
 const css = LitElement.prototype.css;
 
+// Security defense-in-depth: only ever emit our own auth-gated photo endpoint
+// into an href/src. The backend already rejects foreign/crafted photo_url
+// values, but guard here too so a stored bad value can never become a
+// javascript:/external link in a parent's browser.
+const tmSafePhotoUrl = (u) =>
+  typeof u === "string" && u.startsWith("/api/taskmate/photo/") ? u : "";
+
 class TaskMateApprovalsCard extends LitElement {
   static get properties() {
     return {
@@ -744,13 +751,14 @@ class TaskMateApprovalsCard extends LitElement {
   }
 
   _apPhotoDesigned(it, cls, fallback) {
-    if (it.kind !== "completion" || !it.photo) {
+    const photoUrl = tmSafePhotoUrl(it.photo);
+    if (it.kind !== "completion" || !photoUrl) {
       return it.kind === "claim" && it.icon
         ? html`<div class="${cls}"><ha-icon icon="${it.icon}"></ha-icon></div>`
         : "";
     }
-    return html`<a class="ap-d-photo-link" href="${it.photo}" target="_blank" rel="noopener"
-      title="${this._t('approvals.view_photo') || 'View photo'}"><div class="${cls}"><img src="${it.photo}" alt=""></div></a>`;
+    return html`<a class="ap-d-photo-link" href="${photoUrl}" target="_blank" rel="noopener"
+      title="${this._t('approvals.view_photo') || 'View photo'}"><div class="${cls}"><img src="${photoUrl}" alt=""></div></a>`;
   }
 
   _apPlayroom(it, i) {
@@ -1250,10 +1258,10 @@ class TaskMateApprovalsCard extends LitElement {
               ${completion.points}
             </span>
           </div>
-          ${completion.photo_url ? html`
-            <a class="approval-photo" href="${completion.photo_url}" target="_blank" rel="noopener"
+          ${tmSafePhotoUrl(completion.photo_url) ? html`
+            <a class="approval-photo" href="${tmSafePhotoUrl(completion.photo_url)}" target="_blank" rel="noopener"
                title="${this._t('approvals.view_photo') || 'View photo'}">
-              <img src="${completion.photo_url}" alt="" loading="lazy">
+              <img src="${tmSafePhotoUrl(completion.photo_url)}" alt="" loading="lazy">
             </a>
           ` : ''}
         </div>

--- a/custom_components/taskmate/www/taskmate-panel.js
+++ b/custom_components/taskmate/www/taskmate-panel.js
@@ -2435,7 +2435,7 @@ class TaskMatePanel extends HTMLElement {
               return `
                 <div class="tm-approval-item">
                   <div class="tm-approval-icon"><ha-icon icon="${c.bonus_subtask_id ? 'mdi:star-plus' : 'mdi:checkbox-marked-circle-outline'}"></ha-icon></div>
-                  ${c.photo_url ? `<a class="tm-approval-photo" href="${this._esc(c.photo_url)}" target="_blank" rel="noopener" title="${this._t("panel.activity_view_photo")}"><img src="${this._esc(c.photo_url)}" alt="" loading="lazy"></a>` : ""}
+                  ${this._safePhotoUrl(c.photo_url) ? `<a class="tm-approval-photo" href="${this._esc(this._safePhotoUrl(c.photo_url))}" target="_blank" rel="noopener" title="${this._t("panel.activity_view_photo")}"><img src="${this._esc(this._safePhotoUrl(c.photo_url))}" alt="" loading="lazy"></a>` : ""}
                   <div class="tm-approval-body">
                     <div class="tm-approval-line">${this._t("panel.activity_completed_text", {child: this._esc((child && child.name) || "?"), chore: this._esc(choreName)})}</div>
                     <div class="tm-meta">${this._timeAgo(c.completed_at)} · ${chorePoints} ${this._t("panel.activity_points")}</div>
@@ -4937,6 +4937,14 @@ class TaskMatePanel extends HTMLElement {
     return String(str == null ? "" : str)
       .replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
       .replace(/"/g, "&quot;").replace(/'/g, "&#39;");
+  }
+
+  // Security defense-in-depth: only ever emit our own auth-gated photo endpoint
+  // into an href/src. _esc() escapes HTML metacharacters but does NOT neutralize
+  // a javascript:/external scheme, so guard the URL itself. Signed URLs keep the
+  // /api/taskmate/photo/ prefix (the ?authSig= is appended), so they still pass.
+  _safePhotoUrl(u) {
+    return typeof u === "string" && u.startsWith("/api/taskmate/photo/") ? u : "";
   }
 
   _fmtNum(n) {

--- a/custom_components/taskmate/www/taskmate-parent-dashboard-card.js
+++ b/custom_components/taskmate/www/taskmate-parent-dashboard-card.js
@@ -12,6 +12,13 @@ const LitElement = customElements.get("hui-masonry-view")
 const html = LitElement.prototype.html;
 const css = LitElement.prototype.css;
 
+// Security defense-in-depth: only ever emit our own auth-gated photo endpoint
+// into an href/src. The backend already rejects foreign/crafted photo_url
+// values, but guard here too so a stored bad value can never become a
+// javascript:/external link in a parent's browser.
+const tmSafePhotoUrl = (u) =>
+  typeof u === "string" && u.startsWith("/api/taskmate/photo/") ? u : "";
+
 class TaskMateParentDashboardCard extends LitElement {
   static get properties() {
     return {
@@ -780,9 +787,10 @@ class TaskMateParentDashboardCard extends LitElement {
       const time = comp.completed_at
         ? new Date(comp.completed_at).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" }) : "";
       const pts = comp.points || choreMap[comp.chore_id]?.points || 0;
-      const photo = comp.photo_url
-        ? html`<a class="pd-photo-link" href="${comp.photo_url}" target="_blank" rel="noopener"
-            title="${this._t('approvals.view_photo') || 'View photo'}"><div class="pd-photo"><img src="${comp.photo_url}" alt=""></div></a>`
+      const photoUrl = tmSafePhotoUrl(comp.photo_url);
+      const photo = photoUrl
+        ? html`<a class="pd-photo-link" href="${photoUrl}" target="_blank" rel="noopener"
+            title="${this._t('approvals.view_photo') || 'View photo'}"><div class="pd-photo"><img src="${photoUrl}" alt=""></div></a>`
         : "";
       const acts = html`
         <button class="btn good sm round" ?disabled="${isLoading}" title="${this._t('common.approve')}"
@@ -1110,10 +1118,10 @@ class TaskMateParentDashboardCard extends LitElement {
                   +${comp.points || chore?.points || 0}
                 </span>
               </div>
-              ${comp.photo_url ? html`
-                <a class="approval-photo" href="${comp.photo_url}" target="_blank" rel="noopener"
+              ${tmSafePhotoUrl(comp.photo_url) ? html`
+                <a class="approval-photo" href="${tmSafePhotoUrl(comp.photo_url)}" target="_blank" rel="noopener"
                    title="${this._t('approvals.view_photo') || 'View photo'}">
-                  <img src="${comp.photo_url}" alt="" loading="lazy">
+                  <img src="${tmSafePhotoUrl(comp.photo_url)}" alt="" loading="lazy">
                 </a>
               ` : ''}
             </div>

--- a/tests/test_photo_proof.py
+++ b/tests/test_photo_proof.py
@@ -54,11 +54,12 @@ def test_photo_required_forces_pending_even_if_no_approval():
                   assignment_mode="everyone", id="ch1")
     child = Child(name="Mia", id="c1")
     coord = _coord(chore, child)
-    run(coord.async_complete_chore("ch1", "c1", photo_url="http://x/p.jpg"))
+    photo = "/api/taskmate/photo/" + "a" * 32 + ".jpg"
+    run(coord.async_complete_chore("ch1", "c1", photo_url=photo))
     comp = coord._added[0]
     assert comp.approved is False
     assert comp.points_awarded == 0
-    assert comp.photo_url == "http://x/p.jpg"
+    assert comp.photo_url == photo
     coord._award_points.assert_not_awaited()
 
 
@@ -66,8 +67,9 @@ def test_photo_stored_on_completion():
     chore = Chore(name="Room", requires_approval=True, require_photo=True,
                   assignment_mode="everyone", id="ch1")
     coord = _coord(chore, Child(name="Mia", id="c1"))
-    run(coord.async_complete_chore("ch1", "c1", photo_url="http://x/snap.png"))
-    assert coord._added[0].photo_url == "http://x/snap.png"
+    photo = "/api/taskmate/photo/" + "b" * 32 + ".png"
+    run(coord.async_complete_chore("ch1", "c1", photo_url=photo))
+    assert coord._added[0].photo_url == photo
 
 
 def test_photo_required_blocks_completion_without_photo():
@@ -88,6 +90,34 @@ def test_photo_required_blocks_blank_photo():
     coord = _coord(chore, Child(name="Mia", id="c1"))
     with pytest.raises(ValueError):
         run(coord.async_complete_chore("ch1", "c1", photo_url="   "))
+    assert coord._added == []
+
+
+def test_foreign_photo_url_is_rejected_not_stored():
+    # Security: a crafted/foreign photo_url (javascript:, external https, traversal)
+    # must never be stored — it would later render into an href/src in the parent's
+    # approval views. The coordinator drops it to "" at the boundary. With an
+    # approval-required (non-photo) chore the completion still proceeds, but with no
+    # photo attached.
+    chore = Chore(name="Room", requires_approval=True, require_photo=False,
+                  assignment_mode="everyone", id="ch1")
+    coord = _coord(chore, Child(name="Mia", id="c1"))
+    for bad in ("javascript:alert(1)",
+                "https://evil.example/track.png",
+                "/api/taskmate/photo/../../etc/passwd"):
+        coord._added.clear()
+        run(coord.async_complete_chore("ch1", "c1", photo_url=bad))
+        assert coord._added[0].photo_url == ""
+
+
+def test_foreign_photo_url_does_not_satisfy_require_photo():
+    # A crafted photo_url must not satisfy a require_photo chore — once dropped to
+    # "", the require_photo guard fires exactly as if no photo were sent.
+    chore = Chore(name="Room", requires_approval=False, require_photo=True,
+                  assignment_mode="everyone", id="ch1")
+    coord = _coord(chore, Child(name="Mia", id="c1"))
+    with pytest.raises(ValueError):
+        run(coord.async_complete_chore("ch1", "c1", photo_url="javascript:alert(1)"))
     assert coord._added == []
 
 


### PR DESCRIPTION
Closes #582.

Adversarial security review (security-reviewer agent, full-integration scope) surfaced one Medium **stored content-injection** issue. This PR fixes it.

## Problem
`taskmate.complete_chore` accepted `photo_url` as a free-form string, stored it verbatim on the completion, and the approval views rendered it straight into an `href`/`src`. In the default config any authenticated non-admin can complete a chore for an unlinked child, so they could inject `javascript:…` (runs in the reviewing parent's session on click) or an external `https://…` (silent IP/referrer leak via auto-loaded `<img>`). HTML-escaping does not neutralize a dangerous URL scheme/host.

## Fix
- **Backend (primary):** `photos.is_taskmate_photo_url()` — pure validator accepting only `/api/taskmate/photo/<32-hex>.<jpg|png|webp|heic>`. `async_complete_chore` now drops any other value to `""` at the boundary (the single chokepoint for the service, per-chore button entity, automations and Dev Tools), placed before the `require_photo` check so a crafted URL can't satisfy it either.
- **Frontend defense-in-depth:** `tmSafePhotoUrl`/`_safePhotoUrl` (`startsWith('/api/taskmate/photo/'`) at all five render sinks — approvals card ×3 (incl. the designed layout the review missed), parent-dashboard ×2, panel ×1. `startsWith` keeps signed `?authSig=` URLs working.
- **Tests:** existing photo tests updated to realistic URLs + 2 new regression tests (foreign URL stripped; crafted URL does not satisfy `require_photo`).

## Verification
- Ruff clean; pytest no new failures vs `main` baseline; `node --check` clean on all edited JS.
- **Live (dev HA):** `complete_chore` → `taskmate/get_state` — `javascript:` → `""`, external `https://` → `""`, valid taskmate URL preserved (+signed on read).
- **Live (browserless headless render of the real approvals card):** valid completion → safe `/api/taskmate/photo/…` link; stripped completion → no photo link; **zero** `javascript:`/external links in the shadow DOM; no JS errors.