### PR TITLE
i18n: add 7 missing service translations + first_come selector key (I18N-1/2)

### DIFF
--- a/custom_components/taskmate/strings.json
+++ b/custom_components/taskmate/strings.json
@@ -110,6 +110,7 @@
         "alternating": "Alternating — rotate through the assigned children, one per day",
         "random": "Random — pick one assigned child at random each day",
         "balanced": "Balanced — split today's balanced chores evenly across the assigned children",
+        "first_come": "First come, first served — first child to complete it wins; it hides for the rest",
         "unassigned": "Unassigned — no child sees this chore"
       }
     },
@@ -742,6 +743,92 @@
     "rebuild_badges": {
       "name": "Rebuild Badges",
       "description": "Re-evaluate all badges across all children silently (no notifications, no point bonuses)."
+    },
+    "apply_mandatory_penalty": {
+      "name": "Apply Mandatory Penalty",
+      "description": "Deduct the configured penalty points for a missed mandatory chore and clear the review item.",
+      "fields": {
+        "miss_id": {
+          "name": "Miss ID",
+          "description": "The ID of the mandatory-miss review item"
+        }
+      }
+    },
+    "choose_avatar": {
+      "name": "Choose Avatar",
+      "description": "A child switches to an avatar they have unlocked.",
+      "fields": {
+        "child_id": {
+          "name": "Child ID",
+          "description": "The ID of the child"
+        },
+        "icon": {
+          "name": "Avatar icon",
+          "description": "The mdi icon of an unlocked catalogue avatar (e.g. mdi:rocket-launch)."
+        }
+      }
+    },
+    "dismiss_mandatory_chore": {
+      "name": "Dismiss Mandatory Chore",
+      "description": "Clear a missed mandatory chore review item with no penalty.",
+      "fields": {
+        "miss_id": {
+          "name": "Miss ID",
+          "description": "The ID of the mandatory-miss review item"
+        }
+      }
+    },
+    "gift_points": {
+      "name": "Gift Points",
+      "description": "Transfer spendable points from one child to another (parent-controlled).",
+      "fields": {
+        "from_child_id": {
+          "name": "From child ID",
+          "description": "The ID of the child sending points"
+        },
+        "to_child_id": {
+          "name": "To child ID",
+          "description": "The ID of the child receiving points"
+        },
+        "points": {
+          "name": "Points",
+          "description": "The number of points to transfer"
+        }
+      }
+    },
+    "postpone_mandatory_chore": {
+      "name": "Postpone Mandatory Chore",
+      "description": "Give a missed mandatory chore another period (or tomorrow) without a penalty, and clear the review item.",
+      "fields": {
+        "miss_id": {
+          "name": "Miss ID",
+          "description": "The ID of the mandatory-miss review item"
+        }
+      }
+    },
+    "request_swap": {
+      "name": "Request Chore Swap",
+      "description": "A child requests to take over today's rotation assignment of a chore (pending parent approval).",
+      "fields": {
+        "chore_id": {
+          "name": "Chore ID",
+          "description": "The ID of the chore to take over"
+        },
+        "requester_id": {
+          "name": "Requester child ID",
+          "description": "The ID of the child requesting the swap"
+        }
+      }
+    },
+    "test_notification": {
+      "name": "Test Notification",
+      "description": "Send a sample notification of the given type to its enabled recipients (ignores the master on/off so routing can be verified).",
+      "fields": {
+        "type_id": {
+          "name": "Notification type",
+          "description": "Notification type id, e.g. pending_chore_approval, badge_earned, streak_milestone"
+        }
+      }
     }
   },
   "entity": {

--- a/custom_components/taskmate/translations/de.json
+++ b/custom_components/taskmate/translations/de.json
@@ -743,6 +743,92 @@
     "rebuild_badges": {
       "name": "Abzeichen neu berechnen",
       "description": "Bewerten Sie alle Abzeichen für alle Kinder im Hintergrund neu (keine Benachrichtigungen, keine Punkteboni)."
+    },
+    "apply_mandatory_penalty": {
+      "name": "Pflichtstrafe anwenden",
+      "description": "Zieht die konfigurierten Strafpunkte für eine verpasste Pflichtaufgabe ab und entfernt den Prüfeintrag.",
+      "fields": {
+        "miss_id": {
+          "name": "Versäumnis-ID",
+          "description": "Die ID des Prüfeintrags für die verpasste Pflichtaufgabe"
+        }
+      }
+    },
+    "choose_avatar": {
+      "name": "Avatar wählen",
+      "description": "Ein Kind wechselt zu einem freigeschalteten Avatar.",
+      "fields": {
+        "child_id": {
+          "name": "Kind-ID",
+          "description": "Die ID des Kindes"
+        },
+        "icon": {
+          "name": "Avatar-Symbol",
+          "description": "Das mdi-Symbol eines freigeschalteten Katalog-Avatars (z. B. mdi:rocket-launch)."
+        }
+      }
+    },
+    "dismiss_mandatory_chore": {
+      "name": "Pflichtaufgabe verwerfen",
+      "description": "Entfernt den Prüfeintrag einer verpassten Pflichtaufgabe ohne Strafe.",
+      "fields": {
+        "miss_id": {
+          "name": "Versäumnis-ID",
+          "description": "Die ID des Prüfeintrags für die verpasste Pflichtaufgabe"
+        }
+      }
+    },
+    "gift_points": {
+      "name": "Punkte verschenken",
+      "description": "Überträgt ausgebbare Punkte von einem Kind auf ein anderes (elterngesteuert).",
+      "fields": {
+        "from_child_id": {
+          "name": "Von Kind-ID",
+          "description": "Die ID des Kindes, das Punkte sendet"
+        },
+        "to_child_id": {
+          "name": "An Kind-ID",
+          "description": "Die ID des Kindes, das Punkte erhält"
+        },
+        "points": {
+          "name": "Punkte",
+          "description": "Die Anzahl der zu übertragenden Punkte"
+        }
+      }
+    },
+    "postpone_mandatory_chore": {
+      "name": "Pflichtaufgabe verschieben",
+      "description": "Gewährt einer verpassten Pflichtaufgabe ohne Strafe einen weiteren Zeitraum (oder morgen) und entfernt den Prüfeintrag.",
+      "fields": {
+        "miss_id": {
+          "name": "Versäumnis-ID",
+          "description": "Die ID des Prüfeintrags für die verpasste Pflichtaufgabe"
+        }
+      }
+    },
+    "request_swap": {
+      "name": "Aufgabentausch anfragen",
+      "description": "Ein Kind beantragt, die heutige Rotationszuweisung einer Aufgabe zu übernehmen (Genehmigung der Eltern erforderlich).",
+      "fields": {
+        "chore_id": {
+          "name": "Aufgaben-ID",
+          "description": "Die ID der zu übernehmenden Aufgabe"
+        },
+        "requester_id": {
+          "name": "Anfragende Kind-ID",
+          "description": "Die ID des Kindes, das den Tausch beantragt"
+        }
+      }
+    },
+    "test_notification": {
+      "name": "Test-Benachrichtigung",
+      "description": "Sendet eine Beispiel-Benachrichtigung des angegebenen Typs an die aktivierten Empfänger (ignoriert den Hauptschalter, damit das Routing geprüft werden kann).",
+      "fields": {
+        "type_id": {
+          "name": "Benachrichtigungstyp",
+          "description": "ID des Benachrichtigungstyps, z. B. pending_chore_approval, badge_earned, streak_milestone"
+        }
+      }
     }
   },
   "entity": {

--- a/custom_components/taskmate/translations/en-GB.json
+++ b/custom_components/taskmate/translations/en-GB.json
@@ -743,6 +743,92 @@
     "rebuild_badges": {
       "name": "Rebuild Badges",
       "description": "Re-evaluate all badges across all children silently (no notifications, no point bonuses)."
+    },
+    "apply_mandatory_penalty": {
+      "name": "Apply Mandatory Penalty",
+      "description": "Deduct the configured penalty points for a missed mandatory chore and clear the review item.",
+      "fields": {
+        "miss_id": {
+          "name": "Miss ID",
+          "description": "The ID of the mandatory-miss review item"
+        }
+      }
+    },
+    "choose_avatar": {
+      "name": "Choose Avatar",
+      "description": "A child switches to an avatar they have unlocked.",
+      "fields": {
+        "child_id": {
+          "name": "Child ID",
+          "description": "The ID of the child"
+        },
+        "icon": {
+          "name": "Avatar icon",
+          "description": "The mdi icon of an unlocked catalogue avatar (e.g. mdi:rocket-launch)."
+        }
+      }
+    },
+    "dismiss_mandatory_chore": {
+      "name": "Dismiss Mandatory Chore",
+      "description": "Clear a missed mandatory chore review item with no penalty.",
+      "fields": {
+        "miss_id": {
+          "name": "Miss ID",
+          "description": "The ID of the mandatory-miss review item"
+        }
+      }
+    },
+    "gift_points": {
+      "name": "Gift Points",
+      "description": "Transfer spendable points from one child to another (parent-controlled).",
+      "fields": {
+        "from_child_id": {
+          "name": "From child ID",
+          "description": "The ID of the child sending points"
+        },
+        "to_child_id": {
+          "name": "To child ID",
+          "description": "The ID of the child receiving points"
+        },
+        "points": {
+          "name": "Points",
+          "description": "The number of points to transfer"
+        }
+      }
+    },
+    "postpone_mandatory_chore": {
+      "name": "Postpone Mandatory Chore",
+      "description": "Give a missed mandatory chore another period (or tomorrow) without a penalty, and clear the review item.",
+      "fields": {
+        "miss_id": {
+          "name": "Miss ID",
+          "description": "The ID of the mandatory-miss review item"
+        }
+      }
+    },
+    "request_swap": {
+      "name": "Request Chore Swap",
+      "description": "A child requests to take over today's rotation assignment of a chore (pending parent approval).",
+      "fields": {
+        "chore_id": {
+          "name": "Chore ID",
+          "description": "The ID of the chore to take over"
+        },
+        "requester_id": {
+          "name": "Requester child ID",
+          "description": "The ID of the child requesting the swap"
+        }
+      }
+    },
+    "test_notification": {
+      "name": "Test Notification",
+      "description": "Send a sample notification of the given type to its enabled recipients (ignores the master on/off so routing can be verified).",
+      "fields": {
+        "type_id": {
+          "name": "Notification type",
+          "description": "Notification type id, e.g. pending_chore_approval, badge_earned, streak_milestone"
+        }
+      }
     }
   },
   "entity": {

--- a/custom_components/taskmate/translations/en.json
+++ b/custom_components/taskmate/translations/en.json
@@ -743,6 +743,92 @@
     "rebuild_badges": {
       "name": "Rebuild Badges",
       "description": "Re-evaluate all badges across all children silently (no notifications, no point bonuses)."
+    },
+    "apply_mandatory_penalty": {
+      "name": "Apply Mandatory Penalty",
+      "description": "Deduct the configured penalty points for a missed mandatory chore and clear the review item.",
+      "fields": {
+        "miss_id": {
+          "name": "Miss ID",
+          "description": "The ID of the mandatory-miss review item"
+        }
+      }
+    },
+    "choose_avatar": {
+      "name": "Choose Avatar",
+      "description": "A child switches to an avatar they have unlocked.",
+      "fields": {
+        "child_id": {
+          "name": "Child ID",
+          "description": "The ID of the child"
+        },
+        "icon": {
+          "name": "Avatar icon",
+          "description": "The mdi icon of an unlocked catalogue avatar (e.g. mdi:rocket-launch)."
+        }
+      }
+    },
+    "dismiss_mandatory_chore": {
+      "name": "Dismiss Mandatory Chore",
+      "description": "Clear a missed mandatory chore review item with no penalty.",
+      "fields": {
+        "miss_id": {
+          "name": "Miss ID",
+          "description": "The ID of the mandatory-miss review item"
+        }
+      }
+    },
+    "gift_points": {
+      "name": "Gift Points",
+      "description": "Transfer spendable points from one child to another (parent-controlled).",
+      "fields": {
+        "from_child_id": {
+          "name": "From child ID",
+          "description": "The ID of the child sending points"
+        },
+        "to_child_id": {
+          "name": "To child ID",
+          "description": "The ID of the child receiving points"
+        },
+        "points": {
+          "name": "Points",
+          "description": "The number of points to transfer"
+        }
+      }
+    },
+    "postpone_mandatory_chore": {
+      "name": "Postpone Mandatory Chore",
+      "description": "Give a missed mandatory chore another period (or tomorrow) without a penalty, and clear the review item.",
+      "fields": {
+        "miss_id": {
+          "name": "Miss ID",
+          "description": "The ID of the mandatory-miss review item"
+        }
+      }
+    },
+    "request_swap": {
+      "name": "Request Chore Swap",
+      "description": "A child requests to take over today's rotation assignment of a chore (pending parent approval).",
+      "fields": {
+        "chore_id": {
+          "name": "Chore ID",
+          "description": "The ID of the chore to take over"
+        },
+        "requester_id": {
+          "name": "Requester child ID",
+          "description": "The ID of the child requesting the swap"
+        }
+      }
+    },
+    "test_notification": {
+      "name": "Test Notification",
+      "description": "Send a sample notification of the given type to its enabled recipients (ignores the master on/off so routing can be verified).",
+      "fields": {
+        "type_id": {
+          "name": "Notification type",
+          "description": "Notification type id, e.g. pending_chore_approval, badge_earned, streak_milestone"
+        }
+      }
     }
   },
   "entity": {

--- a/custom_components/taskmate/translations/fr.json
+++ b/custom_components/taskmate/translations/fr.json
@@ -743,6 +743,92 @@
     "rebuild_badges": {
       "name": "Recalculer les badges",
       "description": "Réévaluer silencieusement tous les badges pour tous les enfants (sans notifications ni bonus de points)."
+    },
+    "apply_mandatory_penalty": {
+      "name": "Appliquer la pénalité obligatoire",
+      "description": "Déduit les points de pénalité configurés pour une tâche obligatoire manquée et supprime l'élément à vérifier.",
+      "fields": {
+        "miss_id": {
+          "name": "ID d'oubli",
+          "description": "L'ID de l'élément à vérifier pour la tâche obligatoire manquée"
+        }
+      }
+    },
+    "choose_avatar": {
+      "name": "Choisir un avatar",
+      "description": "Un enfant passe à un avatar qu'il a débloqué.",
+      "fields": {
+        "child_id": {
+          "name": "ID enfant",
+          "description": "L'ID de l'enfant"
+        },
+        "icon": {
+          "name": "Icône d'avatar",
+          "description": "L'icône mdi d'un avatar du catalogue débloqué (par ex. mdi:rocket-launch)."
+        }
+      }
+    },
+    "dismiss_mandatory_chore": {
+      "name": "Ignorer la tâche obligatoire",
+      "description": "Supprime l'élément à vérifier d'une tâche obligatoire manquée sans pénalité.",
+      "fields": {
+        "miss_id": {
+          "name": "ID d'oubli",
+          "description": "L'ID de l'élément à vérifier pour la tâche obligatoire manquée"
+        }
+      }
+    },
+    "gift_points": {
+      "name": "Offrir des points",
+      "description": "Transfère des points dépensables d'un enfant à un autre (contrôlé par les parents).",
+      "fields": {
+        "from_child_id": {
+          "name": "ID enfant source",
+          "description": "L'ID de l'enfant qui envoie les points"
+        },
+        "to_child_id": {
+          "name": "ID enfant destinataire",
+          "description": "L'ID de l'enfant qui reçoit les points"
+        },
+        "points": {
+          "name": "Points",
+          "description": "Le nombre de points à transférer"
+        }
+      }
+    },
+    "postpone_mandatory_chore": {
+      "name": "Reporter la tâche obligatoire",
+      "description": "Accorde à une tâche obligatoire manquée une autre période (ou demain) sans pénalité et supprime l'élément à vérifier.",
+      "fields": {
+        "miss_id": {
+          "name": "ID d'oubli",
+          "description": "L'ID de l'élément à vérifier pour la tâche obligatoire manquée"
+        }
+      }
+    },
+    "request_swap": {
+      "name": "Demander un échange de tâche",
+      "description": "Un enfant demande à reprendre l'attribution par rotation d'une tâche pour aujourd'hui (en attente d'approbation parentale).",
+      "fields": {
+        "chore_id": {
+          "name": "ID tâche",
+          "description": "L'ID de la tâche à reprendre"
+        },
+        "requester_id": {
+          "name": "ID enfant demandeur",
+          "description": "L'ID de l'enfant qui demande l'échange"
+        }
+      }
+    },
+    "test_notification": {
+      "name": "Notification de test",
+      "description": "Envoie un exemple de notification du type indiqué à ses destinataires activés (ignore l'interrupteur principal afin de vérifier le routage).",
+      "fields": {
+        "type_id": {
+          "name": "Type de notification",
+          "description": "ID du type de notification, par ex. pending_chore_approval, badge_earned, streak_milestone"
+        }
+      }
     }
   },
   "entity": {

--- a/custom_components/taskmate/translations/nb.json
+++ b/custom_components/taskmate/translations/nb.json
@@ -743,6 +743,92 @@
     "rebuild_badges": {
       "name": "Gjenoppbygg merker",
       "description": "Reevaluer alle merker for alle barn i stillhet (ingen varsler, ingen poengbonuser)."
+    },
+    "apply_mandatory_penalty": {
+      "name": "Bruk obligatorisk straff",
+      "description": "Trekk fra de konfigurerte strafepoengene for en glemt obligatorisk oppgave og fjern gjennomgangselementet.",
+      "fields": {
+        "miss_id": {
+          "name": "Forsømmelse-ID",
+          "description": "ID-en til gjennomgangselementet for den glemte obligatoriske oppgaven"
+        }
+      }
+    },
+    "choose_avatar": {
+      "name": "Velg avatar",
+      "description": "Et barn bytter til en avatar de har låst opp.",
+      "fields": {
+        "child_id": {
+          "name": "Barne-ID",
+          "description": "ID-en til barnet"
+        },
+        "icon": {
+          "name": "Avatar-ikon",
+          "description": "mdi-ikonet til en opplåst katalog-avatar (f.eks. mdi:rocket-launch)."
+        }
+      }
+    },
+    "dismiss_mandatory_chore": {
+      "name": "Avvis obligatorisk oppgave",
+      "description": "Fjern gjennomgangselementet for en glemt obligatorisk oppgave uten straff.",
+      "fields": {
+        "miss_id": {
+          "name": "Forsømmelse-ID",
+          "description": "ID-en til gjennomgangselementet for den glemte obligatoriske oppgaven"
+        }
+      }
+    },
+    "gift_points": {
+      "name": "Gi bort poeng",
+      "description": "Overfør brukbare poeng fra ett barn til et annet (foreldrestyrt).",
+      "fields": {
+        "from_child_id": {
+          "name": "Fra barne-ID",
+          "description": "ID-en til barnet som sender poeng"
+        },
+        "to_child_id": {
+          "name": "Til barne-ID",
+          "description": "ID-en til barnet som mottar poeng"
+        },
+        "points": {
+          "name": "Poeng",
+          "description": "Antall poeng som skal overføres"
+        }
+      }
+    },
+    "postpone_mandatory_chore": {
+      "name": "Utsett obligatorisk oppgave",
+      "description": "Gi en glemt obligatorisk oppgave en ny periode (eller i morgen) uten straff, og fjern gjennomgangselementet.",
+      "fields": {
+        "miss_id": {
+          "name": "Forsømmelse-ID",
+          "description": "ID-en til gjennomgangselementet for den glemte obligatoriske oppgaven"
+        }
+      }
+    },
+    "request_swap": {
+      "name": "Be om oppgavebytte",
+      "description": "Et barn ber om å overta dagens rotasjonstildeling av en oppgave (venter på foreldregodkjenning).",
+      "fields": {
+        "chore_id": {
+          "name": "Oppgave-ID",
+          "description": "ID-en til oppgaven som skal overtas"
+        },
+        "requester_id": {
+          "name": "Barne-ID for forespørsel",
+          "description": "ID-en til barnet som ber om byttet"
+        }
+      }
+    },
+    "test_notification": {
+      "name": "Testvarsel",
+      "description": "Send et eksempelvarsel av den angitte typen til de aktiverte mottakerne (ignorerer hovedbryteren slik at rutingen kan verifiseres).",
+      "fields": {
+        "type_id": {
+          "name": "Varseltype",
+          "description": "ID for varseltype, f.eks. pending_chore_approval, badge_earned, streak_milestone"
+        }
+      }
     }
   },
   "entity": {

--- a/custom_components/taskmate/translations/nn.json
+++ b/custom_components/taskmate/translations/nn.json
@@ -743,6 +743,92 @@
     "rebuild_badges": {
       "name": "Bygg opp att merke",
       "description": "Reevaluer alle merke for alle born i det stille (ingen varsel, ingen poengbonusar)."
+    },
+    "apply_mandatory_penalty": {
+      "name": "Bruk obligatorisk straff",
+      "description": "Trekk frå dei konfigurerte straffepoenga for ei gløymd obligatorisk oppgåve og fjern gjennomgangselementet.",
+      "fields": {
+        "miss_id": {
+          "name": "Forsøming-ID",
+          "description": "ID-en til gjennomgangselementet for den gløymde obligatoriske oppgåva"
+        }
+      }
+    },
+    "choose_avatar": {
+      "name": "Vel avatar",
+      "description": "Eit barn byter til ein avatar dei har låst opp.",
+      "fields": {
+        "child_id": {
+          "name": "Barne-ID",
+          "description": "ID-en til barnet"
+        },
+        "icon": {
+          "name": "Avatar-ikon",
+          "description": "mdi-ikonet til ein opplåst katalog-avatar (t.d. mdi:rocket-launch)."
+        }
+      }
+    },
+    "dismiss_mandatory_chore": {
+      "name": "Avvis obligatorisk oppgåve",
+      "description": "Fjern gjennomgangselementet for ei gløymd obligatorisk oppgåve utan straff.",
+      "fields": {
+        "miss_id": {
+          "name": "Forsøming-ID",
+          "description": "ID-en til gjennomgangselementet for den gløymde obligatoriske oppgåva"
+        }
+      }
+    },
+    "gift_points": {
+      "name": "Gi bort poeng",
+      "description": "Overfør brukbare poeng frå eitt barn til eit anna (foreldrestyrt).",
+      "fields": {
+        "from_child_id": {
+          "name": "Frå barne-ID",
+          "description": "ID-en til barnet som sender poeng"
+        },
+        "to_child_id": {
+          "name": "Til barne-ID",
+          "description": "ID-en til barnet som mottek poeng"
+        },
+        "points": {
+          "name": "Poeng",
+          "description": "Talet på poeng som skal overførast"
+        }
+      }
+    },
+    "postpone_mandatory_chore": {
+      "name": "Utsett obligatorisk oppgåve",
+      "description": "Gi ei gløymd obligatorisk oppgåve ein ny periode (eller i morgon) utan straff, og fjern gjennomgangselementet.",
+      "fields": {
+        "miss_id": {
+          "name": "Forsøming-ID",
+          "description": "ID-en til gjennomgangselementet for den gløymde obligatoriske oppgåva"
+        }
+      }
+    },
+    "request_swap": {
+      "name": "Be om oppgåvebyte",
+      "description": "Eit barn ber om å overta dagens rotasjonstildeling av ei oppgåve (ventar på foreldregodkjenning).",
+      "fields": {
+        "chore_id": {
+          "name": "Oppgåve-ID",
+          "description": "ID-en til oppgåva som skal overtakast"
+        },
+        "requester_id": {
+          "name": "Barne-ID for førespurnad",
+          "description": "ID-en til barnet som ber om bytet"
+        }
+      }
+    },
+    "test_notification": {
+      "name": "Testvarsel",
+      "description": "Send eit eksempelvarsel av den angitte typen til dei aktiverte mottakarane (ignorerer hovudbrytaren slik at rutinga kan verifiserast).",
+      "fields": {
+        "type_id": {
+          "name": "Varseltype",
+          "description": "ID for varseltype, t.d. pending_chore_approval, badge_earned, streak_milestone"
+        }
+      }
     }
   },
   "entity": {

--- a/custom_components/taskmate/translations/pt-BR.json
+++ b/custom_components/taskmate/translations/pt-BR.json
@@ -743,6 +743,92 @@
     "rebuild_badges": {
       "name": "Reconstruir conquistas",
       "description": "Reavaliar todas as conquistas de todas as crianças silenciosamente (sem notificações nem bônus de pontos)."
+    },
+    "apply_mandatory_penalty": {
+      "name": "Aplicar penalidade obrigatória",
+      "description": "Deduz os pontos de penalidade configurados por uma tarefa obrigatória perdida e remove o item de revisão.",
+      "fields": {
+        "miss_id": {
+          "name": "ID da falha",
+          "description": "O ID do item de revisão da tarefa obrigatória perdida"
+        }
+      }
+    },
+    "choose_avatar": {
+      "name": "Escolher avatar",
+      "description": "Uma criança muda para um avatar que desbloqueou.",
+      "fields": {
+        "child_id": {
+          "name": "ID da criança",
+          "description": "O ID da criança"
+        },
+        "icon": {
+          "name": "Ícone do avatar",
+          "description": "O ícone mdi de um avatar do catálogo desbloqueado (ex.: mdi:rocket-launch)."
+        }
+      }
+    },
+    "dismiss_mandatory_chore": {
+      "name": "Dispensar tarefa obrigatória",
+      "description": "Remove o item de revisão de uma tarefa obrigatória perdida sem penalidade.",
+      "fields": {
+        "miss_id": {
+          "name": "ID da falha",
+          "description": "O ID do item de revisão da tarefa obrigatória perdida"
+        }
+      }
+    },
+    "gift_points": {
+      "name": "Presentear pontos",
+      "description": "Transfere pontos disponíveis de uma criança para outra (controlado pelos pais).",
+      "fields": {
+        "from_child_id": {
+          "name": "ID da criança de origem",
+          "description": "O ID da criança que envia os pontos"
+        },
+        "to_child_id": {
+          "name": "ID da criança de destino",
+          "description": "O ID da criança que recebe os pontos"
+        },
+        "points": {
+          "name": "Pontos",
+          "description": "O número de pontos a transferir"
+        }
+      }
+    },
+    "postpone_mandatory_chore": {
+      "name": "Adiar tarefa obrigatória",
+      "description": "Dá a uma tarefa obrigatória perdida outro período (ou amanhã) sem penalidade e remove o item de revisão.",
+      "fields": {
+        "miss_id": {
+          "name": "ID da falha",
+          "description": "O ID do item de revisão da tarefa obrigatória perdida"
+        }
+      }
+    },
+    "request_swap": {
+      "name": "Solicitar troca de tarefa",
+      "description": "Uma criança pede para assumir a atribuição de rodízio de hoje de uma tarefa (sujeito a aprovação dos pais).",
+      "fields": {
+        "chore_id": {
+          "name": "ID da tarefa",
+          "description": "O ID da tarefa a assumir"
+        },
+        "requester_id": {
+          "name": "ID da criança solicitante",
+          "description": "O ID da criança que pede a troca"
+        }
+      }
+    },
+    "test_notification": {
+      "name": "Notificação de teste",
+      "description": "Envia uma notificação de exemplo do tipo indicado aos destinatários ativados (ignora o interruptor principal para que o roteamento possa ser verificado).",
+      "fields": {
+        "type_id": {
+          "name": "Tipo de notificação",
+          "description": "ID do tipo de notificação, ex.: pending_chore_approval, badge_earned, streak_milestone"
+        }
+      }
     }
   },
   "entity": {

--- a/custom_components/taskmate/translations/pt.json
+++ b/custom_components/taskmate/translations/pt.json
@@ -743,6 +743,92 @@
     "rebuild_badges": {
       "name": "Reconstruir conquistas",
       "description": "Reavaliar todas as conquistas de todas as crianças silenciosamente (sem notificações nem bónus de pontos)."
+    },
+    "apply_mandatory_penalty": {
+      "name": "Aplicar penalização obrigatória",
+      "description": "Deduz os pontos de penalização configurados por uma tarefa obrigatória falhada e remove o item de revisão.",
+      "fields": {
+        "miss_id": {
+          "name": "ID da falha",
+          "description": "O ID do item de revisão da tarefa obrigatória falhada"
+        }
+      }
+    },
+    "choose_avatar": {
+      "name": "Escolher avatar",
+      "description": "Uma criança muda para um avatar que desbloqueou.",
+      "fields": {
+        "child_id": {
+          "name": "ID da criança",
+          "description": "O ID da criança"
+        },
+        "icon": {
+          "name": "Ícone do avatar",
+          "description": "O ícone mdi de um avatar do catálogo desbloqueado (ex.: mdi:rocket-launch)."
+        }
+      }
+    },
+    "dismiss_mandatory_chore": {
+      "name": "Dispensar tarefa obrigatória",
+      "description": "Remove o item de revisão de uma tarefa obrigatória falhada sem penalização.",
+      "fields": {
+        "miss_id": {
+          "name": "ID da falha",
+          "description": "O ID do item de revisão da tarefa obrigatória falhada"
+        }
+      }
+    },
+    "gift_points": {
+      "name": "Oferecer pontos",
+      "description": "Transfere pontos disponíveis de uma criança para outra (controlado pelos pais).",
+      "fields": {
+        "from_child_id": {
+          "name": "ID da criança de origem",
+          "description": "O ID da criança que envia os pontos"
+        },
+        "to_child_id": {
+          "name": "ID da criança de destino",
+          "description": "O ID da criança que recebe os pontos"
+        },
+        "points": {
+          "name": "Pontos",
+          "description": "O número de pontos a transferir"
+        }
+      }
+    },
+    "postpone_mandatory_chore": {
+      "name": "Adiar tarefa obrigatória",
+      "description": "Dá a uma tarefa obrigatória falhada outro período (ou amanhã) sem penalização e remove o item de revisão.",
+      "fields": {
+        "miss_id": {
+          "name": "ID da falha",
+          "description": "O ID do item de revisão da tarefa obrigatória falhada"
+        }
+      }
+    },
+    "request_swap": {
+      "name": "Pedir troca de tarefa",
+      "description": "Uma criança pede para assumir a atribuição de rotação de hoje de uma tarefa (sujeito a aprovação dos pais).",
+      "fields": {
+        "chore_id": {
+          "name": "ID da tarefa",
+          "description": "O ID da tarefa a assumir"
+        },
+        "requester_id": {
+          "name": "ID da criança solicitante",
+          "description": "O ID da criança que pede a troca"
+        }
+      }
+    },
+    "test_notification": {
+      "name": "Notificação de teste",
+      "description": "Envia uma notificação de exemplo do tipo indicado aos destinatários ativados (ignora o interruptor principal para que o encaminhamento possa ser verificado).",
+      "fields": {
+        "type_id": {
+          "name": "Tipo de notificação",
+          "description": "ID do tipo de notificação, p. ex. pending_chore_approval, badge_earned, streak_milestone"
+        }
+      }
     }
   },
   "entity": {


### PR DESCRIPTION
## I18N-1 / I18N-2 — missing service translations

`services.yaml` defines 44 services but `strings.json` + all 8 translation files carried only 37 service blocks, so 7 services showed raw `service.field` keys in **Dev Tools → Services** across all 9 locales:

`apply_mandatory_penalty`, `choose_avatar`, `dismiss_mandatory_chore`, `gift_points`, `postpone_mandatory_chore`, `request_swap`, `test_notification`.

All 7 are back-filled (name / description / fields) into `strings.json` and every locale (en, en-GB, de, fr, nb, nn, pt, pt-BR) with **proper translations** (not English-only), per the translate-with-the-feature rule.

Also re-added the `first_come` `assignment_mode` selector option to `strings.json` (it was already in all translations — I18N-2; brings the source template back in sync).

### Testing
- All 9 files valid JSON; each now has 44 service blocks and the `first_come` option.
- Pure additions (775 insertions, 0 deletions — no reformatting).
- hassfest (the **Validate integration** CI job) validates translation structure.

From AUDIT_REPORT.md §3.8.