### PR TITLE
fix(points): reverse streak-milestone bonuses on reject/undo (ERR-1)

### DIFF
--- a/custom_components/taskmate/coord_chores.py
+++ b/custom_components/taskmate/coord_chores.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 from homeassistant.util import dt as dt_util
 
 from . import photos
-from .models import Chore, ChoreCompletion
+from .models import Chore, ChoreCompletion, PointsTransaction
 
 if TYPE_CHECKING:
     pass
@@ -922,6 +922,44 @@ class ChoresMixin:
                             ]
                             child.last_completion_date = (
                                 max(remaining).isoformat() if remaining else None
+                            )
+                        # Reverse any streak milestones this completion unlocked.
+                        # Milestone bonuses are logged as separate transactions
+                        # (not part of points_awarded), so dropping the streak
+                        # below a previously-achieved milestone must refund it.
+                        achieved = list(child.streak_milestones_achieved or [])
+                        lost = [d for d in achieved if d > child.current_streak]
+                        if lost:
+                            try:
+                                milestones = self.parse_milestone_setting(
+                                    self.storage.get_setting(
+                                        "streak_milestones", self.DEFAULT_STREAK_MILESTONES
+                                    )
+                                )
+                            except ValueError:
+                                milestones = self.parse_milestone_setting(
+                                    self.DEFAULT_STREAK_MILESTONES
+                                )
+                            refund = sum(milestones.get(d, 0) for d in lost)
+                            if refund > 0:
+                                child.points = max(0, child.points - refund)
+                                child.total_points_earned = max(
+                                    0, child.total_points_earned - refund
+                                )
+                                child.career_score = (
+                                    child.total_points_earned
+                                    - child.total_penalties_received
+                                )
+                                self.storage.add_points_transaction(
+                                    PointsTransaction(
+                                        child_id=child.id,
+                                        points=-refund,
+                                        reason="Streak milestone reversed",
+                                        created_at=dt_util.now(),
+                                    )
+                                )
+                            child.streak_milestones_achieved = sorted(
+                                d for d in achieved if d <= child.current_streak
                             )
 
                 self.storage.update_child(child)

--- a/tests/test_coordinator_logic.py
+++ b/tests/test_coordinator_logic.py
@@ -1047,3 +1047,60 @@ class TestCareerScore:
         assert child.total_points_earned == 65
         assert child.career_score == 65
         coord.storage.append_career_score_snapshot.assert_called()
+
+
+# ---------------------------------------------------------------------------
+# _reverse_completion_awards — milestone bonus reversal (ERR-1)
+# ---------------------------------------------------------------------------
+
+class TestReverseCompletionMilestones:
+    def test_reject_reverses_milestone_bonus(self):
+        settings = {
+            "streak_milestones_enabled": "true",
+            "streak_milestones": "3:5, 7:10",
+        }
+        # Child crossed to streak 3 today: base 10 + milestone 5 = 15 points.
+        child = _make_child(
+            points=15,
+            current_streak=3,
+            last_completion_date="2024-03-20",
+            streak_milestones_achieved=[3],
+        )
+        completion = ChoreCompletion(
+            chore_id="chore1",
+            child_id=child.id,
+            completed_at=_date(2024, 3, 20),
+            approved=True,
+            points_awarded=10,
+        )
+        coord = _make_coord(settings=settings, children=[child], completions=[completion])
+        coord._reverse_completion_awards(completion, [completion])
+        # both the base (10) and the milestone bonus (5) are reversed
+        assert child.points == 0
+        assert child.total_points_earned == 0
+        assert child.current_streak == 2
+        assert child.streak_milestones_achieved == []
+
+    def test_reject_keeps_milestone_when_streak_stays_above(self):
+        settings = {"streak_milestones_enabled": "true", "streak_milestones": "3:5"}
+        # Streak 5, milestone 3 achieved earlier; rejecting drops streak to 4,
+        # still >= 3, so the milestone and its bonus must remain.
+        child = _make_child(
+            points=10,
+            current_streak=5,
+            last_completion_date="2024-03-20",
+            streak_milestones_achieved=[3],
+        )
+        completion = ChoreCompletion(
+            chore_id="chore1",
+            child_id=child.id,
+            completed_at=_date(2024, 3, 20),
+            approved=True,
+            points_awarded=10,
+        )
+        coord = _make_coord(settings=settings, children=[child], completions=[completion])
+        coord._reverse_completion_awards(completion, [completion])
+        assert child.current_streak == 4
+        assert child.streak_milestones_achieved == [3]
+        # only the base points were reversed; milestone bonus stays
+        assert child.points == 0


### PR DESCRIPTION
## ERR-1 — reject/undo did not reverse streak-milestone bonuses

A streak-milestone bonus is added directly to `child.points` / `total_points_earned` and logged as a **separate** `PointsTransaction`; the value stored as `completion.points_awarded` does **not** include it. `_reverse_completion_awards` only subtracted `points_awarded`, so milestone bonuses survived a reject/undo → points drift on every legitimate reversal.

### Fix
When reversing a completion drops the streak below a previously-achieved milestone, that milestone is now un-achieved and its configured bonus refunded (logged as a reversing transaction). The fix lives in the shared `_reverse_completion_awards`, so it covers both `async_reject_chore` and `async_undo_chore_approval`.

### Testing
- New unit tests in `TestReverseCompletionMilestones`: refund when the streak falls below a milestone threshold; keep the milestone when the streak stays above it.
- `pytest tests/test_coordinator_logic.py tests/test_undo_chore_approval.py` → 81 passed.

Backend-only logic (no UI surface); verified via the pytest path that exercises the actual reversal. From AUDIT_REPORT.md §3.2.