### PR TITLE
chore(ci): correct pinned-action version comments

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Apply path labels
-        uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v5 2026-06-23
+        uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6.1.0 2026-06-27
         with:
           configuration-path: .github/labeler.yml
           sync-labels: true

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6 2026-06-17
 
       - name: Apply labels
-        uses: crazy-max/ghaction-github-labeler@548a7c3603594ec17c819e1239f281a3b801ab4d # v5 2026-06-23
+        uses: crazy-max/ghaction-github-labeler@548a7c3603594ec17c819e1239f281a3b801ab4d # v6.0.0 2026-06-27
         with:
           yaml_file: .github/labels.yml
           # Never delete labels not listed in labels.yml — create/update only.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6 2026-06-17
 
       - name: Set up Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6 2026-06-17
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0 2026-06-27
         with:
           python-version: "3.12"
 

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,7 +12,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v9 2026-06-23
+      - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10.3.0 2026-06-27
         with:
           # Only chase issues that are explicitly waiting on the reporter for
           # information — never sweep the whole tracker.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6 2026-06-17
 
       - name: Set up Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6 2026-06-17
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0 2026-06-27
         with:
           python-version: "3.12"
 


### PR DESCRIPTION
Comment-only cleanup. Dependabot (#608–#612) updated the action SHAs but left the human-written `# vN` annotations stale, so the workflows read misleadingly (e.g. a v6.1.0 SHA labelled `# v5`). This corrects the four comments to match the actual pinned versions. **No SHA changes, no behaviour change.**

- `actions/labeler` `# v5` → `# v6.1.0`
- `crazy-max/ghaction-github-labeler` `# v5` → `# v6.0.0`
- `actions/stale` `# v9` → `# v10.3.0`
- `actions/setup-python` `# v6` → `# v6.3.0` (lint.yml + tests.yml)