### PR TITLE
feat(intents): voice/conversation intents (FEAT-12)

### DIFF
--- a/custom_components/taskmate/__init__.py
+++ b/custom_components/taskmate/__init__.py
@@ -160,6 +160,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await async_register_panel(hass)
     async_register_websocket_commands(hass)
 
+    # Conversation/voice intents (FEAT-12). Lazy import so a missing conversation
+    # stack never blocks setup.
+    try:
+        from .intents import async_setup_intents
+        async_setup_intents(hass)
+    except Exception as err:  # noqa: BLE001
+        _LOGGER.debug("TaskMate intents not registered: %s", err)
+
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     # Register services (only once)

--- a/custom_components/taskmate/intents.py
+++ b/custom_components/taskmate/intents.py
@@ -1,0 +1,104 @@
+"""Home Assistant conversation intents for TaskMate (FEAT-12).
+
+Registers intent handlers so a voice/text assistant can answer questions like
+"how many chores does Malia have left?" or "how many stars does Alex have?".
+
+The default conversation agent matches *sentences* to these intent names; ship
+the example sentences in ``custom_sentences/<lang>/taskmate.yaml`` into your HA
+config (see custom_sentences/README.md). The speech-building logic is kept in
+pure helpers so it is unit-testable without the conversation stack.
+"""
+from __future__ import annotations
+
+import logging
+
+import voluptuous as vol
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import intent
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+INTENT_CHORES_LEFT = "TaskMateChoresLeft"
+INTENT_POINTS = "TaskMatePoints"
+
+
+def _get_coordinator(hass: HomeAssistant):
+    from .coordinator import TaskMateCoordinator
+    for value in hass.data.get(DOMAIN, {}).values():
+        if isinstance(value, TaskMateCoordinator):
+            return value
+    return None
+
+
+def _find_child(coordinator, name: str):
+    """Case-insensitive child lookup by name."""
+    if coordinator is None or not name:
+        return None
+    target = name.strip().lower()
+    for child in coordinator.storage.get_children():
+        if child.name.strip().lower() == target:
+            return child
+    return None
+
+
+def chores_left_speech(coordinator, name: str) -> str:
+    """Speech for 'how many chores does <name> have left'."""
+    child = _find_child(coordinator, name)
+    if child is None:
+        return f"I couldn't find anyone called {name}."
+    count = len(coordinator.get_due_chores_for_child(child.id))
+    if count == 0:
+        return f"{child.name} has finished all their chores. Nice work!"
+    if count == 1:
+        return f"{child.name} has 1 chore left today."
+    return f"{child.name} has {count} chores left today."
+
+
+def points_speech(coordinator, name: str) -> str:
+    """Speech for 'how many points does <name> have'."""
+    child = _find_child(coordinator, name)
+    if child is None:
+        return f"I couldn't find anyone called {name}."
+    points_name = coordinator.storage.get_points_name()
+    return f"{child.name} has {child.points} {points_name}."
+
+
+class _TaskMateIntentBase(intent.IntentHandler):
+    slot_schema = {vol.Required("name"): cv.string}
+
+    def _speech(self, coordinator, name: str) -> str:  # pragma: no cover - overridden
+        raise NotImplementedError
+
+    async def async_handle(self, intent_obj):
+        hass = intent_obj.hass
+        coordinator = _get_coordinator(hass)
+        name = ""
+        slot = (intent_obj.slots or {}).get("name") or {}
+        name = slot.get("value", "") if isinstance(slot, dict) else str(slot)
+        response = intent_obj.create_response()
+        response.async_set_speech(self._speech(coordinator, name))
+        return response
+
+
+class ChoresLeftIntentHandler(_TaskMateIntentBase):
+    intent_type = INTENT_CHORES_LEFT
+
+    def _speech(self, coordinator, name: str) -> str:
+        return chores_left_speech(coordinator, name)
+
+
+class PointsIntentHandler(_TaskMateIntentBase):
+    intent_type = INTENT_POINTS
+
+    def _speech(self, coordinator, name: str) -> str:
+        return points_speech(coordinator, name)
+
+
+def async_setup_intents(hass: HomeAssistant) -> None:
+    """Register TaskMate conversation intents (idempotent enough for reloads)."""
+    intent.async_register(hass, ChoresLeftIntentHandler())
+    intent.async_register(hass, PointsIntentHandler())
+    _LOGGER.debug("Registered TaskMate conversation intents")

--- a/custom_sentences/README.md
+++ b/custom_sentences/README.md
@@ -1,0 +1,27 @@
+# TaskMate voice intents
+
+TaskMate registers Home Assistant [conversation intents](https://www.home-assistant.io/integrations/conversation/)
+so you can ask Assist (voice or text) about chores and points:
+
+- *"How many chores does Malia have left?"* → `TaskMateChoresLeft`
+- *"How many stars does Alex have?"* → `TaskMatePoints`
+
+The intent **handlers** ship with the integration and are registered
+automatically. The **sentences** that trigger them are matched by HA's default
+conversation agent, which loads them from your config's `custom_sentences/<lang>/`
+folder.
+
+## Install the sentences
+
+Copy `en/taskmate.yaml` from this folder into your Home Assistant config:
+
+```
+<config>/custom_sentences/en/taskmate.yaml
+```
+
+Then restart Home Assistant (or reload the conversation integration). Ask Assist
+one of the sentences above — `{name}` matches any of your children by name.
+
+Translations: copy the file under the matching language code (e.g.
+`custom_sentences/de/taskmate.yaml`) and translate the `sentences:` lines; the
+intent names and `lists` keys must stay unchanged.

--- a/custom_sentences/en/taskmate.yaml
+++ b/custom_sentences/en/taskmate.yaml
@@ -1,0 +1,23 @@
+language: "en"
+intents:
+  TaskMateChoresLeft:
+    data:
+      - sentences:
+          - "how many chores (does|has) {name} have left"
+          - "how many chores (are|is) left for {name}"
+          - "(does|has) {name} have any chores left"
+          - "what chores does {name} have left"
+  TaskMatePoints:
+    data:
+      - sentences:
+          - "how many {points_word} does {name} have"
+          - "what is {name}'s balance"
+          - "how many points does {name} have"
+lists:
+  name:
+    wildcard: true
+  points_word:
+    values:
+      - "points"
+      - "stars"
+      - "coins"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -264,6 +264,23 @@ _ha_helpers_entity.DeviceInfo = _FakeDeviceInfo
 _ha_helpers_entity_platform = MagicMock()
 
 
+# ── homeassistant.helpers.intent ─────────────────────────────────────────────
+class _FakeIntentHandler:
+    """Minimal stand-in so intents.py can subclass intent.IntentHandler."""
+
+    slot_schema = None
+
+
+_ha_intent = MagicMock()
+_ha_intent.IntentHandler = _FakeIntentHandler
+_ha_intent.async_register = MagicMock()
+
+# `from homeassistant.helpers import intent` resolves via the helpers package
+# attribute, so the helpers mock must expose our stub.
+_ha_helpers = MagicMock()
+_ha_helpers.intent = _ha_intent
+
+
 # ── homeassistant.util.dt ────────────────────────────────────────────────────
 # coordinator.py imports this as:  from homeassistant.util import dt as dt_util
 
@@ -313,7 +330,8 @@ sys.modules.update(
         "homeassistant.config_entries": MagicMock(),
         "homeassistant.const": MagicMock(),
         "homeassistant.exceptions": _ha_exceptions,
-        "homeassistant.helpers": MagicMock(),
+        "homeassistant.helpers": _ha_helpers,
+        "homeassistant.helpers.intent": _ha_intent,
         "homeassistant.helpers.service": MagicMock(),
         "homeassistant.helpers.storage": _ha_storage_mod,
         "homeassistant.helpers.event": _ha_event,

--- a/tests/test_intents.py
+++ b/tests/test_intents.py
@@ -1,0 +1,46 @@
+"""Tests for TaskMate conversation intents (FEAT-12)."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from custom_components.taskmate import intents
+from custom_components.taskmate.models import Child
+
+
+def _coord(children, *, due=0, points_name="Stars"):
+    c = MagicMock()
+    c.storage.get_children = MagicMock(return_value=children)
+    c.storage.get_points_name = MagicMock(return_value=points_name)
+    c.get_due_chores_for_child = MagicMock(return_value=[object()] * due)
+    return c
+
+
+def test_find_child_case_insensitive():
+    kids = [Child(name="Malia", id="k1"), Child(name="Alex", id="k2")]
+    c = _coord(kids)
+    assert intents._find_child(c, "malia").id == "k1"
+    assert intents._find_child(c, "  ALEX ").id == "k2"
+    assert intents._find_child(c, "nobody") is None
+
+
+def test_chores_left_speech_variants():
+    kids = [Child(name="Malia", id="k1")]
+    assert "couldn't find" in intents.chores_left_speech(_coord(kids), "ghost")
+    assert intents.chores_left_speech(_coord(kids, due=0), "Malia").startswith("Malia has finished")
+    assert "1 chore left" in intents.chores_left_speech(_coord(kids, due=1), "Malia")
+    assert "3 chores left" in intents.chores_left_speech(_coord(kids, due=3), "Malia")
+
+
+def test_points_speech():
+    kids = [Child(name="Alex", id="k2", points=42)]
+    assert intents.points_speech(_coord(kids, points_name="Stars"), "Alex") == "Alex has 42 Stars."
+    assert "couldn't find" in intents.points_speech(_coord(kids), "ghost")
+
+
+def test_setup_registers_two_intents():
+    hass = MagicMock()
+    intents.intent.async_register.reset_mock()
+    intents.async_setup_intents(hass)
+    assert intents.intent.async_register.call_count == 2
+    types = {type(call.args[1]).__name__ for call in intents.intent.async_register.call_args_list}
+    assert types == {"ChoresLeftIntentHandler", "PointsIntentHandler"}


### PR DESCRIPTION
## FEAT-12 — Voice / conversation intents

Ask Home Assistant Assist (voice or text) about TaskMate:

- *"How many chores does Malia have left?"* → `TaskMateChoresLeft`
- *"How many stars does Alex have?"* → `TaskMatePoints`

### Implementation
- **`intents.py`**: pure speech helpers (`chores_left_speech`, `points_speech`, case-insensitive `_find_child`) + two `intent.IntentHandler` subclasses + `async_setup_intents()`. Registered from `async_setup_entry` (lazy import, guarded so a missing conversation stack never blocks setup).
- **`custom_sentences/en/taskmate.yaml`** + README: the sentences a user copies into `<config>/custom_sentences/en/`. The handlers ship with the integration; the trigger sentences are config for HAs default conversation agent (with a `{name}` wildcard).
- conftest gains a minimal `homeassistant.helpers.intent` stub.

### Verification
`pytest`: find-child, chores-left grammar (0 / 1 / n / unknown), points speech, setup registers both handlers. Ruff clean. **Live on ha-dev** via `/api/intent/handle`: `TaskMateChoresLeft` → *"Malia has finished all their chores. Nice work!"*; `TaskMatePoints` → *"Malia has 58 Points."*

Part of the v4.3.1 audit fix campaign. No version bump / release.