### PR TITLE
fix(points): count todays completion when resuming a paused streak (ERR-3)

### DIFF
--- a/custom_components/taskmate/coord_points.py
+++ b/custom_components/taskmate/coord_points.py
@@ -771,6 +771,10 @@ class PointsMixin:
                         child.current_streak = streak_before + 1
                         child.streak_paused = False
                     elif streak_mode == "pause" or streak_paused:
+                        # Resume from a paused gap: today is a completed day, so
+                        # it must count toward the streak (ERR-3 — previously the
+                        # streak resumed at its frozen value, dropping today).
+                        child.current_streak = streak_before + 1
                         child.streak_paused = False
                         _LOGGER.debug("Streak resumed for %s at %d", child.name, child.current_streak)
                     else:

--- a/tests/test_coordinator_logic.py
+++ b/tests/test_coordinator_logic.py
@@ -201,8 +201,9 @@ class TestAwardPointsStreakTracking:
         )
         now = _date(2024, 3, 20)
         self._run_award(coord, child, 10, now)
-        # Streak should be preserved (not reset), paused flag cleared
-        assert child.current_streak == 10
+        # Streak resumes and counts today's completion (10 -> 11); the missed
+        # days are paused over, not reset (ERR-3).
+        assert child.current_streak == 11
         assert child.streak_paused is False
 
     def test_best_streak_updates_when_current_exceeds_it(self):


### PR DESCRIPTION
## ERR-3 — paused streak resume dropped todays completion

In pause mode (or when `streak_paused` is set), resuming after a gap cleared the paused flag but never incremented `current_streak`. The completion that resumed the streak was not counted, so the streak under-counted by one per pause cycle. It now resumes at `streak_before + 1`.

### Testing
- Updated `test_missed_day_in_pause_mode_resumes_streak` (10 → 11).
- `pytest tests/test_coordinator_logic.py` → 76 passed.

Backend-only logic. From AUDIT_REPORT.md §3.2.