### PR TITLE
chore(release): bump manifest to v4.4.0

### DIFF
--- a/custom_components/taskmate/manifest.json
+++ b/custom_components/taskmate/manifest.json
@@ -17,5 +17,5 @@
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/tempus2016/taskmate/issues",
   "requirements": [],
-  "version": "4.3.1"
+  "version": "4.4.0"
 }


### PR DESCRIPTION
Version bump for the **v4.4.0** release.

This rolls up the entire AUDIT_REPORT.md remediation + feature campaign merged since v4.3.1 (PRs #583–#631): all High/Medium security & correctness fixes, the perf/refactor passes, CI tooling, and 14 new features (FEAT-1…FEAT-14).

Manifest only — all functional changes already landed in their own PRs. Smoke-tested on the dev HA instance: integration loads clean, new services + `number`/`select`/`todo` surfaces register, refactored incentive cards serve correctly.

Full notes go on the GitHub release.