### PR TITLE
fix(number): align config-entity defaults with runtime (weekend 2.0, perfect-week 50)

### DIFF
--- a/custom_components/taskmate/number.py
+++ b/custom_components/taskmate/number.py
@@ -18,8 +18,8 @@ from .coordinator import TaskMateCoordinator
 
 # (setting_key, translation_key, min, max, step, default, icon)
 _NUMBERS = [
-    ("weekend_multiplier", "weekend_multiplier", 1.0, 5.0, 0.5, 1.0, "mdi:calendar-weekend"),
-    ("perfect_week_bonus", "perfect_week_bonus", 0, 1000, 1, 0, "mdi:trophy-award"),
+    ("weekend_multiplier", "weekend_multiplier", 1.0, 5.0, 0.5, 2.0, "mdi:calendar-weekend"),
+    ("perfect_week_bonus", "perfect_week_bonus", 0, 1000, 1, 50, "mdi:trophy-award"),
 ]
 
 


### PR DESCRIPTION
The `number` platform defaulted `weekend_multiplier` to **1.0** and `perfect_week_bonus` to **0**, but the bonus logic (`coord_points.py`, `sensor.py`) falls back to **2.0** and **50** when the setting is unset. On a fresh install the entities showed values that did not match what was actually applied (e.g. `number.taskmate_weekend_multiplier` read 1.0 while weekends still paid 2×).

This aligns the entity defaults with the runtime defaults. No behaviour change once a value has been set; only the unset/reset default is corrected. Wiki Configuration-Entities page updated to match.