### PR TITLE
refactor(storage): typed accessors for root flags (ARCH-1)

### DIFF
--- a/custom_components/taskmate/__init__.py
+++ b/custom_components/taskmate/__init__.py
@@ -130,12 +130,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Store initial settings from config entry only on first setup
     # (when storage has never been written yet). Once storage exists, the user
     # controls these values via Settings — never overwrite on restart.
-    if not coordinator.storage._data.get("_initial_setup_done"):
+    if not coordinator.storage.is_initial_setup_done():
         if entry.data.get("points_name"):
             coordinator.storage.set_points_name(entry.data["points_name"])
         if entry.data.get("points_icon"):
             coordinator.storage.set_points_icon(entry.data["points_icon"])
-        coordinator.storage._data["_initial_setup_done"] = True
+        coordinator.storage.mark_initial_setup_done()
     await coordinator.storage.async_save()
 
     hass.data[DOMAIN][entry.entry_id] = coordinator

--- a/custom_components/taskmate/coordinator.py
+++ b/custom_components/taskmate/coordinator.py
@@ -259,9 +259,9 @@ class TaskMateCoordinator(
         if self.notifications.ensure_parent_default_routes():
             await self.storage.async_save()
         # Achievement badges: silent retroactive backfill on first install
-        if self.storage._data.get("badges_backfill_pending"):
+        if self.storage.is_badges_backfill_pending():
             await self.badges.rebuild_all()
-            self.storage._data.pop("badges_backfill_pending", None)
+            self.storage.clear_badges_backfill_pending()
             await self.storage.async_save()
         await self._async_backfill_career_history()
         await self._async_stop_stale_timed_sessions()
@@ -543,7 +543,7 @@ class TaskMateCoordinator(
             "points_transactions": self.storage.get_points_transactions(),
             "points_name": self.storage.get_points_name(),
             "points_icon": self.storage.get_points_icon(),
-            "settings": self.storage._data.get("settings", {}),
+            "settings": self.storage.get_settings(),
             "penalties": self.storage.get_penalties(),
             "bonuses": self.storage.get_bonuses(),
             "pool_allocations": self.storage.get_pool_allocations(),

--- a/custom_components/taskmate/storage.py
+++ b/custom_components/taskmate/storage.py
@@ -1210,6 +1210,25 @@ class TaskMateStorage:
             self._data["settings"] = {}
         self._data["settings"][key] = value
 
+    def get_settings(self) -> dict[str, Any]:
+        """The whole settings dict (live reference; callers must not assume a copy)."""
+        return self._data.get("settings", {}) or {}
+
+    # ── Typed top-level flags (ARCH-1) ────────────────────────────────────
+    # These live at the root of _data (not under "settings"). Accessors keep the
+    # key names + defaults in one place so setup/migration logic can't drift.
+    def is_initial_setup_done(self) -> bool:
+        return bool(self._data.get("_initial_setup_done"))
+
+    def mark_initial_setup_done(self) -> None:
+        self._data["_initial_setup_done"] = True
+
+    def is_badges_backfill_pending(self) -> bool:
+        return bool(self._data.get("badges_backfill_pending"))
+
+    def clear_badges_backfill_pending(self) -> None:
+        self._data.pop("badges_backfill_pending", None)
+
     # Settings
     def get_points_name(self) -> str:
         """Get the points currency name."""


### PR DESCRIPTION
## ARCH-1 — Typed storage accessors

Several setup/migration sites reached into `storage._data[...]` directly for root-level flags, so the key names + defaults were duplicated and could drift.

### Fix
Add typed accessors and route all external callers through them:
- `is_initial_setup_done()` / `mark_initial_setup_done()` (`__init__.py` first-setup guard)
- `is_badges_backfill_pending()` / `clear_badges_backfill_pending()` (coordinator backfill)
- `get_settings()` for the settings dict (`_async_update_data`)

Internal storage code that *sets* `badges_backfill_pending` during load stays in `storage.py` (already encapsulated). No behaviour change.

### Verification
Integration / storage / badges / backup suites green (120); Ruff clean.

Part of the v4.3.1 audit fix campaign. No version bump / release.