### PR TITLE
fix(points-card): track and clear toast auto-hide timer (ERR-4)

### DIFF
--- a/custom_components/taskmate/www/taskmate-points-card.js
+++ b/custom_components/taskmate/www/taskmate-points-card.js
@@ -45,6 +45,7 @@ class TaskMatePointsCard extends LitElement {
     this._loading = {};
     this._dialog = null;
     this._notification = null;
+    this._notificationTimer = null;
   }
 
   static get styles() {
@@ -1124,6 +1125,10 @@ class TaskMatePointsCard extends LitElement {
       document.removeEventListener("keydown", this._dialogKeyHandler);
       this._dialogKeyHandler = null;
     }
+    if (this._notificationTimer) {
+      clearTimeout(this._notificationTimer);
+      this._notificationTimer = null;
+    }
   }
 
   _handleKeyDown(e, child, action) {
@@ -1192,8 +1197,11 @@ class TaskMatePointsCard extends LitElement {
     this._notification = { message, type };
     this.requestUpdate();
 
-    // Auto-hide notification after 3 seconds
-    setTimeout(() => {
+    // Auto-hide after 3s. Track the timer so it is cleared on re-trigger and
+    // on disconnect — avoids requestUpdate() on a detached element (ERR-4).
+    if (this._notificationTimer) clearTimeout(this._notificationTimer);
+    this._notificationTimer = setTimeout(() => {
+      this._notificationTimer = null;
       this._notification = null;
       this.requestUpdate();
     }, 3000);


### PR DESCRIPTION
## ERR-4 — points-card toast `setTimeout` leak

The 3s notification auto-hide timer had no stored handle and was never cleared, so removing the card within 3s fired `requestUpdate()` on a detached element, and rapid actions stacked untracked timers (an older one could clear a newer toast early). The handle is now stored, cleared on re-trigger and in `disconnectedCallback`.

### Testing
Verified on **ha-dev** via browserless: the timer is set when a toast shows, cleared on disconnect, and there are zero console errors past the 3s window.

From AUDIT_REPORT.md §3.2.