### PR TITLE
feat(photos): disk quota + orphan sweep for evidence photos (SEC-2)

### DIFF
--- a/custom_components/taskmate/coordinator.py
+++ b/custom_components/taskmate/coordinator.py
@@ -26,6 +26,7 @@ from .coord_quests import QuestsMixin
 from .coord_rewards import RewardsMixin
 from .coord_templates import TemplatesMixin
 from .coord_timed import TimedMixin
+from . import photos
 from .models import Child
 from .storage import TaskMateStorage
 
@@ -435,6 +436,7 @@ class TaskMateCoordinator(
             # Mandatory 'anytime' chores + postpone-map reset (#532)
             self.async_detect_anytime_mandatory_misses,
             self.async_prune_orphan_misses,
+            self._async_sweep_orphan_photos,
         ]
         # Check for perfect week bonus every Monday at midnight
         if now.weekday() == 0:
@@ -447,6 +449,17 @@ class TaskMateCoordinator(
         # Prune all-chores-done daily flags older than today
         self.storage.prune_all_done_flags(dt_util.now().date().isoformat())
         await self.storage.async_save()
+
+    async def _async_sweep_orphan_photos(self) -> None:
+        """Delete evidence photos not referenced by any completion (SEC-2)."""
+        referenced = [
+            getattr(c, "photo_url", "")
+            for c in self.storage.get_completions()
+            if getattr(c, "photo_url", "")
+        ]
+        removed = await photos.async_sweep_orphan_photos(self.hass, referenced)
+        if removed:
+            _LOGGER.info("Swept %d orphan evidence photo(s)", removed)
 
     @callback
     def _async_scheduled_prune(self, now: datetime) -> None:

--- a/custom_components/taskmate/http_photos.py
+++ b/custom_components/taskmate/http_photos.py
@@ -69,6 +69,15 @@ class TaskMatePhotoUploadView(HomeAssistantView):
         if ext is None:
             return self.json_message("Not a valid image", HTTPStatus.BAD_REQUEST)
 
+        # DoS guard: reject if the photo store is already at its disk budget.
+        used = await self.hass.async_add_executor_job(
+            photos.total_photos_bytes, self.hass
+        )
+        if used + len(data) > photos.MAX_TOTAL_BYTES:
+            return self.json_message(
+                "Photo storage full", HTTPStatus.INSUFFICIENT_STORAGE
+            )
+
         name = f"{uuid.uuid4().hex}.{ext}"
         directory = photos.photos_path(self.hass)
         payload = bytes(data)

--- a/custom_components/taskmate/photos.py
+++ b/custom_components/taskmate/photos.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import logging
 import re
+import time
 from pathlib import Path
 
 _LOGGER = logging.getLogger(__name__)
@@ -24,6 +25,11 @@ URL_PREFIX = "/api/taskmate/photo"
 # Defensive cap. The child card downscales + JPEG-compresses before upload, so a
 # legitimate evidence photo is well under this; the cap only catches abuse/bugs.
 MAX_UPLOAD_BYTES = 8 * 1024 * 1024  # 8 MB
+
+# Total disk budget for all stored evidence photos. Each photo is small (the
+# card downscales + JPEG-compresses before upload), so this is generous — it
+# only caps runaway/abusive uploads (SEC-2).
+MAX_TOTAL_BYTES = 512 * 1024 * 1024  # 512 MB
 
 # Stored filenames are always a generated uuid4().hex + a known image extension.
 # Anything else is rejected before any filesystem access (path-traversal safety).
@@ -144,3 +150,54 @@ async def async_delete_photo(hass, photo_url: str) -> None:
             _LOGGER.debug("Could not delete evidence photo %s: %s", path, err)
 
     await hass.async_add_executor_job(_unlink)
+
+
+def total_photos_bytes(hass) -> int:
+    """Sum of all stored evidence-photo file sizes (0 if the dir is absent)."""
+    directory = photos_path(hass)
+    if not directory.is_dir():
+        return 0
+    total = 0
+    for p in directory.iterdir():
+        if p.is_file() and FILENAME_RE.match(p.name):
+            try:
+                total += p.stat().st_size
+            except OSError:  # pragma: no cover - defensive
+                pass
+    return total
+
+
+async def async_sweep_orphan_photos(hass, referenced_urls, max_age_hours: int = 24) -> int:
+    """Delete stored photos not referenced by any completion (SEC-2).
+
+    Covers photos orphaned by history pruning and uploads that were never
+    attached to a completion. Files younger than ``max_age_hours`` are kept so
+    an in-flight upload (uploaded but not yet submitted) is not removed.
+    Returns the number of files deleted.
+    """
+    prefix = URL_PREFIX + "/"
+    referenced = {
+        url[len(prefix):] for url in referenced_urls
+        if url and url.startswith(prefix)
+    }
+    directory = photos_path(hass)
+
+    def _sweep() -> int:
+        if not directory.is_dir():
+            return 0
+        cutoff = time.time() - max_age_hours * 3600
+        removed = 0
+        for p in directory.iterdir():
+            if not (p.is_file() and FILENAME_RE.match(p.name)):
+                continue
+            if p.name in referenced:
+                continue
+            try:
+                if p.stat().st_mtime < cutoff:
+                    p.unlink()
+                    removed += 1
+            except OSError:  # pragma: no cover - defensive
+                pass
+        return removed
+
+    return await hass.async_add_executor_job(_sweep)

--- a/tests/test_photo_storage.py
+++ b/tests/test_photo_storage.py
@@ -2,6 +2,8 @@
 from __future__ import annotations
 
 import asyncio
+import os
+import time
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -109,3 +111,48 @@ def test_delete_photo_ignores_foreign_url(tmp_path):
     hass = _hass(tmp_path)
     run(photos.async_delete_photo(hass, "http://example.com/x.jpg"))  # no raise, no exec
     hass.async_add_executor_job.assert_not_called()
+
+
+# ── quota + orphan sweep (SEC-2) ─────────────────────────────────────────────
+
+def _write_photo(tmp_path, name, data=b"x", age_hours=0):
+    d = Path(tmp_path, photos.PHOTOS_DIR)
+    d.mkdir(parents=True, exist_ok=True)
+    f = d / name
+    f.write_bytes(data)
+    if age_hours:
+        old = time.time() - age_hours * 3600
+        os.utime(f, (old, old))
+    return f
+
+
+def test_total_photos_bytes(tmp_path):
+    hass = _hass(tmp_path)
+    assert photos.total_photos_bytes(hass) == 0
+    _write_photo(tmp_path, "a" * 32 + ".jpg", b"12345")
+    _write_photo(tmp_path, "b" * 32 + ".png", b"123")
+    # non-photo files are ignored
+    Path(tmp_path, photos.PHOTOS_DIR, "notes.txt").write_bytes(b"ignored")
+    assert photos.total_photos_bytes(hass) == 8
+
+
+def test_sweep_removes_old_unreferenced_only(tmp_path):
+    hass = _hass(tmp_path)
+    keep = "a" * 32 + ".jpg"        # old but referenced -> keep
+    orphan_old = "b" * 32 + ".jpg"  # old + unreferenced -> delete
+    orphan_new = "c" * 32 + ".jpg"  # new + unreferenced -> keep (grace window)
+    _write_photo(tmp_path, keep, age_hours=48)
+    _write_photo(tmp_path, orphan_old, age_hours=48)
+    _write_photo(tmp_path, orphan_new, age_hours=1)
+    referenced = [photos.URL_PREFIX + "/" + keep]
+    removed = run(photos.async_sweep_orphan_photos(hass, referenced))
+    assert removed == 1
+    d = Path(tmp_path, photos.PHOTOS_DIR)
+    assert (d / keep).exists()
+    assert not (d / orphan_old).exists()
+    assert (d / orphan_new).exists()
+
+
+def test_sweep_missing_dir_is_noop(tmp_path):
+    hass = _hass(tmp_path)
+    assert run(photos.async_sweep_orphan_photos(hass, [])) == 0


### PR DESCRIPTION
## SEC-2 — photo upload quota + orphan sweep

The `POST /api/taskmate/photo` endpoint is auth-gated but had **no quota** and orphaned photos were **never reclaimed** (cleanup only ran on reject/prune). A logged-in user (or compromised child token) could fill the HA disk, and photos from pruned completions lingered forever.

### Fix
- Upload rejects with **507 Insufficient Storage** once the store would exceed `MAX_TOTAL_BYTES` (512 MB).
- New `photos.async_sweep_orphan_photos()` deletes stored photos not referenced by any completion **and** older than a 24h grace window (so an upload still mid-flow — uploaded but not yet submitted — is not removed). Wired into midnight maintenance.

### Testing
- New unit tests: `total_photos_bytes` (ignores non-photos), sweep (keeps referenced + keeps recent, deletes old unreferenced), missing-dir no-op. 15 passed.
- Verified on **ha-dev**: integration loads cleanly after a restart (overview sensor populated, no errors from the changed modules).

From AUDIT_REPORT.md §3.1.