### PR TITLE
feat(blueprints): automation blueprint pack (FEAT-11)

### DIFF
--- a/blueprints/automation/taskmate/README.md
+++ b/blueprints/automation/taskmate/README.md
@@ -1,0 +1,42 @@
+# TaskMate automation blueprints
+
+Ready-made [Home Assistant automation blueprints](https://www.home-assistant.io/docs/automation/using_blueprints/)
+that react to TaskMate events. Each one fires on a TaskMate bus event and lets
+you pick the action to run (flash a light, play a sound, send a notification,
+run a scene…).
+
+| Blueprint | Fires on event | Use it for |
+|-----------|----------------|------------|
+| `chore_completed.yaml` | `taskmate_chore_completed` | Flash a light / play a sound when a child completes a chore |
+| `level_up.yaml` | `taskmate_level_up` | Celebrate a new XP level |
+| `reward_approved.yaml` | `taskmate_reward_approved` | Announce / unlock something when a reward is approved |
+| `mandatory_missed.yaml` | `taskmate_mandatory_missed` | React when a mandatory chore's window closes incomplete |
+
+## Importing
+
+In Home Assistant: **Settings → Automations & scenes → Blueprints → Import
+blueprint**, then paste the raw URL of the blueprint, e.g.
+
+```
+https://github.com/tempus2016/taskmate/blob/main/blueprints/automation/taskmate/chore_completed.yaml
+```
+
+Then **Create automation → choose the imported blueprint**, optionally restrict
+it to a single child by name, and pick your action.
+
+## Event data available to your action
+
+The triggering event is available in templates as `trigger.event.data`:
+
+- `chore_completed` → `child_name`, `chore_name`, `points`, `difficulty`
+- `level_up` → `child_name`, `level`
+- `reward_approved` → `child_name`, `reward_name`, `cost`
+- `mandatory_missed` → `child_id`, `chore_id`, `period_id`, `penalty_points`
+
+Example action snippet using event data:
+
+```yaml
+service: notify.mobile_app_phone
+data:
+  message: "{{ trigger.event.data.child_name }} finished {{ trigger.event.data.chore_name }}!"
+```

--- a/blueprints/automation/taskmate/chore_completed.yaml
+++ b/blueprints/automation/taskmate/chore_completed.yaml
@@ -1,0 +1,37 @@
+blueprint:
+  name: TaskMate — Chore completed
+  description: >
+    Run any action when a child completes a TaskMate chore (e.g. flash a light,
+    play a sound, send a notification). The triggering child's name, the chore
+    name, points and difficulty are available to your action via
+    `trigger.event.data` (child_name, chore_name, points, difficulty).
+  domain: automation
+  source_url: https://github.com/tempus2016/taskmate/blob/main/blueprints/automation/taskmate/chore_completed.yaml
+  input:
+    child_filter:
+      name: Only this child (optional)
+      description: Leave blank to react to every child; otherwise enter the exact child name.
+      default: ""
+      selector:
+        text: {}
+    chore_action:
+      name: Action
+      description: What to do when the chore is completed.
+      selector:
+        action: {}
+
+mode: queued
+max: 10
+
+triggers:
+  - trigger: event
+    event_type: taskmate_chore_completed
+
+variables:
+  child_filter: !input child_filter
+
+conditions:
+  - condition: template
+    value_template: "{{ child_filter == '' or trigger.event.data.child_name == child_filter }}"
+
+actions: !input chore_action

--- a/blueprints/automation/taskmate/level_up.yaml
+++ b/blueprints/automation/taskmate/level_up.yaml
@@ -1,0 +1,36 @@
+blueprint:
+  name: TaskMate — Level up
+  description: >
+    Celebrate when a child reaches a new XP level — flash lights, play a fanfare,
+    announce on a speaker, etc. The child's name and new level are available to
+    your action via `trigger.event.data` (child_name, level).
+  domain: automation
+  source_url: https://github.com/tempus2016/taskmate/blob/main/blueprints/automation/taskmate/level_up.yaml
+  input:
+    child_filter:
+      name: Only this child (optional)
+      description: Leave blank to react to every child; otherwise enter the exact child name.
+      default: ""
+      selector:
+        text: {}
+    levelup_action:
+      name: Action
+      description: What to do when the child levels up.
+      selector:
+        action: {}
+
+mode: queued
+max: 10
+
+triggers:
+  - trigger: event
+    event_type: taskmate_level_up
+
+variables:
+  child_filter: !input child_filter
+
+conditions:
+  - condition: template
+    value_template: "{{ child_filter == '' or trigger.event.data.child_name == child_filter }}"
+
+actions: !input levelup_action

--- a/blueprints/automation/taskmate/mandatory_missed.yaml
+++ b/blueprints/automation/taskmate/mandatory_missed.yaml
@@ -1,0 +1,25 @@
+blueprint:
+  name: TaskMate — Mandatory chore missed
+  description: >
+    Run an action when a mandatory chore's time window closes without being
+    completed (e.g. pause the TV, notify a parent, turn the bedroom light red).
+    The event data (`trigger.event.data`) carries child_id, chore_id, period_id
+    and penalty_points. This complements TaskMate's built-in escalation
+    notifications — use it for home-automation reactions, not just messages.
+  domain: automation
+  source_url: https://github.com/tempus2016/taskmate/blob/main/blueprints/automation/taskmate/mandatory_missed.yaml
+  input:
+    missed_action:
+      name: Action
+      description: What to do when a mandatory chore is missed.
+      selector:
+        action: {}
+
+mode: queued
+max: 10
+
+triggers:
+  - trigger: event
+    event_type: taskmate_mandatory_missed
+
+actions: !input missed_action

--- a/blueprints/automation/taskmate/reward_approved.yaml
+++ b/blueprints/automation/taskmate/reward_approved.yaml
@@ -1,0 +1,37 @@
+blueprint:
+  name: TaskMate — Reward approved
+  description: >
+    Run an action when a child's reward claim is approved (e.g. announce
+    "Movie night unlocked!", unlock a smart plug for the games console). The
+    child's name, reward name and cost are available to your action via
+    `trigger.event.data` (child_name, reward_name, cost).
+  domain: automation
+  source_url: https://github.com/tempus2016/taskmate/blob/main/blueprints/automation/taskmate/reward_approved.yaml
+  input:
+    child_filter:
+      name: Only this child (optional)
+      description: Leave blank to react to every child; otherwise enter the exact child name.
+      default: ""
+      selector:
+        text: {}
+    reward_action:
+      name: Action
+      description: What to do when the reward is approved.
+      selector:
+        action: {}
+
+mode: queued
+max: 10
+
+triggers:
+  - trigger: event
+    event_type: taskmate_reward_approved
+
+variables:
+  child_filter: !input child_filter
+
+conditions:
+  - condition: template
+    value_template: "{{ child_filter == '' or trigger.event.data.child_name == child_filter }}"
+
+actions: !input reward_action


### PR DESCRIPTION
## FEAT-11 — Automation blueprint pack

Ships ready-to-import Home Assistant automation blueprints under `blueprints/automation/taskmate/`, so users get one-click automations off TaskMate events without writing YAML.

| Blueprint | Event | Example |
|-----------|-------|---------|
| `chore_completed` | `taskmate_chore_completed` | Flash a light / play a sound on completion |
| `level_up` | `taskmate_level_up` | Celebrate a new XP level |
| `reward_approved` | `taskmate_reward_approved` | Announce / unlock on reward approval |
| `mandatory_missed` | `taskmate_mandatory_missed` | React when a mandatory window closes incomplete |

- Each blueprint fires on the event and runs a user-selected `action`; the chore/level/reward ones also expose an optional **exact child-name filter**.
- The full event payload is available to the chosen action via `trigger.event.data` (documented per-event in the README).
- Modern plural `triggers:` / `actions:` keys; `mode: queued`.

### Verification
All four parse as YAML and every `!input` resolves to a declared input (validated with HAs `!input` tag registered). README documents import-by-URL + event-data fields. No code paths touched.

Part of the v4.3.1 audit fix campaign. No version bump / release.