### PR TITLE
fix(audit): record mutating service calls in the admin audit log (SEC-3)

### DIFF
--- a/custom_components/taskmate/__init__.py
+++ b/custom_components/taskmate/__init__.py
@@ -286,6 +286,48 @@ async def _async_require_admin(hass: HomeAssistant, call: ServiceCall) -> None:
             raise Unauthorized(context=call.context)
 
 
+_AUDIT_TARGET_KEYS = (
+    "chore_id", "reward_id", "penalty_id", "bonus_id", "badge_id",
+    "task_group_id", "miss_id", "claim_id", "transaction_id", "type_id",
+)
+
+
+async def _async_record_service_audit(hass: HomeAssistant, call: ServiceCall) -> None:
+    """Record a mutating service call in the admin audit log (SEC-3).
+
+    The panel's WebSocket path audits every config change; the equivalent
+    ``taskmate.*`` services did not, so point/penalty/chore mutations made via
+    Dev Tools or automations left no trail. Best-effort: never block the action.
+    """
+    coordinator = _get_coordinator(hass)
+    if not coordinator:
+        return
+    user_id = call.context.user_id or ""
+    user_name = ""
+    if user_id:
+        try:
+            user = await hass.auth.async_get_user(user_id)
+            user_name = user.name if user else ""
+        except Exception:  # noqa: BLE001 - audit must never break the action
+            user_name = ""
+    target = ""
+    cid = call.data.get(ATTR_CHILD_ID) or call.data.get("child_id") or call.data.get("to_child_id")
+    if cid:
+        child = coordinator.get_child(cid)
+        target = getattr(child, "name", "") or str(cid)
+    else:
+        for key in _AUDIT_TARGET_KEYS:
+            if call.data.get(key):
+                target = f"{key}={call.data[key]}"
+                break
+    try:
+        await coordinator.async_record_audit(
+            user_id, user_name, f"service.{call.service}", target
+        )
+    except Exception:  # noqa: BLE001 - audit must never break the action
+        _LOGGER.debug("Failed to record service audit for %s", call.service, exc_info=True)
+
+
 def _safe(handler):
     """Surface coordinator validation errors as clean service errors.
 
@@ -338,6 +380,7 @@ async def _async_register_services(hass: HomeAssistant) -> None:
         async def wrapped(call: ServiceCall) -> None:
             await _async_require_admin(hass, call)
             await handler(call)
+            await _async_record_service_audit(hass, call)
         # Compose with _safe so admin handlers also convert coordinator
         # ValueErrors into clean validation errors. The admin gate raises
         # Unauthorized (not ValueError), so it is unaffected and still 401s.

--- a/tests/test_service_admin_gate.py
+++ b/tests/test_service_admin_gate.py
@@ -51,3 +51,51 @@ async def test_rejects_unknown_user():
     """A user_id that no longer resolves to a user is rejected, not allowed."""
     with pytest.raises(tm.Unauthorized):
         await tm._async_require_admin(_hass(None), _call("uid-ghost"))
+
+
+# ---------------------------------------------------------------------------
+# SEC-3: mutating service calls are recorded in the admin audit log
+# ---------------------------------------------------------------------------
+
+def _audit_call(user_id, service, data):
+    call = MagicMock()
+    call.context.user_id = user_id
+    call.service = service
+    call.data = data
+    return call
+
+
+@pytest.mark.asyncio
+async def test_service_audit_records_with_child_name(monkeypatch):
+    coordinator = MagicMock()
+    coordinator.get_child = MagicMock(return_value=MagicMock(name="x"))
+    coordinator.get_child.return_value.name = "Malia"
+    coordinator.async_record_audit = AsyncMock()
+    monkeypatch.setattr(tm, "_get_coordinator", lambda hass: coordinator)
+    hass = _hass(MagicMock(name="Parent"))
+    hass.auth.async_get_user.return_value.name = "Parent"
+    await tm._async_record_service_audit(hass, _audit_call("uid-admin", "add_points", {"child_id": "c1", "points": 5}))
+    coordinator.async_record_audit.assert_awaited_once()
+    args = coordinator.async_record_audit.await_args.args
+    assert args[0] == "uid-admin"
+    assert args[2] == "service.add_points"
+    assert args[3] == "Malia"
+
+
+@pytest.mark.asyncio
+async def test_service_audit_falls_back_to_id_target(monkeypatch):
+    coordinator = MagicMock()
+    coordinator.async_record_audit = AsyncMock()
+    monkeypatch.setattr(tm, "_get_coordinator", lambda hass: coordinator)
+    hass = _hass(None)
+    await tm._async_record_service_audit(hass, _audit_call(None, "add_chore", {"chore_id": "ch9"}))
+    args = coordinator.async_record_audit.await_args.args
+    assert args[2] == "service.add_chore"
+    assert args[3] == "chore_id=ch9"
+
+
+@pytest.mark.asyncio
+async def test_service_audit_noop_without_coordinator(monkeypatch):
+    monkeypatch.setattr(tm, "_get_coordinator", lambda hass: None)
+    # must not raise
+    await tm._async_record_service_audit(_hass(None), _audit_call("u", "add_points", {}))


### PR DESCRIPTION
## SEC-3 — service mutations were not audited

The panel/WebSocket path records every mutating command in the admin audit log, but the equivalent `taskmate.*` **services** did not. An admin (or automation) could move points / apply penalties / add-remove chores via Dev Tools with **no audit trail**, undermining the audit feature.

### Fix
The `_admin` wrapper (which gates all mutating services) now records a `service.<name>` audit entry after the handler succeeds, resolving the child name as the target where possible (falling back to the relevant id). Best-effort — auditing never blocks or fails the action; context-less automation calls are recorded with an empty user.

### Testing
- Unit tests: records with child-name target, id-target fallback, no-op without coordinator (7 passed; 38 across audit/service suites).
- **Live on ha-dev**: calling `add_points` produced `service.add_points` audit entry with the user (`John`) and target (`Malia`) resolved.

From AUDIT_REPORT.md §3.1.