### PR TITLE
fix(cards): guard bonuses/penalties create+edit against double-submit (ERR-5)

### DIFF
--- a/custom_components/taskmate/www/taskmate-bonuses-card.js
+++ b/custom_components/taskmate/www/taskmate-bonuses-card.js
@@ -50,6 +50,7 @@ class TaskMateBonusesCard extends LitElement {
     this._editMode = false;
     this._loading = {};
     this._editingBonus = null;
+    this._saving = false;
     this._showNewForm = false;
     this._toast = null;
     this._newForm = { name: "", points: "", description: "", icon: "mdi:star-circle-outline" };
@@ -528,6 +529,8 @@ class TaskMateBonusesCard extends LitElement {
 
   async _saveEdit() {
     if (!this._editingBonus?.name || !this._editingBonus?.points) return;
+    if (this._saving) return;
+    this._saving = true;
     try {
       await this.hass.callService("taskmate", "update_bonus", {
         bonus_id: this._editingBonus.id,
@@ -539,6 +542,8 @@ class TaskMateBonusesCard extends LitElement {
       this._editingBonus = null;
     } catch (e) {
       this._showToast(this._t('bonuses.toast_save_failed'));
+    } finally {
+      this._saving = false;
     }
   }
 
@@ -558,6 +563,8 @@ class TaskMateBonusesCard extends LitElement {
 
   async _saveNew() {
     if (!this._newForm.name || !this._newForm.points) return;
+    if (this._saving) return;
+    this._saving = true;
     try {
       await this.hass.callService("taskmate", "add_bonus", {
         name: this._newForm.name,
@@ -570,6 +577,8 @@ class TaskMateBonusesCard extends LitElement {
       this._showToast(this._t('bonuses.toast_saved'));
     } catch (e) {
       this._showToast(this._t('bonuses.toast_add_failed'));
+    } finally {
+      this._saving = false;
     }
   }
 

--- a/custom_components/taskmate/www/taskmate-penalties-card.js
+++ b/custom_components/taskmate/www/taskmate-penalties-card.js
@@ -50,6 +50,7 @@ class TaskMatePenaltiesCard extends LitElement {
     this._editMode = false;
     this._loading = {};
     this._editingPenalty = null;
+    this._saving = false;
     this._showNewForm = false;
     this._toast = null;
     this._newForm = { name: "", points: "", description: "", icon: "mdi:alert-circle-outline" };
@@ -528,6 +529,8 @@ class TaskMatePenaltiesCard extends LitElement {
 
   async _saveEdit() {
     if (!this._editingPenalty?.name || !this._editingPenalty?.points) return;
+    if (this._saving) return;
+    this._saving = true;
     try {
       await this.hass.callService("taskmate", "update_penalty", {
         penalty_id: this._editingPenalty.id,
@@ -539,6 +542,8 @@ class TaskMatePenaltiesCard extends LitElement {
       this._editingPenalty = null;
     } catch (e) {
       this._showToast(this._t('penalties.toast_save_failed'));
+    } finally {
+      this._saving = false;
     }
   }
 
@@ -558,6 +563,8 @@ class TaskMatePenaltiesCard extends LitElement {
 
   async _saveNew() {
     if (!this._newForm.name || !this._newForm.points) return;
+    if (this._saving) return;
+    this._saving = true;
     try {
       await this.hass.callService("taskmate", "add_penalty", {
         name: this._newForm.name,
@@ -568,6 +575,8 @@ class TaskMatePenaltiesCard extends LitElement {
       this._showNewForm = false;
     } catch (e) {
       this._showToast(this._t('penalties.toast_add_failed'));
+    } finally {
+      this._saving = false;
     }
   }
 


### PR DESCRIPTION
## ERR-5 — double-submit on bonuses/penalties create & edit

`_saveNew`/`_saveEdit` had no in-flight guard (only `_applyBonus`/`_applyPenalty` did), so a fast double-click fired `add_`/`update_` services twice → duplicate rows / double point updates. Added a `_saving` flag set synchronously before the first `await` and reset in a `finally`, to both `bonuses-card` and `penalties-card`.

### Testing
Verified on **ha-dev** via browserless: firing `_saveNew` twice in one tick now calls the service **exactly once** for both cards, zero console errors.

From AUDIT_REPORT.md §3.2.