### PR TITLE
feat(entities): expose key settings as number/select entities (FEAT-9)

### DIFF
--- a/custom_components/taskmate/__init__.py
+++ b/custom_components/taskmate/__init__.py
@@ -114,7 +114,7 @@ from .websocket import async_register_websocket_commands
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.BUTTON, Platform.BINARY_SENSOR, Platform.CALENDAR]
+PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.BUTTON, Platform.BINARY_SENSOR, Platform.CALENDAR, Platform.NUMBER, Platform.SELECT]
 
 # Track if services are registered
 SERVICES_REGISTERED = "services_registered"

--- a/custom_components/taskmate/number.py
+++ b/custom_components/taskmate/number.py
@@ -1,0 +1,73 @@
+"""Number platform — expose key numeric TaskMate settings as entities (FEAT-9).
+
+Lets the points-bearing knobs be read and changed from automations/scripts and
+the HA UI without a service call. Values are persisted through the same
+settings store the panel uses, so panel and entity stay in sync.
+"""
+from __future__ import annotations
+
+from homeassistant.components.number import NumberEntity, NumberMode
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .coordinator import TaskMateCoordinator
+
+# (setting_key, translation_key, min, max, step, default, icon)
+_NUMBERS = [
+    ("weekend_multiplier", "weekend_multiplier", 1.0, 5.0, 0.5, 1.0, "mdi:calendar-weekend"),
+    ("perfect_week_bonus", "perfect_week_bonus", 0, 1000, 1, 0, "mdi:trophy-award"),
+]
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up the TaskMate setting-number entities."""
+    coordinator: TaskMateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    async_add_entities(TaskMateSettingNumber(coordinator, entry, *cfg) for cfg in _NUMBERS)
+
+
+class TaskMateSettingNumber(CoordinatorEntity, NumberEntity):
+    """A single numeric TaskMate setting surfaced as a number entity."""
+
+    _attr_has_entity_name = True
+    _attr_mode = NumberMode.BOX
+
+    def __init__(self, coordinator, entry, key, tkey, mn, mx, step, default, icon) -> None:
+        super().__init__(coordinator)
+        self._entry = entry
+        self._key = key
+        self._default = default
+        self._attr_translation_key = tkey
+        self._attr_unique_id = f"{entry.entry_id}_setting_{key}"
+        self._attr_native_min_value = mn
+        self._attr_native_max_value = mx
+        self._attr_native_step = step
+        self._attr_icon = icon
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._entry.entry_id)},
+            name="TaskMate",
+            manufacturer="TaskMate",
+            model="Family Chore Manager",
+        )
+
+    @property
+    def native_value(self) -> float:
+        raw = self.coordinator.storage.get_setting(self._key, self._default)
+        try:
+            return float(raw)
+        except (TypeError, ValueError):
+            return float(self._default)
+
+    async def async_set_native_value(self, value: float) -> None:
+        stored = int(value) if float(value).is_integer() else value
+        self.coordinator.storage.set_setting(self._key, stored)
+        await self.coordinator.storage.async_save()
+        await self.coordinator.async_refresh()

--- a/custom_components/taskmate/select.py
+++ b/custom_components/taskmate/select.py
@@ -1,0 +1,63 @@
+"""Select platform — expose key choice TaskMate settings as entities (FEAT-9)."""
+from __future__ import annotations
+
+from homeassistant.components.select import SelectEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .coordinator import TaskMateCoordinator
+
+# (setting_key, translation_key, options, default, icon)
+_SELECTS = [
+    ("streak_reset_mode", "streak_reset_mode", ["reset", "pause"], "reset", "mdi:restart"),
+    ("card_design", "card_design", ["classic", "playroom", "console", "cleanpro"], "classic", "mdi:palette"),
+]
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up the TaskMate setting-select entities."""
+    coordinator: TaskMateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    async_add_entities(TaskMateSettingSelect(coordinator, entry, *cfg) for cfg in _SELECTS)
+
+
+class TaskMateSettingSelect(CoordinatorEntity, SelectEntity):
+    """A single choice TaskMate setting surfaced as a select entity."""
+
+    _attr_has_entity_name = True
+
+    def __init__(self, coordinator, entry, key, tkey, options, default, icon) -> None:
+        super().__init__(coordinator)
+        self._entry = entry
+        self._key = key
+        self._default = default
+        self._attr_translation_key = tkey
+        self._attr_unique_id = f"{entry.entry_id}_setting_{key}"
+        self._attr_options = options
+        self._attr_icon = icon
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._entry.entry_id)},
+            name="TaskMate",
+            manufacturer="TaskMate",
+            model="Family Chore Manager",
+        )
+
+    @property
+    def current_option(self) -> str:
+        val = str(self.coordinator.storage.get_setting(self._key, self._default))
+        return val if val in self._attr_options else self._default
+
+    async def async_select_option(self, option: str) -> None:
+        if option not in self._attr_options:
+            return
+        self.coordinator.storage.set_setting(self._key, option)
+        await self.coordinator.storage.async_save()
+        await self.coordinator.async_refresh()

--- a/custom_components/taskmate/strings.json
+++ b/custom_components/taskmate/strings.json
@@ -839,6 +839,22 @@
       "child_badges": {
         "unit_of_measurement": "badges"
       }
+    },
+    "number": {
+      "weekend_multiplier": {
+        "name": "Weekend multiplier"
+      },
+      "perfect_week_bonus": {
+        "name": "Perfect week bonus"
+      }
+    },
+    "select": {
+      "streak_reset_mode": {
+        "name": "Streak reset mode"
+      },
+      "card_design": {
+        "name": "Card design"
+      }
     }
   }
 }

--- a/custom_components/taskmate/translations/de.json
+++ b/custom_components/taskmate/translations/de.json
@@ -839,6 +839,22 @@
       "child_badges": {
         "unit_of_measurement": "Abzeichen"
       }
+    },
+    "number": {
+      "weekend_multiplier": {
+        "name": "Wochenend-Multiplikator"
+      },
+      "perfect_week_bonus": {
+        "name": "Bonus für perfekte Woche"
+      }
+    },
+    "select": {
+      "streak_reset_mode": {
+        "name": "Streak-Zurücksetzmodus"
+      },
+      "card_design": {
+        "name": "Kartendesign"
+      }
     }
   }
 }

--- a/custom_components/taskmate/translations/en-GB.json
+++ b/custom_components/taskmate/translations/en-GB.json
@@ -839,6 +839,22 @@
       "child_badges": {
         "unit_of_measurement": "badges"
       }
+    },
+    "number": {
+      "weekend_multiplier": {
+        "name": "Weekend multiplier"
+      },
+      "perfect_week_bonus": {
+        "name": "Perfect week bonus"
+      }
+    },
+    "select": {
+      "streak_reset_mode": {
+        "name": "Streak reset mode"
+      },
+      "card_design": {
+        "name": "Card design"
+      }
     }
   }
 }

--- a/custom_components/taskmate/translations/en.json
+++ b/custom_components/taskmate/translations/en.json
@@ -839,6 +839,22 @@
       "child_badges": {
         "unit_of_measurement": "badges"
       }
+    },
+    "number": {
+      "weekend_multiplier": {
+        "name": "Weekend multiplier"
+      },
+      "perfect_week_bonus": {
+        "name": "Perfect week bonus"
+      }
+    },
+    "select": {
+      "streak_reset_mode": {
+        "name": "Streak reset mode"
+      },
+      "card_design": {
+        "name": "Card design"
+      }
     }
   }
 }

--- a/custom_components/taskmate/translations/fr.json
+++ b/custom_components/taskmate/translations/fr.json
@@ -839,6 +839,22 @@
       "child_badges": {
         "unit_of_measurement": "badges"
       }
+    },
+    "number": {
+      "weekend_multiplier": {
+        "name": "Multiplicateur week-end"
+      },
+      "perfect_week_bonus": {
+        "name": "Bonus de semaine parfaite"
+      }
+    },
+    "select": {
+      "streak_reset_mode": {
+        "name": "Mode de réinitialisation de série"
+      },
+      "card_design": {
+        "name": "Design de carte"
+      }
     }
   }
 }

--- a/custom_components/taskmate/translations/nb.json
+++ b/custom_components/taskmate/translations/nb.json
@@ -839,6 +839,22 @@
       "child_badges": {
         "unit_of_measurement": "merker"
       }
+    },
+    "number": {
+      "weekend_multiplier": {
+        "name": "Helgemultiplikator"
+      },
+      "perfect_week_bonus": {
+        "name": "Bonus for perfekt uke"
+      }
+    },
+    "select": {
+      "streak_reset_mode": {
+        "name": "Tilbakestillingsmodus for rekke"
+      },
+      "card_design": {
+        "name": "Kortdesign"
+      }
     }
   }
 }

--- a/custom_components/taskmate/translations/nn.json
+++ b/custom_components/taskmate/translations/nn.json
@@ -839,6 +839,22 @@
       "child_badges": {
         "unit_of_measurement": "merke"
       }
+    },
+    "number": {
+      "weekend_multiplier": {
+        "name": "Helgemultiplikator"
+      },
+      "perfect_week_bonus": {
+        "name": "Bonus for perfekt veke"
+      }
+    },
+    "select": {
+      "streak_reset_mode": {
+        "name": "Tilbakestillingsmodus for rekkje"
+      },
+      "card_design": {
+        "name": "Kortdesign"
+      }
     }
   }
 }

--- a/custom_components/taskmate/translations/pt-BR.json
+++ b/custom_components/taskmate/translations/pt-BR.json
@@ -839,6 +839,22 @@
       "child_badges": {
         "unit_of_measurement": "medalhas"
       }
+    },
+    "number": {
+      "weekend_multiplier": {
+        "name": "Multiplicador de fim de semana"
+      },
+      "perfect_week_bonus": {
+        "name": "Bônus de semana perfeita"
+      }
+    },
+    "select": {
+      "streak_reset_mode": {
+        "name": "Modo de redefinição de sequência"
+      },
+      "card_design": {
+        "name": "Design do cartão"
+      }
     }
   }
 }

--- a/custom_components/taskmate/translations/pt.json
+++ b/custom_components/taskmate/translations/pt.json
@@ -839,6 +839,22 @@
       "child_badges": {
         "unit_of_measurement": "medalhas"
       }
+    },
+    "number": {
+      "weekend_multiplier": {
+        "name": "Multiplicador de fim de semana"
+      },
+      "perfect_week_bonus": {
+        "name": "Bónus de semana perfeita"
+      }
+    },
+    "select": {
+      "streak_reset_mode": {
+        "name": "Modo de reposição de sequência"
+      },
+      "card_design": {
+        "name": "Design do cartão"
+      }
     }
   }
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -173,6 +173,29 @@ _ha_components_button = MagicMock()
 _ha_components_button.ButtonEntity = _FakeButtonEntity
 
 
+class _FakeNumberEntity:
+    pass
+
+
+class _FakeNumberMode:
+    BOX = "box"
+    SLIDER = "slider"
+    AUTO = "auto"
+
+
+_ha_components_number = MagicMock()
+_ha_components_number.NumberEntity = _FakeNumberEntity
+_ha_components_number.NumberMode = _FakeNumberMode
+
+
+class _FakeSelectEntity:
+    pass
+
+
+_ha_components_select = MagicMock()
+_ha_components_select.SelectEntity = _FakeSelectEntity
+
+
 class _FakeDeviceInfo(dict):
     """DeviceInfo behaves like a TypedDict; accept kwargs like the real one."""
 
@@ -246,6 +269,8 @@ _ha_components = MagicMock()
 _ha_components.websocket_api = _ha_websocket_api
 _ha_components.calendar = _ha_components_calendar
 _ha_components.button = _ha_components_button
+_ha_components.number = _ha_components_number
+_ha_components.select = _ha_components_select
 
 sys.modules.update(
     {
@@ -266,6 +291,8 @@ sys.modules.update(
         "homeassistant.components.sensor": _ha_components_sensor,
         "homeassistant.components.binary_sensor": _ha_components_binary_sensor,
         "homeassistant.components.button": _ha_components_button,
+        "homeassistant.components.number": _ha_components_number,
+        "homeassistant.components.select": _ha_components_select,
         "homeassistant.components.calendar": _ha_components_calendar,
         "homeassistant.components.websocket_api": _ha_websocket_api,
         "homeassistant.util": _ha_util,

--- a/tests/test_settings_entities.py
+++ b/tests/test_settings_entities.py
@@ -1,0 +1,77 @@
+"""Tests for the number/select config-setting entities (FEAT-9)."""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+from custom_components.taskmate.number import TaskMateSettingNumber
+from custom_components.taskmate.select import TaskMateSettingSelect
+
+
+def run(coro):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+def _coord(settings=None):
+    s = settings or {}
+    coord = MagicMock()
+    coord.storage.get_setting = MagicMock(side_effect=lambda k, d=None: s.get(k, d))
+    coord.storage.set_setting = MagicMock(side_effect=lambda k, v: s.__setitem__(k, v))
+    coord.storage.async_save = AsyncMock()
+    coord.async_refresh = AsyncMock()
+    return coord, s
+
+
+def _entry():
+    e = MagicMock()
+    e.entry_id = "e1"
+    return e
+
+
+def test_number_reads_default_and_value():
+    coord, _ = _coord({"weekend_multiplier": "2.0"})
+    num = TaskMateSettingNumber(coord, _entry(), "weekend_multiplier", "weekend_multiplier", 1.0, 5.0, 0.5, 1.0, "mdi:x")
+    assert num._attr_unique_id == "e1_setting_weekend_multiplier"
+    assert num.native_value == 2.0
+    # missing setting -> default
+    coord2, _ = _coord({})
+    num2 = TaskMateSettingNumber(coord2, _entry(), "weekend_multiplier", "weekend_multiplier", 1.0, 5.0, 0.5, 1.0, "mdi:x")
+    assert num2.native_value == 1.0
+
+
+def test_number_set_persists_int_when_integer():
+    coord, store = _coord({})
+    num = TaskMateSettingNumber(coord, _entry(), "perfect_week_bonus", "perfect_week_bonus", 0, 1000, 1, 0, "mdi:x")
+    run(num.async_set_native_value(25.0))
+    assert store["perfect_week_bonus"] == 25
+    assert isinstance(store["perfect_week_bonus"], int)
+    coord.async_refresh.assert_awaited_once()
+
+
+def test_number_set_keeps_float_step():
+    coord, store = _coord({})
+    num = TaskMateSettingNumber(coord, _entry(), "weekend_multiplier", "weekend_multiplier", 1.0, 5.0, 0.5, 1.0, "mdi:x")
+    run(num.async_set_native_value(1.5))
+    assert store["weekend_multiplier"] == 1.5
+
+
+def test_select_current_option_falls_back_for_invalid():
+    coord, _ = _coord({"streak_reset_mode": "bogus"})
+    sel = TaskMateSettingSelect(coord, _entry(), "streak_reset_mode", "streak_reset_mode", ["reset", "pause"], "reset", "mdi:x")
+    assert sel.current_option == "reset"
+    coord2, _ = _coord({"streak_reset_mode": "pause"})
+    sel2 = TaskMateSettingSelect(coord2, _entry(), "streak_reset_mode", "streak_reset_mode", ["reset", "pause"], "reset", "mdi:x")
+    assert sel2.current_option == "pause"
+
+
+def test_select_set_persists_and_rejects_invalid():
+    coord, store = _coord({})
+    sel = TaskMateSettingSelect(coord, _entry(), "card_design", "card_design", ["classic", "playroom"], "classic", "mdi:x")
+    run(sel.async_select_option("playroom"))
+    assert store["card_design"] == "playroom"
+    run(sel.async_select_option("hacker"))  # invalid -> ignored
+    assert store["card_design"] == "playroom"


### PR DESCRIPTION
## FEAT-9 — number/select config entities

Adds `number` and `select` platforms so the points-bearing settings are readable/settable from automations, scripts and the HA UI **without a service call** — persisted through the same settings store the panel uses, so panel and entity stay in sync:
- **number:** `weekend_multiplier`, `perfect_week_bonus`
- **select:** `streak_reset_mode`, `card_design`

Registers `Platform.NUMBER`/`SELECT`, adds conftest stubs for both component modules, and entity **name translations in all 9 locales**.

### Testing
- Unit tests: value/default read, set persists int-vs-float correctly, select falls back on invalid stored value and rejects invalid options. 5 passed.
- **Live on ha-dev**: all 4 entities present with correct states; `number.set_value` / `select.select_option` update both the entity **and** the underlying taskmate setting (verified `card_design=playroom`, `weekend_multiplier=1.5` via WS `get_state`), then restored.

From AUDIT_REPORT.md §5 (FEAT-9).