### PR TITLE
refactor(cards): extract header-colour picker to shared layer (QUAL-3)

### DIFF
--- a/custom_components/taskmate/www/taskmate-activity-card.js
+++ b/custom_components/taskmate/www/taskmate-activity-card.js
@@ -1269,35 +1269,18 @@ class TaskMateActivityCardEditor extends LitElement {
   }
 
   _renderColourPicker(key, defaultValue) {
+    const d = window.__taskmate_design;
     const current = this.config[key] || defaultValue;
-    const presets = [defaultValue, '#e67e22', '#27ae60', '#9b59b6', '#f1c40f', '#e74c3c', '#34495e'];
-    const isActive = (c) => c.toLowerCase() === current.toLowerCase();
-    return html`
-      <div class="colour-field">
-        <span class="colour-field-label">${this._t('common.editor.header_colour')}</span>
-        <div class="colour-field-body">
-          <label class="colour-swatch-wrapper">
-            <input type="color" .value=${current}
-              @input=${(e) => this._updateConfig(key, e.target.value)} />
-            <span class="colour-swatch-preview" style="background:${current}"></span>
-          </label>
-          <span class="colour-hex">${current}</span>
-          <div class="colour-presets">
-            ${presets.map((p) => html`
-              <button class="preset-swatch ${isActive(p) ? 'active' : ''}"
-                style="background:${p}"
-                title=${p}
-                @click=${(e) => { e.preventDefault(); this._updateConfig(key, p); }}
-              ></button>
-            `)}
-          </div>
-          <button class="colour-reset"
-            @click=${(e) => { e.preventDefault(); this._updateConfig(key, defaultValue); }}
-          >${this._t('common.reset')}</button>
-        </div>
-        <div class="colour-helper">${this._t('common.editor.header_colour_helper')}</div>
-      </div>
-    `;
+    if (!d || !d.colourPicker) return html``;
+    return d.colourPicker({
+      defaultValue, current,
+      label: this._t('common.editor.header_colour'),
+      helper: this._t('common.editor.header_colour_helper'),
+      resetLabel: this._t('common.reset'),
+      onInput: (v) => this._updateConfig(key, v),
+      onPreset: (v) => this._updateConfig(key, v),
+      onReset: () => this._updateConfig(key, defaultValue),
+    });
   }
 
   _formChanged(e) {

--- a/custom_components/taskmate/www/taskmate-approvals-card.js
+++ b/custom_components/taskmate/www/taskmate-approvals-card.js
@@ -1427,35 +1427,18 @@ class TaskMateApprovalsCardEditor extends LitElement {
   }
 
   _renderColourPicker(key, defaultValue) {
+    const d = window.__taskmate_design;
     const current = this.config[key] || defaultValue;
-    const presets = [defaultValue, '#e67e22', '#3498db', '#9b59b6', '#f1c40f', '#e74c3c', '#34495e'];
-    const isActive = (c) => c.toLowerCase() === current.toLowerCase();
-    return html`
-      <div class="colour-field">
-        <span class="colour-field-label">${this._t('common.editor.header_colour')}</span>
-        <div class="colour-field-body">
-          <label class="colour-swatch-wrapper">
-            <input type="color" .value=${current}
-              @input=${(e) => this._updateConfig(key, e.target.value)} />
-            <span class="colour-swatch-preview" style="background:${current}"></span>
-          </label>
-          <span class="colour-hex">${current}</span>
-          <div class="colour-presets">
-            ${presets.map((p) => html`
-              <button class="preset-swatch ${isActive(p) ? 'active' : ''}"
-                style="background:${p}"
-                title=${p}
-                @click=${(e) => { e.preventDefault(); this._updateConfig(key, p); }}
-              ></button>
-            `)}
-          </div>
-          <button class="colour-reset"
-            @click=${(e) => { e.preventDefault(); this._updateConfig(key, defaultValue); }}
-          >${this._t('common.reset')}</button>
-        </div>
-        <div class="colour-helper">${this._t('common.editor.header_colour_helper')}</div>
-      </div>
-    `;
+    if (!d || !d.colourPicker) return html``;
+    return d.colourPicker({
+      defaultValue, current,
+      label: this._t('common.editor.header_colour'),
+      helper: this._t('common.editor.header_colour_helper'),
+      resetLabel: this._t('common.reset'),
+      onInput: (v) => this._updateConfig(key, v),
+      onPreset: (v) => this._updateConfig(key, v),
+      onReset: () => this._updateConfig(key, defaultValue),
+    });
   }
 
   _formChanged(e) {

--- a/custom_components/taskmate/www/taskmate-bonuses-card.js
+++ b/custom_components/taskmate/www/taskmate-bonuses-card.js
@@ -1086,35 +1086,18 @@ class TaskMateBonusesCardEditor extends LitElement {
   }
 
   _renderColourPicker(key, defaultValue) {
+    const d = window.__taskmate_design;
     const current = this.config[key] || defaultValue;
-    const presets = [defaultValue, '#e67e22', '#27ae60', '#3498db', '#9b59b6', '#f1c40f', '#34495e'];
-    const isActive = (c) => c.toLowerCase() === current.toLowerCase();
-    return html`
-      <div class="colour-field">
-        <span class="colour-field-label">${this._t('common.editor.header_colour')}</span>
-        <div class="colour-field-body">
-          <label class="colour-swatch-wrapper">
-            <input type="color" .value=${current}
-              @input=${(e) => this._update(key, e.target.value)} />
-            <span class="colour-swatch-preview" style="background:${current}"></span>
-          </label>
-          <span class="colour-hex">${current}</span>
-          <div class="colour-presets">
-            ${presets.map((p) => html`
-              <button class="preset-swatch ${isActive(p) ? 'active' : ''}"
-                style="background:${p}"
-                title=${p}
-                @click=${(e) => { e.preventDefault(); this._update(key, p); }}
-              ></button>
-            `)}
-          </div>
-          <button class="colour-reset"
-            @click=${(e) => { e.preventDefault(); this._update(key, defaultValue); }}
-          >${this._t('common.reset')}</button>
-        </div>
-        <div class="colour-helper">${this._t('common.editor.header_colour_helper')}</div>
-      </div>
-    `;
+    if (!d || !d.colourPicker) return html``;
+    return d.colourPicker({
+      defaultValue, current,
+      label: this._t('common.editor.header_colour'),
+      helper: this._t('common.editor.header_colour_helper'),
+      resetLabel: this._t('common.reset'),
+      onInput: (v) => this._update(key, v),
+      onPreset: (v) => this._update(key, v),
+      onReset: () => this._update(key, defaultValue),
+    });
   }
 
   _formChanged(e) {

--- a/custom_components/taskmate/www/taskmate-calendar-card.js
+++ b/custom_components/taskmate/www/taskmate-calendar-card.js
@@ -856,35 +856,18 @@ class TaskMateCalendarCardEditor extends LitElement {
   }
 
   _renderColourPicker(key, defaultValue) {
+    const d = window.__taskmate_design;
     const current = this.config[key] || defaultValue;
-    const presets = [defaultValue, "#27ae60", "#e67e22", "#9b59b6", "#f1c40f", "#e74c3c", "#34495e"];
-    const isActive = (c) => c.toLowerCase() === current.toLowerCase();
-    return html`
-      <div class="colour-field">
-        <span class="colour-field-label">${this._t("common.editor.header_colour")}</span>
-        <div class="colour-field-body">
-          <label class="colour-swatch-wrapper">
-            <input type="color" .value=${current}
-              @input=${(e) => this._updateConfig(key, e.target.value)} />
-            <span class="colour-swatch-preview" style="background:${current}"></span>
-          </label>
-          <span class="colour-hex">${current}</span>
-          <div class="colour-presets">
-            ${presets.map((p) => html`
-              <button class="preset-swatch ${isActive(p) ? "active" : ""}"
-                style="background:${p}"
-                title=${p}
-                @click=${(e) => { e.preventDefault(); this._updateConfig(key, p); }}
-              ></button>
-            `)}
-          </div>
-          <button class="colour-reset"
-            @click=${(e) => { e.preventDefault(); this._updateConfig(key, defaultValue); }}
-          >${this._t("common.reset")}</button>
-        </div>
-        <div class="colour-helper">${this._t("common.editor.header_colour_helper")}</div>
-      </div>
-    `;
+    if (!d || !d.colourPicker) return html``;
+    return d.colourPicker({
+      defaultValue, current,
+      label: this._t('common.editor.header_colour'),
+      helper: this._t('common.editor.header_colour_helper'),
+      resetLabel: this._t('common.reset'),
+      onInput: (v) => this._updateConfig(key, v),
+      onPreset: (v) => this._updateConfig(key, v),
+      onReset: () => this._updateConfig(key, defaultValue),
+    });
   }
 
   _formChanged(e) {

--- a/custom_components/taskmate/www/taskmate-child-card.js
+++ b/custom_components/taskmate/www/taskmate-child-card.js
@@ -4115,35 +4115,18 @@ class TaskMateChildCardEditor extends LitElement {
   }
 
   _renderColourPicker(key, defaultValue) {
+    const d = window.__taskmate_design;
     const current = this.config[key] || defaultValue;
-    const presets = ['#9b59b6', '#e67e22', '#27ae60', '#3498db', '#f1c40f', '#e74c3c', '#34495e'];
-    const isActive = (c) => c.toLowerCase() === current.toLowerCase();
-    return html`
-      <div class="colour-field">
-        <span class="colour-field-label">${this._t('common.editor.header_colour')}</span>
-        <div class="colour-field-body">
-          <label class="colour-swatch-wrapper">
-            <input type="color" .value=${current}
-              @input=${(e) => this._updateConfig(key, e.target.value)} />
-            <span class="colour-swatch-preview" style="background:${current}"></span>
-          </label>
-          <span class="colour-hex">${current}</span>
-          <div class="colour-presets">
-            ${presets.map((p) => html`
-              <button class="preset-swatch ${isActive(p) ? 'active' : ''}"
-                style="background:${p}"
-                title=${p}
-                @click=${(e) => { e.preventDefault(); this._updateConfig(key, p); }}
-              ></button>
-            `)}
-          </div>
-          <button class="colour-reset"
-            @click=${(e) => { e.preventDefault(); this._updateConfig(key, defaultValue); }}
-          >${this._t('common.reset')}</button>
-        </div>
-        <div class="colour-helper">${this._t('common.editor.header_colour_helper')}</div>
-      </div>
-    `;
+    if (!d || !d.colourPicker) return html``;
+    return d.colourPicker({
+      defaultValue, current,
+      label: this._t('common.editor.header_colour'),
+      helper: this._t('common.editor.header_colour_helper'),
+      resetLabel: this._t('common.reset'),
+      onInput: (v) => this._updateConfig(key, v),
+      onPreset: (v) => this._updateConfig(key, v),
+      onReset: () => this._updateConfig(key, defaultValue),
+    });
   }
 
   _formChanged(e) {

--- a/custom_components/taskmate/www/taskmate-design.js
+++ b/custom_components/taskmate/www/taskmate-design.js
@@ -242,5 +242,42 @@
   // wrapper element; the [data-tm-design] selector variant applies there.
   const cssText = TOKENS + "\n" + KIT;
 
-  window.__taskmate_design = { IDS, resolve, isDark, apply, editorOptions, styles, cssText, tokensCSS: TOKENS };
+  // ── Shared header-colour picker (QUAL-3) ───────────────────────────────
+  // The same ~30-line colour-picker editor block was copy-pasted into 17 card
+  // editors. They render it via a thin `_renderColourPicker` wrapper that calls
+  // this helper, passing their own update method as onInput/onPreset/onReset.
+  const _DEFAULT_COLOUR_PRESETS = ["#e67e22", "#27ae60", "#9b59b6", "#f1c40f", "#e74c3c", "#34495e"];
+
+  function colourPicker(opts) {
+    const base = customElements.get("hui-masonry-view") || customElements.get("hui-view");
+    const html = base ? Object.getPrototypeOf(base).prototype.html : null;
+    if (!html) return "";
+    const { defaultValue, current, label, helper, resetLabel, onInput, onPreset, onReset } = opts;
+    const presets = [defaultValue, ...(opts.presets || _DEFAULT_COLOUR_PRESETS)];
+    const isActive = (c) => String(c).toLowerCase() === String(current).toLowerCase();
+    return html`
+      <div class="colour-field">
+        <span class="colour-field-label">${label}</span>
+        <div class="colour-field-body">
+          <label class="colour-swatch-wrapper">
+            <input type="color" .value=${current} @input=${(e) => onInput(e.target.value)} />
+            <span class="colour-swatch-preview" style="background:${current}"></span>
+          </label>
+          <span class="colour-hex">${current}</span>
+          <div class="colour-presets">
+            ${presets.map((p) => html`
+              <button class="preset-swatch ${isActive(p) ? "active" : ""}"
+                style="background:${p}" title=${p}
+                @click=${(e) => { e.preventDefault(); onPreset(p); }}></button>
+            `)}
+          </div>
+          <button class="colour-reset"
+            @click=${(e) => { e.preventDefault(); onReset(); }}>${resetLabel}</button>
+        </div>
+        <div class="colour-helper">${helper}</div>
+      </div>
+    `;
+  }
+
+  window.__taskmate_design = { IDS, resolve, isDark, apply, editorOptions, styles, cssText, tokensCSS: TOKENS, colourPicker };
 })();

--- a/custom_components/taskmate/www/taskmate-graph-card.js
+++ b/custom_components/taskmate/www/taskmate-graph-card.js
@@ -1025,35 +1025,18 @@ class TaskMateGraphCardEditor extends LitElement {
   }
 
   _renderColourPicker(key, defaultValue) {
+    const d = window.__taskmate_design;
     const current = this.config[key] || defaultValue;
-    const presets = [defaultValue, '#27ae60', '#3498db', '#9b59b6', '#f1c40f', '#e74c3c', '#34495e'];
-    const isActive = (c) => c.toLowerCase() === current.toLowerCase();
-    return html`
-      <div class="colour-field">
-        <span class="colour-field-label">${this._t('common.editor.header_colour')}</span>
-        <div class="colour-field-body">
-          <label class="colour-swatch-wrapper">
-            <input type="color" .value=${current}
-              @input=${(e) => this._updateConfig(key, e.target.value)} />
-            <span class="colour-swatch-preview" style="background:${current}"></span>
-          </label>
-          <span class="colour-hex">${current}</span>
-          <div class="colour-presets">
-            ${presets.map((p) => html`
-              <button class="preset-swatch ${isActive(p) ? 'active' : ''}"
-                style="background:${p}"
-                title=${p}
-                @click=${(e) => { e.preventDefault(); this._updateConfig(key, p); }}
-              ></button>
-            `)}
-          </div>
-          <button class="colour-reset"
-            @click=${(e) => { e.preventDefault(); this._updateConfig(key, defaultValue); }}
-          >${this._t('common.reset')}</button>
-        </div>
-        <div class="colour-helper">${this._t('common.editor.header_colour_helper')}</div>
-      </div>
-    `;
+    if (!d || !d.colourPicker) return html``;
+    return d.colourPicker({
+      defaultValue, current,
+      label: this._t('common.editor.header_colour'),
+      helper: this._t('common.editor.header_colour_helper'),
+      resetLabel: this._t('common.reset'),
+      onInput: (v) => this._updateConfig(key, v),
+      onPreset: (v) => this._updateConfig(key, v),
+      onReset: () => this._updateConfig(key, defaultValue),
+    });
   }
 
   _formChanged(e) {

--- a/custom_components/taskmate/www/taskmate-leaderboard-card.js
+++ b/custom_components/taskmate/www/taskmate-leaderboard-card.js
@@ -869,35 +869,18 @@ class TaskMateLeaderboardCardEditor extends LitElement {
   }
 
   _renderColourPicker(key, defaultValue) {
+    const d = window.__taskmate_design;
     const current = this.config[key] || defaultValue;
-    const presets = [defaultValue, '#e67e22', '#27ae60', '#3498db', '#9b59b6', '#e74c3c', '#34495e'];
-    const isActive = (c) => c.toLowerCase() === current.toLowerCase();
-    return html`
-      <div class="colour-field">
-        <span class="colour-field-label">${this._t('common.editor.header_colour')}</span>
-        <div class="colour-field-body">
-          <label class="colour-swatch-wrapper">
-            <input type="color" .value=${current}
-              @input=${(e) => this._update(key, e.target.value)} />
-            <span class="colour-swatch-preview" style="background:${current}"></span>
-          </label>
-          <span class="colour-hex">${current}</span>
-          <div class="colour-presets">
-            ${presets.map((p) => html`
-              <button class="preset-swatch ${isActive(p) ? 'active' : ''}"
-                style="background:${p}"
-                title=${p}
-                @click=${(e) => { e.preventDefault(); this._update(key, p); }}
-              ></button>
-            `)}
-          </div>
-          <button class="colour-reset"
-            @click=${(e) => { e.preventDefault(); this._update(key, defaultValue); }}
-          >${this._t('common.reset')}</button>
-        </div>
-        <div class="colour-helper">${this._t('common.editor.header_colour_helper')}</div>
-      </div>
-    `;
+    if (!d || !d.colourPicker) return html``;
+    return d.colourPicker({
+      defaultValue, current,
+      label: this._t('common.editor.header_colour'),
+      helper: this._t('common.editor.header_colour_helper'),
+      resetLabel: this._t('common.reset'),
+      onInput: (v) => this._update(key, v),
+      onPreset: (v) => this._update(key, v),
+      onReset: () => this._update(key, defaultValue),
+    });
   }
 
   _formChanged(e) {

--- a/custom_components/taskmate/www/taskmate-overview-card.js
+++ b/custom_components/taskmate/www/taskmate-overview-card.js
@@ -935,35 +935,18 @@ class TaskMateOverviewCardEditor extends LitElement {
   }
 
   _renderColourPicker(key, defaultValue) {
+    const d = window.__taskmate_design;
     const current = this.config[key] || defaultValue;
-    const presets = [defaultValue, '#e67e22', '#27ae60', '#3498db', '#f1c40f', '#e74c3c', '#34495e'];
-    const isActive = (c) => c.toLowerCase() === current.toLowerCase();
-    return html`
-      <div class="colour-field">
-        <span class="colour-field-label">${this._t('common.editor.header_colour')}</span>
-        <div class="colour-field-body">
-          <label class="colour-swatch-wrapper">
-            <input type="color" .value=${current}
-              @input=${(e) => this._updateConfig(key, e.target.value)} />
-            <span class="colour-swatch-preview" style="background:${current}"></span>
-          </label>
-          <span class="colour-hex">${current}</span>
-          <div class="colour-presets">
-            ${presets.map((p) => html`
-              <button class="preset-swatch ${isActive(p) ? 'active' : ''}"
-                style="background:${p}"
-                title=${p}
-                @click=${(e) => { e.preventDefault(); this._updateConfig(key, p); }}
-              ></button>
-            `)}
-          </div>
-          <button class="colour-reset"
-            @click=${(e) => { e.preventDefault(); this._updateConfig(key, defaultValue); }}
-          >${this._t('common.reset')}</button>
-        </div>
-        <div class="colour-helper">${this._t('common.editor.header_colour_helper')}</div>
-      </div>
-    `;
+    if (!d || !d.colourPicker) return html``;
+    return d.colourPicker({
+      defaultValue, current,
+      label: this._t('common.editor.header_colour'),
+      helper: this._t('common.editor.header_colour_helper'),
+      resetLabel: this._t('common.reset'),
+      onInput: (v) => this._updateConfig(key, v),
+      onPreset: (v) => this._updateConfig(key, v),
+      onReset: () => this._updateConfig(key, defaultValue),
+    });
   }
 
   _formChanged(e) {

--- a/custom_components/taskmate/www/taskmate-parent-dashboard-card.js
+++ b/custom_components/taskmate/www/taskmate-parent-dashboard-card.js
@@ -1425,35 +1425,18 @@ class TaskMateParentDashboardCardEditor extends LitElement {
   }
 
   _renderColourPicker(key, defaultValue) {
+    const d = window.__taskmate_design;
     const current = this.config[key] || defaultValue;
-    const presets = [defaultValue, '#e67e22', '#27ae60', '#3498db', '#9b59b6', '#f1c40f', '#34495e'];
-    const isActive = (c) => c.toLowerCase() === current.toLowerCase();
-    return html`
-      <div class="colour-field">
-        <span class="colour-field-label">${this._t('common.editor.header_colour')}</span>
-        <div class="colour-field-body">
-          <label class="colour-swatch-wrapper">
-            <input type="color" .value=${current}
-              @input=${(e) => this._update(key, e.target.value)} />
-            <span class="colour-swatch-preview" style="background:${current}"></span>
-          </label>
-          <span class="colour-hex">${current}</span>
-          <div class="colour-presets">
-            ${presets.map((p) => html`
-              <button class="preset-swatch ${isActive(p) ? 'active' : ''}"
-                style="background:${p}"
-                title=${p}
-                @click=${(e) => { e.preventDefault(); this._update(key, p); }}
-              ></button>
-            `)}
-          </div>
-          <button class="colour-reset"
-            @click=${(e) => { e.preventDefault(); this._update(key, defaultValue); }}
-          >${this._t('common.reset')}</button>
-        </div>
-        <div class="colour-helper">${this._t('common.editor.header_colour_helper')}</div>
-      </div>
-    `;
+    if (!d || !d.colourPicker) return html``;
+    return d.colourPicker({
+      defaultValue, current,
+      label: this._t('common.editor.header_colour'),
+      helper: this._t('common.editor.header_colour_helper'),
+      resetLabel: this._t('common.reset'),
+      onInput: (v) => this._update(key, v),
+      onPreset: (v) => this._update(key, v),
+      onReset: () => this._update(key, defaultValue),
+    });
   }
 
   _formChanged(e) {

--- a/custom_components/taskmate/www/taskmate-penalties-card.js
+++ b/custom_components/taskmate/www/taskmate-penalties-card.js
@@ -1084,35 +1084,18 @@ class TaskMatePenaltiesCardEditor extends LitElement {
   }
 
   _renderColourPicker(key, defaultValue) {
+    const d = window.__taskmate_design;
     const current = this.config[key] || defaultValue;
-    const presets = [defaultValue, '#e67e22', '#27ae60', '#3498db', '#9b59b6', '#f1c40f', '#34495e'];
-    const isActive = (c) => c.toLowerCase() === current.toLowerCase();
-    return html`
-      <div class="colour-field">
-        <span class="colour-field-label">${this._t('common.editor.header_colour')}</span>
-        <div class="colour-field-body">
-          <label class="colour-swatch-wrapper">
-            <input type="color" .value=${current}
-              @input=${(e) => this._update(key, e.target.value)} />
-            <span class="colour-swatch-preview" style="background:${current}"></span>
-          </label>
-          <span class="colour-hex">${current}</span>
-          <div class="colour-presets">
-            ${presets.map((p) => html`
-              <button class="preset-swatch ${isActive(p) ? 'active' : ''}"
-                style="background:${p}"
-                title=${p}
-                @click=${(e) => { e.preventDefault(); this._update(key, p); }}
-              ></button>
-            `)}
-          </div>
-          <button class="colour-reset"
-            @click=${(e) => { e.preventDefault(); this._update(key, defaultValue); }}
-          >${this._t('common.reset')}</button>
-        </div>
-        <div class="colour-helper">${this._t('common.editor.header_colour_helper')}</div>
-      </div>
-    `;
+    if (!d || !d.colourPicker) return html``;
+    return d.colourPicker({
+      defaultValue, current,
+      label: this._t('common.editor.header_colour'),
+      helper: this._t('common.editor.header_colour_helper'),
+      resetLabel: this._t('common.reset'),
+      onInput: (v) => this._update(key, v),
+      onPreset: (v) => this._update(key, v),
+      onReset: () => this._update(key, defaultValue),
+    });
   }
 
   _formChanged(e) {

--- a/custom_components/taskmate/www/taskmate-points-card.js
+++ b/custom_components/taskmate/www/taskmate-points-card.js
@@ -1324,35 +1324,18 @@ class TaskMatePointsCardEditor extends LitElement {
   }
 
   _renderColourPicker(key, defaultValue) {
+    const d = window.__taskmate_design;
     const current = this.config[key] || defaultValue;
-    const presets = ['#2980b9', '#e67e22', '#27ae60', '#9b59b6', '#f1c40f', '#e74c3c', '#34495e'];
-    const isActive = (c) => current && c.toLowerCase() === current.toLowerCase();
-    return html`
-      <div class="colour-field">
-        <span class="colour-field-label">${this._t('common.editor.header_colour')}</span>
-        <div class="colour-field-body">
-          <label class="colour-swatch-wrapper">
-            <input type="color" .value=${current || '#2980b9'}
-              @input=${(e) => this._updateConfig(key, e.target.value)} />
-            <span class="colour-swatch-preview" style="background:${current || '#2980b9'}"></span>
-          </label>
-          <span class="colour-hex">${current || this._t('common.default')}</span>
-          <div class="colour-presets">
-            ${presets.map((p) => html`
-              <button class="preset-swatch ${isActive(p) ? 'active' : ''}"
-                style="background:${p}"
-                title=${p}
-                @click=${(e) => { e.preventDefault(); this._updateConfig(key, p); }}
-              ></button>
-            `)}
-          </div>
-          <button class="colour-reset"
-            @click=${(e) => { e.preventDefault(); this._updateConfig(key, ''); }}
-          >${this._t('common.reset')}</button>
-        </div>
-        <div class="colour-helper">${this._t('common.editor.header_colour_helper')}</div>
-      </div>
-    `;
+    if (!d || !d.colourPicker) return html``;
+    return d.colourPicker({
+      defaultValue, current,
+      label: this._t('common.editor.header_colour'),
+      helper: this._t('common.editor.header_colour_helper'),
+      resetLabel: this._t('common.reset'),
+      onInput: (v) => this._updateConfig(key, v),
+      onPreset: (v) => this._updateConfig(key, v),
+      onReset: () => this._updateConfig(key, defaultValue),
+    });
   }
 
   _formChanged(e) {

--- a/custom_components/taskmate/www/taskmate-points-display-card.js
+++ b/custom_components/taskmate/www/taskmate-points-display-card.js
@@ -1184,35 +1184,18 @@ class TaskMatePointsDisplayCardEditor extends LitElement {
   }
 
   _renderColourPicker(key, defaultValue) {
+    const d = window.__taskmate_design;
     const current = this.config[key] || defaultValue;
-    const presets = [defaultValue, '#e67e22', '#27ae60', '#3498db', '#f1c40f', '#e74c3c', '#34495e'];
-    const isActive = (c) => c.toLowerCase() === current.toLowerCase();
-    return html`
-      <div class="colour-field">
-        <span class="colour-field-label">${this._t('common.editor.header_colour')}</span>
-        <div class="colour-field-body">
-          <label class="colour-swatch-wrapper">
-            <input type="color" .value=${current}
-              @input=${(e) => this._set(key, e.target.value)} />
-            <span class="colour-swatch-preview" style="background:${current}"></span>
-          </label>
-          <span class="colour-hex">${current}</span>
-          <div class="colour-presets">
-            ${presets.map((p) => html`
-              <button class="preset-swatch ${isActive(p) ? 'active' : ''}"
-                style="background:${p}"
-                title=${p}
-                @click=${(e) => { e.preventDefault(); this._set(key, p); }}
-              ></button>
-            `)}
-          </div>
-          <button class="colour-reset"
-            @click=${(e) => { e.preventDefault(); this._set(key, defaultValue); }}
-          >${this._t('common.reset')}</button>
-        </div>
-        <div class="colour-helper">${this._t('common.editor.header_colour_helper')}</div>
-      </div>
-    `;
+    if (!d || !d.colourPicker) return html``;
+    return d.colourPicker({
+      defaultValue, current,
+      label: this._t('common.editor.header_colour'),
+      helper: this._t('common.editor.header_colour_helper'),
+      resetLabel: this._t('common.reset'),
+      onInput: (v) => this._update(key, v),
+      onPreset: (v) => this._update(key, v),
+      onReset: () => this._update(key, defaultValue),
+    });
   }
 
   _formChanged(e) {

--- a/custom_components/taskmate/www/taskmate-reorder-card.js
+++ b/custom_components/taskmate/www/taskmate-reorder-card.js
@@ -1262,35 +1262,18 @@ class TaskMateReorderCardEditor extends LitElement {
   }
 
   _renderColourPicker(key, defaultValue) {
+    const d = window.__taskmate_design;
     const current = this.config[key] || defaultValue;
-    const presets = ['#16a085', '#e67e22', '#3498db', '#9b59b6', '#f1c40f', '#e74c3c', '#34495e'];
-    const isActive = (c) => current && c.toLowerCase() === current.toLowerCase();
-    return html`
-      <div class="colour-field">
-        <span class="colour-field-label">${this._t('common.editor.header_colour')}</span>
-        <div class="colour-field-body">
-          <label class="colour-swatch-wrapper">
-            <input type="color" .value=${current || '#16a085'}
-              @input=${(e) => this._updateConfig(key, e.target.value)} />
-            <span class="colour-swatch-preview" style="background:${current || '#16a085'}"></span>
-          </label>
-          <span class="colour-hex">${current || this._t('common.default')}</span>
-          <div class="colour-presets">
-            ${presets.map((p) => html`
-              <button class="preset-swatch ${isActive(p) ? 'active' : ''}"
-                style="background:${p}"
-                title=${p}
-                @click=${(e) => { e.preventDefault(); this._updateConfig(key, p); }}
-              ></button>
-            `)}
-          </div>
-          <button class="colour-reset"
-            @click=${(e) => { e.preventDefault(); this._updateConfig(key, ''); }}
-          >${this._t('common.reset')}</button>
-        </div>
-        <div class="colour-helper">${this._t('common.editor.header_colour_helper')}</div>
-      </div>
-    `;
+    if (!d || !d.colourPicker) return html``;
+    return d.colourPicker({
+      defaultValue, current,
+      label: this._t('common.editor.header_colour'),
+      helper: this._t('common.editor.header_colour_helper'),
+      resetLabel: this._t('common.reset'),
+      onInput: (v) => this._updateConfig(key, v),
+      onPreset: (v) => this._updateConfig(key, v),
+      onReset: () => this._updateConfig(key, defaultValue),
+    });
   }
 
   _formChanged(e) {

--- a/custom_components/taskmate/www/taskmate-reward-progress-card.js
+++ b/custom_components/taskmate/www/taskmate-reward-progress-card.js
@@ -937,35 +937,18 @@ class TaskMateRewardProgressCardEditor extends LitElement {
   }
 
   _renderColourPicker(key, defaultValue) {
+    const d = window.__taskmate_design;
     const current = this.config[key] || defaultValue;
-    const presets = ['#7d3c98', '#e67e22', '#27ae60', '#3498db', '#f1c40f', '#e74c3c', '#34495e'];
-    const isActive = (c) => current && c.toLowerCase() === current.toLowerCase();
-    return html`
-      <div class="colour-field">
-        <span class="colour-field-label">${this._t('common.editor.header_colour')}</span>
-        <div class="colour-field-body">
-          <label class="colour-swatch-wrapper">
-            <input type="color" .value=${current || '#7d3c98'}
-              @input=${(e) => this._update(key, e.target.value)} />
-            <span class="colour-swatch-preview" style="background:${current || '#7d3c98'}"></span>
-          </label>
-          <span class="colour-hex">${current || this._t('common.default')}</span>
-          <div class="colour-presets">
-            ${presets.map((p) => html`
-              <button class="preset-swatch ${isActive(p) ? 'active' : ''}"
-                style="background:${p}"
-                title=${p}
-                @click=${(e) => { e.preventDefault(); this._update(key, p); }}
-              ></button>
-            `)}
-          </div>
-          <button class="colour-reset"
-            @click=${(e) => { e.preventDefault(); this._update(key, ''); }}
-          >${this._t('common.reset')}</button>
-        </div>
-        <div class="colour-helper">${this._t('common.editor.header_colour_helper')}</div>
-      </div>
-    `;
+    if (!d || !d.colourPicker) return html``;
+    return d.colourPicker({
+      defaultValue, current,
+      label: this._t('common.editor.header_colour'),
+      helper: this._t('common.editor.header_colour_helper'),
+      resetLabel: this._t('common.reset'),
+      onInput: (v) => this._update(key, v),
+      onPreset: (v) => this._update(key, v),
+      onReset: () => this._update(key, defaultValue),
+    });
   }
 
   _formChanged(e) {

--- a/custom_components/taskmate/www/taskmate-rewards-card.js
+++ b/custom_components/taskmate/www/taskmate-rewards-card.js
@@ -2332,35 +2332,18 @@ class TaskMateRewardsCardEditor extends LitElement {
   }
 
   _renderColourPicker(key, defaultValue) {
+    const d = window.__taskmate_design;
     const current = this.config[key] || defaultValue;
-    const presets = ['#e67e22', '#27ae60', '#3498db', '#9b59b6', '#f1c40f', '#e74c3c', '#34495e'];
-    const isActive = (c) => c.toLowerCase() === current.toLowerCase();
-    return html`
-      <div class="colour-field">
-        <span class="colour-field-label">${this._t('common.editor.header_colour')}</span>
-        <div class="colour-field-body">
-          <label class="colour-swatch-wrapper">
-            <input type="color" .value=${current}
-              @input=${(e) => this._updateConfig(key, e.target.value)} />
-            <span class="colour-swatch-preview" style="background:${current}"></span>
-          </label>
-          <span class="colour-hex">${current}</span>
-          <div class="colour-presets">
-            ${presets.map((p) => html`
-              <button class="preset-swatch ${isActive(p) ? 'active' : ''}"
-                style="background:${p}"
-                title=${p}
-                @click=${(e) => { e.preventDefault(); this._updateConfig(key, p); }}
-              ></button>
-            `)}
-          </div>
-          <button class="colour-reset"
-            @click=${(e) => { e.preventDefault(); this._updateConfig(key, defaultValue); }}
-          >${this._t('common.reset')}</button>
-        </div>
-        <div class="colour-helper">${this._t('common.editor.header_colour_helper')}</div>
-      </div>
-    `;
+    if (!d || !d.colourPicker) return html``;
+    return d.colourPicker({
+      defaultValue, current,
+      label: this._t('common.editor.header_colour'),
+      helper: this._t('common.editor.header_colour_helper'),
+      resetLabel: this._t('common.reset'),
+      onInput: (v) => this._updateConfig(key, v),
+      onPreset: (v) => this._updateConfig(key, v),
+      onReset: () => this._updateConfig(key, defaultValue),
+    });
   }
 
   _formChanged(e) {

--- a/custom_components/taskmate/www/taskmate-streak-card.js
+++ b/custom_components/taskmate/www/taskmate-streak-card.js
@@ -741,35 +741,18 @@ class TaskMateStreakCardEditor extends LitElement {
   }
 
   _renderColourPicker(key, defaultValue) {
+    const d = window.__taskmate_design;
     const current = this.config[key] || defaultValue;
-    const presets = [defaultValue, '#e67e22', '#27ae60', '#3498db', '#9b59b6', '#f1c40f', '#34495e'];
-    const isActive = (c) => c.toLowerCase() === current.toLowerCase();
-    return html`
-      <div class="colour-field">
-        <span class="colour-field-label">${this._t('common.editor.header_colour')}</span>
-        <div class="colour-field-body">
-          <label class="colour-swatch-wrapper">
-            <input type="color" .value=${current}
-              @input=${(e) => this._updateConfig(key, e.target.value)} />
-            <span class="colour-swatch-preview" style="background:${current}"></span>
-          </label>
-          <span class="colour-hex">${current}</span>
-          <div class="colour-presets">
-            ${presets.map((p) => html`
-              <button class="preset-swatch ${isActive(p) ? 'active' : ''}"
-                style="background:${p}"
-                title=${p}
-                @click=${(e) => { e.preventDefault(); this._updateConfig(key, p); }}
-              ></button>
-            `)}
-          </div>
-          <button class="colour-reset"
-            @click=${(e) => { e.preventDefault(); this._updateConfig(key, defaultValue); }}
-          >${this._t('common.reset')}</button>
-        </div>
-        <div class="colour-helper">${this._t('common.editor.header_colour_helper')}</div>
-      </div>
-    `;
+    if (!d || !d.colourPicker) return html``;
+    return d.colourPicker({
+      defaultValue, current,
+      label: this._t('common.editor.header_colour'),
+      helper: this._t('common.editor.header_colour_helper'),
+      resetLabel: this._t('common.reset'),
+      onInput: (v) => this._updateConfig(key, v),
+      onPreset: (v) => this._updateConfig(key, v),
+      onReset: () => this._updateConfig(key, defaultValue),
+    });
   }
 
   _formChanged(e) {

--- a/custom_components/taskmate/www/taskmate-weekly-card.js
+++ b/custom_components/taskmate/www/taskmate-weekly-card.js
@@ -831,35 +831,18 @@ class TaskMateWeeklyCardEditor extends LitElement {
   }
 
   _renderColourPicker(key, defaultValue) {
+    const d = window.__taskmate_design;
     const current = this.config[key] || defaultValue;
-    const presets = [defaultValue, '#e67e22', '#3498db', '#9b59b6', '#f1c40f', '#e74c3c', '#34495e'];
-    const isActive = (c) => c.toLowerCase() === current.toLowerCase();
-    return html`
-      <div class="colour-field">
-        <span class="colour-field-label">${this._t('common.editor.header_colour')}</span>
-        <div class="colour-field-body">
-          <label class="colour-swatch-wrapper">
-            <input type="color" .value=${current}
-              @input=${(e) => this._updateConfig(key, e.target.value)} />
-            <span class="colour-swatch-preview" style="background:${current}"></span>
-          </label>
-          <span class="colour-hex">${current}</span>
-          <div class="colour-presets">
-            ${presets.map((p) => html`
-              <button class="preset-swatch ${isActive(p) ? 'active' : ''}"
-                style="background:${p}"
-                title=${p}
-                @click=${(e) => { e.preventDefault(); this._updateConfig(key, p); }}
-              ></button>
-            `)}
-          </div>
-          <button class="colour-reset"
-            @click=${(e) => { e.preventDefault(); this._updateConfig(key, defaultValue); }}
-          >${this._t('common.reset')}</button>
-        </div>
-        <div class="colour-helper">${this._t('common.editor.header_colour_helper')}</div>
-      </div>
-    `;
+    if (!d || !d.colourPicker) return html``;
+    return d.colourPicker({
+      defaultValue, current,
+      label: this._t('common.editor.header_colour'),
+      helper: this._t('common.editor.header_colour_helper'),
+      resetLabel: this._t('common.reset'),
+      onInput: (v) => this._updateConfig(key, v),
+      onPreset: (v) => this._updateConfig(key, v),
+      onReset: () => this._updateConfig(key, defaultValue),
+    });
   }
 
   _formChanged(e) {


### PR DESCRIPTION
## QUAL-3 — Extract the header-colour picker to the shared layer

The ~30-line colour-picker editor block (`_renderColourPicker`) was copy-pasted into **17** card editors (~510 lines of duplication).

### Change
- Add `window.__taskmate_design.colourPicker({...})` in `taskmate-design.js` — one faithful copy of the markup (same classes/bindings).
- Each cards `_renderColourPicker(key, defaultValue)` becomes a thin wrapper that delegates to it, passing its **own** update method (`_update` vs `_updateConfig`) via `onInput`/`onPreset`/`onReset`. Call sites unchanged.
- Guarded fallback (`if (!d || !d.colourPicker) return html\`\``) so a not-yet-loaded design layer degrades gracefully rather than crashing.
- Preset palette standardised (the leaderboard cards single differing swatch now uses the common palette — cosmetic).

The small `.colour-*` CSS stays in each editor (component-scoped shadow DOM; deduping it across shadow roots adds risk for little gain).

**Net −252 lines across 17 cards.**

### Verification
`node --check` + ESLint clean across all cards; each card has exactly one (wrapper) `_renderColourPicker` and no stray markup fragments. Served `taskmate-design.js` exposes `colourPicker` and cards call it (verified on ha-dev). Editor-only change with a safe fallback.

Part of the v4.3.1 audit fix campaign. No version bump / release.