### PR TITLE
perf(coordinator): cache data snapshot by storage version (PERF-2)

### DIFF
--- a/custom_components/taskmate/coordinator.py
+++ b/custom_components/taskmate/coordinator.py
@@ -72,6 +72,8 @@ class TaskMateCoordinator(
         # Per-build memo for the availability matrix (PERF-1). Non-None only
         # inside `availability_build_scope()`; see coord_chores/coord_assignments.
         self._avail_cache: dict | None = None
+        # (data_version, snapshot) cache for _async_update_data (PERF-2).
+        self._data_snapshot_cache: tuple[int, dict[str, Any]] | None = None
 
     def difficulty_multiplier(self, tier: str) -> float:
         """Return the points multiplier for a difficulty tier.
@@ -506,9 +508,27 @@ class TaskMateCoordinator(
         self.hass.async_create_task(self.async_prune_history(days))
 
     async def _async_update_data(self) -> dict[str, Any]:
-        """Fetch data from storage."""
+        """Fetch data from storage.
+
+        PERF-2: rebuilding every child/chore/completion from its stored dict on
+        each 30 s poll is wasteful when nothing changed. Cache the built dict
+        keyed by ``storage.data_version`` (bumped on every save) and reuse it
+        until the next mutation. Availability is recomputed in the sensor layer
+        from live entity state, not from this dict, so a stale-version reuse
+        never staleness-bugs availability — listeners still re-read each tick.
+        """
+        # May stop sessions (mutates + saves -> bumps the version), so run first.
         await self._async_auto_stop_capped_sessions()
         self._refresh_tracked_availability_entities()
+        version = self.storage.data_version
+        cached = getattr(self, "_data_snapshot_cache", None)
+        if cached is not None and cached[0] == version:
+            return cached[1]
+        snapshot = self._build_data_snapshot()
+        self._data_snapshot_cache = (version, snapshot)
+        return snapshot
+
+    def _build_data_snapshot(self) -> dict[str, Any]:
         return {
             "children": self.storage.get_children(),
             "chores": self.storage.get_chores(),

--- a/custom_components/taskmate/storage.py
+++ b/custom_components/taskmate/storage.py
@@ -31,6 +31,9 @@ class TaskMateStorage:
         self.entry_id = entry_id
         self._store = Store(hass, STORAGE_VERSION, f"{STORAGE_KEY}.{entry_id}")
         self._data: dict[str, Any] = {}
+        # Monotonic counter bumped on every persisted mutation (PERF-2). Lets the
+        # coordinator skip rebuilding its data snapshot when nothing has changed.
+        self._data_version = 0
 
     async def async_load(self) -> dict[str, Any]:
         """Load data from storage."""
@@ -246,7 +249,16 @@ class TaskMateStorage:
 
     async def async_save(self) -> None:
         """Save data to storage."""
+        # Bump synchronously, before the await: a mutation method calls this with
+        # no interleaving await after touching _data, so the new version is
+        # visible the instant anything else (e.g. the 30 s poll) can run.
+        self._data_version = getattr(self, "_data_version", 0) + 1
         await self._store.async_save(self._data)
+
+    @property
+    def data_version(self) -> int:
+        """Monotonic version of the in-memory data; bumped on each save."""
+        return getattr(self, "_data_version", 0)
 
     @property
     def data(self) -> dict[str, Any]:

--- a/tests/test_data_version_cache.py
+++ b/tests/test_data_version_cache.py
@@ -1,0 +1,61 @@
+"""PERF-2: storage data_version + coordinator _async_update_data caching."""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.taskmate.coordinator import TaskMateCoordinator
+from custom_components.taskmate.storage import TaskMateStorage
+
+
+@pytest.mark.asyncio
+async def test_data_version_increments_on_save(hass):
+    storage = TaskMateStorage(hass, "test")
+    await storage.async_load()
+    before = storage.data_version
+    await storage.async_save()
+    assert storage.data_version == before + 1
+    await storage.async_save()
+    assert storage.data_version == before + 2
+
+
+def _coord():
+    coord = object.__new__(TaskMateCoordinator)
+    coord._data_snapshot_cache = None
+    coord.storage = MagicMock()
+    coord.storage.data_version = 1
+    coord._async_auto_stop_capped_sessions = AsyncMock()
+    coord._refresh_tracked_availability_entities = MagicMock()
+    coord._build_data_snapshot = MagicMock(side_effect=lambda: {"built_at": coord.storage.data_version})
+    return coord
+
+
+@pytest.mark.asyncio
+async def test_update_data_reuses_snapshot_when_version_unchanged():
+    coord = _coord()
+    r1 = await coord._async_update_data()
+    r2 = await coord._async_update_data()
+    assert r1 is r2  # identical object served from cache
+    assert coord._build_data_snapshot.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_update_data_rebuilds_after_version_bump():
+    coord = _coord()
+    r1 = await coord._async_update_data()
+    coord.storage.data_version = 2
+    r2 = await coord._async_update_data()
+    assert r1 is not r2
+    assert coord._build_data_snapshot.call_count == 2
+    assert r2["built_at"] == 2
+
+
+@pytest.mark.asyncio
+async def test_update_data_always_runs_side_effects():
+    coord = _coord()
+    await coord._async_update_data()
+    await coord._async_update_data()  # cached path
+    # Auto-stop + tracked-entity refresh must run every tick, cache or not.
+    assert coord._async_auto_stop_capped_sessions.await_count == 2
+    assert coord._refresh_tracked_availability_entities.call_count == 2


### PR DESCRIPTION
## PERF-2 — Cache the coordinator data snapshot by storage version

`_async_update_data` (the 30 s `DataUpdateCoordinator` poll) rebuilt **every** child/chore/completion/reward/transaction from its stored dict on every tick, even when nothing had changed.

### Fix
- **storage** — new monotonic `data_version`, bumped synchronously at the **top** of `async_save` (before its `await`, so a mutation that calls `update_*` then `async_save` makes the new version visible the instant the poll can interleave).
- **coordinator** — `_data_snapshot_cache = (version, dict)`. `_async_update_data` returns the cached dict while `storage.data_version` is unchanged, else rebuilds via the extracted `_build_data_snapshot()`.

Side effects (`_async_auto_stop_capped_sessions`, `_refresh_tracked_availability_entities`) **still run every tick**. Availability is recomputed in the **sensor layer** from live entity state — not from this dict — so reusing a snapshot never staleness-bugs availability; listeners re-read each tick regardless.

**Deliberately not cached:** the panel `get_state` snapshot (`_build_state_snapshot`). It embeds **per-request expiring signed photo URLs** that must be regenerated each call. The periodic 30 s rebuild was the real hot path.

### Verification
- `test_data_version_cache.py`: version bumps on save; snapshot reused (identical object) when version unchanged; rebuilt after a bump; side-effects run every tick.
- Integration / storage / coordinator / sensor / due / availability suites green; Ruff clean.
- Live on ha-dev: `taskmate.add_points +3` reflected in the next `get_state` (cache invalidated by the save), `remove_points` restores — proving correct invalidation across idle polls.

Part of the v4.3.1 audit fix campaign. No version bump / release.