### PR TITLE
chore(release): bump version to 4.4.2

### DIFF
--- a/custom_components/taskmate/manifest.json
+++ b/custom_components/taskmate/manifest.json
@@ -17,5 +17,5 @@
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/tempus2016/taskmate/issues",
   "requirements": [],
-  "version": "4.4.1"
+  "version": "4.4.2"
 }


### PR DESCRIPTION
Version bump for the v4.4.2 patch release.

Includes #642 (fixes #641 — allocate_points_to_pool crash).