### PR TITLE
feat(todo): native per-child to-do list platform (FEAT-8)

### DIFF
--- a/custom_components/taskmate/__init__.py
+++ b/custom_components/taskmate/__init__.py
@@ -114,7 +114,7 @@ from .websocket import async_register_websocket_commands
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.BUTTON, Platform.BINARY_SENSOR, Platform.CALENDAR, Platform.NUMBER, Platform.SELECT]
+PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.BUTTON, Platform.BINARY_SENSOR, Platform.CALENDAR, Platform.NUMBER, Platform.SELECT, Platform.TODO]
 
 # Track if services are registered
 SERVICES_REGISTERED = "services_registered"

--- a/custom_components/taskmate/coord_chores.py
+++ b/custom_components/taskmate/coord_chores.py
@@ -1225,6 +1225,48 @@ class ChoresMixin:
         days_since = (today - last_dt).days
         return days_since >= window_days
 
+    def get_due_chores_for_child(self, child_id: str) -> list:
+        """Chores this child should still act on today (their outstanding to-dos).
+
+        The single backend definition matching what the child card surfaces:
+        assigned to the child, scheduled/available today, and not yet completed
+        up to the daily limit. ``is_chore_available_for_child`` already covers
+        enabled/vacation/disabled_for/rotation/visibility/recurrence; on top of
+        that this adds the everyone-mode ``assigned_to`` membership, the
+        ``specific_days`` ``due_days`` filter, and the completed-today cap.
+        Used by the todo platform (and reusable by cards/automations).
+        """
+        today = dt_util.as_local(dt_util.now()).date()
+        dow = ("monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday")[today.weekday()]
+        completions = self.storage.get_completions()
+        out = []
+        for chore in self.storage.get_chores():
+            if not self.is_chore_available_for_child(chore, child_id):
+                continue
+            assigned = getattr(chore, "assigned_to", []) or []
+            if assigned and child_id not in assigned:
+                continue
+            if getattr(chore, "schedule_mode", "specific_days") == "specific_days":
+                due_days = getattr(chore, "due_days", []) or []
+                if due_days and dow not in due_days:
+                    continue
+            limit = getattr(chore, "daily_limit", 1) or 1
+            done = 0
+            for c in completions:
+                if c.chore_id != chore.id or c.child_id != child_id:
+                    continue
+                if getattr(c, "bonus_subtask_id", ""):
+                    continue
+                try:
+                    if dt_util.as_local(c.completed_at).date() == today:
+                        done += 1
+                except (AttributeError, TypeError, ValueError):
+                    continue
+            if done >= limit:
+                continue
+            out.append(chore)
+        return out
+
     async def _async_expire_dated_chores(self) -> None:
         """Soft-disable any enabled chore whose expires_on date has passed."""
         today = dt_util.as_local(dt_util.now()).date()

--- a/custom_components/taskmate/todo.py
+++ b/custom_components/taskmate/todo.py
@@ -1,0 +1,80 @@
+"""Todo platform — each child's outstanding chores as a native HA to-do list (FEAT-8).
+
+Exposes one TodoListEntity per child, listing the chores they still need to do
+today (via the shared get_due_chores_for_child). Checking an item off completes
+the chore, so the native HA to-do card and voice assistants can drive TaskMate
+without the custom cards.
+"""
+from __future__ import annotations
+
+from homeassistant.components.todo import (
+    TodoItem,
+    TodoItemStatus,
+    TodoListEntity,
+    TodoListEntityFeature,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .coordinator import TaskMateCoordinator
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up a to-do list per child, adding new children as they appear."""
+    coordinator: TaskMateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    tracked: set[str] = set()
+
+    @callback
+    def _add_new() -> None:
+        new = []
+        for child in coordinator.data.get("children", []):
+            if child.id not in tracked:
+                new.append(TaskMateChildTodoList(coordinator, entry, child))
+                tracked.add(child.id)
+        if new:
+            async_add_entities(new)
+
+    _add_new()
+    entry.async_on_unload(coordinator.async_add_listener(_add_new))
+
+
+class TaskMateChildTodoList(CoordinatorEntity, TodoListEntity):
+    """A child's outstanding chores as a to-do list."""
+
+    _attr_supported_features = TodoListEntityFeature.UPDATE_TODO_ITEM
+
+    def __init__(self, coordinator, entry, child) -> None:
+        super().__init__(coordinator)
+        self._entry = entry
+        self._child_id = child.id
+        self._attr_unique_id = f"{entry.entry_id}_{child.id}_todo"
+        self._attr_name = child.name
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._entry.entry_id)},
+            name="TaskMate",
+            manufacturer="TaskMate",
+            model="Family Chore Manager",
+        )
+
+    @property
+    def todo_items(self) -> list[TodoItem]:
+        if not self.coordinator.get_child(self._child_id):
+            return []
+        return [
+            TodoItem(summary=chore.name, uid=chore.id, status=TodoItemStatus.NEEDS_ACTION)
+            for chore in self.coordinator.get_due_chores_for_child(self._child_id)
+        ]
+
+    async def async_update_todo_item(self, item: TodoItem) -> None:
+        """Checking an item off completes the chore for this child."""
+        if item.status == TodoItemStatus.COMPLETED and item.uid:
+            await self.coordinator.async_complete_chore(item.uid, self._child_id)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -196,6 +196,35 @@ _ha_components_select = MagicMock()
 _ha_components_select.SelectEntity = _FakeSelectEntity
 
 
+class _FakeTodoItem:
+    def __init__(self, summary=None, uid=None, status=None, **kw):
+        self.summary = summary
+        self.uid = uid
+        self.status = status
+
+
+class _FakeTodoItemStatus:
+    NEEDS_ACTION = "needs_action"
+    COMPLETED = "completed"
+
+
+class _FakeTodoListEntity:
+    pass
+
+
+class _FakeTodoListEntityFeature:
+    UPDATE_TODO_ITEM = 4
+    CREATE_TODO_ITEM = 1
+    DELETE_TODO_ITEM = 2
+
+
+_ha_components_todo = MagicMock()
+_ha_components_todo.TodoItem = _FakeTodoItem
+_ha_components_todo.TodoItemStatus = _FakeTodoItemStatus
+_ha_components_todo.TodoListEntity = _FakeTodoListEntity
+_ha_components_todo.TodoListEntityFeature = _FakeTodoListEntityFeature
+
+
 class _FakeDeviceInfo(dict):
     """DeviceInfo behaves like a TypedDict; accept kwargs like the real one."""
 
@@ -271,6 +300,7 @@ _ha_components.calendar = _ha_components_calendar
 _ha_components.button = _ha_components_button
 _ha_components.number = _ha_components_number
 _ha_components.select = _ha_components_select
+_ha_components.todo = _ha_components_todo
 
 sys.modules.update(
     {
@@ -293,6 +323,7 @@ sys.modules.update(
         "homeassistant.components.button": _ha_components_button,
         "homeassistant.components.number": _ha_components_number,
         "homeassistant.components.select": _ha_components_select,
+        "homeassistant.components.todo": _ha_components_todo,
         "homeassistant.components.calendar": _ha_components_calendar,
         "homeassistant.components.websocket_api": _ha_websocket_api,
         "homeassistant.util": _ha_util,

--- a/tests/test_due_chores.py
+++ b/tests/test_due_chores.py
@@ -1,0 +1,81 @@
+"""Tests for get_due_chores_for_child (FEAT-8 shared helper).
+
+is_chore_available_for_child is mocked so these isolate the *added* filtering:
+assigned_to membership, specific_days due_days, and the completed-today cap.
+"""
+from __future__ import annotations
+
+import datetime as dt
+from datetime import timezone
+from unittest.mock import MagicMock, patch
+
+from custom_components.taskmate.coordinator import TaskMateCoordinator
+from custom_components.taskmate.models import Chore, ChoreCompletion
+
+UTC = timezone.utc
+NOW = dt.datetime(2026, 4, 20, 10, 0, 0, tzinfo=UTC)  # Monday
+
+
+def _coord(chores, completions=None, available=True):
+    coord = object.__new__(TaskMateCoordinator)
+    coord.storage = MagicMock()
+    coord.storage.get_chores = MagicMock(return_value=chores)
+    coord.storage.get_completions = MagicMock(return_value=completions or [])
+    if callable(available):
+        coord.is_chore_available_for_child = MagicMock(side_effect=available)
+    else:
+        coord.is_chore_available_for_child = MagicMock(return_value=available)
+    return coord
+
+
+def _due(coord, child_id="ch1"):
+    with patch("custom_components.taskmate.coord_chores.dt_util.now", return_value=NOW):
+        return [c.name for c in coord.get_due_chores_for_child(child_id)]
+
+
+def test_includes_assigned_and_everyone_excludes_others():
+    chores = [
+        Chore(name="Everyone", assigned_to=[], id="a"),
+        Chore(name="Mine", assigned_to=["ch1"], id="b"),
+        Chore(name="Sibling", assigned_to=["ch2"], id="c"),
+    ]
+    assert _due(_coord(chores)) == ["Everyone", "Mine"]
+
+
+def test_specific_days_due_filter():
+    chores = [
+        Chore(name="MonOnly", schedule_mode="specific_days", due_days=["monday"], id="a"),
+        Chore(name="TueOnly", schedule_mode="specific_days", due_days=["tuesday"], id="b"),
+        Chore(name="AnyDay", schedule_mode="specific_days", due_days=[], id="c"),
+    ]
+    assert _due(_coord(chores)) == ["MonOnly", "AnyDay"]
+
+
+def test_excludes_completed_up_to_daily_limit():
+    chores = [
+        Chore(name="Once", daily_limit=1, id="a"),
+        Chore(name="Twice", daily_limit=2, id="b"),
+    ]
+    comps = [
+        ChoreCompletion(chore_id="a", child_id="ch1", completed_at=NOW),       # Once done -> excluded
+        ChoreCompletion(chore_id="b", child_id="ch1", completed_at=NOW),       # Twice 1/2 -> still due
+    ]
+    assert _due(_coord(chores, comps)) == ["Twice"]
+
+
+def test_completion_by_other_child_does_not_count():
+    chores = [Chore(name="Once", daily_limit=1, id="a")]
+    comps = [ChoreCompletion(chore_id="a", child_id="ch2", completed_at=NOW)]
+    assert _due(_coord(chores, comps)) == ["Once"]
+
+
+def test_bonus_subtask_completion_does_not_count():
+    chores = [Chore(name="Once", daily_limit=1, id="a")]
+    comps = [ChoreCompletion(chore_id="a", child_id="ch1", completed_at=NOW, bonus_subtask_id="bs1")]
+    assert _due(_coord(chores, comps)) == ["Once"]
+
+
+def test_unavailable_chores_excluded():
+    chores = [Chore(name="A", id="a"), Chore(name="B", id="b")]
+    avail = lambda chore, cid: chore.id == "a"  # only A available
+    assert _due(_coord(chores, available=avail)) == ["A"]

--- a/tests/test_todo.py
+++ b/tests/test_todo.py
@@ -1,0 +1,65 @@
+"""Tests for the per-child todo platform (FEAT-8)."""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+from custom_components.taskmate.models import Chore, Child
+from custom_components.taskmate.todo import TaskMateChildTodoList
+from homeassistant.components.todo import TodoItem, TodoItemStatus
+
+
+def run(coro):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+def _entry():
+    e = MagicMock()
+    e.entry_id = "e1"
+    return e
+
+
+def _coord(child, due=None):
+    coord = MagicMock()
+    coord.get_child = MagicMock(return_value=child)
+    coord.get_due_chores_for_child = MagicMock(return_value=due or [])
+    coord.async_complete_chore = AsyncMock()
+    return coord
+
+
+def test_todo_items_map_due_chores():
+    child = Child(name="Malia", id="ch1")
+    due = [Chore(name="Dishes", id="c1"), Chore(name="Trash", id="c2")]
+    ent = TaskMateChildTodoList(_coord(child, due), _entry(), child)
+    assert ent._attr_name == "Malia"
+    assert ent._attr_unique_id == "e1_ch1_todo"
+    items = ent.todo_items
+    assert [(i.summary, i.uid, i.status) for i in items] == [
+        ("Dishes", "c1", TodoItemStatus.NEEDS_ACTION),
+        ("Trash", "c2", TodoItemStatus.NEEDS_ACTION),
+    ]
+
+
+def test_todo_items_empty_when_child_missing():
+    ent = TaskMateChildTodoList(_coord(None), _entry(), Child(name="Gone", id="ch1"))
+    assert ent.todo_items == []
+
+
+def test_check_item_completes_chore():
+    child = Child(name="Malia", id="ch1")
+    coord = _coord(child)
+    ent = TaskMateChildTodoList(coord, _entry(), child)
+    run(ent.async_update_todo_item(TodoItem(summary="Dishes", uid="c1", status=TodoItemStatus.COMPLETED)))
+    coord.async_complete_chore.assert_awaited_once_with("c1", "ch1")
+
+
+def test_uncheck_item_does_nothing():
+    child = Child(name="Malia", id="ch1")
+    coord = _coord(child)
+    ent = TaskMateChildTodoList(coord, _entry(), child)
+    run(ent.async_update_todo_item(TodoItem(summary="Dishes", uid="c1", status=TodoItemStatus.NEEDS_ACTION)))
+    coord.async_complete_chore.assert_not_awaited()


### PR DESCRIPTION
## FEAT-8 — native `todo` platform

Each child gets a `todo.taskmate_<name>` entity listing the chores they still need to do today; checking an item off completes the chore. This lets the **native HA to-do card and voice assistants** drive TaskMate without the custom cards.

### Key addition: a shared definition of "due chores"
Adds `coordinator.get_due_chores_for_child()` — the single backend definition of a child's outstanding chores: `assigned_to` membership + `specific_days` `due_days` + a completed-today cap, layered on top of `is_chore_available_for_child`. Previously this logic only lived (duplicated) in the cards' JS. Reusable by cards/automations and unit-tested in isolation.

Registers `Platform.TODO` (per-child, dynamic add as children appear) + conftest stubs.

### Testing
- 6 helper tests (assigned/everyone split, due_days filter, daily-limit cap, other-child/bonus-subtask ignored, availability gate) + 4 entity tests (item mapping, empty when child gone, check-off completes, uncheck no-op).
- **Live on ha-dev**: `todo.taskmate_vaiha` lists her 4 real chores via `todo.get_items`; HA-native `todo.update_item` check-off completed "Make bed" (list 4→3); restored cleanly.

From AUDIT_REPORT.md §5 (FEAT-8).