### PR TITLE
fix(calendar): project interval recurrences without recurrence_start (ERR-2, QUAL-1)

### DIFF
--- a/custom_components/taskmate/coord_calendar.py
+++ b/custom_components/taskmate/coord_calendar.py
@@ -151,6 +151,10 @@ class CalendarMixin:
         recurrence = getattr(chore, "recurrence", "weekly")
         recurrence_day = (getattr(chore, "recurrence_day", "") or "").lower()
         recurrence_start = getattr(chore, "recurrence_start", "") or ""
+        # For interval recurrences, fall back to created_date as the cadence
+        # anchor when no explicit recurrence_start is set — otherwise these
+        # chores never project onto the calendar at all (ERR-2).
+        anchor_iso = recurrence_start or created_iso
         day_dow = self._SCHEDULE_DOW[day.weekday()]
 
         if recurrence_day and recurrence in ("weekly", "every_2_weeks"):
@@ -166,18 +170,18 @@ class CalendarMixin:
                     pass
             return True
 
-        if recurrence == "every_2_days" and recurrence_start:
+        if recurrence == "every_2_days" and anchor_iso:
             try:
-                anchor = date.fromisoformat(recurrence_start)
+                anchor = date.fromisoformat(anchor_iso)
                 diff = (day - anchor).days
                 return diff >= 0 and diff % 2 == 0
             except ValueError:
                 return False
 
         month_steps = {"monthly": 1, "every_3_months": 3, "every_6_months": 6}.get(recurrence)
-        if month_steps and recurrence_start:
+        if month_steps and anchor_iso:
             try:
-                anchor = date.fromisoformat(recurrence_start)
+                anchor = date.fromisoformat(anchor_iso)
                 if day < anchor:
                     return False
                 months_diff = (day.year - anchor.year) * 12 + (day.month - anchor.month)

--- a/custom_components/taskmate/coord_chores.py
+++ b/custom_components/taskmate/coord_chores.py
@@ -25,6 +25,13 @@ def _add_months(d: date, months: int) -> date:
     return date(year, month, min(d.day, monthrange(year, month)[1]))
 
 
+_DOW_MAP = {
+    'monday': 0, 'tuesday': 1, 'wednesday': 2, 'thursday': 3,
+    'friday': 4, 'saturday': 5, 'sunday': 6,
+}
+_MONTH_STEPS = {'monthly': 1, 'every_3_months': 3, 'every_6_months': 6}
+
+
 class ChoresMixin:
     """Mixin providing chore CRUD and completion logic."""
 
@@ -1179,11 +1186,7 @@ class ChoresMixin:
                 except ValueError:
                     pass
             if first_occurrence_mode == 'wait_for_first_occurrence' and recurrence_day:
-                day_map = {
-                    'monday': 0, 'tuesday': 1, 'wednesday': 2, 'thursday': 3,
-                    'friday': 4, 'saturday': 5, 'sunday': 6
-                }
-                target_dow = day_map.get(recurrence_day.lower())
+                target_dow = _DOW_MAP.get(recurrence_day.lower())
                 if target_dow is not None and today.weekday() != target_dow:
                     return False
             return True
@@ -1208,18 +1211,14 @@ class ChoresMixin:
 
         # weekly/every_2_weeks with specific day — only available on that day
         if recurrence_day and recurrence in ('weekly', 'every_2_weeks'):
-            day_map = {
-                'monday': 0, 'tuesday': 1, 'wednesday': 2, 'thursday': 3,
-                'friday': 4, 'saturday': 5, 'sunday': 6
-            }
-            target_dow = day_map.get(recurrence_day.lower())
+            target_dow = _DOW_MAP.get(recurrence_day.lower())
             if target_dow is not None and today.weekday() != target_dow:
                 return False
 
         # Month-based recurrences use real calendar months so availability
         # matches the calendar projection (a "monthly" chore re-opens on the
         # same day next month, not after a fixed 30 days)
-        month_steps = {'monthly': 1, 'every_3_months': 3, 'every_6_months': 6}.get(recurrence)
+        month_steps = _MONTH_STEPS.get(recurrence)
         if month_steps:
             return today >= _add_months(last_dt, month_steps)
 

--- a/custom_components/taskmate/www/taskmate-calendar-card.js
+++ b/custom_components/taskmate/www/taskmate-calendar-card.js
@@ -333,6 +333,9 @@ class TaskMateCalendarCard extends LitElement {
       const recurrence = chore.recurrence || "weekly";
       const recurrenceDay = (chore.recurrence_day || "").toLowerCase();
       const recurrenceStart = chore.recurrence_start || "";
+      // Fall back to created_date as the cadence anchor for interval
+      // recurrences with no explicit start, so they still project (ERR-2).
+      const anchorStr = recurrenceStart || createdDate;
 
       if (recurrenceDay && (recurrence === "weekly" || recurrence === "every_2_weeks")) {
         if (recurrenceDay !== dayDow) return false;
@@ -347,9 +350,9 @@ class TaskMateCalendarCard extends LitElement {
         return true;
       }
 
-      if (recurrence === "every_2_days" && recurrenceStart) {
+      if (recurrence === "every_2_days" && anchorStr) {
         try {
-          const anchor = new Date(recurrenceStart + "T00:00:00");
+          const anchor = new Date(anchorStr + "T00:00:00");
           const diff = diffDays(dayDate, anchor);
           if (diff < 0) return false;
           return diff % 2 === 0;
@@ -357,9 +360,9 @@ class TaskMateCalendarCard extends LitElement {
       }
 
       const monthSteps = { monthly: 1, every_3_months: 3, every_6_months: 6 }[recurrence];
-      if (monthSteps && recurrenceStart) {
+      if (monthSteps && anchorStr) {
         try {
-          const anchor = new Date(recurrenceStart + "T00:00:00");
+          const anchor = new Date(anchorStr + "T00:00:00");
           if (dayDate < anchor) return false;
           const monthsDiff =
             (dayDate.getFullYear() - anchor.getFullYear()) * 12 +

--- a/tests/test_calendar_projection.py
+++ b/tests/test_calendar_projection.py
@@ -192,3 +192,67 @@ def test_projection_horizon_honors_settings_clamp():
     run_async(coord._publish_chore_to_calendars(chore, today))
     # Horizon is clamped to MAX_CALENDAR_PROJECTION_DAYS=90.
     assert coord.hass.services.async_call.await_count == 90
+
+
+# ---------------------------------------------------------------------------
+# ERR-2: interval recurrences fall back to created_date when no recurrence_start
+# ---------------------------------------------------------------------------
+
+def test_schedule_helper_monthly_without_start_uses_created_date():
+    coord = _coord([])
+    chore = Chore(
+        name="Pay allowance",
+        schedule_mode="recurring",
+        recurrence="monthly",
+        created_date="2026-04-10",
+    )
+    # Projects on the created day-of-month, and the same day next month
+    assert coord._is_chore_scheduled_for_date(chore, date(2026, 4, 10)) is True
+    assert coord._is_chore_scheduled_for_date(chore, date(2026, 5, 10)) is True
+    # but not on other days
+    assert coord._is_chore_scheduled_for_date(chore, date(2026, 4, 11)) is False
+    assert coord._is_chore_scheduled_for_date(chore, date(2026, 4, 25)) is False
+
+
+def test_schedule_helper_quarterly_without_start_projects():
+    coord = _coord([])
+    chore = Chore(
+        name="Deep clean",
+        schedule_mode="recurring",
+        recurrence="every_3_months",
+        created_date="2026-01-15",
+    )
+    assert coord._is_chore_scheduled_for_date(chore, date(2026, 1, 15)) is True
+    assert coord._is_chore_scheduled_for_date(chore, date(2026, 4, 15)) is True   # +3 months
+    assert coord._is_chore_scheduled_for_date(chore, date(2026, 2, 15)) is False  # +1 month
+    assert coord._is_chore_scheduled_for_date(chore, date(2026, 7, 15)) is True   # +6 months
+
+
+def test_schedule_helper_every_2_days_without_start_uses_created_date():
+    coord = _coord([])
+    chore = Chore(
+        name="Water plants",
+        schedule_mode="recurring",
+        recurrence="every_2_days",
+        created_date="2026-04-20",
+    )
+    assert coord._is_chore_scheduled_for_date(chore, date(2026, 4, 20)) is True
+    assert coord._is_chore_scheduled_for_date(chore, date(2026, 4, 22)) is True
+    assert coord._is_chore_scheduled_for_date(chore, date(2026, 4, 21)) is False
+
+
+def test_schedule_helper_explicit_start_overrides_created_date():
+    coord = _coord([])
+    # recurrence_start anchors the cadence, not created_date
+    chore = Chore(
+        name="Bins out",
+        schedule_mode="recurring",
+        recurrence="monthly",
+        created_date="2026-04-01",
+        recurrence_start="2026-04-03",
+    )
+    assert coord._is_chore_scheduled_for_date(chore, date(2026, 4, 3)) is True
+    assert coord._is_chore_scheduled_for_date(chore, date(2026, 5, 3)) is True
+    # anchored to recurrence_start (3rd), not created_date (1st)
+    assert coord._is_chore_scheduled_for_date(chore, date(2026, 4, 1)) is False
+    assert coord._is_chore_scheduled_for_date(chore, date(2026, 4, 10)) is False


### PR DESCRIPTION
## ERR-2 / QUAL-1 — interval recurrences never projected without `recurrence_start`

Month-based (`monthly`/`every_3_months`/`every_6_months`) and `every_2_days` chores were never projected onto the HA calendar entity or the calendar card unless an explicit `recurrence_start` was set — so quarterly/biannual chores **never appeared anywhere**, despite being claimable.

### Fix
Both the Python projection (`coord_calendar._is_chore_scheduled_for_date`) and its JS card mirror (`taskmate-calendar-card.js _isChoreScheduledOn`) now fall back to `created_date` as the cadence anchor when `recurrence_start` is empty. An explicit `recurrence_start` still takes precedence.

**QUAL-1:** extracted the weekday map (was duplicated 3×) and the month-steps map into module-level `_DOW_MAP` / `_MONTH_STEPS` in `coord_chores.py`.

**Scope note:** the completion-relative *availability* model (`is_chore_available_for_child`) is intentionally left unchanged — it is heavily relied upon and tested. This PR fixes the concrete, verified "never projects" bug; the availability vs calendar models legitimately differ (completion-relative vs schedule-relative).

### Testing
- 4 new cases in `test_calendar_projection.py` (monthly / quarterly / every_2_days without start; explicit-start precedence). `pytest` over calendar/assignment/coordinator/expiry suites → **165 passed**.
- Card mirror verified on **ha-dev** via browserless: 9 date assertions (quarterly/monthly/every_2_days project on the right days, not others), zero console errors.

From AUDIT_REPORT.md §3.2 / §3.4.