### PR TITLE
chore: remove dead code + correct set_setting typing (ERR-9, dead code)

### DIFF
--- a/custom_components/taskmate/storage.py
+++ b/custom_components/taskmate/storage.py
@@ -1126,11 +1126,11 @@ class TaskMateStorage:
         ]
 
     # Generic settings
-    def get_setting(self, key: str, default: str = "") -> str:
-        """Get a generic setting value."""
+    def get_setting(self, key: str, default: Any = "") -> Any:
+        """Get a generic setting value (may be a bool/number/list, not just str)."""
         return self._data.get("settings", {}).get(key, default)
 
-    def set_setting(self, key: str, value: str) -> None:
+    def set_setting(self, key: str, value: Any) -> None:
         """Set a generic setting value."""
         if "settings" not in self._data:
             self._data["settings"] = {}

--- a/custom_components/taskmate/www/taskmate-child-card.js
+++ b/custom_components/taskmate/www/taskmate-child-card.js
@@ -2956,8 +2956,6 @@ class TaskMateChildCard extends LitElement {
     // Get tomorrow midnight in HA timezone
     const tomorrow = new Date(now.toLocaleDateString("en-CA", { timeZone: tz }) + "T00:00:00");
     tomorrow.setDate(tomorrow.getDate() + 1);
-    // Convert back to UTC ms
-    const tomorrowUTC = new Date(tomorrow.toLocaleString("en-US", { timeZone: tz }));
     const diffMs = tomorrow - now;
     if (diffMs <= 0) return null;
 

--- a/custom_components/taskmate/www/taskmate-rewards-card.js
+++ b/custom_components/taskmate/www/taskmate-rewards-card.js
@@ -483,23 +483,6 @@ class TaskMateRewardsCard extends LitElement {
         box-shadow: 0 3px 10px rgba(241, 196, 15, 0.4);
       }
 
-      /* Dynamic reward styles */
-      .reward-row.dynamic {
-        border: 1px dashed rgba(52, 152, 219, 0.5);
-      }
-
-      .cost-badge.dynamic-cost {
-        background: linear-gradient(135deg, #3498db 0%, #2980b9 100%);
-        box-shadow: 0 2px 8px rgba(52, 152, 219, 0.3);
-        position: relative;
-      }
-
-      .dynamic-indicator {
-        font-size: 0.9rem;
-        margin-top: 2px;
-        filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.3));
-      }
-
       /* Reward icon + claim button wrapper */
       /* Child picker shown when no child_id configured */
       .child-picker-row {


### PR DESCRIPTION
## Dead code + typing cleanup (ERR-9, §3.3)

- `storage.get_setting`/`set_setting` were annotated `str` despite storing bools/numbers/lists (the root of float-as-string round-tripping). Annotated as `Any`.
- `rewards-card`: removed dead `.reward-row.dynamic` / `.cost-badge.dynamic-cost` / `.dynamic-indicator` CSS — dynamic/surge pricing was deliberately removed long ago.
- `child-card`: removed the unused `tomorrowUTC` local in `_getMidnightCountdown`.

### Testing
`pytest tests/test_storage.py` → 40 passed; both cards register on **ha-dev** via browserless with zero console errors.

From AUDIT_REPORT.md §3.2 / §3.3.