### PR TITLE
fix(cards): observer leak, badge subscribe race, mdi-icon-size typo (ERR-6/8/9)

### DIFF
--- a/custom_components/taskmate/www/taskmate-approvals-card.js
+++ b/custom_components/taskmate/www/taskmate-approvals-card.js
@@ -130,7 +130,7 @@ class TaskMateApprovalsCard extends LitElement {
       }
 
       .time-header ha-icon {
-        --mdi-icon-size: 16px;
+        --mdc-icon-size: 16px;
       }
 
       .approval-item {
@@ -209,7 +209,7 @@ class TaskMateApprovalsCard extends LitElement {
       }
 
       .points-badge ha-icon {
-        --mdi-icon-size: 14px;
+        --mdc-icon-size: 14px;
       }
 
       .duration-badge {
@@ -224,7 +224,7 @@ class TaskMateApprovalsCard extends LitElement {
         font-size: 0.85em;
       }
       .duration-badge ha-icon {
-        --mdi-icon-size: 14px;
+        --mdc-icon-size: 14px;
       }
 
       .action-buttons {
@@ -305,7 +305,7 @@ class TaskMateApprovalsCard extends LitElement {
       }
 
       .action-button ha-icon {
-        --mdi-icon-size: 20px;
+        --mdc-icon-size: 20px;
       }
 
       .action-button.loading {
@@ -324,7 +324,7 @@ class TaskMateApprovalsCard extends LitElement {
       }
 
       .empty-state ha-icon {
-        --mdi-icon-size: 48px;
+        --mdc-icon-size: 48px;
         margin-bottom: 16px;
         opacity: 0.5;
       }
@@ -350,7 +350,7 @@ class TaskMateApprovalsCard extends LitElement {
       }
 
       .error-state ha-icon {
-        --mdi-icon-size: 48px;
+        --mdc-icon-size: 48px;
         margin-bottom: 16px;
       }
 

--- a/custom_components/taskmate/www/taskmate-child-card.js
+++ b/custom_components/taskmate/www/taskmate-child-card.js
@@ -111,8 +111,9 @@ class TaskMateChildCard extends LitElement {
   }
 
   _subscribeBadgeEvents() {
-    if (this._badgeEventUnsub) return;
+    if (this._badgeEventUnsub || this._badgeSubscribing) return;
     if (!this.hass?.connection) return;
+    this._badgeSubscribing = true;
     this.hass.connection.subscribeEvents((event) => {
       const data = event.data || {};
       const configChild = this.config?.child_id;
@@ -123,12 +124,13 @@ class TaskMateChildCard extends LitElement {
         setTimeout(() => { this._justEarnedBadge = null; this.requestUpdate(); }, 1800);
       }
     }, "taskmate_badge_earned").then(unsub => {
+      this._badgeSubscribing = false;
       if (!this.isConnected) {
         unsub();
         return;
       }
       this._badgeEventUnsub = unsub;
-    }).catch(() => {});
+    }).catch(() => { this._badgeSubscribing = false; });
   }
 
   _tierColor(tier) {

--- a/custom_components/taskmate/www/taskmate-config-sounds.js
+++ b/custom_components/taskmate/www/taskmate-config-sounds.js
@@ -588,6 +588,7 @@
       childList: true,
       subtree: true,
     });
+    window._taskmateSoundObserver = observer;
 
     debugLog('[TaskMate Config] Sound change observer started');
   }
@@ -611,6 +612,10 @@
       if (window._taskmateScanTimeout) {
         clearTimeout(window._taskmateScanTimeout);
         window._taskmateScanTimeout = null;
+      }
+      if (window._taskmateSoundObserver) {
+        window._taskmateSoundObserver.disconnect();
+        window._taskmateSoundObserver = null;
       }
     };
     // pagehide covers SPA navigation in HA; beforeunload covers full reloads.


### PR DESCRIPTION
## ERR-6 / ERR-8 / ERR-9 — small card leaks & cleanup

- **ERR-6** `config-sounds`: the body-wide `MutationObserver` was created in a local `const` unreachable from `cleanup`, so it was never `.disconnect()`ed (only the interval/timeout were cleared). Hoisted to `window._taskmateSoundObserver` and disconnected on cleanup.
- **ERR-8** `child-card`: `_subscribeBadgeEvents` guarded only on `_badgeEventUnsub` (null while the subscribe promise is in flight), so a fast disconnect→reconnect could start a 2nd subscription. Added a `_badgeSubscribing` in-flight flag.
- **ERR-9** `approvals-card`: `--mdi-icon-size` → `--mdc-icon-size` (6×) — the typo custom property had no effect.

### Testing
Verified on **ha-dev** via browserless: double `_subscribeBadgeEvents()` → exactly 1 subscribe; config-sounds observer present then disconnected on `pagehide` (poll cleared too); zero console errors.

From AUDIT_REPORT.md §3.2 / §3.3.