### PR TITLE
perf(availability): memoize per-build chore matrix work (PERF-1)

### DIFF
--- a/custom_components/taskmate/coord_assignments.py
+++ b/custom_components/taskmate/coord_assignments.py
@@ -258,6 +258,20 @@ class AssignmentsMixin:
         parent has skipped. Stale skip state (skip_date != today) is ignored at
         read time and cleared during the midnight refresh.
         """
+        # PERF-1: the active set depends only on the chore for "today" (the
+        # availability matrix calls this per chore × child). Memoize per chore
+        # within an availability build scope. Skip when an explicit `today` is
+        # passed (callers that probe other days must not read today's cache).
+        cache = getattr(self, "_avail_cache", None)
+        if cache is not None and today is None:
+            cached = cache["active"].get(chore.id)
+            if cached is None:
+                cached = self._compute_active_children_uncached(chore, None)
+                cache["active"][chore.id] = cached
+            return cached
+        return self._compute_active_children_uncached(chore, today)
+
+    def _compute_active_children_uncached(self, chore: Chore, today: date | None = None) -> list[str]:
         mode = getattr(chore, "assignment_mode", "everyone")
         require_availability = getattr(chore, "require_availability", False)
 
@@ -464,6 +478,16 @@ class AssignmentsMixin:
         """
         if getattr(chore, 'assignment_mode', 'everyone') == 'everyone':
             return False
+        # PERF-1: result depends only on the chore; memoize per availability build.
+        cache = getattr(self, "_avail_cache", None)
+        if cache is not None and chore.id in cache["rotation_done"]:
+            return cache["rotation_done"][chore.id]
+        result = self._is_rotation_done_today_uncached(chore)
+        if cache is not None:
+            cache["rotation_done"][chore.id] = result
+        return result
+
+    def _is_rotation_done_today_uncached(self, chore) -> bool:
         pool = set(self._chore_assignment_pool(chore))
         if not pool:
             return False
@@ -471,7 +495,7 @@ class AssignmentsMixin:
         active_child_id = getattr(chore, 'assignment_current_child_id', '') or ''
         completions_today = 0
         completed_bonus_ids_today: set[str] = set()
-        for comp in self.storage.get_completions():
+        for comp in self._cached_completions():
             if comp.chore_id != chore.id:
                 continue
             comp_dt = comp.completed_at

--- a/custom_components/taskmate/coord_chores.py
+++ b/custom_components/taskmate/coord_chores.py
@@ -1149,7 +1149,7 @@ class ChoresMixin:
         depends_on = getattr(chore, 'depends_on', []) or []
         if depends_on:
             dep_today = dt_util.as_local(dt_util.now()).date()
-            completions = self.storage.get_completions()
+            completions = self._cached_completions()
             for dep_id in depends_on:
                 satisfied = any(
                     c.chore_id == dep_id
@@ -1258,33 +1258,34 @@ class ChoresMixin:
         """
         today = dt_util.as_local(dt_util.now()).date()
         dow = ("monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday")[today.weekday()]
-        completions = self.storage.get_completions()
         out = []
-        for chore in self.storage.get_chores():
-            if not self.is_chore_available_for_child(chore, child_id):
-                continue
-            assigned = getattr(chore, "assigned_to", []) or []
-            if assigned and child_id not in assigned:
-                continue
-            if getattr(chore, "schedule_mode", "specific_days") == "specific_days":
-                due_days = getattr(chore, "due_days", []) or []
-                if due_days and dow not in due_days:
+        with self.availability_build_scope():
+            completions = self._cached_completions()
+            for chore in self.storage.get_chores():
+                if not self.is_chore_available_for_child(chore, child_id):
                     continue
-            limit = getattr(chore, "daily_limit", 1) or 1
-            done = 0
-            for c in completions:
-                if c.chore_id != chore.id or c.child_id != child_id:
+                assigned = getattr(chore, "assigned_to", []) or []
+                if assigned and child_id not in assigned:
                     continue
-                if getattr(c, "bonus_subtask_id", ""):
+                if getattr(chore, "schedule_mode", "specific_days") == "specific_days":
+                    due_days = getattr(chore, "due_days", []) or []
+                    if due_days and dow not in due_days:
+                        continue
+                limit = getattr(chore, "daily_limit", 1) or 1
+                done = 0
+                for c in completions:
+                    if c.chore_id != chore.id or c.child_id != child_id:
+                        continue
+                    if getattr(c, "bonus_subtask_id", ""):
+                        continue
+                    try:
+                        if dt_util.as_local(c.completed_at).date() == today:
+                            done += 1
+                    except (AttributeError, TypeError, ValueError):
+                        continue
+                if done >= limit:
                     continue
-                try:
-                    if dt_util.as_local(c.completed_at).date() == today:
-                        done += 1
-                except (AttributeError, TypeError, ValueError):
-                    continue
-            if done >= limit:
-                continue
-            out.append(chore)
+                out.append(chore)
         return out
 
     async def _async_expire_dated_chores(self) -> None:

--- a/custom_components/taskmate/coordinator.py
+++ b/custom_components/taskmate/coordinator.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from contextlib import contextmanager
 from datetime import date, datetime, timedelta
 import logging
 import random
@@ -68,6 +69,9 @@ class TaskMateCoordinator(
         self._unsub_surprise: Callable[[], None] | None = None
         self._unsub_weekly: Callable[[], None] | None = None
         self._unsub_mandatory: list[Callable[[], None]] = []
+        # Per-build memo for the availability matrix (PERF-1). Non-None only
+        # inside `availability_build_scope()`; see coord_chores/coord_assignments.
+        self._avail_cache: dict | None = None
 
     def difficulty_multiplier(self, tier: str) -> float:
         """Return the points multiplier for a difficulty tier.
@@ -152,6 +156,38 @@ class TaskMateCoordinator(
         if not entity_id:
             return False
         return self._read_entity_active(entity_id) is True
+
+    @contextmanager
+    def availability_build_scope(self):
+        """Memoize chore-only computations for one availability build (PERF-1).
+
+        The availability matrix calls ``is_chore_available_for_child`` for every
+        chore × child. Several inner computations depend only on the chore (the
+        rotation active-set, the rotation-done check) or are re-fetched from
+        storage repeatedly (the completions list, which ``get_completions``
+        rebuilds from dicts on each call). Inside this scope those are computed
+        once and cached. The build is fully synchronous (no awaits), so storage
+        cannot mutate while the cache is live. Re-entrant scopes reuse the cache.
+        """
+        if getattr(self, "_avail_cache", None) is not None:
+            yield  # already inside a scope — reuse the existing cache
+            return
+        self._avail_cache = {
+            "completions": self.storage.get_completions(),
+            "active": {},
+            "rotation_done": {},
+        }
+        try:
+            yield
+        finally:
+            self._avail_cache = None
+
+    def _cached_completions(self) -> list:
+        """Completions list, served from the availability cache when in scope."""
+        cache = getattr(self, "_avail_cache", None)
+        if cache is not None:
+            return cache["completions"]
+        return self.storage.get_completions()
 
     def _is_child_on_vacation(self, child, on: date | None = None) -> bool:
         """True when ``child`` should be treated as away (streak frozen, chores

--- a/custom_components/taskmate/sensor.py
+++ b/custom_components/taskmate/sensor.py
@@ -293,11 +293,12 @@ def _build_chore_availability(coordinator: TaskMateCoordinator, common: dict) ->
     children = common["children"]
     chores = common["chores"]
     availability: dict[str, dict[str, bool]] = {}
-    for c in chores:
-        per_child = {}
-        for child in children:
-            per_child[child.id] = coordinator.is_chore_available_for_child(c, child.id)
-        availability[c.id] = per_child
+    with coordinator.availability_build_scope():
+        for c in chores:
+            per_child = {}
+            for child in children:
+                per_child[child.id] = coordinator.is_chore_available_for_child(c, child.id)
+            availability[c.id] = per_child
     return availability
 
 

--- a/tests/test_availability_cache.py
+++ b/tests/test_availability_cache.py
@@ -1,0 +1,91 @@
+"""PERF-1: availability_build_scope memoizes per-chore work and completions."""
+from __future__ import annotations
+
+import datetime as dt
+from datetime import timezone
+from unittest.mock import MagicMock, patch
+
+from custom_components.taskmate.coordinator import TaskMateCoordinator
+from custom_components.taskmate.models import Chore
+
+UTC = timezone.utc
+NOW = dt.datetime(2026, 4, 20, 10, 0, 0, tzinfo=UTC)  # Monday
+
+
+def _coord(chores, completions=None):
+    coord = object.__new__(TaskMateCoordinator)
+    coord.hass = MagicMock()
+    coord.storage = MagicMock()
+    coord.storage.get_chores = MagicMock(return_value=chores)
+    coord.storage.get_completions = MagicMock(return_value=completions or [])
+    coord.storage.get_children = MagicMock(return_value=[])
+    coord.storage.get_child = MagicMock(return_value=None)
+    # Isolate the rotation/completions logic from the unrelated gates.
+    coord._is_child_on_vacation = MagicMock(return_value=False)
+    coord._is_visibility_entity_active = MagicMock(return_value=True)
+    return coord
+
+
+def test_scope_fetches_completions_once_across_many_lookups():
+    # depends_on forces is_chore_available_for_child to read completions.
+    chores = [
+        Chore(name=f"c{i}", assigned_to=["k1"], depends_on=["dep"], id=f"id{i}")
+        for i in range(5)
+    ]
+    coord = _coord(chores)
+
+    with patch("custom_components.taskmate.coord_chores.dt_util.now", return_value=NOW), \
+         patch("custom_components.taskmate.coord_assignments.dt_util.now", return_value=NOW):
+        with coord.availability_build_scope():
+            for c in chores:
+                for kid in ("k1", "k2", "k3"):
+                    coord.is_chore_available_for_child(c, kid)
+
+    # get_completions: once at scope entry. Never again inside the scope.
+    assert coord.storage.get_completions.call_count == 1
+
+
+def test_rotation_done_memoized_per_chore():
+    chore = Chore(name="rot", assignment_mode="alternating", assigned_to=["k1", "k2"], id="r1")
+    coord = _coord([chore])
+    coord._is_rotation_done_today_uncached = MagicMock(return_value=False)
+    coord._compute_active_children_uncached = MagicMock(return_value=["k1", "k2"])
+
+    with patch("custom_components.taskmate.coord_chores.dt_util.now", return_value=NOW), \
+         patch("custom_components.taskmate.coord_assignments.dt_util.now", return_value=NOW):
+        with coord.availability_build_scope():
+            for kid in ("k1", "k2"):
+                coord.is_chore_available_for_child(chore, kid)
+
+    # Despite two children, the chore-only computations run once each.
+    assert coord._is_rotation_done_today_uncached.call_count == 1
+    assert coord._compute_active_children_uncached.call_count == 1
+
+
+def test_no_scope_means_no_cache_state_leaks():
+    chore = Chore(name="x", assigned_to=["k1"], depends_on=["dep"], id="x1")
+    coord = _coord([chore])
+    with patch("custom_components.taskmate.coord_chores.dt_util.now", return_value=NOW), \
+         patch("custom_components.taskmate.coord_assignments.dt_util.now", return_value=NOW):
+        coord.is_chore_available_for_child(chore, "k1")
+    # Outside a scope the cache is never created; storage is queried directly.
+    assert getattr(coord, "_avail_cache", None) is None
+    assert coord.storage.get_completions.call_count == 1
+
+
+def test_scope_clears_cache_on_exit():
+    coord = _coord([])
+    with coord.availability_build_scope():
+        assert coord._avail_cache is not None
+    assert coord._avail_cache is None
+
+
+def test_nested_scope_reuses_outer_cache():
+    coord = _coord([])
+    with coord.availability_build_scope():
+        outer = coord._avail_cache
+        with coord.availability_build_scope():
+            assert coord._avail_cache is outer  # inner reuses, doesn't replace
+        # Inner exit must NOT clear the outer scope's cache.
+        assert coord._avail_cache is outer
+    assert coord._avail_cache is None


### PR DESCRIPTION
## PERF-1 — Availability matrix precompute

The chore-availability matrix (`sensor.taskmate_chore_availability`, rebuilt every 30 s refresh) calls `is_chore_available_for_child` for **every chore × child**. Several inner computations are redundant:
- `_is_rotation_done_today(chore)` and `_compute_active_children(chore)` depend only on the **chore**, yet run once per child.
- `storage.get_completions()` rebuilds every `ChoreCompletion` from its dict on **each** call, and is hit per chore×child (rotation-done + `depends_on`).

Net cost: O(chores × children × completions), and O(chores² × children) for `balanced` mode.

### Fix
New `coordinator.availability_build_scope()` — a **synchronous, re-entrant** context that snapshots completions once and memoizes the chore-only helpers per `chore.id`:
- `_compute_active_children(today=None)` → thin caching wrapper over new `_compute_active_children_uncached`.
- `_is_rotation_done_today` → caching wrapper over new `_is_rotation_done_today_uncached`.
- `depends_on` scan + rotation-done read completions via `_cached_completions()`.

Wired into `sensor._build_chore_availability` and `coordinator.get_due_chores_for_child`. **Behaviour is identical outside a scope** (cache stays `None`); the build has no `await`s, so storage cannot mutate while the snapshot is live. Explicit-`today` callers (calendar projection, clone preview) bypass the cache. Returned active-lists are read-only at every call site (audited).

### Verification
- `test_availability_cache.py`: completions fetched once across many lookups, per-chore memoization (1 call despite N children), no cache when unscoped, scope cleanup, nested-scope reuse.
- Full chore/assignment/rotation/sensor/due/todo/calendar suites green; Ruff clean. (Full-suite shows the 3 pre-existing order-pollution failures + 9 errors documented in memory — pass in isolation, unrelated.)
- Live on ha-dev: matrix recomputes correctly (8 chores × 2 children populated); `todo.taskmate_*` open counts unchanged (0 / 4).

Part of the v4.3.1 audit fix campaign. No version bump / release.