### PR TITLE
feat(chores): chore dependencies / unlocks (FEAT-1)

### DIFF
--- a/custom_components/taskmate/coord_chores.py
+++ b/custom_components/taskmate/coord_chores.py
@@ -41,6 +41,7 @@ class ChoresMixin:
         points: int = 10,
         description: str = "",
         assigned_to: list[str] | None = None,
+        depends_on: list[str] | None = None,
         requires_approval: bool = True,
         time_category: str = "anytime",
         claim_allowance_minutes: int = 0,
@@ -90,6 +91,7 @@ class ChoresMixin:
             points=points,
             description=description,
             assigned_to=pool,
+            depends_on=depends_on or [],
             requires_approval=requires_approval,
             time_category=time_category,
             claim_allowance_minutes=max(0, int(claim_allowance_minutes or 0)),
@@ -1141,6 +1143,24 @@ class ChoresMixin:
         visibility_operator = getattr(chore, 'visibility_operator', 'equals')
         if not self._is_visibility_entity_active(visibility_entity, visibility_state, visibility_operator):
             return False
+
+        # Chore dependencies (FEAT-1): this chore unlocks only once every chore
+        # it depends on has an approved completion today by this same child.
+        depends_on = getattr(chore, 'depends_on', []) or []
+        if depends_on:
+            dep_today = dt_util.as_local(dt_util.now()).date()
+            completions = self.storage.get_completions()
+            for dep_id in depends_on:
+                satisfied = any(
+                    c.chore_id == dep_id
+                    and c.child_id == child_id
+                    and c.approved
+                    and not getattr(c, 'bonus_subtask_id', '')
+                    and dt_util.as_local(c.completed_at).date() == dep_today
+                    for c in completions
+                )
+                if not satisfied:
+                    return False
 
         schedule_mode = getattr(chore, 'schedule_mode', 'specific_days')
 

--- a/custom_components/taskmate/models.py
+++ b/custom_components/taskmate/models.py
@@ -248,6 +248,7 @@ class Chore:
     # One-shot chore fields
     enabled: bool = True  # False = soft-disabled (completed or expired)
     disabled_for: list[str] = field(default_factory=list)  # Child IDs this chore is disabled for
+    depends_on: list[str] = field(default_factory=list)  # Chore IDs that must be approved-completed today before this is available
     created_date: str = ""  # ISO date for one-shot expiry, e.g. "2026-04-16"
     expires_on: str = ""  # optional ISO end date; chore auto-disables the day after
     # Time-of-day incentive: when due_time (HH:MM) is set, a completion at/before
@@ -316,6 +317,7 @@ class Chore:
             visibility_operator=data.get("visibility_operator", "equals"),
             enabled=data.get("enabled", True),
             disabled_for=list(data.get("disabled_for", [])),
+            depends_on=list(data.get("depends_on", []) or []),
             created_date=data.get("created_date", ""),
             expires_on=data.get("expires_on", ""),
             due_time=data.get("due_time", ""),
@@ -370,6 +372,7 @@ class Chore:
             "visibility_operator": self.visibility_operator,
             "enabled": self.enabled,
             "disabled_for": self.disabled_for,
+            "depends_on": self.depends_on,
             "created_date": self.created_date,
             "expires_on": self.expires_on,
             "due_time": self.due_time,

--- a/custom_components/taskmate/sensor.py
+++ b/custom_components/taskmate/sensor.py
@@ -197,12 +197,14 @@ def _build_chores_list(coordinator: TaskMateCoordinator, common: dict) -> list[d
     chores_list = []
     for c in chores:
         assigned_to = c.assigned_to if isinstance(c.assigned_to, list) else []
+        depends_on = c.depends_on if isinstance(getattr(c, "depends_on", None), list) else []
         record: dict = {
             "id": c.id,
             "name": c.name,
             "points": c.points,
             "time_category": c.time_category,
             "assigned_to": assigned_to,
+            "depends_on": depends_on,
             "schedule_mode": getattr(c, 'schedule_mode', 'specific_days'),
             "enabled": getattr(c, 'enabled', True),
             "assignment_mode": getattr(c, 'assignment_mode', 'everyone'),

--- a/custom_components/taskmate/websocket.py
+++ b/custom_components/taskmate/websocket.py
@@ -438,7 +438,7 @@ async def _ws_list_ha_users(hass, connection, msg, coordinator):
 # assignment_current_child_id, publish_calendar_published_dates, etc.) is
 # coordinator-managed runtime state and intentionally not exposed.
 _CHORE_EDITABLE_FIELDS = {
-    "name", "description", "points", "assigned_to", "requires_approval",
+    "name", "description", "points", "assigned_to", "depends_on", "requires_approval",
     "time_category", "claim_allowance_minutes", "daily_limit", "completion_sound",
     "difficulty",
     "schedule_mode", "due_days", "recurrence", "recurrence_day",
@@ -460,6 +460,7 @@ def _chore_payload_schema(*, require_name: bool):
         vol.Optional("description"): str,
         vol.Optional("points"): vol.All(int, vol.Range(min=0)),
         vol.Optional("assigned_to"): [str],
+        vol.Optional("depends_on"): [str],
         vol.Optional("requires_approval"): bool,
         vol.Optional("time_category"): str,
         vol.Optional("claim_allowance_minutes"): vol.All(int, vol.Range(min=0)),

--- a/custom_components/taskmate/www/locales/de.json
+++ b/custom_components/taskmate/www/locales/de.json
@@ -1478,5 +1478,7 @@
   "panel.toast_challenge_added": "Challenge hinzugefügt",
   "panel.toast_challenge_updated": "Challenge aktualisiert",
   "panel.settings_allow_negative_label": "Negatives Guthaben zulassen",
-  "panel.settings_allow_negative_hint": "Strafen dürfen das Guthaben eines Kindes unter null senken, statt bei null zu stoppen."
+  "panel.settings_allow_negative_hint": "Strafen dürfen das Guthaben eines Kindes unter null senken, statt bei null zu stoppen.",
+  "panel.chore_depends_label": "Hängt ab von",
+  "panel.chore_depends_hint": "Diese Aufgabe bleibt verborgen, bis die ausgewählten Aufgaben heute für das Kind genehmigt sind."
 }

--- a/custom_components/taskmate/www/locales/en-GB.json
+++ b/custom_components/taskmate/www/locales/en-GB.json
@@ -1478,5 +1478,7 @@
   "panel.toast_challenge_added": "Challenge added",
   "panel.toast_challenge_updated": "Challenge updated",
   "panel.settings_allow_negative_label": "Allow negative balance",
-  "panel.settings_allow_negative_hint": "Let penalties take a child's balance below zero instead of stopping at zero."
+  "panel.settings_allow_negative_hint": "Let penalties take a child's balance below zero instead of stopping at zero.",
+  "panel.chore_depends_label": "Depends on",
+  "panel.chore_depends_hint": "This chore stays hidden until the selected chores are approved for the child today."
 }

--- a/custom_components/taskmate/www/locales/en.json
+++ b/custom_components/taskmate/www/locales/en.json
@@ -1478,5 +1478,7 @@
   "panel.toast_challenge_added": "Challenge added",
   "panel.toast_challenge_updated": "Challenge updated",
   "panel.settings_allow_negative_label": "Allow negative balance",
-  "panel.settings_allow_negative_hint": "Let penalties take a child's balance below zero instead of stopping at zero."
+  "panel.settings_allow_negative_hint": "Let penalties take a child's balance below zero instead of stopping at zero.",
+  "panel.chore_depends_label": "Depends on",
+  "panel.chore_depends_hint": "This chore stays hidden until the selected chores are approved for the child today."
 }

--- a/custom_components/taskmate/www/locales/fr.json
+++ b/custom_components/taskmate/www/locales/fr.json
@@ -1478,5 +1478,7 @@
   "panel.toast_challenge_added": "Défi ajouté",
   "panel.toast_challenge_updated": "Défi mis à jour",
   "panel.settings_allow_negative_label": "Autoriser le solde négatif",
-  "panel.settings_allow_negative_hint": "Les pénalités peuvent faire passer le solde d'un enfant sous zéro au lieu de s'arrêter à zéro."
+  "panel.settings_allow_negative_hint": "Les pénalités peuvent faire passer le solde d'un enfant sous zéro au lieu de s'arrêter à zéro.",
+  "panel.chore_depends_label": "Dépend de",
+  "panel.chore_depends_hint": "Cette tâche reste masquée tant que les tâches sélectionnées ne sont pas approuvées pour l'enfant aujourd'hui."
 }

--- a/custom_components/taskmate/www/locales/nb.json
+++ b/custom_components/taskmate/www/locales/nb.json
@@ -1478,5 +1478,7 @@
   "panel.toast_challenge_added": "Utfordring lagt til",
   "panel.toast_challenge_updated": "Utfordring oppdatert",
   "panel.settings_allow_negative_label": "Tillat negativ saldo",
-  "panel.settings_allow_negative_hint": "La straff trekke et barns saldo under null i stedet for å stoppe på null."
+  "panel.settings_allow_negative_hint": "La straff trekke et barns saldo under null i stedet for å stoppe på null.",
+  "panel.chore_depends_label": "Avhenger av",
+  "panel.chore_depends_hint": "Denne oppgaven er skjult til de valgte oppgavene er godkjent for barnet i dag."
 }

--- a/custom_components/taskmate/www/locales/nn.json
+++ b/custom_components/taskmate/www/locales/nn.json
@@ -1478,5 +1478,7 @@
   "panel.toast_challenge_added": "Utfordring lagt til",
   "panel.toast_challenge_updated": "Utfordring oppdatert",
   "panel.settings_allow_negative_label": "Tillat negativ saldo",
-  "panel.settings_allow_negative_hint": "La straff trekkje eit barns saldo under null i staden for å stoppe på null."
+  "panel.settings_allow_negative_hint": "La straff trekkje eit barns saldo under null i staden for å stoppe på null.",
+  "panel.chore_depends_label": "Avheng av",
+  "panel.chore_depends_hint": "Denne oppgåva er skjult til dei valde oppgåvene er godkjende for barnet i dag."
 }

--- a/custom_components/taskmate/www/locales/pt-BR.json
+++ b/custom_components/taskmate/www/locales/pt-BR.json
@@ -1478,5 +1478,7 @@
   "panel.toast_challenge_added": "Desafio adicionado",
   "panel.toast_challenge_updated": "Desafio atualizado",
   "panel.settings_allow_negative_label": "Permitir saldo negativo",
-  "panel.settings_allow_negative_hint": "Permite que penalidades deixem o saldo de uma criança abaixo de zero, em vez de parar em zero."
+  "panel.settings_allow_negative_hint": "Permite que penalidades deixem o saldo de uma criança abaixo de zero, em vez de parar em zero.",
+  "panel.chore_depends_label": "Depende de",
+  "panel.chore_depends_hint": "Esta tarefa fica oculta até as tarefas selecionadas serem aprovadas para a criança hoje."
 }

--- a/custom_components/taskmate/www/locales/pt.json
+++ b/custom_components/taskmate/www/locales/pt.json
@@ -1478,5 +1478,7 @@
   "panel.toast_challenge_added": "Desafio adicionado",
   "panel.toast_challenge_updated": "Desafio atualizado",
   "panel.settings_allow_negative_label": "Permitir saldo negativo",
-  "panel.settings_allow_negative_hint": "Permite que penalizações deixem o saldo de uma criança abaixo de zero, em vez de parar em zero."
+  "panel.settings_allow_negative_hint": "Permite que penalizações deixem o saldo de uma criança abaixo de zero, em vez de parar em zero.",
+  "panel.chore_depends_label": "Depende de",
+  "panel.chore_depends_hint": "Esta tarefa fica oculta até as tarefas selecionadas serem aprovadas para a criança hoje."
 }

--- a/custom_components/taskmate/www/taskmate-panel.js
+++ b/custom_components/taskmate/www/taskmate-panel.js
@@ -469,6 +469,7 @@ class TaskMatePanel extends HTMLElement {
     if (act === "toggle-day")        { this._toggleArrayField("due_days", t.dataset.day); return; }
     if (act === "toggle-bulk-day")   { this._toggleArrayField("due_days", t.dataset.day); return; }
     if (act === "toggle-assigned")   { this._toggleArrayField("assigned_to", t.dataset.id); return; }
+    if (act === "toggle-depends")    { this._toggleArrayField("depends_on", t.dataset.id); return; }
     if (act === "toggle-calendar")   { this._toggleArrayField("publish_calendar_entities", t.dataset.id); return; }
     if (act === "add-bonus-subtask") { this._addBonusSubtask(); return; }
     if (act === "remove-bonus-subtask") { this._removeBonusSubtask(Number(t.dataset.idx)); return; }
@@ -1130,6 +1131,7 @@ class TaskMatePanel extends HTMLElement {
       chore_names: names,
       points: Number(d.points) || 10,
       assigned_to: d.assigned_to || [],
+      depends_on: d.depends_on || [],
       requires_approval: !!d.requires_approval,
       time_category: d.time_category || "anytime",
       schedule_mode: d.schedule_mode || "specific_days",
@@ -1215,6 +1217,7 @@ class TaskMatePanel extends HTMLElement {
       mandatory: false, mandatory_penalty_points: 0,
       require_photo: false,
       publish_calendar_entities: [],
+      depends_on: [],
       bonus_subtasks: [],
     };
     if (id) {
@@ -1225,6 +1228,7 @@ class TaskMatePanel extends HTMLElement {
         assigned_to: [...(c.assigned_to || [])],
         due_days: [...(c.due_days || [])],
         publish_calendar_entities: [...(c.publish_calendar_entities || [])],
+        depends_on: [...(c.depends_on || [])],
         bonus_subtasks: (c.bonus_subtasks || []).map(b => ({...b})),
         visibility_operator: c.visibility_operator || "none",
         manual_start_child_id: "",
@@ -4253,6 +4257,19 @@ class TaskMatePanel extends HTMLElement {
             <span class="tm-field-hint">${this._t("panel.chore_assign_hint")}</span>
           </div>
         ` : `<div class="tm-field"><span class="tm-field-hint">${this._t("panel.chore_assign_no_children")}</span></div>`) : "",
+        (this._state.chores || []).filter(x => x.id !== d.id).length > 0 ? `
+          <div class="tm-field">
+            <span class="tm-field-label">${this._t("panel.chore_depends_label")}</span>
+            <div class="tm-chip-row">
+              ${(this._state.chores || []).filter(x => x.id !== d.id).map(c => `
+                <button type="button" class="tm-chip-btn ${(d.depends_on || []).includes(c.id) ? "tm-chip-on" : ""}" data-act="toggle-depends" data-id="${this._esc(c.id)}">
+                  ${this._esc(c.name)}
+                </button>
+              `).join("")}
+            </div>
+            <span class="tm-field-hint">${this._t("panel.chore_depends_hint")}</span>
+          </div>
+        ` : "",
         showRotation && children.length > 0 ? this._select(
           this._t("panel.chore_rotation_label"), "manual_start_child_id", d.manual_start_child_id,
           [{ v: "", l: this._t("panel.chore_rotation_no_override") }, ...children.map(c => ({ v: c.id, l: c.name }))],

--- a/tests/test_due_chores.py
+++ b/tests/test_due_chores.py
@@ -10,7 +10,7 @@ from datetime import timezone
 from unittest.mock import MagicMock, patch
 
 from custom_components.taskmate.coordinator import TaskMateCoordinator
-from custom_components.taskmate.models import Chore, ChoreCompletion
+from custom_components.taskmate.models import Child, Chore, ChoreCompletion
 
 UTC = timezone.utc
 NOW = dt.datetime(2026, 4, 20, 10, 0, 0, tzinfo=UTC)  # Monday
@@ -79,3 +79,51 @@ def test_unavailable_chores_excluded():
     chores = [Chore(name="A", id="a"), Chore(name="B", id="b")]
     avail = lambda chore, cid: chore.id == "a"  # only A available
     assert _due(_coord(chores, available=avail)) == ["A"]
+
+
+# ---------------------------------------------------------------------------
+# FEAT-1: chore dependency gating in is_chore_available_for_child
+# ---------------------------------------------------------------------------
+
+def _avail_coord(chore, child, completions):
+    coord = object.__new__(TaskMateCoordinator)
+    coord.storage = MagicMock()
+    coord.storage.get_child = MagicMock(return_value=child)
+    coord.storage.get_completions = MagicMock(return_value=completions)
+    coord._is_child_on_vacation = MagicMock(return_value=False)
+    coord._is_visibility_entity_active = MagicMock(return_value=True)
+    return coord
+
+
+def _avail(chore, child, completions):
+    coord = _avail_coord(chore, child, completions)
+    with patch("custom_components.taskmate.coord_chores.dt_util.now", return_value=NOW):
+        return coord.is_chore_available_for_child(chore, child.id)
+
+
+def _dep_chore():
+    return Chore(name="B", id="B", depends_on=["A"], schedule_mode="specific_days",
+                 due_days=[], assignment_mode="everyone", enabled=True)
+
+
+def test_dependency_unmet_blocks_chore():
+    child = Child(name="K", id="ch1")
+    assert _avail(_dep_chore(), child, []) is False
+
+
+def test_dependency_met_unlocks_chore():
+    child = Child(name="K", id="ch1")
+    comps = [ChoreCompletion(chore_id="A", child_id="ch1", approved=True, completed_at=NOW)]
+    assert _avail(_dep_chore(), child, comps) is True
+
+
+def test_dependency_unapproved_completion_does_not_unlock():
+    child = Child(name="K", id="ch1")
+    comps = [ChoreCompletion(chore_id="A", child_id="ch1", approved=False, completed_at=NOW)]
+    assert _avail(_dep_chore(), child, comps) is False
+
+
+def test_dependency_met_by_other_child_does_not_unlock():
+    child = Child(name="K", id="ch1")
+    comps = [ChoreCompletion(chore_id="A", child_id="ch2", approved=True, completed_at=NOW)]
+    assert _avail(_dep_chore(), child, comps) is False


### PR DESCRIPTION
## FEAT-1 — chore dependencies / unlocks

A chore can now **depend on** other chores: it stays unavailable for a child until every chore in its `depends_on` has an **approved completion by that same child today**. (e.g. "Get dressed" only unlocks after "Make bed" is approved.)

### Surfaces
- **models**: `Chore.depends_on` (+ from_dict/to_dict)
- **gating**: added to `is_chore_available_for_child`, so it flows through the availability matrix, the cards, `get_due_chores_for_child` **and** the new todo platform automatically
- **websocket**: `depends_on` in the add/update schema + `_CHORE_EDITABLE_FIELDS` (applied generically); `async_add_chore` param
- **sensor**: `depends_on` exposed in `_build_chores_list` so the editor pre-selects current deps
- **panel**: a "Depends on" multi-select in the chore editor (mirrors the proven `assigned_to` chip picker), wired through the draft + save
- **i18n**: `panel.chore_depends_label`/`_hint` in all 8 locales

### Testing
- 4 gating unit tests (unmet blocks, met unlocks, unapproved doesn't unlock, other-child doesn't unlock); 147 across model/availability/calendar/assignment suites green.
- **Live on ha-dev**: created B depending on A — B unavailable (`False`) until A was approved for the child, then `True`; picker + locale labels confirmed served live. Test chores cleaned up.

From AUDIT_REPORT.md §5 (FEAT-1).