### PR TITLE
chore(release): v4.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1434,6 +1434,13 @@ Beyond the sensors above, TaskMate also exposes:
  
 ## Changelog
  
+### v4.4.1
+ 
+**Fixes**
+- **Photo-proof upload no longer fails on long sessions** — the child card's photo upload sent a manually-cached access token that expires after ~30 min, so an aged session got a `401` shown as the misleading *"Upload failed. Check your connection."* It now refreshes the token when expired and retries once on a `401`. ([#636](https://github.com/tempus2016/taskmate/pull/636))
+- **No more `taskmate-panel` "already defined" console error after upgrades** — guarded the panel's `customElements.define()` so a browser briefly holding both the old and new panel module (different `?v=` cache-busters) no longer throws an uncaught error. ([#636](https://github.com/tempus2016/taskmate/pull/636))
+- **Config-entity defaults now match the applied bonus** — the `weekend_multiplier` and `perfect_week_bonus` number entities defaulted to `1.0`/`0`, but the bonus logic falls back to `2.0`/`50` when unset, so a fresh install displayed values that didn't match what was actually applied. Defaults aligned. ([#635](https://github.com/tempus2016/taskmate/pull/635))
+ 
 ### v4.4.0
  
 **New features**

--- a/custom_components/taskmate/manifest.json
+++ b/custom_components/taskmate/manifest.json
@@ -17,5 +17,5 @@
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/tempus2016/taskmate/issues",
   "requirements": [],
-  "version": "4.4.0"
+  "version": "4.4.1"
 }


### PR DESCRIPTION
## v4.4.1 — bug-fix release

Bumps `manifest.json` to 4.4.1 and documents the fixes below.

### Fixes
- **Photo-proof upload 401 on long sessions** (#636) — token refresh + single retry.
- **`taskmate-panel` "already defined" console error after upgrades** (#636) — guarded `customElements.define()`.
- **Config-entity defaults aligned with runtime** (#635) — `weekend_multiplier` 1.0→2.0, `perfect_week_bonus` 0→50.

No feature changes; no breaking changes. Verified on the dev HA instance.