### PR TITLE
fix(rewards): grow card to fit all rewards in designed styles (#604)

### DIFF
--- a/custom_components/taskmate/www/locales/de.json
+++ b/custom_components/taskmate/www/locales/de.json
@@ -1154,6 +1154,8 @@
   "rewards.deposit_points": "Zahlen Sie {amount} ein",
   "rewards.editor.enable_pool_mode": "Pool-Modus aktivieren (Spargläser)",
   "rewards.editor.enable_pool_mode_helper": "Jede Belohnung wird zu einem eigenen Sparpool – Kinder weisen Punkte direkt einem Ziel zu, anstatt sie aus einem globalen Guthaben auszugeben",
+  "rewards.editor.expand_to_fit": "Karte an alle Belohnungen anpassen",
+  "rewards.editor.expand_to_fit_helper": "Vergrößert die Karte, um jede Belohnung anzuzeigen, anstatt eine Liste mit fester Höhe zu scrollen (nur gestaltete Stile)",
   "rewards.editor.entity": "Entität",
   "rewards.editor.entity_helper": "Die TaskMate-Übersichtssensoreinheit",
   "rewards.editor.filter_by_child": "Nach Kind filtern",

--- a/custom_components/taskmate/www/locales/en-GB.json
+++ b/custom_components/taskmate/www/locales/en-GB.json
@@ -1207,6 +1207,8 @@
   "rewards.deposit_points": "Deposit {amount}",
   "rewards.editor.enable_pool_mode": "Enable Pool Mode (Savings Jars)",
   "rewards.editor.enable_pool_mode_helper": "Each reward becomes a dedicated savings pool — children allocate points directly to a goal rather than spending from a global balance",
+  "rewards.editor.expand_to_fit": "Expand card to fit all rewards",
+  "rewards.editor.expand_to_fit_helper": "Grow the card to show every reward instead of scrolling a fixed-height list (designed styles only)",
   "rewards.editor.entity": "Entity",
   "rewards.editor.entity_helper": "The TaskMate overview sensor entity",
   "rewards.editor.filter_by_child": "Filter by Child",

--- a/custom_components/taskmate/www/locales/en.json
+++ b/custom_components/taskmate/www/locales/en.json
@@ -1207,6 +1207,8 @@
   "rewards.deposit_points": "Deposit {amount}",
   "rewards.editor.enable_pool_mode": "Enable Pool Mode (Savings Jars)",
   "rewards.editor.enable_pool_mode_helper": "Each reward becomes a dedicated savings pool — children allocate points directly to a goal rather than spending from a global balance",
+  "rewards.editor.expand_to_fit": "Expand card to fit all rewards",
+  "rewards.editor.expand_to_fit_helper": "Grow the card to show every reward instead of scrolling a fixed-height list (designed styles only)",
   "rewards.editor.entity": "Entity",
   "rewards.editor.entity_helper": "The TaskMate overview sensor entity",
   "rewards.editor.filter_by_child": "Filter by Child",

--- a/custom_components/taskmate/www/locales/fr.json
+++ b/custom_components/taskmate/www/locales/fr.json
@@ -1154,6 +1154,8 @@
   "rewards.deposit_points": "Déposer {amount}",
   "rewards.editor.enable_pool_mode": "Activer le mode cagnotte (tirelires)",
   "rewards.editor.enable_pool_mode_helper": "Chaque récompense devient une cagnotte dédiée — les enfants allouent des points directement à un objectif plutôt que de dépenser depuis un solde global",
+  "rewards.editor.expand_to_fit": "Agrandir la carte pour toutes les récompenses",
+  "rewards.editor.expand_to_fit_helper": "Agrandit la carte pour afficher chaque récompense au lieu de faire défiler une liste à hauteur fixe (styles personnalisés uniquement)",
   "rewards.editor.entity": "Entité",
   "rewards.editor.entity_helper": "L'entité du capteur de vue d'ensemble TaskMate",
   "rewards.editor.filter_by_child": "Filtrer par enfant",

--- a/custom_components/taskmate/www/locales/nb.json
+++ b/custom_components/taskmate/www/locales/nb.json
@@ -1154,6 +1154,8 @@
   "rewards.deposit_points": "Sett inn {amount}",
   "rewards.editor.enable_pool_mode": "Aktiver spareglassmodus",
   "rewards.editor.enable_pool_mode_helper": "Hver belønning blir et dedikert spareglass — barna tildeler poeng direkte til et mål i stedet for å bruke fra en felles saldo",
+  "rewards.editor.expand_to_fit": "Utvid kortet til alle belønninger",
+  "rewards.editor.expand_to_fit_helper": "Lar kortet vokse slik at alle belønninger vises, i stedet for å bla i en liste med fast høyde (kun designede stiler)",
   "rewards.editor.entity": "Entitet",
   "rewards.editor.entity_helper": "TaskMate oversiktssensor-entiteten",
   "rewards.editor.filter_by_child": "Filtrer etter barn",

--- a/custom_components/taskmate/www/locales/nn.json
+++ b/custom_components/taskmate/www/locales/nn.json
@@ -1154,6 +1154,8 @@
   "rewards.deposit_points": "Set inn {amount}",
   "rewards.editor.enable_pool_mode": "Aktiver spareglasmodus",
   "rewards.editor.enable_pool_mode_helper": "Kvar løning blir eit dedikert spareglas — borna tildeler poeng direkte til eit mål i staden for å bruke frå ein felles saldo",
+  "rewards.editor.expand_to_fit": "Utvid kortet til alle løningar",
+  "rewards.editor.expand_to_fit_helper": "Lèt kortet veksa slik at alle løningar vert viste, i staden for å bla i ei liste med fast høgd (berre designa stilar)",
   "rewards.editor.entity": "Entitet",
   "rewards.editor.entity_helper": "TaskMate oversiktssensor-entiteten",
   "rewards.editor.filter_by_child": "Filtrer etter born",

--- a/custom_components/taskmate/www/locales/pt-BR.json
+++ b/custom_components/taskmate/www/locales/pt-BR.json
@@ -1154,6 +1154,8 @@
   "rewards.deposit_points": "Depositar {amount}",
   "rewards.editor.enable_pool_mode": "Ativar modo mealheiro",
   "rewards.editor.enable_pool_mode_helper": "Cada recompensa torna-se um mealheiro dedicado — as crianças alocam pontos diretamente a um objetivo em vez de gastar de um saldo global",
+  "rewards.editor.expand_to_fit": "Expandir o cartão para todas as recompensas",
+  "rewards.editor.expand_to_fit_helper": "Aumenta o cartão para mostrar todas as recompensas em vez de rolar uma lista de altura fixa (apenas estilos personalizados)",
   "rewards.editor.entity": "Entidade",
   "rewards.editor.entity_helper": "A entidade sensor de visão geral do TaskMate",
   "rewards.editor.filter_by_child": "Filtrar por Criança",

--- a/custom_components/taskmate/www/locales/pt.json
+++ b/custom_components/taskmate/www/locales/pt.json
@@ -1159,6 +1159,8 @@
   "rewards.deposit_points": "Depositar {amount}",
   "rewards.editor.enable_pool_mode": "Ativar modo mealheiro",
   "rewards.editor.enable_pool_mode_helper": "Cada recompensa torna-se um mealheiro dedicado — as crianças alocam pontos diretamente a um objetivo em vez de gastar de um saldo global",
+  "rewards.editor.expand_to_fit": "Expandir o cartão para todas as recompensas",
+  "rewards.editor.expand_to_fit_helper": "Aumenta o cartão para mostrar todas as recompensas em vez de percorrer uma lista de altura fixa (apenas estilos personalizados)",
   "rewards.editor.entity": "Entidade",
   "rewards.editor.entity_helper": "A entidade sensor de visão geral do TaskMate",
   "rewards.editor.filter_by_child": "Filtrar por Criança",

--- a/custom_components/taskmate/www/taskmate-rewards-card.js
+++ b/custom_components/taskmate/www/taskmate-rewards-card.js
@@ -956,8 +956,10 @@ class TaskMateRewardsCard extends LitElement {
 
       /* ── Designed (playroom / console / cleanpro) — shared .tmd kit comes
          from taskmate-design.js styles(); only card-specific layout below. ── */
-      .rw-list { display: flex; flex-direction: column; gap: 11px;
-                 max-height: 360px; overflow-y: auto; }
+      .rw-list { display: flex; flex-direction: column; gap: 11px; }
+      /* #604: default is fluid — the list grows to fit every reward. Opt into a
+         fixed 360px scroll region with expand_to_fit: false. */
+      .rw-list.rw-scroll { max-height: 360px; overflow-y: auto; }
       .rw-jackpot-label { align-self: flex-start; background: var(--tmd-gold); color: #3a2e26;
                           border-color: transparent; font-weight: 800; text-transform: uppercase;
                           letter-spacing: 0.04em; font-size: 10.5px; margin-bottom: 2px; }
@@ -1027,6 +1029,7 @@ class TaskMateRewardsCard extends LitElement {
       child_id: null, // Optional: filter rewards for a specific child
       show_child_badges: true, // Show which children can claim each reward
       enable_pool_mode: false, // v3.0: "savings jar" allocation mode (opt-in per card)
+      expand_to_fit: true, // #604: grow the card to fit all rewards (designed styles). false = fixed 360px scroll.
       deposit_amounts: [1, 5, 10], // #559: quick-deposit button amounts for pool/jackpot rewards
       header_color: '#e67e22',
       ...config,
@@ -1942,7 +1945,7 @@ class TaskMateRewardsCard extends LitElement {
         ${(anyPoolReward && activeChild) || activeChild
           ? this._designChildSelector(activeChild, pointsIcon, pointsName, design)
           : ''}
-        <div class="rw-list">
+        <div class="rw-list ${this.config.expand_to_fit === false ? 'rw-scroll' : ''}">
           ${sortedRewards.map((r) => this._designRewardRow(r, children, pointsIcon, pointsName, design))}
         </div>`;
 
@@ -2268,6 +2271,10 @@ class TaskMateRewardsCardEditor extends LitElement {
         name: 'enable_pool_mode',
         selector: { boolean: {} },
       },
+      {
+        name: 'expand_to_fit',
+        selector: { boolean: {} },
+      },
     ];
   }
 
@@ -2279,6 +2286,7 @@ class TaskMateRewardsCardEditor extends LitElement {
       card_design: this._t('common.design.field_label'),
       show_child_badges: this._t('rewards.editor.show_child_badges'),
       enable_pool_mode: this._t('rewards.editor.enable_pool_mode'),
+      expand_to_fit: this._t('rewards.editor.expand_to_fit'),
     };
     return labels[schemaEntry.name] ?? schemaEntry.name;
   };
@@ -2290,6 +2298,7 @@ class TaskMateRewardsCardEditor extends LitElement {
       child_id: this._t('rewards.editor.filter_by_child_helper'),
       show_child_badges: this._t('rewards.editor.show_child_badges_helper'),
       enable_pool_mode: this._t('rewards.editor.enable_pool_mode_helper'),
+      expand_to_fit: this._t('rewards.editor.expand_to_fit_helper'),
     };
     return helpers[schemaEntry.name] ?? '';
   };
@@ -2306,6 +2315,7 @@ class TaskMateRewardsCardEditor extends LitElement {
       card_design: this.config.card_design || 'global',
       show_child_badges: this.config.show_child_badges !== false,
       enable_pool_mode: this.config.enable_pool_mode === true,
+      expand_to_fit: this.config.expand_to_fit !== false,
     };
 
     return html`
@@ -2369,6 +2379,9 @@ class TaskMateRewardsCardEditor extends LitElement {
         // Default is true — omit to keep config minimal
         delete newConfig[key];
       } else if (key === 'enable_pool_mode' && value === false) {
+        delete newConfig[key];
+      } else if (key === 'expand_to_fit' && value === true) {
+        // Default is true (fluid) — omit to keep config minimal
         delete newConfig[key];
       } else {
         newConfig[key] = value;


### PR DESCRIPTION
Fixes #604.

## Problem
In the designed card styles (playroom / console / cleanpro) the rewards list was capped at a fixed `360px` scroll region (`.rw-list { max-height: 360px; overflow-y: auto }`). With more rewards than fit, the card looked truncated/cut off. The Classic style had no cap and grew to fit.

## Change
- `.rw-list` is now **fluid by default** — it grows to show every reward, matching Classic.
- New card option **`expand_to_fit`** (default `true`). Set to `false` to restore the fixed-height scrolling list.
- Wired into the visual editor (boolean toggle, label + helper).
- Strings translated into all locales (en, en-GB, de, fr, nb, nn, pt, pt-BR).

Only the designed styles are affected; Classic already grew to fit, so the option is a no-op there.

## Testing
- `node -c` syntax check passes; all locale JSON parses.
- `pytest tests/test_card_design_setting.py tests/test_frontend_retired_cards.py` → 11 passed.
- Confirmed ha-dev live-serves the updated card (new rule present via bind-mount).