### PR TITLE
perf(services): gate service-desc rebuild on data_version (PERF-4)

### DIFF
--- a/custom_components/taskmate/__init__.py
+++ b/custom_components/taskmate/__init__.py
@@ -240,18 +240,20 @@ def _async_update_service_descriptions(hass: HomeAssistant) -> None:
     if not coordinator:
         return
 
-    options: dict[str, list[dict[str, str]]] = {}
-    for field, getter in _DYNAMIC_SELECTOR_FIELDS.items():
-        entities = getattr(coordinator.storage, getter)()
-        options[field] = [{"label": e.name, "value": e.id} for e in entities]
-
-    # Re-registering schemas deep-copies every dynamic service description;
-    # skip the whole pass when the option sets haven't changed since last time.
-    fingerprint = repr(options)
+    # PERF-4: the dynamic selectors mirror children/chores/rewards/etc., which
+    # only change via a save (bumping storage.data_version). Use that as the
+    # fingerprint and short-circuit BEFORE hydrating every entity from its dict
+    # + repr()-ing them — both of which previously ran on every listener fire.
+    fingerprint = coordinator.storage.data_version
     domain_data = hass.data.setdefault(DOMAIN, {})
     if domain_data.get("_service_desc_fingerprint") == fingerprint:
         return
     domain_data["_service_desc_fingerprint"] = fingerprint
+
+    options: dict[str, list[dict[str, str]]] = {}
+    for field, getter in _DYNAMIC_SELECTOR_FIELDS.items():
+        entities = getattr(coordinator.storage, getter)()
+        options[field] = [{"label": e.name, "value": e.id} for e in entities]
 
     base = _load_base_descriptions()
 

--- a/tests/test_service_desc_fingerprint.py
+++ b/tests/test_service_desc_fingerprint.py
@@ -1,0 +1,44 @@
+"""PERF-4: service-description rebuild is gated by storage.data_version."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from custom_components.taskmate import (
+    _async_update_service_descriptions,
+)
+from custom_components.taskmate.const import DOMAIN
+from custom_components.taskmate.coordinator import TaskMateCoordinator
+
+
+def _hass_with_coord(version):
+    coord = object.__new__(TaskMateCoordinator)
+    storage = MagicMock()
+    storage.data_version = version
+    for getter in ("get_children", "get_chores", "get_rewards",
+                   "get_penalties", "get_bonuses", "get_task_groups"):
+        setattr(storage, getter, MagicMock(return_value=[]))
+    coord.storage = storage
+    hass = MagicMock()
+    hass.data = {DOMAIN: {"entry1": coord}}
+    return hass, coord
+
+
+def test_skips_rebuild_when_version_unchanged():
+    hass, coord = _hass_with_coord(version=5)
+    with patch("custom_components.taskmate.async_set_service_schema"), \
+         patch("custom_components.taskmate._load_base_descriptions", return_value={}):
+        _async_update_service_descriptions(hass)   # first pass -> builds
+        assert coord.storage.get_children.call_count == 1
+        _async_update_service_descriptions(hass)   # same version -> short-circuit
+        assert coord.storage.get_children.call_count == 1
+
+
+def test_rebuilds_after_version_bump():
+    hass, coord = _hass_with_coord(version=5)
+    with patch("custom_components.taskmate.async_set_service_schema"), \
+         patch("custom_components.taskmate._load_base_descriptions", return_value={}):
+        _async_update_service_descriptions(hass)
+        assert coord.storage.get_children.call_count == 1
+        coord.storage.data_version = 6
+        _async_update_service_descriptions(hass)   # version changed -> rebuild
+        assert coord.storage.get_children.call_count == 2


### PR DESCRIPTION
## PERF-4 — Cheaper service-description fingerprint

`_async_update_service_descriptions` fires on every coordinator listener update. Before its short-circuit it **hydrated every** child/chore/reward/penalty/bonus/group from its stored dict and `repr()`-ed the whole option set as the change fingerprint — on every fire, even when nothing relevant changed.

### Fix
The dynamic selectors mirror those collections, which only change via a save (bumping `storage.data_version`, added in PERF-2). Use that O(1) counter as the fingerprint and short-circuit **before** any hydration; build the option lists only when the version actually changed. Conservative: it never misses a real change (every entity mutation saves), at worst it rebuilds on an unrelated save.

### Verification
`test_service_desc_fingerprint.py`: hydration skipped when version unchanged; runs again after a bump. Ruff clean.

Part of the v4.3.1 audit fix campaign. No version bump / release.