### PR TITLE
fix(storage): re-validate photo_url on config import (SEC-5)

### DIFF
--- a/custom_components/taskmate/storage.py
+++ b/custom_components/taskmate/storage.py
@@ -993,6 +993,28 @@ class TaskMateStorage:
             self._data["quest_progress"] = {}
         if not isinstance(self._data.get("challenge_progress"), dict):
             self._data["challenge_progress"] = {}
+        self._sanitize_imported_records()
+
+    def _sanitize_imported_records(self) -> None:
+        """Re-validate untrusted inner records after a full-replace import (SEC-5).
+
+        ``import_data`` deep-copies the payload in with only top-level coercion,
+        so a crafted backup could smuggle a ``photo_url`` that bypasses the
+        ``is_taskmate_photo_url`` gate enforced at the ``complete_chore``
+        boundary. Strip any completion ``photo_url`` that isn't one of our own
+        well-formed photo URLs so the panel never renders a foreign/dangerous one.
+        """
+        from .photos import is_taskmate_photo_url
+        for comp in self._data.get("completions", []):
+            if not isinstance(comp, dict):
+                continue
+            url = comp.get("photo_url")
+            if url and not is_taskmate_photo_url(url):
+                _LOGGER.warning(
+                    "Import: dropped non-TaskMate photo_url on completion %s",
+                    comp.get("id", "?"),
+                )
+                comp["photo_url"] = ""
 
     def replace_completions(self, completions: list[ChoreCompletion]) -> None:
         """Replace all completions with the given list."""

--- a/tests/test_config_backup.py
+++ b/tests/test_config_backup.py
@@ -44,6 +44,29 @@ async def test_storage_import_replaces_and_ensures_keys(hass):
 
 
 @pytest.mark.asyncio
+async def test_import_strips_foreign_photo_url(hass):
+    """SEC-5: a crafted backup can't smuggle a non-TaskMate photo_url."""
+    storage = TaskMateStorage(hass, "sec5")
+    await storage.async_load()
+    storage.import_data({
+        "completions": [
+            {"id": "c1", "chore_id": "x", "child_id": "k",
+             "photo_url": "javascript:alert(1)"},
+            {"id": "c2", "chore_id": "x", "child_id": "k",
+             "photo_url": "https://evil.example/p.png"},
+            {"id": "c3", "chore_id": "x", "child_id": "k",
+             "photo_url": "/api/taskmate/photo/" + "a" * 32 + ".jpg"},  # one of ours
+            {"id": "c4", "chore_id": "x", "child_id": "k", "photo_url": ""},
+        ],
+    })
+    by_id = {c["id"]: c for c in storage._data["completions"]}
+    assert by_id["c1"]["photo_url"] == ""   # dangerous scheme stripped
+    assert by_id["c2"]["photo_url"] == ""   # foreign host stripped
+    assert by_id["c3"]["photo_url"] == "/api/taskmate/photo/" + "a" * 32 + ".jpg"  # kept
+    assert by_id["c4"]["photo_url"] == ""
+
+
+@pytest.mark.asyncio
 async def test_storage_import_rejects_non_dict(hass):
     storage = TaskMateStorage(hass, "imp2")
     await storage.async_load()


### PR DESCRIPTION
## SEC-5 — Re-validate inner records on config import

`import_data` deep-copied the export payload in with only **top-level** type coercion. A crafted backup could therefore smuggle a completion `photo_url` that bypasses the `is_taskmate_photo_url` gate enforced at the `complete_chore` boundary — and the admin panel would render it (`javascript:` / foreign `url()` / external host).

### Fix
`_sanitize_imported_records()` (called at the end of `import_data`) strips any completion `photo_url` that is not one of our own well-formed `/api/taskmate/photo/<32-hex>.<ext>` URLs, logging each drop.

### Verification
- `test_import_strips_foreign_photo_url`: `javascript:` scheme, foreign host, and blank are dropped; a valid TaskMate URL is preserved. Backup suite green; Ruff clean.
- Import is already admin-gated; this is defence-in-depth on the payload contents.

Part of the v4.3.1 audit fix campaign. No version bump / release.