### PR TITLE
fix(services): allocate_points_to_pool crash — use storage.get_children() (#641)

### DIFF
--- a/custom_components/taskmate/__init__.py
+++ b/custom_components/taskmate/__init__.py
@@ -384,7 +384,7 @@ async def _async_require_linked_child(
     # Target child is unlinked (kiosk). A user who is themselves linked to a
     # *different* child must not act through an unlinked child (SEC-4); truly
     # unlinked/anonymous callers keep the open kiosk behaviour.
-    others = coordinator.get_children() or []
+    others = coordinator.storage.get_children() or []
     if any(getattr(c, "linked_user_id", "") == user_id for c in others):
         raise Unauthorized(context=call.context)
 

--- a/tests/test_service_linked_child_gate.py
+++ b/tests/test_service_linked_child_gate.py
@@ -34,7 +34,10 @@ def _coordinator(linked_user_id, others=None):
         coord.get_child.return_value = None
     else:
         coord.get_child.return_value = MagicMock(linked_user_id=linked_user_id)
-    coord.get_children.return_value = others or []
+    # The guard reads the full roster via coordinator.storage.get_children();
+    # mirror that exact path so a regression to a non-existent coordinator
+    # method (issue #641) is caught here rather than only at runtime.
+    coord.storage.get_children.return_value = others or []
     return coord
 
 


### PR DESCRIPTION
## Summary

Fixes the crash reported in #641:

> `Failed to allocate_points_to_pool: 'TaskMateCoordinator' object has no attribute 'get_children'`

## Root cause

The SEC-4 kiosk cross-child guard `_async_require_linked_child` (in `__init__.py`) called `coordinator.get_children()`. That method does not exist on the coordinator — it lives on `coordinator.storage`. Every other call site in the codebase already uses `storage.get_children()`. The guard runs on `allocate_points_to_pool` (and the other open child services) whenever the caller is a non-admin user targeting an **unlinked** child, so a Rewards Card deposit from a non-admin/kiosk session hit the missing attribute and 500-ed.

Introduced in 8aee631 (SEC-4).

## Why tests did not catch it

`test_service_linked_child_gate.py` built its coordinator as a bare `MagicMock`, which **auto-creates** any attribute accessed — so `coordinator.get_children()` silently "worked" in tests while failing in production. The mock has been pointed at `coordinator.storage.get_children()` to mirror the real call path; reverting the production fix now makes the SEC-4 test fail (the auto-mock returns a non-iterable), so the regression is caught here next time.

## Changes

- `custom_components/taskmate/__init__.py` — `coordinator.get_children()` → `coordinator.storage.get_children()` (one line).
- `tests/test_service_linked_child_gate.py` — mock now stubs `coordinator.storage.get_children` (the real path). Red→green verified.

## Verification

- `pytest tests/test_service_linked_child_gate.py` — RED with the corrected mock before the fix, GREEN after.
- Full service/reward suite (72 tests) passes; `ruff` clean.
- On the dev HA instance the guard path was confirmed live for linked children; the exact non-admin/unlinked crash path could not be driven over REST because the dev non-admin test token is expired (HA rejects it at the HTTP layer before the guard). The unit test reproduces the failing path precisely.

No version bump / release included (per the no-release-without-asking rule).