### PR TITLE
fix(security): sanitize header_color before CSS interpolation (SEC-1)

### DIFF
--- a/custom_components/taskmate/www/taskmate-approvals-card.js
+++ b/custom_components/taskmate/www/taskmate-approvals-card.js
@@ -17,6 +17,8 @@ const css = LitElement.prototype.css;
 const tmSafePhotoUrl = (u) =>
   typeof u === "string" && u.startsWith("/api/taskmate/photo/") ? u : "";
 
+const _safeColor = (c, d) => (typeof c === "string" && /^#[0-9a-fA-F]{3,8}$/.test(c) ? c : d);
+
 class TaskMateApprovalsCard extends LitElement {
   static get properties() {
     return {
@@ -504,7 +506,7 @@ class TaskMateApprovalsCard extends LitElement {
 
     return html`
       <ha-card>
-        <style>:host { --taskmate-header-bg: ${this.config.header_color || '#27ae60'}; }</style>
+        <style>:host { --taskmate-header-bg: ${_safeColor(this.config.header_color, '#27ae60')}; }</style>
         <div class="card-header">
           <div class="header-left">
             <ha-icon class="header-icon" icon="mdi:check-circle-outline"></ha-icon>
@@ -652,7 +654,7 @@ class TaskMateApprovalsCard extends LitElement {
 
   _renderDesigned(design) {
     const entity = this.hass.states[this.config.entity];
-    const hd = this.config.header_color || '#27ae60';
+    const hd = _safeColor(this.config.header_color, '#27ae60');
 
     if (!entity) {
       return html`<ha-card class="tmd" style="--hd:${hd}">

--- a/custom_components/taskmate/www/taskmate-badges-card.js
+++ b/custom_components/taskmate/www/taskmate-badges-card.js
@@ -20,6 +20,8 @@ const css = LitElement.prototype.css;
 
 const DESIGN_HEADER = "#6c5ce7";
 
+const _safeColor = (c, d) => (typeof c === "string" && /^#[0-9a-fA-F]{3,8}$/.test(c) ? c : d);
+
 class TaskMateBadgesCard extends LitElement {
   static get properties() {
     return {
@@ -653,7 +655,7 @@ TaskMateBadgesCard.prototype._designLockedTile = function (b) {
 };
 
 TaskMateBadgesCard.prototype._renderDesigned = function (design, d) {
-  const hd = this.config.header_color || DESIGN_HEADER;
+  const hd = _safeColor(this.config.header_color, DESIGN_HEADER);
   const ic = design === "console" ? "✦" : design === "cleanpro" ? "◈" : "🎖️";
   const sub = d.childName;
   const countPill = this._t("badges.count_label", { earned: d.earned.length, total: d.totalBadges });

--- a/custom_components/taskmate/www/taskmate-child-card.js
+++ b/custom_components/taskmate/www/taskmate-child-card.js
@@ -23,6 +23,8 @@ const LitElement = customElements.get("hui-masonry-view")
 const html = LitElement.prototype.html;
 const css = LitElement.prototype.css;
 
+const _safeColor = (c, d) => (typeof c === "string" && /^#[0-9a-fA-F]{3,8}$/.test(c) ? c : d);
+
 class TaskMateChildCard extends LitElement {
   static get properties() {
     return {
@@ -2001,7 +2003,7 @@ class TaskMateChildCard extends LitElement {
 
     return html`
       <ha-card>
-        <style>:host { --taskmate-header-bg: ${this.config.header_color || '#9b59b6'}; }</style>
+        <style>:host { --taskmate-header-bg: ${_safeColor(this.config.header_color, '#9b59b6')}; }</style>
         <div class="card-header">
           <div class="header-left">
             ${(() => {
@@ -2208,7 +2210,7 @@ class TaskMateChildCard extends LitElement {
 
   _renderDesigned(design) {
     const entity = this.hass.states[this.config.entity];
-    const hd = this.config.header_color || "#ff7043";
+    const hd = _safeColor(this.config.header_color, "#ff7043");
 
     const header = (title, sub, pill) => html`
       <div class="tmd-hd">

--- a/custom_components/taskmate/www/taskmate-parent-dashboard-card.js
+++ b/custom_components/taskmate/www/taskmate-parent-dashboard-card.js
@@ -19,6 +19,8 @@ const css = LitElement.prototype.css;
 const tmSafePhotoUrl = (u) =>
   typeof u === "string" && u.startsWith("/api/taskmate/photo/") ? u : "";
 
+const _safeColor = (c, d) => (typeof c === "string" && /^#[0-9a-fA-F]{3,8}$/.test(c) ? c : d);
+
 class TaskMateParentDashboardCard extends LitElement {
   static get properties() {
     return {
@@ -522,7 +524,7 @@ class TaskMateParentDashboardCard extends LitElement {
 
     return html`
       <ha-card>
-        <style>:host { --taskmate-header-bg: ${this.config.header_color || '#c0392b'}; }</style>
+        <style>:host { --taskmate-header-bg: ${_safeColor(this.config.header_color, '#c0392b')}; }</style>
         <div class="card-header">
           <div class="header-content">
             <ha-icon class="header-icon" icon="mdi:shield-account"></ha-icon>
@@ -612,7 +614,7 @@ class TaskMateParentDashboardCard extends LitElement {
   }
 
   _renderDesigned(design) {
-    const hd = this.config.header_color || '#c0392b';
+    const hd = _safeColor(this.config.header_color, '#c0392b');
     const entity = this.hass.states[this.config.entity];
 
     if (!entity) {

--- a/custom_components/taskmate/www/taskmate-points-card.js
+++ b/custom_components/taskmate/www/taskmate-points-card.js
@@ -13,6 +13,8 @@ const css = LitElement.prototype.css;
 
 const DESIGN_HEADER = "#8e44ad";
 
+const _safeColor = (c, d) => (typeof c === "string" && /^#[0-9a-fA-F]{3,8}$/.test(c) ? c : d);
+
 class TaskMatePointsCard extends LitElement {
   static get properties() {
     return {
@@ -729,8 +731,9 @@ class TaskMatePointsCard extends LitElement {
       return this._renderDesigned(design, children, pointsName, pointsIcon);
     }
 
-    const headerStyle = this.config.header_color
-      ? `--taskmate-header-bg: ${this.config.header_color};`
+    const _hc = _safeColor(this.config.header_color, '');
+    const headerStyle = _hc
+      ? `--taskmate-header-bg: ${_hc};`
       : '';
 
     return html`
@@ -794,7 +797,7 @@ class TaskMatePointsCard extends LitElement {
   }
 
   _renderDesigned(design, children, pointsName, pointsIcon) {
-    const hd = this.config.header_color || DESIGN_HEADER;
+    const hd = _safeColor(this.config.header_color, DESIGN_HEADER);
 
     const header = design === "console"
       ? html`<div class="tmd-hd">

--- a/custom_components/taskmate/www/taskmate-points-display-card.js
+++ b/custom_components/taskmate/www/taskmate-points-display-card.js
@@ -79,6 +79,8 @@ function childAvatar(child, colour) {
 
 /* ─── Main card ────────────────────────────────────────────────────────── */
 
+const _safeColor = (c, d) => (typeof c === "string" && /^#[0-9a-fA-F]{3,8}$/.test(c) ? c : d);
+
 class TaskMatePointsDisplayCard extends LitElement {
 
   static get properties() {
@@ -622,7 +624,7 @@ class TaskMatePointsDisplayCard extends LitElement {
   /* ── Render helpers ─────────────────────────────────────────────────── */
 
   _headerStyle() {
-    return `background: ${this.config.header_color || DEFAULT_HEADER};`;
+    return `background: ${_safeColor(this.config.header_color, DEFAULT_HEADER)};`;
   }
 
   _defaultTitle() {
@@ -770,7 +772,7 @@ class TaskMatePointsDisplayCard extends LitElement {
       <div class="cumulative-wrap">
         <div class="cumulative-total">
           <div class="points-label">${this._t("points_display.combined_family_total")}</div>
-          <div class="points-number" style="color:${this.config.header_color || DEFAULT_HEADER}">
+          <div class="points-number" style="color:${_safeColor(this.config.header_color, DEFAULT_HEADER)}">
             <span class="points-star">\u{1F31F}</span>${total.toLocaleString()}
           </div>
           <div class="secondary-info">
@@ -870,7 +872,7 @@ class TaskMatePointsDisplayCard extends LitElement {
   _renderDesigned(design) {
     const mode  = this.config.mode || "single";
     const title = this.config.title || this._defaultTitle();
-    const hd    = this.config.header_color || DEFAULT_HEADER;
+    const hd    = _safeColor(this.config.header_color, DEFAULT_HEADER);
     const tz    = this.hass?.config?.time_zone || Intl.DateTimeFormat().resolvedOptions().timeZone;
 
     let ranked = this._rankedChildren();

--- a/custom_components/taskmate/www/taskmate-rewards-card.js
+++ b/custom_components/taskmate/www/taskmate-rewards-card.js
@@ -15,6 +15,8 @@ const LitElement = customElements.get("hui-masonry-view")
 const html = LitElement.prototype.html;
 const css = LitElement.prototype.css;
 
+const _safeColor = (c, d) => (typeof c === "string" && /^#[0-9a-fA-F]{3,8}$/.test(c) ? c : d);
+
 class TaskMateRewardsCard extends LitElement {
   static get properties() {
     return {
@@ -1182,7 +1184,7 @@ class TaskMateRewardsCard extends LitElement {
 
     return html`
       <ha-card>
-        <style>:host { --taskmate-header-bg: ${this.config.header_color || '#e67e22'}; }</style>
+        <style>:host { --taskmate-header-bg: ${_safeColor(this.config.header_color, '#e67e22')}; }</style>
         <div class="card-header">
           <div class="header-content">
             <ha-icon class="header-icon" icon="mdi:gift-outline"></ha-icon>
@@ -1914,7 +1916,7 @@ class TaskMateRewardsCard extends LitElement {
 
   _renderDesigned(design) {
     const entity = this.hass.states[this.config.entity];
-    const hd = this.config.header_color || '#e67e22';
+    const hd = _safeColor(this.config.header_color, '#e67e22');
 
     if (!entity) {
       return html`<ha-card class="tmd" style="--hd:${hd}">


### PR DESCRIPTION
## SEC-1 — CSS injection via unescaped `header_color`

Lit does **not** escape interpolation inside `<style>` blocks, so a Lovelace card-config `header_color` such as `red} :host{display:none} x{a:url(//evil)` could inject arbitrary CSS (content hiding / button-overlay spoofing / outbound `url()` exfil).

The `_safeColor(c, d)` helper (`/^#[0-9a-fA-F]{3,8}$/`) already protected the other 11 cards. This applies it to the 7 that interpolated `header_color` raw:

- `taskmate-approvals-card.js`
- `taskmate-parent-dashboard-card.js`
- `taskmate-rewards-card.js`
- `taskmate-child-card.js`
- `taskmate-points-card.js`
- `taskmate-badges-card.js`
- `taskmate-points-display-card.js`

### Testing
- ES-module syntax check passes on all 7.
- Verified on the **ha-dev** instance via browserless: all 7 modules register with **zero console errors**, and a malicious `header_color` now falls back to the default (card stays `display:block`, fully visible — no breakout).

From the v4.3.1 codebase audit (AUDIT_REPORT.md §3.1).