### PR TITLE
fix(assignments): run availability listener on loop + cache tracked entities (PERF-5)

### DIFF
--- a/custom_components/taskmate/coord_assignments.py
+++ b/custom_components/taskmate/coord_assignments.py
@@ -7,6 +7,7 @@ import logging
 from datetime import date
 from typing import TYPE_CHECKING, Any
 
+from homeassistant.core import callback
 from homeassistant.util import dt as dt_util
 
 from .models import Chore
@@ -20,19 +21,34 @@ _LOGGER = logging.getLogger(__name__)
 class AssignmentsMixin:
     """Mixin providing assignment rotation, availability, and visibility logic."""
 
-    def _availability_state_changed(self, event: Any) -> None:
-        """Cheap bus-filter: only dispatch a re-eval when a tracked availability entity changes."""
-        data = getattr(event, "data", None) or {}
-        entity_id = data.get("entity_id")
-        if not entity_id:
-            return
+    def _refresh_tracked_availability_entities(self) -> None:
+        """Rebuild the cached set of entities that gate child availability.
+
+        Children only change via mutations (which trigger a coordinator
+        refresh), so this is rebuilt on refresh rather than on every bus
+        state_changed event — which fires for every entity in HA (PERF-5).
+        """
         tracked: set[str] = set()
         for c in self.storage.get_children():
             if getattr(c, "availability_entity", ""):
                 tracked.add(c.availability_entity)
             if getattr(c, "unavailability_entity", ""):
                 tracked.add(c.unavailability_entity)
-        if entity_id not in tracked:
+        self._tracked_availability_entities = tracked
+
+    @callback
+    def _availability_state_changed(self, event: Any) -> None:
+        """Cheap bus-filter: dispatch a re-eval only when a tracked entity changes.
+
+        Decorated @callback so it runs on the event loop (a plain listener runs
+        in the executor, where async_create_task raises) and reads the cached
+        tracked-entity set rather than rescanning all children per event.
+        """
+        data = getattr(event, "data", None) or {}
+        entity_id = data.get("entity_id")
+        if not entity_id:
+            return
+        if entity_id not in getattr(self, "_tracked_availability_entities", set()):
             return
         self.hass.async_create_task(self._async_reevaluate_availability())
 

--- a/custom_components/taskmate/coordinator.py
+++ b/custom_components/taskmate/coordinator.py
@@ -64,6 +64,7 @@ class TaskMateCoordinator(
         self._unsub_midnight: Callable[[], None] | None = None
         self._unsub_prune: Callable[[], None] | None = None
         self._unsub_availability: Callable[[], None] | None = None
+        self._tracked_availability_entities: set[str] = set()
         self._unsub_surprise: Callable[[], None] | None = None
         self._unsub_weekly: Callable[[], None] | None = None
         self._unsub_mandatory: list[Callable[[], None]] = []
@@ -238,6 +239,7 @@ class TaskMateCoordinator(
         # Re-evaluate availability-aware chore assignments when any HA entity
         # state changes. The callback filters cheaply on entity id so only
         # relevant flips trigger a recompute.
+        self._refresh_tracked_availability_entities()
         self._unsub_availability = self.hass.bus.async_listen(
             "state_changed", self._availability_state_changed
         )
@@ -470,6 +472,7 @@ class TaskMateCoordinator(
     async def _async_update_data(self) -> dict[str, Any]:
         """Fetch data from storage."""
         await self._async_auto_stop_capped_sessions()
+        self._refresh_tracked_availability_entities()
         return {
             "children": self.storage.get_children(),
             "chores": self.storage.get_chores(),


### PR DESCRIPTION
## PERF-5 + thread-safety — availability state listener

`_availability_state_changed` was registered via `bus.async_listen` but **not** decorated `@callback`, so HA ran it in the executor thread — where its `self.hass.async_create_task(...)` raises *"Detected ... calls hass.async_create_task from a thread other than the event loop"* (observed live in the ha-dev error log).

### Fix
- Decorate the listener `@callback` so it runs on the event loop (where `async_create_task` is safe).
- It also rescanned **every child on every `state_changed` event** (which fires constantly for all entities). Cache the tracked availability-entity set and rebuild it on coordinator refresh — children only change via mutations, which trigger a refresh (PERF-5).

### Testing
- `pytest` assignment/rotation/integration → 75 passed.
- ha-dev restarts cleanly; the thread-safety RuntimeError no longer appears in the error log.

From AUDIT_REPORT.md §3.5 (and a live finding during this run).