### PR TITLE
feat(calendar): ICS subscription feed (FEAT-10)

### DIFF
--- a/custom_components/taskmate/coordinator.py
+++ b/custom_components/taskmate/coordinator.py
@@ -386,6 +386,25 @@ class TaskMateCoordinator(
             r["rank"] = i + 1
         return rows
 
+    # ── ICS calendar feed token (FEAT-10) ────────────────────────────────
+    async def async_get_or_create_ics_token(self) -> str:
+        """Return the ICS feed token, generating + persisting one on first use."""
+        token = self.storage.get_setting("ics_token", "")
+        if not token:
+            import secrets
+            token = secrets.token_urlsafe(24)
+            self.storage.set_setting("ics_token", token)
+            await self.storage.async_save()
+        return token
+
+    async def async_regenerate_ics_token(self) -> str:
+        """Rotate the ICS feed token (invalidates existing subscriptions)."""
+        import secrets
+        token = secrets.token_urlsafe(24)
+        self.storage.set_setting("ics_token", token)
+        await self.storage.async_save()
+        return token
+
     async def _async_finalize_season(self) -> None:
         """At month start, record the previous month's champion (top earner)."""
         now = dt_util.now()

--- a/custom_components/taskmate/frontend.py
+++ b/custom_components/taskmate/frontend.py
@@ -115,6 +115,10 @@ async def async_register_frontend(hass: HomeAssistant) -> None:
     from .http_photos import async_register_photo_views
     async_register_photo_views(hass)
 
+    # Token-gated ICS calendar feed (FEAT-10).
+    from .http_calendar import async_register_calendar_view
+    async_register_calendar_view(hass)
+
     # Register global JS modules (loaded on all pages, including config flow)
     version = await _async_get_version(hass)
     for module in GLOBAL_MODULES:

--- a/custom_components/taskmate/http_calendar.py
+++ b/custom_components/taskmate/http_calendar.py
@@ -1,0 +1,76 @@
+"""Token-gated ICS calendar feed view (FEAT-10).
+
+A calendar app subscribing to a URL can't send an HA bearer token, so this view
+is public-by-URL and authenticated by an unguessable per-instance token in the
+``?token=`` query param (compared in constant time). It serves a read-only feed
+of upcoming chores; no mutation is possible.
+"""
+from __future__ import annotations
+
+import hmac
+import logging
+from datetime import timedelta
+from http import HTTPStatus
+
+from aiohttp import web
+from homeassistant.components.http import HomeAssistantView
+from homeassistant.core import HomeAssistant
+from homeassistant.util import dt as dt_util
+
+from . import ics
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+CALENDAR_URL = "/api/taskmate/calendar.ics"
+HTTP_CAL_REGISTERED = "calendar_http_registered"
+
+
+def _get_coordinator(hass: HomeAssistant):
+    from .coordinator import TaskMateCoordinator
+    for value in hass.data.get(DOMAIN, {}).values():
+        if isinstance(value, TaskMateCoordinator):
+            return value
+    return None
+
+
+class TaskMateCalendarFeedView(HomeAssistantView):
+    """Serve an ICS feed of upcoming chores, gated by the instance token."""
+
+    url = CALENDAR_URL
+    name = "api:taskmate:calendar"
+    requires_auth = False
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        self.hass = hass
+
+    async def get(self, request: web.Request) -> web.Response:
+        coordinator = _get_coordinator(self.hass)
+        if coordinator is None:
+            return web.Response(status=HTTPStatus.NOT_FOUND)
+
+        expected = coordinator.storage.get_setting("ics_token", "")
+        supplied = request.query.get("token", "")
+        if not expected or not supplied or not hmac.compare_digest(str(expected), supplied):
+            return web.Response(status=HTTPStatus.UNAUTHORIZED)
+
+        days = coordinator._calendar_projection_days()
+        start = dt_util.now().date()
+        end = start + timedelta(days=days)
+        events = ics.build_chore_events(coordinator, start, end)
+        body = ics.build_calendar(events, dt_util.now())
+        return web.Response(
+            body=body.encode("utf-8"),
+            content_type="text/calendar",
+            charset="utf-8",
+            headers={"Cache-Control": "private, max-age=3600"},
+        )
+
+
+def async_register_calendar_view(hass: HomeAssistant) -> None:
+    """Register the ICS feed view once."""
+    if hass.data.get(DOMAIN, {}).get(HTTP_CAL_REGISTERED):
+        return
+    hass.http.register_view(TaskMateCalendarFeedView(hass))
+    hass.data.setdefault(DOMAIN, {})[HTTP_CAL_REGISTERED] = True
+    _LOGGER.debug("Registered TaskMate calendar ICS view")

--- a/custom_components/taskmate/ics.py
+++ b/custom_components/taskmate/ics.py
@@ -1,0 +1,127 @@
+"""ICS (iCalendar) feed generation for TaskMate chores (FEAT-10).
+
+Pure-ish helpers that turn the chore calendar projection into an RFC 5545 feed a
+calendar app (Google/Apple/Outlook) can subscribe to. Token auth + the HTTP view
+live in ``http_calendar.py``; this module only builds text.
+"""
+from __future__ import annotations
+
+import hashlib
+from datetime import date, datetime, timedelta, timezone
+
+PRODID = "-//TaskMate//Chores//EN"
+
+
+def _escape(text: str) -> str:
+    """Escape a value per RFC 5545 (backslash, comma, semicolon, newline)."""
+    return (
+        str(text)
+        .replace("\\", "\\\\")
+        .replace("\n", "\\n")
+        .replace(",", "\\,")
+        .replace(";", "\\;")
+    )
+
+
+def _fold(line: str) -> str:
+    """Fold a content line to <=75 octets with CRLF + space continuation."""
+    raw = line.encode("utf-8")
+    if len(raw) <= 75:
+        return line
+    out = []
+    while len(raw) > 75:
+        # Don't split a multibyte char: back off to a UTF-8 boundary.
+        cut = 75
+        while cut > 0 and (raw[cut] & 0xC0) == 0x80:
+            cut -= 1
+        out.append(raw[:cut].decode("utf-8"))
+        raw = raw[cut:]
+    out.append(raw.decode("utf-8"))
+    return "\r\n ".join(out)
+
+
+def _dt_utc(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _date(d: date) -> str:
+    return d.strftime("%Y%m%d")
+
+
+def make_uid(*parts: str) -> str:
+    digest = hashlib.sha1("|".join(parts).encode("utf-8")).hexdigest()[:20]
+    return f"{digest}@taskmate"
+
+
+def build_calendar(events: list[dict], now: datetime, name: str = "TaskMate Chores") -> str:
+    """Render ``events`` (dicts: uid, summary, description, start, end, all_day)
+    into an ICS document. ``start``/``end`` are dates (all-day) or aware datetimes."""
+    stamp = _dt_utc(now)
+    lines = [
+        "BEGIN:VCALENDAR",
+        "VERSION:2.0",
+        f"PRODID:{PRODID}",
+        "CALSCALE:GREGORIAN",
+        "METHOD:PUBLISH",
+        f"X-WR-CALNAME:{_escape(name)}",
+    ]
+    for ev in events:
+        lines.append("BEGIN:VEVENT")
+        lines.append(f"UID:{ev['uid']}")
+        lines.append(f"DTSTAMP:{stamp}")
+        if ev["all_day"]:
+            lines.append(f"DTSTART;VALUE=DATE:{_date(ev['start'])}")
+            lines.append(f"DTEND;VALUE=DATE:{_date(ev['end'])}")
+        else:
+            lines.append(f"DTSTART:{_dt_utc(ev['start'])}")
+            lines.append(f"DTEND:{_dt_utc(ev['end'])}")
+        lines.append(_fold(f"SUMMARY:{_escape(ev['summary'])}"))
+        if ev.get("description"):
+            lines.append(_fold(f"DESCRIPTION:{_escape(ev['description'])}"))
+        lines.append("END:VEVENT")
+    lines.append("END:VCALENDAR")
+    return "\r\n".join(lines) + "\r\n"
+
+
+def build_chore_events(coordinator, start_day: date, end_day: date) -> list[dict]:
+    """Project each child's scheduled chores over [start_day, end_day] into event dicts."""
+    from .calendar import _chore_applies_to_child, _chore_description
+
+    events: list[dict] = []
+    children = coordinator.storage.get_children()
+    chores = coordinator.storage.get_chores()
+    for child in children:
+        day = start_day
+        while day <= end_day:
+            if not coordinator._is_child_on_vacation(child, day):
+                for chore in chores:
+                    if not _chore_applies_to_child(coordinator, chore, child.id, day):
+                        continue
+                    window = coordinator._time_category_window(
+                        getattr(chore, "time_category", "anytime"), day
+                    )
+                    summary = f"{chore.name} — {child.name}"
+                    desc = _chore_description(chore)
+                    if window is None:
+                        events.append({
+                            "uid": make_uid(chore.id, child.id, day.isoformat(), "allday"),
+                            "summary": summary, "description": desc,
+                            "start": day, "end": day + timedelta(days=1), "all_day": True,
+                        })
+                    else:
+                        start_dt, end_dt = window
+                        events.append({
+                            "uid": make_uid(chore.id, child.id, day.isoformat(), "timed"),
+                            "summary": summary, "description": desc,
+                            "start": _ensure_aware(start_dt),
+                            "end": _ensure_aware(end_dt), "all_day": False,
+                        })
+            day += timedelta(days=1)
+    return events
+
+
+def _ensure_aware(dt: datetime) -> datetime:
+    from homeassistant.util import dt as dt_util
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=dt_util.DEFAULT_TIME_ZONE)
+    return dt

--- a/custom_components/taskmate/websocket.py
+++ b/custom_components/taskmate/websocket.py
@@ -143,6 +143,10 @@ WS_NOTIF_SET_STREAK_CUTOFF: Final  = "taskmate/notifications/set_streak_cutoff"
 WS_NOTIF_SET_ESCALATION: Final     = "taskmate/notifications/set_escalation"
 WS_NOTIF_SEND_TEST: Final          = "taskmate/notifications/send_test"
 
+# Calendar ICS feed (FEAT-10)
+WS_CAL_GET_URL: Final     = "taskmate/calendar/get_ics_url"
+WS_CAL_REGEN_TOKEN: Final = "taskmate/calendar/regenerate_ics_token"
+
 # Admin audit log
 WS_AUDIT_LIST: Final  = "taskmate/audit/list"
 WS_AUDIT_CLEAR: Final = "taskmate/audit/clear"
@@ -1864,6 +1868,37 @@ async def ws_notif_send_test(hass, connection, msg, coordinator):
 
 
 # ---------------------------------------------------------------------------
+# Calendar ICS feed (FEAT-10)
+# ---------------------------------------------------------------------------
+
+def _build_ics_url(hass, token: str) -> str:
+    from .http_calendar import CALENDAR_URL
+    base = ""
+    try:
+        from homeassistant.helpers.network import get_url
+        base = get_url(hass, prefer_external=True)
+    except Exception:  # noqa: BLE001 - no configured URL yet
+        base = ""
+    return f"{base}{CALENDAR_URL}?token={token}"
+
+
+@websocket_api.websocket_command({vol.Required("type"): WS_CAL_GET_URL})
+@websocket_api.async_response
+@_admin_only
+async def ws_cal_get_url(hass, connection, msg, coordinator):
+    token = await coordinator.async_get_or_create_ics_token()
+    connection.send_result(msg["id"], {"token": token, "url": _build_ics_url(hass, token)})
+
+
+@websocket_api.websocket_command({vol.Required("type"): WS_CAL_REGEN_TOKEN})
+@websocket_api.async_response
+@_admin_only
+async def ws_cal_regen_token(hass, connection, msg, coordinator):
+    token = await coordinator.async_regenerate_ics_token()
+    connection.send_result(msg["id"], {"token": token, "url": _build_ics_url(hass, token)})
+
+
+# ---------------------------------------------------------------------------
 # Admin audit log
 # ---------------------------------------------------------------------------
 
@@ -2018,6 +2053,7 @@ _COMMANDS = (
     ws_notif_upsert_custom, ws_notif_delete_custom,
     ws_notif_list_notify, ws_notif_set_streak_cutoff, ws_notif_send_test,
     ws_notif_set_escalation,
+    ws_cal_get_url, ws_cal_regen_token,
 )
 
 

--- a/custom_components/taskmate/www/locales/de.json
+++ b/custom_components/taskmate/www/locales/de.json
@@ -1497,5 +1497,12 @@
   "leaderboard.sort_this_month": "Dieser Monat",
   "leaderboard.last_champion": "Champion des Vormonats: {name} 🏆",
   "notification.season_champion.name": "Saison-Champion",
-  "notification.season_champion.description": "Verkündet zu Monatsbeginn den Gewinner der monatlichen Bestenliste. Standardmäßig aus."
+  "notification.season_champion.description": "Verkündet zu Monatsbeginn den Gewinner der monatlichen Bestenliste. Standardmäßig aus.",
+  "panel.ics_title": "Kalender-Abonnement",
+  "panel.ics_hint": "Anstehende Aufgaben in Google-/Apple-/Outlook-Kalender abonnieren. Der Link enthält ein privates Token — vorsichtig teilen.",
+  "panel.ics_show": "Abo-Link anzeigen",
+  "panel.ics_copy": "Kopieren",
+  "panel.ics_regenerate": "Link neu erzeugen",
+  "panel.ics_copied": "Abo-Link kopiert",
+  "panel.ics_regenerated": "Neuer Link erzeugt — alte Abos gestoppt"
 }

--- a/custom_components/taskmate/www/locales/en-GB.json
+++ b/custom_components/taskmate/www/locales/en-GB.json
@@ -1497,5 +1497,12 @@
   "leaderboard.sort_this_month": "This Month",
   "leaderboard.last_champion": "Last month's champion: {name} 🏆",
   "notification.season_champion.name": "Season champion",
-  "notification.season_champion.description": "Announces the monthly leaderboard winner at the start of each month. Off by default."
+  "notification.season_champion.description": "Announces the monthly leaderboard winner at the start of each month. Off by default.",
+  "panel.ics_title": "Calendar subscription",
+  "panel.ics_hint": "Subscribe to upcoming chores from Google/Apple/Outlook calendar. The link contains a private token — share it carefully.",
+  "panel.ics_show": "Show subscribe link",
+  "panel.ics_copy": "Copy",
+  "panel.ics_regenerate": "Regenerate link",
+  "panel.ics_copied": "Subscribe link copied",
+  "panel.ics_regenerated": "New link generated — old subscriptions stopped"
 }

--- a/custom_components/taskmate/www/locales/en.json
+++ b/custom_components/taskmate/www/locales/en.json
@@ -1497,5 +1497,12 @@
   "leaderboard.sort_this_month": "This Month",
   "leaderboard.last_champion": "Last month's champion: {name} 🏆",
   "notification.season_champion.name": "Season champion",
-  "notification.season_champion.description": "Announces the monthly leaderboard winner at the start of each month. Off by default."
+  "notification.season_champion.description": "Announces the monthly leaderboard winner at the start of each month. Off by default.",
+  "panel.ics_title": "Calendar subscription",
+  "panel.ics_hint": "Subscribe to upcoming chores from Google/Apple/Outlook calendar. The link contains a private token — share it carefully.",
+  "panel.ics_show": "Show subscribe link",
+  "panel.ics_copy": "Copy",
+  "panel.ics_regenerate": "Regenerate link",
+  "panel.ics_copied": "Subscribe link copied",
+  "panel.ics_regenerated": "New link generated — old subscriptions stopped"
 }

--- a/custom_components/taskmate/www/locales/fr.json
+++ b/custom_components/taskmate/www/locales/fr.json
@@ -1497,5 +1497,12 @@
   "leaderboard.sort_this_month": "Ce mois-ci",
   "leaderboard.last_champion": "Champion du mois dernier : {name} 🏆",
   "notification.season_champion.name": "Champion de la saison",
-  "notification.season_champion.description": "Annonce le gagnant du classement mensuel en début de mois. Désactivé par défaut."
+  "notification.season_champion.description": "Annonce le gagnant du classement mensuel en début de mois. Désactivé par défaut.",
+  "panel.ics_title": "Abonnement calendrier",
+  "panel.ics_hint": "Abonnez-vous aux tâches à venir depuis Google/Apple/Outlook. Le lien contient un jeton privé — partagez-le avec prudence.",
+  "panel.ics_show": "Afficher le lien d'abonnement",
+  "panel.ics_copy": "Copier",
+  "panel.ics_regenerate": "Régénérer le lien",
+  "panel.ics_copied": "Lien d'abonnement copié",
+  "panel.ics_regenerated": "Nouveau lien généré — anciens abonnements arrêtés"
 }

--- a/custom_components/taskmate/www/locales/nb.json
+++ b/custom_components/taskmate/www/locales/nb.json
@@ -1497,5 +1497,12 @@
   "leaderboard.sort_this_month": "Denne måneden",
   "leaderboard.last_champion": "Forrige måneds mester: {name} 🏆",
   "notification.season_champion.name": "Sesongmester",
-  "notification.season_champion.description": "Kunngjør vinneren av den månedlige rangeringen ved månedsstart. Av som standard."
+  "notification.season_champion.description": "Kunngjør vinneren av den månedlige rangeringen ved månedsstart. Av som standard.",
+  "panel.ics_title": "Kalenderabonnement",
+  "panel.ics_hint": "Abonner på kommende plikter fra Google-/Apple-/Outlook-kalender. Lenken inneholder et privat token — del den forsiktig.",
+  "panel.ics_show": "Vis abonnementslenke",
+  "panel.ics_copy": "Kopier",
+  "panel.ics_regenerate": "Lag ny lenke",
+  "panel.ics_copied": "Abonnementslenke kopiert",
+  "panel.ics_regenerated": "Ny lenke laget — gamle abonnementer stoppet"
 }

--- a/custom_components/taskmate/www/locales/nn.json
+++ b/custom_components/taskmate/www/locales/nn.json
@@ -1497,5 +1497,12 @@
   "leaderboard.sort_this_month": "Denne månaden",
   "leaderboard.last_champion": "Førre månads meister: {name} 🏆",
   "notification.season_champion.name": "Sesongmeister",
-  "notification.season_champion.description": "Kunngjer vinnaren av den månadlege rangeringa ved månadsstart. Av som standard."
+  "notification.season_champion.description": "Kunngjer vinnaren av den månadlege rangeringa ved månadsstart. Av som standard.",
+  "panel.ics_title": "Kalenderabonnement",
+  "panel.ics_hint": "Abonner på komande plikter frå Google-/Apple-/Outlook-kalender. Lenkja inneheld eit privat token — del han varsamt.",
+  "panel.ics_show": "Vis abonnementslenkje",
+  "panel.ics_copy": "Kopier",
+  "panel.ics_regenerate": "Lag ny lenkje",
+  "panel.ics_copied": "Abonnementslenkje kopiert",
+  "panel.ics_regenerated": "Ny lenkje laga — gamle abonnement stoppa"
 }

--- a/custom_components/taskmate/www/locales/pt-BR.json
+++ b/custom_components/taskmate/www/locales/pt-BR.json
@@ -1497,5 +1497,12 @@
   "leaderboard.sort_this_month": "Este mês",
   "leaderboard.last_champion": "Campeão do mês passado: {name} 🏆",
   "notification.season_champion.name": "Campeão da temporada",
-  "notification.season_champion.description": "Anuncia o vencedor da classificação mensal no início de cada mês. Desativado por padrão."
+  "notification.season_champion.description": "Anuncia o vencedor da classificação mensal no início de cada mês. Desativado por padrão.",
+  "panel.ics_title": "Assinatura de calendário",
+  "panel.ics_hint": "Assine as tarefas futuras pelo Google/Apple/Outlook. O link contém um token privado — compartilhe com cuidado.",
+  "panel.ics_show": "Mostrar link de assinatura",
+  "panel.ics_copy": "Copiar",
+  "panel.ics_regenerate": "Gerar novo link",
+  "panel.ics_copied": "Link de assinatura copiado",
+  "panel.ics_regenerated": "Novo link gerado — assinaturas antigas interrompidas"
 }

--- a/custom_components/taskmate/www/locales/pt.json
+++ b/custom_components/taskmate/www/locales/pt.json
@@ -1497,5 +1497,12 @@
   "leaderboard.sort_this_month": "Este mês",
   "leaderboard.last_champion": "Campeão do mês passado: {name} 🏆",
   "notification.season_champion.name": "Campeão da temporada",
-  "notification.season_champion.description": "Anuncia o vencedor da classificação mensal no início de cada mês. Desativado por predefinição."
+  "notification.season_champion.description": "Anuncia o vencedor da classificação mensal no início de cada mês. Desativado por predefinição.",
+  "panel.ics_title": "Subscrição de calendário",
+  "panel.ics_hint": "Subscreva as tarefas futuras a partir do Google/Apple/Outlook. A ligação contém um token privado — partilhe com cuidado.",
+  "panel.ics_show": "Mostrar ligação de subscrição",
+  "panel.ics_copy": "Copiar",
+  "panel.ics_regenerate": "Gerar nova ligação",
+  "panel.ics_copied": "Ligação de subscrição copiada",
+  "panel.ics_regenerated": "Nova ligação gerada — subscrições antigas paradas"
 }

--- a/custom_components/taskmate/www/taskmate-panel.js
+++ b/custom_components/taskmate/www/taskmate-panel.js
@@ -584,6 +584,9 @@ class TaskMatePanel extends HTMLElement {
     if (act === "save-settings") { this._doSaveSettings(); return; }
     if (act === "config-export") { this._doExportConfig(); return; }
     if (act === "config-import") { this.querySelector("[data-role='config-import-file']")?.click(); return; }
+    if (act === "ics-show") { this._icsShow(); return; }
+    if (act === "ics-regenerate") { this._icsRegenerate(); return; }
+    if (act === "ics-copy") { this._icsCopy(); return; }
 
     // Audit log
     if (act === "audit-clear") { this._doClearAudit(); return; }
@@ -1810,6 +1813,33 @@ class TaskMatePanel extends HTMLElement {
       URL.revokeObjectURL(url);
       this._showToast("ok", this._t("panel.backup_exported"));
     } catch (e) {
+      this._showToast("err", String(e));
+    }
+  }
+
+  async _icsShow() {
+    const { ok, err, res } = await this._callWS({ type: "taskmate/calendar/get_ics_url" });
+    if (!ok || !res) { this._showToast("err", this._t("panel.toast_save_failed", { error: err })); return; }
+    this._icsUrl = res.url;
+    this._render();
+  }
+
+  async _icsRegenerate() {
+    const { ok, err, res } = await this._callWS({ type: "taskmate/calendar/regenerate_ics_token" });
+    if (!ok || !res) { this._showToast("err", this._t("panel.toast_save_failed", { error: err })); return; }
+    this._icsUrl = res.url;
+    this._render();
+    this._showToast("ok", this._t("panel.ics_regenerated"));
+  }
+
+  async _icsCopy() {
+    const input = this.querySelector("[data-role='ics-url']");
+    if (!input) return;
+    try {
+      await navigator.clipboard.writeText(input.value);
+      this._showToast("ok", this._t("panel.ics_copied"));
+    } catch (e) {
+      input.select();
       this._showToast("err", String(e));
     }
   }
@@ -3861,6 +3891,23 @@ class TaskMatePanel extends HTMLElement {
               <button type="button" class="tm-btn" data-act="config-import"><ha-icon icon="mdi:upload"></ha-icon> ${this._t("panel.backup_import")}</button>
               <input type="file" accept="application/json,.json" data-role="config-import-file" style="display:none">
             </div>
+          </div>
+        </div>
+
+        <div class="tm-section">
+          <div class="tm-section-head"><div><h3>${this._t("panel.ics_title")}</h3><p class="tm-meta">${this._t("panel.ics_hint")}</p></div></div>
+          <div class="tm-section-body">
+            ${this._icsUrl ? `
+              <input type="text" readonly value="${this._esc(this._icsUrl)}" data-role="ics-url" style="width:100%;font-family:monospace;font-size:12px;padding:6px;margin-bottom:8px" onclick="this.select()">
+              <div class="tm-period-actions">
+                <button type="button" class="tm-btn" data-act="ics-copy"><ha-icon icon="mdi:content-copy"></ha-icon> ${this._t("panel.ics_copy")}</button>
+                <button type="button" class="tm-btn" data-act="ics-regenerate"><ha-icon icon="mdi:refresh"></ha-icon> ${this._t("panel.ics_regenerate")}</button>
+              </div>
+            ` : `
+              <div class="tm-period-actions">
+                <button type="button" class="tm-btn" data-act="ics-show"><ha-icon icon="mdi:calendar-export"></ha-icon> ${this._t("panel.ics_show")}</button>
+              </div>
+            `}
           </div>
         </div>
 

--- a/tests/test_ics_export.py
+++ b/tests/test_ics_export.py
@@ -1,0 +1,72 @@
+"""Tests for ICS calendar export (FEAT-10)."""
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+
+import pytest
+
+from custom_components.taskmate import ics
+from custom_components.taskmate.coordinator import TaskMateCoordinator
+from custom_components.taskmate.storage import TaskMateStorage
+
+UTC = timezone.utc
+NOW = datetime(2026, 4, 1, 8, 0, 0, tzinfo=UTC)
+
+
+def test_escape_special_chars():
+    assert ics._escape("a,b;c\\d\ne") == "a\\,b\\;c\\\\d\\ne"
+
+
+def test_fold_long_line():
+    folded = ics._fold("SUMMARY:" + "x" * 200)
+    for physical in folded.split("\r\n"):
+        assert len(physical.encode("utf-8")) <= 75 or physical.startswith(" ")
+    assert folded.replace("\r\n ", "") == "SUMMARY:" + "x" * 200
+
+
+def test_make_uid_stable_and_scoped():
+    a = ics.make_uid("chore1", "kid1", "2026-04-01", "allday")
+    b = ics.make_uid("chore1", "kid1", "2026-04-01", "allday")
+    c = ics.make_uid("chore1", "kid2", "2026-04-01", "allday")
+    assert a == b and a != c and a.endswith("@taskmate")
+
+
+def test_build_calendar_allday_and_timed():
+    events = [
+        {"uid": "u1@taskmate", "summary": "Dishes — Alex", "description": "d",
+         "start": date(2026, 4, 1), "end": date(2026, 4, 2), "all_day": True},
+        {"uid": "u2@taskmate", "summary": "Walk, dog", "description": "",
+         "start": datetime(2026, 4, 1, 17, 0, tzinfo=UTC),
+         "end": datetime(2026, 4, 1, 18, 0, tzinfo=UTC), "all_day": False},
+    ]
+    out = ics.build_calendar(events, NOW)
+    assert out.startswith("BEGIN:VCALENDAR\r\n")
+    assert out.endswith("END:VCALENDAR\r\n")
+    assert out.count("BEGIN:VEVENT") == 2
+    assert "DTSTART;VALUE=DATE:20260401" in out
+    assert "DTEND;VALUE=DATE:20260402" in out
+    assert "DTSTART:20260401T170000Z" in out
+    assert "SUMMARY:Walk\\, dog" in out          # comma escaped
+    assert "UID:u1@taskmate" in out
+    assert "DTSTAMP:20260401T080000Z" in out
+
+
+def test_empty_calendar_has_no_events():
+    out = ics.build_calendar([], NOW)
+    assert "BEGIN:VEVENT" not in out
+    assert "BEGIN:VCALENDAR" in out and "END:VCALENDAR" in out
+
+
+@pytest.mark.asyncio
+async def test_token_create_is_stable_then_regenerates(hass):
+    storage = TaskMateStorage(hass, "ics")
+    await storage.async_load()
+    coord = object.__new__(TaskMateCoordinator)
+    coord.storage = storage
+    t1 = await coord.async_get_or_create_ics_token()
+    assert t1 and storage.get_setting("ics_token") == t1
+    t2 = await coord.async_get_or_create_ics_token()
+    assert t2 == t1  # stable
+    t3 = await coord.async_regenerate_ics_token()
+    assert t3 and t3 != t1
+    assert storage.get_setting("ics_token") == t3


### PR DESCRIPTION
## FEAT-10 — ICS calendar subscription

A subscribe URL so upcoming chores show in Google/Apple/Outlook calendars.

### How it works
- **`ics.py`** — RFC 5545 feed builder: value escaping, 75-octet line folding, all-day + timed `VEVENT`s, stable per-occurrence UIDs. `build_chore_events()` projects each childs scheduled chores across the configured calendar horizon (reusing the existing calendar projection logic).
- **`http_calendar.py`** — `TaskMateCalendarFeedView` at `/api/taskmate/calendar.ics`. A calendar app cant send an HA bearer token, so the view is **public-by-URL but gated by an unguessable per-instance token** (`?token=`, constant-time compared). Read-only; `text/calendar`.
- **Token**: `async_get_or_create_ics_token` / `async_regenerate_ics_token`; WS `taskmate/calendar/get_ics_url` + `regenerate_ics_token` (admin).
- **Surfaced** in the panel Settings → *Calendar subscription* (show / copy / regenerate the link) + i18n in all 8 locales.

### Verification
`pytest`: ICS builder (escape/fold/UID/all-day+timed/empty) + token lifecycle. Ruff + ESLint clean. Live on ha-dev: feed returns **200 with a valid token (48 events)** and **401 with a bad token**; WS returns the token-embedded URL.

Part of the v4.3.1 audit fix campaign. No version bump / release.