### PR TITLE
perf(storage): debounce saves via async_delay_save (PERF-3)

### DIFF
--- a/custom_components/taskmate/coordinator.py
+++ b/custom_components/taskmate/coordinator.py
@@ -448,6 +448,9 @@ class TaskMateCoordinator(
             self._unsub_weekly()
             self._unsub_weekly = None
         self.disarm_mandatory_schedules()
+        # Flush any pending debounced save so an entry unload/reload can't drop
+        # the last mutation (PERF-3).
+        await self.storage.async_save_now()
 
     @callback
     def _async_midnight_streak_check(self, now: datetime) -> None:

--- a/custom_components/taskmate/storage.py
+++ b/custom_components/taskmate/storage.py
@@ -21,6 +21,11 @@ _LOGGER = logging.getLogger(__name__)
 STORAGE_VERSION = 1
 STORAGE_KEY = f"{DOMAIN}.storage"
 
+# Debounce window for coalescing the 2-4 saves a single operation can trigger
+# into one disk write (PERF-3). Small enough that a crash loses at most this
+# much; HA flushes pending delayed saves on shutdown.
+_SAVE_DEBOUNCE_SECONDS = 1.0
+
 
 class TaskMateStorage:
     """Manage TaskMate data storage."""
@@ -248,10 +253,23 @@ class TaskMateStorage:
         await self.async_save()
 
     async def async_save(self) -> None:
-        """Save data to storage."""
-        # Bump synchronously, before the await: a mutation method calls this with
+        """Persist data, debounced (PERF-3).
+
+        A single TaskMate operation often calls this 2-4× (e.g. mutate a record,
+        award points, refresh). ``Store.async_delay_save`` coalesces all of them
+        into one disk write after a short delay, instead of serialising the whole
+        ``_data`` blob each time. HA flushes any pending delayed write on
+        shutdown; ``async_shutdown`` also forces a flush via ``async_save_now``.
+        Use ``async_save_now`` when an immediate on-disk write is required.
+        """
+        # Bump synchronously, before any await: a mutation method calls this with
         # no interleaving await after touching _data, so the new version is
         # visible the instant anything else (e.g. the 30 s poll) can run.
+        self._data_version = getattr(self, "_data_version", 0) + 1
+        self._store.async_delay_save(lambda: self._data, _SAVE_DEBOUNCE_SECONDS)
+
+    async def async_save_now(self) -> None:
+        """Persist data immediately, bypassing the debounce (shutdown/flush)."""
         self._data_version = getattr(self, "_data_version", 0) + 1
         await self._store.async_save(self._data)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -83,6 +83,10 @@ class FakeStore:
     async def async_save(self, data):
         self._data = data
 
+    def async_delay_save(self, data_func, delay=0):
+        # Tests want deterministic persistence: write through immediately.
+        self._data = data_func()
+
 
 _ha_storage_mod = MagicMock()
 _ha_storage_mod.Store = FakeStore

--- a/tests/test_save_debounce.py
+++ b/tests/test_save_debounce.py
@@ -1,0 +1,73 @@
+"""PERF-3: async_save debounces; async_save_now writes through."""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.taskmate.storage import TaskMateStorage
+
+
+class _SpyStore:
+    def __init__(self):
+        self.delay_calls = []
+        self.immediate_calls = []
+
+    def async_delay_save(self, data_func, delay=0):
+        self.delay_calls.append((data_func(), delay))
+
+    async def async_save(self, data):
+        self.immediate_calls.append(data)
+
+
+@pytest.mark.asyncio
+async def test_async_save_uses_delay_save():
+    storage = object.__new__(TaskMateStorage)
+    storage._data = {"x": 1}
+    storage._store = _SpyStore()
+    await storage.async_save()
+    assert len(storage._store.delay_calls) == 1
+    assert storage._store.delay_calls[0][0] == {"x": 1}
+    assert storage._store.delay_calls[0][1] > 0  # non-zero debounce
+    assert storage._store.immediate_calls == []  # no direct write
+    assert storage.data_version == 1
+
+
+@pytest.mark.asyncio
+async def test_async_save_now_writes_through():
+    storage = object.__new__(TaskMateStorage)
+    storage._data = {"x": 2}
+    storage._store = _SpyStore()
+    await storage.async_save_now()
+    assert storage._store.immediate_calls == [{"x": 2}]
+    assert storage._store.delay_calls == []
+    assert storage.data_version == 1
+
+
+@pytest.mark.asyncio
+async def test_repeated_saves_each_bump_version_and_debounce():
+    storage = object.__new__(TaskMateStorage)
+    storage._data = {}
+    storage._store = _SpyStore()
+    for _ in range(4):
+        await storage.async_save()
+    # Each call schedules a (coalescing) delayed write; HA collapses them to one
+    # real disk write. Version still advances per logical save.
+    assert len(storage._store.delay_calls) == 4
+    assert storage.data_version == 4
+
+
+@pytest.mark.asyncio
+async def test_shutdown_flushes_pending_save():
+    from custom_components.taskmate.coordinator import TaskMateCoordinator
+    coord = object.__new__(TaskMateCoordinator)
+    coord.storage = MagicMock()
+    coord.storage.async_save_now = AsyncMock()
+    coord._unsub_midnight = None
+    coord._unsub_prune = None
+    coord._unsub_availability = None
+    coord._unsub_surprise = None
+    coord._unsub_weekly = None
+    coord.disarm_mandatory_schedules = MagicMock()
+    await coord.async_shutdown()
+    coord.storage.async_save_now.assert_awaited_once()


### PR DESCRIPTION
## PERF-3 — Debounce storage saves

A single TaskMate operation frequently calls `async_save` **2-4×** (mutate a record → award points → refresh), each serialising the **entire** `_data` blob to disk.

### Fix
Route `async_save` through `Store.async_delay_save(lambda: _data, 1.0s)`, which coalesces rapid saves into **one** debounced disk write. The 1 s window fully absorbs the within-operation duplicates while keeping any crash-loss window tiny.

- **storage** — `async_save` now debounced; new `async_save_now()` for immediate writes; the `data_version` bump still happens per logical save, so PERF-2 cache invalidation stays correct.
- **coordinator** — `async_shutdown` calls `await storage.async_save_now()` so an entry unload/reload flushes any pending write (HA already flushes delayed saves on full shutdown; this covers reloads too).
- **tests/conftest** — `FakeStore.async_delay_save` writes through immediately for deterministic test persistence.

### Verification
- `test_save_debounce.py`: `async_save` uses `async_delay_save` (no direct write) and bumps version each call; `async_save_now` writes through; `async_shutdown` flushes.
- Storage / integration / backup / coordinator / data-version suites green; Ruff clean. (The 3 `TestOneShotChores` failures in mixed runs are the documented pre-existing order-pollution — they fail identically on the unchanged tree and pass in isolation.)
- Live on ha-dev: `add_points +5` → waited out the debounce → **full HA restart** → balance persisted (63), proving the delayed write lands; reverted.

Part of the v4.3.1 audit fix campaign. No version bump / release.