### PR TITLE
feat(notifications): per-child quiet hours / DND (FEAT-5)

### DIFF
--- a/custom_components/taskmate/coord_notifications.py
+++ b/custom_components/taskmate/coord_notifications.py
@@ -67,6 +67,39 @@ NOTIFICATION_TYPES_BY_ID: dict[str, NotificationTypeMeta] = {
 }
 
 
+def _parse_hhmm(value: str) -> tuple[int, int] | None:
+    """Parse "HH:MM" into (hour, minute); None if blank/malformed."""
+    if not value:
+        return None
+    try:
+        hour, minute = map(int, value.split(":", 1))
+    except (ValueError, AttributeError):
+        return None
+    if 0 <= hour <= 23 and 0 <= minute <= 59:
+        return hour, minute
+    return None
+
+
+def _is_within_quiet_hours(start: str, end: str, now) -> bool:
+    """True if ``now`` (a datetime) falls inside the [start, end) HH:MM window.
+
+    Both bounds must be set, else quiet hours are disabled. A start later than
+    the end denotes an overnight window (e.g. 20:00-07:00). The end bound is
+    exclusive so a window of 07:00-07:00 (equal bounds) is treated as disabled.
+    """
+    s = _parse_hhmm(start)
+    e = _parse_hhmm(end)
+    if s is None or e is None or s == e:
+        return False
+    cur = now.hour * 60 + now.minute
+    start_m = s[0] * 60 + s[1]
+    end_m = e[0] * 60 + e[1]
+    if start_m < end_m:
+        return start_m <= cur < end_m
+    # Overnight window: active from start through midnight to end.
+    return cur >= start_m or cur < end_m
+
+
 class _SafeDict(dict):
     """str.format_map dict that leaves missing keys as `{key}` literal."""
     def __missing__(self, key: str) -> str:
@@ -99,6 +132,11 @@ class NotificationCoordinator:
 
         for recipient_id, route in cfg.routes.items():
             if not route.enabled:
+                continue
+            if self._child_in_quiet_hours(recipient_id):
+                # Do-not-disturb: suppress this child's notifications during
+                # their configured quiet-hours window. Parent routes (and the
+                # bus event below) are unaffected.
                 continue
             notify_service = self._resolve_notify_service(recipient_id)
             if not notify_service:
@@ -153,6 +191,19 @@ class NotificationCoordinator:
             sent.append(recipient_id)
         await self._fire_persistent_notification(type_id, message)
         return sent
+
+    def _child_in_quiet_hours(self, recipient_id: str) -> bool:
+        """True if ``recipient_id`` is a child currently inside their quiet-hours
+        (do-not-disturb) window. Non-child recipients are never suppressed."""
+        if not recipient_id.startswith("child:"):
+            return False
+        child = self.storage.get_child(recipient_id.split(":", 1)[1])
+        if child is None:
+            return False
+        from homeassistant.util import dt as dt_util
+        return _is_within_quiet_hours(
+            child.quiet_hours_start, child.quiet_hours_end, dt_util.now()
+        )
 
     def _resolve_notify_service(self, recipient_id: str) -> str:
         if recipient_id.startswith("child:"):

--- a/custom_components/taskmate/models.py
+++ b/custom_components/taskmate/models.py
@@ -156,6 +156,8 @@ class Child:
     total_penalties_received: int = 0
     notify_service: str | None = None
     linked_user_id: str = ""  # HA user id; when set, only that user (or an admin) may self-serve as this child
+    quiet_hours_start: str = ""  # "HH:MM" — start of do-not-disturb window; empty = no quiet hours
+    quiet_hours_end: str = ""    # "HH:MM" — end of do-not-disturb window; start>end means overnight
     level: int = 1  # cached XP level (derived from total_points_earned)
     id: str = field(default_factory=generate_id)
 
@@ -184,6 +186,8 @@ class Child:
             total_penalties_received=data.get("total_penalties_received", 0),
             notify_service=data.get("notify_service", None),
             linked_user_id=data.get("linked_user_id", ""),
+            quiet_hours_start=data.get("quiet_hours_start", ""),
+            quiet_hours_end=data.get("quiet_hours_end", ""),
             level=int(data.get("level", 1) or 1),
             id=data.get("id", generate_id()),
         )
@@ -212,6 +216,8 @@ class Child:
             "total_penalties_received": self.total_penalties_received,
             "notify_service": self.notify_service,
             "linked_user_id": self.linked_user_id,
+            "quiet_hours_start": self.quiet_hours_start,
+            "quiet_hours_end": self.quiet_hours_end,
             "level": self.level,
             "id": self.id,
         }

--- a/custom_components/taskmate/websocket.py
+++ b/custom_components/taskmate/websocket.py
@@ -133,6 +133,7 @@ WS_NOTIF_GET_STATE: Final          = "taskmate/notifications/get_state"
 WS_NOTIF_SET_MASTER: Final         = "taskmate/notifications/set_master_enabled"
 WS_NOTIF_SET_ROUTE: Final          = "taskmate/notifications/set_route"
 WS_NOTIF_SET_CHILD_NOTIFY: Final   = "taskmate/notifications/set_child_notify"
+WS_NOTIF_SET_CHILD_QUIET: Final    = "taskmate/notifications/set_child_quiet"
 WS_NOTIF_UPSERT_PARENT: Final      = "taskmate/notifications/upsert_parent"
 WS_NOTIF_DELETE_PARENT: Final      = "taskmate/notifications/delete_parent"
 WS_NOTIF_UPSERT_CUSTOM: Final      = "taskmate/notifications/upsert_custom"
@@ -1611,6 +1612,8 @@ async def ws_notif_get_state(hass, connection, msg, coordinator):
                     "id": f"child:{ch.id}",
                     "name": ch.name,
                     "notify_service": ch.notify_service,
+                    "quiet_hours_start": ch.quiet_hours_start,
+                    "quiet_hours_end": ch.quiet_hours_end,
                 }
                 for ch in c.storage.get_children()
             ],
@@ -1684,6 +1687,42 @@ async def ws_notif_set_child_notify(hass, connection, msg, coordinator):
     c.storage.update_child(child)
     await c.storage.async_save()
     await c.notifications.async_setup_schedules()
+    connection.send_result(msg["id"], {"ok": True})
+
+
+def _validate_hhmm_or_empty(value):
+    """voluptuous validator: '' (disabled) or a valid 'HH:MM' string."""
+    if value in (None, ""):
+        return ""
+    if not isinstance(value, str):
+        raise vol.Invalid("must be a string")
+    parts = value.split(":")
+    if len(parts) != 2 or not (parts[0].isdigit() and parts[1].isdigit()):
+        raise vol.Invalid("must be HH:MM")
+    hour, minute = int(parts[0]), int(parts[1])
+    if not (0 <= hour <= 23 and 0 <= minute <= 59):
+        raise vol.Invalid("HH:MM out of range")
+    return f"{hour:02d}:{minute:02d}"
+
+
+@websocket_api.websocket_command({
+    vol.Required("type"): WS_NOTIF_SET_CHILD_QUIET,
+    vol.Required("child_id"): str,
+    vol.Required("quiet_hours_start"): _validate_hhmm_or_empty,
+    vol.Required("quiet_hours_end"): _validate_hhmm_or_empty,
+})
+@websocket_api.async_response
+@_admin_only
+async def ws_notif_set_child_quiet(hass, connection, msg, coordinator):
+    c = coordinator
+    child = c.storage.get_child(msg["child_id"])
+    if child is None:
+        connection.send_error(msg["id"], "not_found", "Child not found")
+        return
+    child.quiet_hours_start = msg["quiet_hours_start"]
+    child.quiet_hours_end = msg["quiet_hours_end"]
+    c.storage.update_child(child)
+    await c.storage.async_save()
     connection.send_result(msg["id"], {"ok": True})
 
 
@@ -1956,7 +1995,7 @@ _COMMANDS = (
     _ws_templates_save_from, _ws_templates_create, _ws_templates_update,
     _ws_templates_delete,
     ws_notif_get_state, ws_notif_set_master, ws_notif_set_route,
-    ws_notif_set_child_notify,
+    ws_notif_set_child_notify, ws_notif_set_child_quiet,
     ws_notif_upsert_parent, ws_notif_delete_parent,
     ws_notif_upsert_custom, ws_notif_delete_custom,
     ws_notif_list_notify, ws_notif_set_streak_cutoff, ws_notif_send_test,

--- a/custom_components/taskmate/www/locales/de.json
+++ b/custom_components/taskmate/www/locales/de.json
@@ -1480,5 +1480,7 @@
   "panel.settings_allow_negative_label": "Negatives Guthaben zulassen",
   "panel.settings_allow_negative_hint": "Strafen dürfen das Guthaben eines Kindes unter null senken, statt bei null zu stoppen.",
   "panel.chore_depends_label": "Hängt ab von",
-  "panel.chore_depends_hint": "Diese Aufgabe bleibt verborgen, bis die ausgewählten Aufgaben heute für das Kind genehmigt sind."
+  "panel.chore_depends_hint": "Diese Aufgabe bleibt verborgen, bis die ausgewählten Aufgaben heute für das Kind genehmigt sind.",
+  "panel.notif_quiet_hours_label": "Ruhezeiten",
+  "panel.notif_quiet_hours_desc": "In diesem Zeitraum werden keine Erinnerungen an dieses Kind gesendet (Nicht stören). Zum Deaktivieren leer lassen."
 }

--- a/custom_components/taskmate/www/locales/en-GB.json
+++ b/custom_components/taskmate/www/locales/en-GB.json
@@ -1480,5 +1480,7 @@
   "panel.settings_allow_negative_label": "Allow negative balance",
   "panel.settings_allow_negative_hint": "Let penalties take a child's balance below zero instead of stopping at zero.",
   "panel.chore_depends_label": "Depends on",
-  "panel.chore_depends_hint": "This chore stays hidden until the selected chores are approved for the child today."
+  "panel.chore_depends_hint": "This chore stays hidden until the selected chores are approved for the child today.",
+  "panel.notif_quiet_hours_label": "Quiet hours",
+  "panel.notif_quiet_hours_desc": "No reminders are sent to this child during this window (do-not-disturb). Leave blank to disable."
 }

--- a/custom_components/taskmate/www/locales/en.json
+++ b/custom_components/taskmate/www/locales/en.json
@@ -1480,5 +1480,7 @@
   "panel.settings_allow_negative_label": "Allow negative balance",
   "panel.settings_allow_negative_hint": "Let penalties take a child's balance below zero instead of stopping at zero.",
   "panel.chore_depends_label": "Depends on",
-  "panel.chore_depends_hint": "This chore stays hidden until the selected chores are approved for the child today."
+  "panel.chore_depends_hint": "This chore stays hidden until the selected chores are approved for the child today.",
+  "panel.notif_quiet_hours_label": "Quiet hours",
+  "panel.notif_quiet_hours_desc": "No reminders are sent to this child during this window (do-not-disturb). Leave blank to disable."
 }

--- a/custom_components/taskmate/www/locales/fr.json
+++ b/custom_components/taskmate/www/locales/fr.json
@@ -1480,5 +1480,7 @@
   "panel.settings_allow_negative_label": "Autoriser le solde négatif",
   "panel.settings_allow_negative_hint": "Les pénalités peuvent faire passer le solde d'un enfant sous zéro au lieu de s'arrêter à zéro.",
   "panel.chore_depends_label": "Dépend de",
-  "panel.chore_depends_hint": "Cette tâche reste masquée tant que les tâches sélectionnées ne sont pas approuvées pour l'enfant aujourd'hui."
+  "panel.chore_depends_hint": "Cette tâche reste masquée tant que les tâches sélectionnées ne sont pas approuvées pour l'enfant aujourd'hui.",
+  "panel.notif_quiet_hours_label": "Heures silencieuses",
+  "panel.notif_quiet_hours_desc": "Aucun rappel n'est envoyé à cet enfant pendant cette plage horaire (ne pas déranger). Laisser vide pour désactiver."
 }

--- a/custom_components/taskmate/www/locales/nb.json
+++ b/custom_components/taskmate/www/locales/nb.json
@@ -1480,5 +1480,7 @@
   "panel.settings_allow_negative_label": "Tillat negativ saldo",
   "panel.settings_allow_negative_hint": "La straff trekke et barns saldo under null i stedet for å stoppe på null.",
   "panel.chore_depends_label": "Avhenger av",
-  "panel.chore_depends_hint": "Denne oppgaven er skjult til de valgte oppgavene er godkjent for barnet i dag."
+  "panel.chore_depends_hint": "Denne oppgaven er skjult til de valgte oppgavene er godkjent for barnet i dag.",
+  "panel.notif_quiet_hours_label": "Stilletimer",
+  "panel.notif_quiet_hours_desc": "Ingen påminnelser sendes til dette barnet i dette tidsrommet (ikke forstyrr). La stå tomt for å deaktivere."
 }

--- a/custom_components/taskmate/www/locales/nn.json
+++ b/custom_components/taskmate/www/locales/nn.json
@@ -1480,5 +1480,7 @@
   "panel.settings_allow_negative_label": "Tillat negativ saldo",
   "panel.settings_allow_negative_hint": "La straff trekkje eit barns saldo under null i staden for å stoppe på null.",
   "panel.chore_depends_label": "Avheng av",
-  "panel.chore_depends_hint": "Denne oppgåva er skjult til dei valde oppgåvene er godkjende for barnet i dag."
+  "panel.chore_depends_hint": "Denne oppgåva er skjult til dei valde oppgåvene er godkjende for barnet i dag.",
+  "panel.notif_quiet_hours_label": "Stilletimar",
+  "panel.notif_quiet_hours_desc": "Ingen påminningar vert sende til dette barnet i dette tidsrommet (ikkje forstyrr). Lat stå tomt for å deaktivere."
 }

--- a/custom_components/taskmate/www/locales/pt-BR.json
+++ b/custom_components/taskmate/www/locales/pt-BR.json
@@ -1480,5 +1480,7 @@
   "panel.settings_allow_negative_label": "Permitir saldo negativo",
   "panel.settings_allow_negative_hint": "Permite que penalidades deixem o saldo de uma criança abaixo de zero, em vez de parar em zero.",
   "panel.chore_depends_label": "Depende de",
-  "panel.chore_depends_hint": "Esta tarefa fica oculta até as tarefas selecionadas serem aprovadas para a criança hoje."
+  "panel.chore_depends_hint": "Esta tarefa fica oculta até as tarefas selecionadas serem aprovadas para a criança hoje.",
+  "panel.notif_quiet_hours_label": "Horário de silêncio",
+  "panel.notif_quiet_hours_desc": "Nenhum lembrete é enviado para esta criança durante este período (não perturbe). Deixe em branco para desativar."
 }

--- a/custom_components/taskmate/www/locales/pt.json
+++ b/custom_components/taskmate/www/locales/pt.json
@@ -1480,5 +1480,7 @@
   "panel.settings_allow_negative_label": "Permitir saldo negativo",
   "panel.settings_allow_negative_hint": "Permite que penalizações deixem o saldo de uma criança abaixo de zero, em vez de parar em zero.",
   "panel.chore_depends_label": "Depende de",
-  "panel.chore_depends_hint": "Esta tarefa fica oculta até as tarefas selecionadas serem aprovadas para a criança hoje."
+  "panel.chore_depends_hint": "Esta tarefa fica oculta até as tarefas selecionadas serem aprovadas para a criança hoje.",
+  "panel.notif_quiet_hours_label": "Horário de silêncio",
+  "panel.notif_quiet_hours_desc": "Nenhum lembrete é enviado a esta criança durante este período (não perturbar). Deixe em branco para desativar."
 }

--- a/custom_components/taskmate/www/taskmate-panel.js
+++ b/custom_components/taskmate/www/taskmate-panel.js
@@ -773,6 +773,13 @@ class TaskMatePanel extends HTMLElement {
       this._notifSetChildNotify(t.dataset.childId, t.value);
       return;
     }
+    if (t.dataset.act === "notif-set-child-quiet") {
+      const row = t.closest("[data-quiet-row]");
+      const startEl = row && row.querySelector('[data-quiet-bound="start"]');
+      const endEl = row && row.querySelector('[data-quiet-bound="end"]');
+      this._notifSetChildQuiet(t.dataset.childId, (startEl && startEl.value) || "", (endEl && endEl.value) || "");
+      return;
+    }
     if (t.dataset.act === "notif-set-parent-notify") {
       const p = (this._notifState && this._notifState.recipients && this._notifState.recipients.parents || []).find(x => x.id === t.dataset.parentId);
       if (p) this._notifUpsertParent({ ...p, notify_service: t.value });
@@ -1891,6 +1898,11 @@ class TaskMatePanel extends HTMLElement {
 
   async _notifSetChildNotify(childId, notifyService) {
     await this._callWS({ type: "taskmate/notifications/set_child_notify", child_id: childId, notify_service: notifyService || null });
+    await this._fetchState();
+  }
+
+  async _notifSetChildQuiet(childId, start, end) {
+    await this._callWS({ type: "taskmate/notifications/set_child_quiet", child_id: childId, quiet_hours_start: start || "", quiet_hours_end: end || "" });
     await this._fetchState();
   }
 
@@ -3886,14 +3898,23 @@ class TaskMatePanel extends HTMLElement {
         <div class="tm-grid-2">
           <div>
             <h4>${this._t("panel.notif_recipients_children")}</h4>
-            ${ns.recipients.children.map(c => `
-              <div class="tm-row" style="display:flex;gap:10px;align-items:center;padding:8px 0;border-top:1px solid var(--tm-border,#3a3a3a)">
-                <div style="flex:1"><strong>${this._esc(c.name)}</strong></div>
-                <select class="tm-notif-select" data-act="notif-set-child-notify" data-child-id="${this._esc(c.id.replace(/^child:/, ""))}">
+            ${ns.recipients.children.map(c => {
+              const cid = c.id.replace(/^child:/, "");
+              return `
+              <div class="tm-row" data-quiet-row style="display:flex;flex-wrap:wrap;gap:10px;align-items:center;padding:8px 0;border-top:1px solid var(--tm-border,#3a3a3a)">
+                <div style="flex:1;min-width:120px"><strong>${this._esc(c.name)}</strong></div>
+                <select class="tm-notif-select" data-act="notif-set-child-notify" data-child-id="${this._esc(cid)}">
                   ${optTags(c.notify_service)}
                 </select>
+                <div class="tm-meta" style="display:flex;align-items:center;gap:6px;width:100%" title="${this._t("panel.notif_quiet_hours_desc")}">
+                  <ha-icon icon="mdi:bell-sleep" style="--mdc-icon-size:16px"></ha-icon>
+                  <span>${this._t("panel.notif_quiet_hours_label")}</span>
+                  <input type="time" class="tm-notif-time-input" data-act="notif-set-child-quiet" data-quiet-bound="start" data-child-id="${this._esc(cid)}" value="${this._esc(c.quiet_hours_start || "")}" style="margin:0;width:90px">
+                  <span>–</span>
+                  <input type="time" class="tm-notif-time-input" data-act="notif-set-child-quiet" data-quiet-bound="end" data-child-id="${this._esc(cid)}" value="${this._esc(c.quiet_hours_end || "")}" style="margin:0;width:90px">
+                </div>
               </div>
-            `).join("")}
+            `;}).join("")}
           </div>
           <div>
             <h4>${this._t("panel.notif_recipients_parents")}</h4>

--- a/tests/test_quiet_hours.py
+++ b/tests/test_quiet_hours.py
@@ -1,0 +1,150 @@
+"""Tests for per-child quiet hours / do-not-disturb (FEAT-5)."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock
+
+import pytest
+
+from custom_components.taskmate.coord_notifications import (
+    NotificationCoordinator,
+    _is_within_quiet_hours,
+)
+from custom_components.taskmate.models import Child, NotificationRoute
+from custom_components.taskmate.storage import TaskMateStorage
+
+from .conftest import dt_util_mock
+
+
+def _at(hour: int, minute: int = 0) -> datetime:
+    return datetime(2026, 1, 1, hour, minute, tzinfo=timezone.utc)
+
+
+# --- pure window logic -----------------------------------------------------
+
+def test_disabled_when_either_bound_blank():
+    assert _is_within_quiet_hours("", "07:00", _at(3)) is False
+    assert _is_within_quiet_hours("20:00", "", _at(3)) is False
+    assert _is_within_quiet_hours("", "", _at(3)) is False
+
+
+def test_disabled_when_bounds_equal():
+    assert _is_within_quiet_hours("07:00", "07:00", _at(7)) is False
+
+
+def test_disabled_when_malformed():
+    assert _is_within_quiet_hours("notatime", "07:00", _at(3)) is False
+    assert _is_within_quiet_hours("25:00", "07:00", _at(3)) is False
+
+
+def test_daytime_window():
+    # School hours 09:00-15:00
+    assert _is_within_quiet_hours("09:00", "15:00", _at(8, 59)) is False
+    assert _is_within_quiet_hours("09:00", "15:00", _at(9, 0)) is True   # start inclusive
+    assert _is_within_quiet_hours("09:00", "15:00", _at(12, 0)) is True
+    assert _is_within_quiet_hours("09:00", "15:00", _at(15, 0)) is False  # end exclusive
+    assert _is_within_quiet_hours("09:00", "15:00", _at(16, 0)) is False
+
+
+def test_overnight_window():
+    # Bedtime 20:00-07:00
+    assert _is_within_quiet_hours("20:00", "07:00", _at(19, 59)) is False
+    assert _is_within_quiet_hours("20:00", "07:00", _at(20, 0)) is True   # start inclusive
+    assert _is_within_quiet_hours("20:00", "07:00", _at(23, 30)) is True
+    assert _is_within_quiet_hours("20:00", "07:00", _at(2, 0)) is True
+    assert _is_within_quiet_hours("20:00", "07:00", _at(6, 59)) is True
+    assert _is_within_quiet_hours("20:00", "07:00", _at(7, 0)) is False   # end exclusive
+    assert _is_within_quiet_hours("20:00", "07:00", _at(12, 0)) is False
+
+
+# --- dispatch integration --------------------------------------------------
+
+@pytest.fixture
+async def coord(hass):
+    storage = TaskMateStorage(hass, "test")
+    await storage.async_load()
+    return NotificationCoordinator(hass, storage)
+
+
+@pytest.mark.asyncio
+async def test_fire_suppresses_child_during_quiet_hours(coord, hass, monkeypatch):
+    hass.services.async_call = AsyncMock()
+    hass.bus.async_fire = AsyncMock()
+
+    child = Child(
+        name="Alex",
+        notify_service="notify.alex",
+        quiet_hours_start="20:00",
+        quiet_hours_end="07:00",
+    )
+    coord.storage.add_child(child)
+    coord.storage.set_notification_master("badge_earned", True)
+    coord.storage.set_notification_route(
+        "badge_earned", f"child:{child.id}", NotificationRoute(enabled=True)
+    )
+
+    # Pretend it is 22:00 — inside the window. The conftest dt_util mock is the
+    # single source of "now" the integration sees.
+    monkeypatch.setattr(dt_util_mock, "_now", _at(22))
+
+    await coord.fire("badge_earned", {"child_name": "Alex", "badge_name": "Star"})
+
+    notify_calls = [c for c in hass.services.async_call.call_args_list if c[0][0] == "notify"]
+    assert notify_calls == []
+    # Bus event still fires, but the suppressed child is not a recipient
+    name, payload = hass.bus.async_fire.call_args[0]
+    assert payload["recipients"] == []
+
+
+@pytest.mark.asyncio
+async def test_fire_delivers_child_outside_quiet_hours(coord, hass, monkeypatch):
+    hass.services.async_call = AsyncMock()
+    hass.bus.async_fire = AsyncMock()
+
+    child = Child(
+        name="Alex",
+        notify_service="notify.alex",
+        quiet_hours_start="20:00",
+        quiet_hours_end="07:00",
+    )
+    coord.storage.add_child(child)
+    coord.storage.set_notification_master("badge_earned", True)
+    coord.storage.set_notification_route(
+        "badge_earned", f"child:{child.id}", NotificationRoute(enabled=True)
+    )
+
+    monkeypatch.setattr(dt_util_mock, "_now", _at(12))  # midday, outside window
+
+    await coord.fire("badge_earned", {"child_name": "Alex", "badge_name": "Star"})
+
+    notify_calls = [c for c in hass.services.async_call.call_args_list if c[0][0] == "notify"]
+    assert len(notify_calls) == 1
+    assert notify_calls[0][0][1] == "alex"
+
+
+@pytest.mark.asyncio
+async def test_quiet_hours_does_not_suppress_parents(coord, hass, monkeypatch):
+    from custom_components.taskmate.models import ParentRecipient
+
+    hass.services.async_call = AsyncMock()
+    hass.bus.async_fire = AsyncMock()
+
+    p = ParentRecipient(name="John", notify_service="notify.john")
+    coord.storage.upsert_parent_recipient(p)
+    coord.storage.set_notification_master("badge_earned", True)
+    coord.storage.set_notification_route("badge_earned", p.id, NotificationRoute(enabled=True))
+
+    monkeypatch.setattr(dt_util_mock, "_now", _at(3))  # 3am — would be quiet for a child
+
+    await coord.fire("badge_earned", {"child_name": "Alex", "badge_name": "Star"})
+
+    notify_calls = [c for c in hass.services.async_call.call_args_list if c[0][0] == "notify"]
+    assert len(notify_calls) == 1
+    assert notify_calls[0][0][1] == "john"
+
+
+def test_child_round_trips_quiet_hours():
+    child = Child(name="Alex", quiet_hours_start="20:00", quiet_hours_end="07:00")
+    restored = Child.from_dict(child.to_dict())
+    assert restored.quiet_hours_start == "20:00"
+    assert restored.quiet_hours_end == "07:00"


### PR DESCRIPTION
## FEAT-5 — Per-child quiet hours / DND

Suppresses a child's TaskMate notifications during a configurable do-not-disturb window (e.g. school hours, bedtime). Complements the existing notification routing.

### Behaviour
- Each child has a quiet-hours window (`quiet_hours_start` / `quiet_hours_end`, `HH:MM`).
- In `NotificationCoordinator.fire()`, a child route is **skipped** when the current local time is inside the window.
- `start > end` denotes an **overnight** window (e.g. `20:00`–`07:00`); the end bound is **exclusive**; either bound **blank = disabled**.
- **Parent routes are unaffected** — a parent still gets "X completed a chore — awaiting approval" at any hour. The bus event also still fires (suppressed child simply isn't a recipient).

### Changes
- **models** — `Child.quiet_hours_start` / `quiet_hours_end` (+ (de)serialise).
- **coord_notifications** — pure `_is_within_quiet_hours()` helper + `_child_in_quiet_hours()` gate in `fire()`.
- **websocket** — fields surfaced in `notifications/get_state`; new `notifications/set_child_quiet` command (admin-only) with `HH:MM` validation.
- **panel** — per-child quiet-hours time inputs in the Notifications → Recipients section.
- **i18n** — `panel.notif_quiet_hours_label` / `_desc` in all 8 locales.
- **tests** — `test_quiet_hours.py`: window logic (normal / overnight / disabled / equal-bounds / boundaries), dispatch suppression, parent-unaffected, model round-trip.

### Verification
- `pytest tests/test_quiet_hours.py` + notification/models/storage suites green; Ruff clean.
- Live on ha-dev: WS round-trip set→get (`20:00`/`07:00`), invalid `99:99` rejected (`invalid_format`), clear→`""`. Panel JS `node --check` clean.

Part of the v4.3.1 audit fix+feature campaign. No version bump / release.