### PR TITLE
chore: remove internal-tooling refs from tracked .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@ __pycache__/
 .pytest_cache/
 .ruff_cache/
 .tmp/
-.claude/
 
 # Dev environment - generated files
 dev/config/.storage/auth
@@ -39,7 +38,3 @@ scripts/screenshots/
 
 # Node / JS tooling (CI-3)
 node_modules/
-
-# Internal audit artifacts — never commit
-AUDIT_PROMPT.md
-AUDIT_REPORT.md


### PR DESCRIPTION
Removes references to internal-only tooling from the tracked `.gitignore`:

- `.claude/`
- `AUDIT_PROMPT.md`
- `AUDIT_REPORT.md` (and the "Internal audit artifacts" comment)

These files must stay ignored locally, but listing them in a committed `.gitignore` advertised their existence in the published repo. They are now ignored via `.git/info/exclude` (local, never committed) instead, so the public repo carries no trace of them.

No functional change.