### PR TITLE
fix(security): tighten kiosk cross-child gate + clamp negative point args (SEC-4/6)

### DIFF
--- a/custom_components/taskmate/__init__.py
+++ b/custom_components/taskmate/__init__.py
@@ -363,12 +363,20 @@ async def _async_require_linked_child(
         return
     child = coordinator.get_child(child_id)
     linked = getattr(child, "linked_user_id", "") if child else ""
-    if not linked or linked == user_id:
+    if linked == user_id:
         return
     user = await hass.auth.async_get_user(user_id)
     if user is not None and user.is_admin:
         return
-    raise Unauthorized(context=call.context)
+    if linked:
+        # Target child is linked to a different user and caller isn't admin.
+        raise Unauthorized(context=call.context)
+    # Target child is unlinked (kiosk). A user who is themselves linked to a
+    # *different* child must not act through an unlinked child (SEC-4); truly
+    # unlinked/anonymous callers keep the open kiosk behaviour.
+    others = coordinator.get_children() or []
+    if any(getattr(c, "linked_user_id", "") == user_id for c in others):
+        raise Unauthorized(context=call.context)
 
 
 async def _async_register_services(hass: HomeAssistant) -> None:

--- a/custom_components/taskmate/coord_points.py
+++ b/custom_components/taskmate/coord_points.py
@@ -233,6 +233,8 @@ class PointsMixin:
 
     async def async_add_points(self, child_id: str, points: int, reason: str = "") -> None:
         """Add points to a child (bonus)."""
+        if points < 0:
+            raise ValueError("points must be non-negative")
         child = self.get_child(child_id)
         if not child:
             raise ValueError(f"Child {child_id} not found")
@@ -262,6 +264,8 @@ class PointsMixin:
 
     async def async_remove_points(self, child_id: str, points: int, reason: str = "") -> None:
         """Remove points from a child (penalty)."""
+        if points < 0:
+            raise ValueError("points must be non-negative")
         child = self.get_child(child_id)
         if not child:
             raise ValueError(f"Child {child_id} not found")

--- a/tests/test_coordinator_logic.py
+++ b/tests/test_coordinator_logic.py
@@ -1123,3 +1123,23 @@ class TestNegativeBalancePolicy:
         coord = _make_coord(settings={"allow_negative_balance": "true"}, children=[child])
         run(coord.async_remove_points(child.id, 8, reason="Penalty: test"))
         assert child.points == -3
+
+
+# ---------------------------------------------------------------------------
+# SEC-6: coordinator-layer guard against negative point arguments
+# ---------------------------------------------------------------------------
+
+class TestPointArgSignGuard:
+    def test_add_points_rejects_negative(self):
+        child = _make_child(points=10)
+        coord = _make_coord(children=[child])
+        with pytest.raises(ValueError):
+            run(coord.async_add_points(child.id, -5))
+        assert child.points == 10  # unchanged
+
+    def test_remove_points_rejects_negative(self):
+        child = _make_child(points=10)
+        coord = _make_coord(children=[child])
+        with pytest.raises(ValueError):
+            run(coord.async_remove_points(child.id, -5))
+        assert child.points == 10

--- a/tests/test_service_linked_child_gate.py
+++ b/tests/test_service_linked_child_gate.py
@@ -27,12 +27,13 @@ def _hass(user):
     return hass
 
 
-def _coordinator(linked_user_id):
+def _coordinator(linked_user_id, others=None):
     coord = MagicMock()
     if linked_user_id is None:
         coord.get_child.return_value = None
     else:
         coord.get_child.return_value = MagicMock(linked_user_id=linked_user_id)
+    coord.get_children.return_value = others or []
     return coord
 
 
@@ -84,3 +85,22 @@ async def test_other_non_admin_rejected():
         await tm._async_require_linked_child(
             _hass(MagicMock(is_admin=False)), _call("uid-sibling"), _coordinator("uid-malia"), "child-1"
         )
+
+
+@pytest.mark.asyncio
+async def test_unlinked_child_blocks_known_other_child():
+    """SEC-4: a user linked to a different child can't act via an unlinked child."""
+    coord = _coordinator("", others=[MagicMock(linked_user_id="uid-sibling")])
+    with pytest.raises(tm.Unauthorized):
+        await tm._async_require_linked_child(
+            _hass(MagicMock(is_admin=False)), _call("uid-sibling"), coord, "child-1"
+        )
+
+
+@pytest.mark.asyncio
+async def test_unlinked_child_admin_still_allowed_with_other_links():
+    """An admin is allowed through an unlinked child even when other links exist."""
+    coord = _coordinator("", others=[MagicMock(linked_user_id="uid-sibling")])
+    await tm._async_require_linked_child(
+        _hass(MagicMock(is_admin=True)), _call("uid-parent"), coord, "child-1"
+    )


### PR DESCRIPTION
## SEC-4 + SEC-6 — security hardening

**SEC-4 — kiosk cross-child completion.** `_async_require_linked_child` left unlinked (kiosk) children fully open, so a child account *linked* to a different child could self-serve as an unlinked sibling (point farming / impersonation). Now: if the caller is themselves linked to another child, they must be an admin to act through an unlinked child. Truly unlinked/anonymous kiosk callers keep the open behaviour; the linked-child and admin paths are unchanged.

**SEC-6 — negative point arguments.** `async_add_points` / `async_remove_points` now reject negative `points` (defense-in-depth — every reachable caller already validates via `cv.positive_int` / `vol.Range`, but the coordinator no longer trusts that).

### Testing
- New unit tests: known-other-child blocked, admin still allowed through an unlinked child, add/remove reject negative. `pytest` linked-child + admin-gate + logic + integration green in isolation (the 3 cross-file failures are the documented pre-existing order pollution; CI `pytest -v` is green).
- ha-dev restarts cleanly.

From AUDIT_REPORT.md §3.1.