### PR TITLE
fix(graph-card): resolve Today/Yesterday tooltip labels in HA timezone (ERR-7)

### DIFF
--- a/custom_components/taskmate/www/taskmate-graph-card.js
+++ b/custom_components/taskmate/www/taskmate-graph-card.js
@@ -907,8 +907,9 @@ class TaskMateGraphCard extends LitElement {
 
   _formatTooltipDate(dateStr) {
     const d = new Date(dateStr + "T12:00:00");
-    const today = new Date().toLocaleDateString("en-CA");
-    const yesterday = new Date(Date.now() - 86400000).toLocaleDateString("en-CA");
+    const tz = this.hass?.config?.time_zone || Intl.DateTimeFormat().resolvedOptions().timeZone;
+    const today = new Date().toLocaleDateString("en-CA", { timeZone: tz });
+    const yesterday = new Date(Date.now() - 86400000).toLocaleDateString("en-CA", { timeZone: tz });
     if (dateStr === today) return this._t('common.today');
     if (dateStr === yesterday) return this._t('common.yesterday');
     return d.toLocaleDateString(undefined, { weekday: "short", month: "short", day: "numeric" });


### PR DESCRIPTION
## ERR-7 — graph-card tooltip Today/Yesterday in HA timezone

`_formatTooltipDate` compared an HA-timezone day key (`dateStr`) against browser-local `today`/`yesterday` (no `timeZone`), so the tooltip labels could be off by one when the viewer's device timezone differs from the HA server. Now derives today/yesterday from `hass.config.time_zone` to match the bucket keys.

(The child-card `_getMidnightCountdown` half of ERR-7 was already resolved by removing the unused `tomorrowUTC` in #598; the remaining `tomorrow` is HA-tz midnight.)

### Testing
Verified on **ha-dev** via browserless at `Pacific/Kiritimati` (UTC+14): the HA-tz today key resolves to "Today", zero console errors.

From AUDIT_REPORT.md §3.2.