### PR TITLE
feat(cards): photo-proof gallery card (FEAT-13)

### DIFF
--- a/custom_components/taskmate/frontend.py
+++ b/custom_components/taskmate/frontend.py
@@ -44,6 +44,7 @@ CARDS: Final = [
     "taskmate-bonuses-card.js",
     "taskmate-points-display-card.js",
     "taskmate-calendar-card.js",
+    "taskmate-photo-gallery-card.js",
 ]
 
 # Cards that USED to ship but were removed. Their files no longer exist, so any

--- a/custom_components/taskmate/sensor.py
+++ b/custom_components/taskmate/sensor.py
@@ -508,6 +508,33 @@ def _build_recent_completions(common: dict, limit: int = 35) -> list[dict]:
     return out
 
 
+def _build_photo_gallery(common: dict, limit: int = 40) -> list[dict]:
+    """Recent completions that carry an evidence photo, newest first (FEAT-13).
+
+    Returns the raw (unsigned) ``/api/taskmate/photo/<file>`` path; the gallery
+    card signs each via ``auth/sign_path`` before rendering (a card's <img> can't
+    send a bearer token).
+    """
+    child_lookup = common["child_lookup"]
+    chore_lookup = common["chore_lookup"]
+    with_photos = [
+        c for c in common["all_completions"] if getattr(c, "photo_url", "")
+    ]
+    recent = sorted(with_photos, key=lambda c: c.completed_at, reverse=True)[:limit]
+    out = []
+    for comp in recent:
+        chore = chore_lookup.get(comp.chore_id)
+        out.append({
+            "completion_id": comp.id,
+            "child_name": child_lookup[comp.child_id].name if comp.child_id in child_lookup else "",
+            "chore_name": chore.name if chore else "",
+            "approved": comp.approved,
+            "completed_at": comp.completed_at.isoformat() if hasattr(comp.completed_at, "isoformat") else str(comp.completed_at),
+            "photo_url": comp.photo_url,
+        })
+    return out
+
+
 def _build_recent_transactions(common: dict, limit: int = 20) -> list[dict]:
     """Unified activity feed of manual point adjustments and reward claims.
 
@@ -905,6 +932,7 @@ class TaskMateActivitySensor(_CachedAttrsSensor):
             "recent_completions": _build_recent_completions(common),
             "recent_transactions": _build_recent_transactions(common),
             "career_score_history": career_history,
+            "photo_gallery": _build_photo_gallery(common),
         }
 
 

--- a/custom_components/taskmate/www/locales/de.json
+++ b/custom_components/taskmate/www/locales/de.json
@@ -1504,5 +1504,8 @@
   "panel.ics_copy": "Kopieren",
   "panel.ics_regenerate": "Link neu erzeugen",
   "panel.ics_copied": "Abo-Link kopiert",
-  "panel.ics_regenerated": "Neuer Link erzeugt — alte Abos gestoppt"
+  "panel.ics_regenerated": "Neuer Link erzeugt — alte Abos gestoppt",
+  "gallery.default_title": "Fotogalerie",
+  "gallery.empty": "Noch keine Nachweisfotos",
+  "gallery.pending": "ausstehend"
 }

--- a/custom_components/taskmate/www/locales/en-GB.json
+++ b/custom_components/taskmate/www/locales/en-GB.json
@@ -1504,5 +1504,8 @@
   "panel.ics_copy": "Copy",
   "panel.ics_regenerate": "Regenerate link",
   "panel.ics_copied": "Subscribe link copied",
-  "panel.ics_regenerated": "New link generated — old subscriptions stopped"
+  "panel.ics_regenerated": "New link generated — old subscriptions stopped",
+  "gallery.default_title": "Photo gallery",
+  "gallery.empty": "No evidence photos yet",
+  "gallery.pending": "pending"
 }

--- a/custom_components/taskmate/www/locales/en.json
+++ b/custom_components/taskmate/www/locales/en.json
@@ -1504,5 +1504,8 @@
   "panel.ics_copy": "Copy",
   "panel.ics_regenerate": "Regenerate link",
   "panel.ics_copied": "Subscribe link copied",
-  "panel.ics_regenerated": "New link generated — old subscriptions stopped"
+  "panel.ics_regenerated": "New link generated — old subscriptions stopped",
+  "gallery.default_title": "Photo gallery",
+  "gallery.empty": "No evidence photos yet",
+  "gallery.pending": "pending"
 }

--- a/custom_components/taskmate/www/locales/fr.json
+++ b/custom_components/taskmate/www/locales/fr.json
@@ -1504,5 +1504,8 @@
   "panel.ics_copy": "Copier",
   "panel.ics_regenerate": "Régénérer le lien",
   "panel.ics_copied": "Lien d'abonnement copié",
-  "panel.ics_regenerated": "Nouveau lien généré — anciens abonnements arrêtés"
+  "panel.ics_regenerated": "Nouveau lien généré — anciens abonnements arrêtés",
+  "gallery.default_title": "Galerie photo",
+  "gallery.empty": "Aucune photo de preuve pour l'instant",
+  "gallery.pending": "en attente"
 }

--- a/custom_components/taskmate/www/locales/nb.json
+++ b/custom_components/taskmate/www/locales/nb.json
@@ -1504,5 +1504,8 @@
   "panel.ics_copy": "Kopier",
   "panel.ics_regenerate": "Lag ny lenke",
   "panel.ics_copied": "Abonnementslenke kopiert",
-  "panel.ics_regenerated": "Ny lenke laget — gamle abonnementer stoppet"
+  "panel.ics_regenerated": "Ny lenke laget — gamle abonnementer stoppet",
+  "gallery.default_title": "Fotogalleri",
+  "gallery.empty": "Ingen bevisbilder ennå",
+  "gallery.pending": "venter"
 }

--- a/custom_components/taskmate/www/locales/nn.json
+++ b/custom_components/taskmate/www/locales/nn.json
@@ -1504,5 +1504,8 @@
   "panel.ics_copy": "Kopier",
   "panel.ics_regenerate": "Lag ny lenkje",
   "panel.ics_copied": "Abonnementslenkje kopiert",
-  "panel.ics_regenerated": "Ny lenkje laga — gamle abonnement stoppa"
+  "panel.ics_regenerated": "Ny lenkje laga — gamle abonnement stoppa",
+  "gallery.default_title": "Fotogalleri",
+  "gallery.empty": "Ingen bevisbilete enno",
+  "gallery.pending": "ventar"
 }

--- a/custom_components/taskmate/www/locales/pt-BR.json
+++ b/custom_components/taskmate/www/locales/pt-BR.json
@@ -1504,5 +1504,8 @@
   "panel.ics_copy": "Copiar",
   "panel.ics_regenerate": "Gerar novo link",
   "panel.ics_copied": "Link de assinatura copiado",
-  "panel.ics_regenerated": "Novo link gerado — assinaturas antigas interrompidas"
+  "panel.ics_regenerated": "Novo link gerado — assinaturas antigas interrompidas",
+  "gallery.default_title": "Galeria de fotos",
+  "gallery.empty": "Ainda sem fotos de comprovação",
+  "gallery.pending": "pendente"
 }

--- a/custom_components/taskmate/www/locales/pt.json
+++ b/custom_components/taskmate/www/locales/pt.json
@@ -1504,5 +1504,8 @@
   "panel.ics_copy": "Copiar",
   "panel.ics_regenerate": "Gerar nova ligação",
   "panel.ics_copied": "Ligação de subscrição copiada",
-  "panel.ics_regenerated": "Nova ligação gerada — subscrições antigas paradas"
+  "panel.ics_regenerated": "Nova ligação gerada — subscrições antigas paradas",
+  "gallery.default_title": "Galeria de fotos",
+  "gallery.empty": "Ainda sem fotos de comprovação",
+  "gallery.pending": "pendente"
 }

--- a/custom_components/taskmate/www/taskmate-photo-gallery-card.js
+++ b/custom_components/taskmate/www/taskmate-photo-gallery-card.js
@@ -1,0 +1,160 @@
+/**
+ * TaskMate Photo Gallery Card
+ * A history grid of chore-evidence photos. Reads the activity sensor's
+ * `photo_gallery` attribute and renders thumbnails. A card's <img> can't send a
+ * bearer token, so each photo path is signed via the `auth/sign_path` WS command
+ * before use.
+ */
+
+const LitElement = customElements.get("hui-masonry-view")
+  ? Object.getPrototypeOf(customElements.get("hui-masonry-view"))
+  : Object.getPrototypeOf(customElements.get("hui-view"));
+
+const html = LitElement.prototype.html;
+const css = LitElement.prototype.css;
+
+const _safeColor = (c, d) => (typeof c === "string" && /^#[0-9a-fA-F]{3,8}$/.test(c) ? c : d);
+
+class TaskMatePhotoGalleryCard extends LitElement {
+  static get properties() {
+    return { hass: { type: Object }, config: { type: Object }, _signed: { state: true } };
+  }
+
+  constructor() {
+    super();
+    this._signed = {};        // photo_url -> signed path
+    this._inflight = new Set();
+  }
+
+  setConfig(config) {
+    if (!config || !config.entity) {
+      throw new Error("A TaskMate activity entity is required");
+    }
+    this.config = config;
+  }
+
+  static getStubConfig() {
+    return { entity: "sensor.taskmate_activity" };
+  }
+
+  getCardSize() {
+    return 4;
+  }
+
+  _t(key, params) {
+    const fn = window.__taskmate_localize;
+    return fn ? fn(this.hass, key, params) : key;
+  }
+
+  _gallery() {
+    const entity = this.hass && this.hass.states[this.config.entity];
+    const items = (entity && entity.attributes && entity.attributes.photo_gallery) || [];
+    return this.config.max ? items.slice(0, Number(this.config.max)) : items;
+  }
+
+  async _ensureSigned(items) {
+    for (const it of items) {
+      const url = it.photo_url;
+      if (!url || this._signed[url] || this._inflight.has(url)) continue;
+      this._inflight.add(url);
+      try {
+        const res = await this.hass.callWS({ type: "auth/sign_path", path: url, expires: 3600 });
+        if (res && res.path) {
+          this._signed = { ...this._signed, [url]: res.path };
+        }
+      } catch (e) {
+        // Leave unsigned; the tile shows a placeholder.
+        console.warn("taskmate: sign_path failed", e);
+      } finally {
+        this._inflight.delete(url);
+      }
+    }
+  }
+
+  updated() {
+    this._ensureSigned(this._gallery());
+  }
+
+  render() {
+    if (!this.hass || !this.config) return html``;
+    const entity = this.hass.states[this.config.entity];
+    if (!entity) {
+      return html`<ha-card><div class="empty"><ha-icon icon="mdi:alert-circle"></ha-icon><div>${this._t("common.entity_not_found", { entity: this.config.entity })}</div></div></ha-card>`;
+    }
+    const items = this._gallery();
+    return html`
+      <ha-card>
+        <style>:host { --tm-gallery-header: ${_safeColor(this.config.header_color, "#5d6d7e")}; }</style>
+        <div class="card-header" style="background: var(--tm-gallery-header);">
+          <ha-icon icon="mdi:image-multiple"></ha-icon>
+          <span>${this.config.title || this._t("gallery.default_title")}</span>
+        </div>
+        ${items.length === 0
+          ? html`<div class="empty"><ha-icon icon="mdi:camera-off"></ha-icon><div>${this._t("gallery.empty")}</div></div>`
+          : html`
+            <div class="grid">
+              ${items.map((it) => this._tile(it))}
+            </div>`}
+      </ha-card>
+    `;
+  }
+
+  _tile(it) {
+    const src = this._signed[it.photo_url];
+    const when = this._formatDate(it.completed_at);
+    return html`
+      <div class="tile" title="${it.chore_name} — ${it.child_name}">
+        ${src
+          ? html`<a href="${src}" target="_blank" rel="noopener"><img src="${src}" alt="${it.chore_name}" loading="lazy"></a>`
+          : html`<div class="ph"><ha-icon icon="mdi:image"></ha-icon></div>`}
+        <div class="cap">
+          <span class="who">${it.child_name}</span>
+          <span class="what">${it.chore_name}</span>
+          <span class="when">${when}${it.approved ? "" : " · " + this._t("gallery.pending")}</span>
+        </div>
+      </div>
+    `;
+  }
+
+  _formatDate(iso) {
+    if (!iso) return "";
+    const tz = (this.hass && this.hass.config && this.hass.config.time_zone) || undefined;
+    const d = new Date(iso);
+    if (isNaN(d.getTime())) return "";
+    return d.toLocaleDateString(undefined, { timeZone: tz, month: "short", day: "numeric" });
+  }
+
+  static get styles() {
+    return css`
+      ha-card { overflow: hidden; }
+      .card-header {
+        display: flex; align-items: center; gap: 8px;
+        padding: 12px 16px; color: #fff; font-weight: 600;
+      }
+      .grid {
+        display: grid; gap: 10px; padding: 14px;
+        grid-template-columns: repeat(auto-fill, minmax(110px, 1fr));
+      }
+      .tile { display: flex; flex-direction: column; border-radius: 8px; overflow: hidden; background: var(--secondary-background-color, #f5f5f5); }
+      .tile img, .tile .ph {
+        width: 100%; aspect-ratio: 1 / 1; object-fit: cover; display: block;
+      }
+      .tile .ph { display: flex; align-items: center; justify-content: center; color: var(--secondary-text-color); }
+      .cap { padding: 6px 8px; display: flex; flex-direction: column; gap: 1px; font-size: 0.72rem; }
+      .cap .who { font-weight: 600; }
+      .cap .what { color: var(--primary-text-color); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+      .cap .when { color: var(--secondary-text-color); }
+      .empty { display: flex; flex-direction: column; align-items: center; gap: 8px; padding: 32px 16px; color: var(--secondary-text-color); }
+    `;
+  }
+}
+
+customElements.define("taskmate-photo-gallery-card", TaskMatePhotoGalleryCard);
+
+window.customCards = window.customCards || [];
+window.customCards.push({
+  type: "taskmate-photo-gallery-card",
+  name: "TaskMate Photo Gallery",
+  description: "History grid of chore-evidence photos",
+  preview: true,
+});

--- a/tests/test_photo_gallery.py
+++ b/tests/test_photo_gallery.py
@@ -1,0 +1,51 @@
+"""Tests for the photo-gallery sensor slice (FEAT-13)."""
+from __future__ import annotations
+
+import datetime as dt
+from datetime import timezone
+
+from custom_components.taskmate.models import Child, ChoreCompletion
+from custom_components.taskmate.sensor import _build_photo_gallery
+
+UTC = timezone.utc
+
+
+def _common(children, completions):
+    return {
+        "child_lookup": {c.id: c for c in children},
+        "chore_lookup": {},
+        "all_completions": completions,
+    }
+
+
+def _comp(cid, when, photo="", approved=True):
+    return ChoreCompletion(chore_id="x", child_id=cid, completed_at=when,
+                           approved=approved, photo_url=photo)
+
+
+def test_gallery_includes_only_photos_newest_first():
+    kids = [Child(name="Alex", id="k1")]
+    comps = [
+        _comp("k1", dt.datetime(2026, 4, 1, 9, 0, tzinfo=UTC), photo="/api/taskmate/photo/a.jpg"),
+        _comp("k1", dt.datetime(2026, 4, 3, 9, 0, tzinfo=UTC), photo="/api/taskmate/photo/b.jpg"),
+        _comp("k1", dt.datetime(2026, 4, 2, 9, 0, tzinfo=UTC)),  # no photo -> excluded
+    ]
+    out = _build_photo_gallery(_common(kids, comps))
+    assert [o["photo_url"] for o in out] == ["/api/taskmate/photo/b.jpg", "/api/taskmate/photo/a.jpg"]
+    assert out[0]["child_name"] == "Alex"
+
+
+def test_gallery_respects_limit():
+    kids = [Child(name="Alex", id="k1")]
+    comps = [
+        _comp("k1", dt.datetime(2026, 4, d, 9, 0, tzinfo=UTC), photo=f"/api/taskmate/photo/{d}.jpg")
+        for d in range(1, 10)
+    ]
+    out = _build_photo_gallery(_common(kids, comps), limit=3)
+    assert len(out) == 3
+
+
+def test_gallery_empty_when_no_photos():
+    kids = [Child(name="Alex", id="k1")]
+    comps = [_comp("k1", dt.datetime(2026, 4, 1, 9, 0, tzinfo=UTC))]
+    assert _build_photo_gallery(_common(kids, comps)) == []


### PR DESCRIPTION
## FEAT-13 — Photo-proof gallery card

A history grid of chore-evidence photos, building on the photo-proof feature (the quota + orphan sweep already shipped in SEC-2).

- **Sensor**: the activity sensor gains a `photo_gallery` attribute (`_build_photo_gallery()`) — completions that carry a `photo_url`, newest first, capped at 40.
- **Card** (`taskmate-photo-gallery-card.js`): responsive thumbnail grid with child/chore/date captions and a pending badge. A cards `<img>` cant send a bearer token, so each photo path is signed via the `auth/sign_path` WS command (1 h) and cached; clicking opens the full image. Empty state when there are no photos.
- Registered in the card module list + picker; i18n in all 8 locales.

### Verification
`pytest`: gallery builder (photos-only, newest-first, limit, empty). Ruff + ESLint clean (new card adds 0 lint errors). Live on ha-dev: card served at `/taskmate/taskmate-photo-gallery-card.js` (200); activity sensor exposes `photo_gallery` (1 real photo present).

Part of the v4.3.1 audit fix campaign. No version bump / release.