### PR TITLE
feat(cards): add getEntitySuggestion for HA 2026.6 card-picker suggestions

### DIFF
--- a/custom_components/taskmate/www/taskmate-activity-card.js
+++ b/custom_components/taskmate/www/taskmate-activity-card.js
@@ -1327,6 +1327,8 @@ window.customCards.push({
   name: "TaskMate Activity Feed",
   description: "Timeline of recent chore completions and reward claims",
   preview: true,
+  getEntitySuggestion: (hass, entityId) =>
+    window.__taskmate_suggest(hass, entityId, "taskmate-activity-card", "overview"),
 });
 
 // Version is injected by the HA resource URL (?v=x.x.x) and read from the DOM

--- a/custom_components/taskmate/www/taskmate-approvals-card.js
+++ b/custom_components/taskmate/www/taskmate-approvals-card.js
@@ -1491,6 +1491,8 @@ window.customCards.push({
   name: "TaskMate Approvals",
   description: "A card to manage pending chore approvals for TaskMate",
   preview: true,
+  getEntitySuggestion: (hass, entityId) =>
+    window.__taskmate_suggest(hass, entityId, "taskmate-approvals-card", "overview"),
 });
 
 // Version is injected by the HA resource URL (?v=x.x.x) and read from the DOM

--- a/custom_components/taskmate/www/taskmate-badges-card.js
+++ b/custom_components/taskmate/www/taskmate-badges-card.js
@@ -763,6 +763,8 @@ window.customCards.push({
   name: "TaskMate Badges",
   description: "Achievement badge grid for a single child",
   preview: true,
+  getEntitySuggestion: (hass, entityId) =>
+    window.__taskmate_suggest(hass, entityId, "taskmate-badges-card", "overview"),
 });
 
 const _tmBadgesVersion = new URLSearchParams(

--- a/custom_components/taskmate/www/taskmate-calendar-card.js
+++ b/custom_components/taskmate/www/taskmate-calendar-card.js
@@ -908,6 +908,8 @@ window.customCards.push({
   name: "TaskMate Calendar",
   description: "One-day view of chores assigned to each child",
   preview: true,
+  getEntitySuggestion: (hass, entityId) =>
+    window.__taskmate_suggest(hass, entityId, "taskmate-calendar-card", "overview"),
 });
 
 const _tmVersion = new URLSearchParams(

--- a/custom_components/taskmate/www/taskmate-child-card.js
+++ b/custom_components/taskmate/www/taskmate-child-card.js
@@ -4191,6 +4191,8 @@ window.customCards.push({
   name: "TaskMate Child Card",
   description: "A fun, kid-friendly card for children to complete their chores!",
   preview: true,
+  getEntitySuggestion: (hass, entityId) =>
+    window.__taskmate_suggest(hass, entityId, "taskmate-child-card", "overview"),
 });
 
 // Version is injected by the HA resource URL (?v=x.x.x) and read from the DOM

--- a/custom_components/taskmate/www/taskmate-design.js
+++ b/custom_components/taskmate/www/taskmate-design.js
@@ -280,4 +280,38 @@
   }
 
   window.__taskmate_design = { IDS, resolve, isDark, apply, editorOptions, styles, cssText, tokensCSS: TOKENS, colourPicker };
+
+  // ── Card-picker entity suggestions (HA 2026.6+) ────────────────────────────
+  // Custom cards may add getEntitySuggestion(hass, entityId) to their
+  // window.customCards entry; when a user picks an entity in the card picker,
+  // HA shows matching cards in a "Community" section. This shared helper lets
+  // every TaskMate card opt in with a one-liner. We identify a TaskMate sensor
+  // by its attribute SIGNATURE rather than its entity_id, so suggestions still
+  // work after an entity_id rename and across multi-instance setups (e.g.
+  // sensor.taskmate_overview_2). getEntitySuggestion runs at pick-time, by
+  // which point every card module (and getStubConfig) is defined — so reading
+  // this global from a card's registration closure is load-order safe.
+  //
+  //   role "overview" — the hub sensor (sensor.taskmate_overview): carries
+  //                     points_name + the children[] summary. Almost every card
+  //                     reads from it.
+  //   role "activity" — the activity sensor (sensor.taskmate_activity):
+  //                     recent_completions[] + photo_gallery. Used by the photo
+  //                     gallery card.
+  window.__taskmate_suggest = window.__taskmate_suggest || function (hass, entityId, type, role) {
+    if (!entityId || typeof entityId !== "string" || !entityId.startsWith("sensor.")) return null;
+    const a = hass && hass.states && hass.states[entityId] && hass.states[entityId].attributes;
+    if (!a) return null;
+    const isOverview = a.points_name !== undefined && Array.isArray(a.children);
+    const isActivity = Array.isArray(a.recent_completions) && a.photo_gallery !== undefined;
+    if (!(role === "activity" ? isActivity : isOverview)) return null;
+    // Mirror the card's own stub defaults (mode/title/days/…) so a suggested
+    // card lands configured exactly as if added manually, just on this entity.
+    let stub = {};
+    try {
+      const el = customElements.get(type);
+      if (el && typeof el.getStubConfig === "function") stub = el.getStubConfig() || {};
+    } catch (e) { stub = {}; }
+    return { config: Object.assign({}, stub, { type: "custom:" + type, entity: entityId }) };
+  };
 })();

--- a/custom_components/taskmate/www/taskmate-family-goal-card.js
+++ b/custom_components/taskmate/www/taskmate-family-goal-card.js
@@ -105,4 +105,6 @@ window.customCards.push({
   name: "TaskMate Family Goal",
   description: "Shared family goal progress toward a combined points target",
   preview: true,
+  getEntitySuggestion: (hass, entityId) =>
+    window.__taskmate_suggest(hass, entityId, "taskmate-family-goal-card", "overview"),
 });

--- a/custom_components/taskmate/www/taskmate-graph-card.js
+++ b/custom_components/taskmate/www/taskmate-graph-card.js
@@ -1078,6 +1078,8 @@ window.customCards.push({
   name: "TaskMate Points Graph",
   description: "Line graph tracking daily or cumulative points over time",
   preview: true,
+  getEntitySuggestion: (hass, entityId) =>
+    window.__taskmate_suggest(hass, entityId, "taskmate-graph-card", "overview"),
 });
 
 // Version is injected by the HA resource URL (?v=x.x.x) and read from the DOM

--- a/custom_components/taskmate/www/taskmate-incentive-card.js
+++ b/custom_components/taskmate/www/taskmate-incentive-card.js
@@ -1128,7 +1128,11 @@ export function createIncentiveCard(P) {
   customElements.define(P.tag, IncentiveCard);
   customElements.define(P.tag + "-editor", IncentiveCardEditor);
   window.customCards = window.customCards || [];
-  window.customCards.push({ type: P.tag, name: P.cardName, description: P.cardDesc, preview: true });
+  window.customCards.push({
+    type: P.tag, name: P.cardName, description: P.cardDesc, preview: true,
+    getEntitySuggestion: (hass, entityId) =>
+      window.__taskmate_suggest(hass, entityId, P.tag, "overview"),
+  });
   console.info("%c TASKMATE " + P.bannerName + " CARD ",
     "background:" + P.bannerColor + ";color:white;font-weight:bold;padding:2px 4px;border-radius:4px;");
 }

--- a/custom_components/taskmate/www/taskmate-leaderboard-card.js
+++ b/custom_components/taskmate/www/taskmate-leaderboard-card.js
@@ -919,6 +919,8 @@ window.customCards.push({
   name: "TaskMate Leaderboard",
   description: "Multi-child competitive ranking by points, streak, or weekly activity",
   preview: true,
+  getEntitySuggestion: (hass, entityId) =>
+    window.__taskmate_suggest(hass, entityId, "taskmate-leaderboard-card", "overview"),
 });
 
 // Version is injected by the HA resource URL (?v=x.x.x) and read from the DOM

--- a/custom_components/taskmate/www/taskmate-overview-card.js
+++ b/custom_components/taskmate/www/taskmate-overview-card.js
@@ -980,6 +980,8 @@ window.customCards.push({
   name: "TaskMate Overview",
   description: "At-a-glance parent dashboard for all children",
   preview: true,
+  getEntitySuggestion: (hass, entityId) =>
+    window.__taskmate_suggest(hass, entityId, "taskmate-overview-card", "overview"),
 });
 
 // Version is injected by the HA resource URL (?v=x.x.x) and read from the DOM

--- a/custom_components/taskmate/www/taskmate-parent-dashboard-card.js
+++ b/custom_components/taskmate/www/taskmate-parent-dashboard-card.js
@@ -1475,6 +1475,8 @@ window.customCards.push({
   name: "TaskMate Parent Dashboard",
   description: "Unified parent view with approvals, child progress, and quick point controls",
   preview: true,
+  getEntitySuggestion: (hass, entityId) =>
+    window.__taskmate_suggest(hass, entityId, "taskmate-parent-dashboard-card", "overview"),
 });
 
 // Version is injected by the HA resource URL (?v=x.x.x) and read from the DOM

--- a/custom_components/taskmate/www/taskmate-photo-gallery-card.js
+++ b/custom_components/taskmate/www/taskmate-photo-gallery-card.js
@@ -157,4 +157,6 @@ window.customCards.push({
   name: "TaskMate Photo Gallery",
   description: "History grid of chore-evidence photos",
   preview: true,
+  getEntitySuggestion: (hass, entityId) =>
+    window.__taskmate_suggest(hass, entityId, "taskmate-photo-gallery-card", "activity"),
 });

--- a/custom_components/taskmate/www/taskmate-points-card.js
+++ b/custom_components/taskmate/www/taskmate-points-card.js
@@ -1389,6 +1389,8 @@ window.customCards.push({
   name: "TaskMate Points Card",
   description: "A parent-friendly card to add or remove points from children",
   preview: true,
+  getEntitySuggestion: (hass, entityId) =>
+    window.__taskmate_suggest(hass, entityId, "taskmate-points-card", "overview"),
 });
 
 // Version is injected by the HA resource URL (?v=x.x.x) and read from the DOM

--- a/custom_components/taskmate/www/taskmate-points-display-card.js
+++ b/custom_components/taskmate/www/taskmate-points-display-card.js
@@ -1243,6 +1243,8 @@ window.customCards.push({
   description: "Kid-friendly display of points. Supports single child, all children, or combined family total.",
   preview:     true,
   configElement: "taskmate-points-display-card-editor",
+  getEntitySuggestion: (hass, entityId) =>
+    window.__taskmate_suggest(hass, entityId, "taskmate-points-display-card", "overview"),
 });
 
 // Version is injected by the HA resource URL (?v=x.x.x) and read from the DOM

--- a/custom_components/taskmate/www/taskmate-reorder-card.js
+++ b/custom_components/taskmate/www/taskmate-reorder-card.js
@@ -1309,6 +1309,8 @@ window.customCards.push({
   name: "TaskMate Reorder Card",
   description: "A card for reordering chores per child, organized by time category",
   preview: true,
+  getEntitySuggestion: (hass, entityId) =>
+    window.__taskmate_suggest(hass, entityId, "taskmate-reorder-card", "overview"),
 });
 
 // Version is injected by the HA resource URL (?v=x.x.x) and read from the DOM

--- a/custom_components/taskmate/www/taskmate-reward-progress-card.js
+++ b/custom_components/taskmate/www/taskmate-reward-progress-card.js
@@ -980,6 +980,8 @@ window.customCards.push({
   name: "TaskMate Reward Progress",
   description: "Full-screen motivational reward progress display",
   preview: true,
+  getEntitySuggestion: (hass, entityId) =>
+    window.__taskmate_suggest(hass, entityId, "taskmate-reward-progress-card", "overview"),
 });
 
 // Version is injected by the HA resource URL (?v=x.x.x) and read from the DOM

--- a/custom_components/taskmate/www/taskmate-rewards-card.js
+++ b/custom_components/taskmate/www/taskmate-rewards-card.js
@@ -2403,6 +2403,8 @@ window.customCards.push({
   name: "TaskMate Rewards Card",
   description: "A card displaying available rewards with star costs",
   preview: true,
+  getEntitySuggestion: (hass, entityId) =>
+    window.__taskmate_suggest(hass, entityId, "taskmate-rewards-card", "overview"),
 });
 
 // Version is injected by the HA resource URL (?v=x.x.x) and read from the DOM

--- a/custom_components/taskmate/www/taskmate-streak-card.js
+++ b/custom_components/taskmate/www/taskmate-streak-card.js
@@ -795,6 +795,8 @@ window.customCards.push({
   name: "TaskMate Streaks & Achievements",
   description: "Consecutive day streaks and milestone badges for each child",
   preview: true,
+  getEntitySuggestion: (hass, entityId) =>
+    window.__taskmate_suggest(hass, entityId, "taskmate-streak-card", "overview"),
 });
 
 // Version is injected by the HA resource URL (?v=x.x.x) and read from the DOM

--- a/custom_components/taskmate/www/taskmate-weekly-card.js
+++ b/custom_components/taskmate/www/taskmate-weekly-card.js
@@ -882,6 +882,8 @@ window.customCards.push({
   name: "TaskMate Weekly Summary",
   description: "Week at a glance — chores, points, and daily bar chart",
   preview: true,
+  getEntitySuggestion: (hass, entityId) =>
+    window.__taskmate_suggest(hass, entityId, "taskmate-weekly-card", "overview"),
 });
 
 // Version is injected by the HA resource URL (?v=x.x.x) and read from the DOM


### PR DESCRIPTION
Implements [custom card suggestions](https://developers.home-assistant.io/blog/2026/05/27/custom-card-suggestions) (HA 2026.6+). When a user selects a TaskMate sensor in the card picker, matching TaskMate cards now appear in the **Community** section.

## How it works
- New shared helper `window.__taskmate_suggest(hass, entityId, type, role)` in `taskmate-design.js` (loaded early + globally).
- Identifies a TaskMate sensor by its **attribute signature**, not its `entity_id`, so suggestions survive entity renames and multi-instance setups (`sensor.taskmate_overview_2`):
  - `role "overview"` → hub sensor (`points_name` + `children[]`)
  - `role "activity"` → activity sensor (`recent_completions[]` + `photo_gallery`)
- Mirrors each card`s own `getStubConfig()` defaults, so a suggested card lands configured exactly as if added manually — just bound to the picked entity.
- Every card type opts in with a one-liner; the incentive factory covers penalties & bonuses. Photo Gallery uses `activity`, all others `overview`.
- Degrades gracefully on HA < 2026.6 (the extra key is ignored).

## Verification (real HA 2026.6.4 frontend, via browserless)
| Selected entity | Cards suggested |
|---|---|
| `sensor.taskmate_overview` | 19 (all overview cards, correct config + stub defaults) |
| `sensor.taskmate_activity` | 1 (Photo Gallery) |
| unrelated `sensor.*` | 0 |

All 20 card types loaded with no import/page errors, all expose `getEntitySuggestion`, none threw. All JS files parse as ES modules; helper passed node unit tests incl. edge cases.

No new user-facing strings (HA uses each card`s existing `name` in the picker), so no translations needed.