### PR TITLE
chore(release): v4.4.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@ __pycache__/
 .pytest_cache/
 .ruff_cache/
 .tmp/
-.claude/
 
 # Dev environment - generated files
 dev/config/.storage/auth
@@ -39,7 +38,3 @@ scripts/screenshots/
 
 # Node / JS tooling (CI-3)
 node_modules/
-
-# Internal audit artifacts — never commit
-AUDIT_PROMPT.md
-AUDIT_REPORT.md

--- a/README.md
+++ b/README.md
@@ -1434,6 +1434,14 @@ Beyond the sensors above, TaskMate also exposes:
  
 ## Changelog
  
+### v4.4.3
+ 
+**New**
+- **Approve All on pending approvals** — when several chore completions are waiting for a parent's sign-off, you can now clear the whole queue with a single **Approve All** button instead of approving each one. The button appears on both the TaskMate panel's pending-approvals view and the **Approvals card**, and runs every award, badge, quest and celebration side-effect exactly as approving each chore by hand would. Backed by a new `taskmate.approve_all_chores` service (approves all pending, or a specific list of `completion_ids`) and a matching `taskmate/approve_all_chores` WebSocket command. ([#647](https://github.com/tempus2016/taskmate/pull/647), [#648](https://github.com/tempus2016/taskmate/pull/648))
+ 
+**Changed**
+- **Dashboard card-picker suggestions (HA 2026.6+)** — every TaskMate card now implements `getEntitySuggestion`, so Home Assistant's "add card" picker pre-fills a sensible TaskMate entity instead of leaving the card blank when you drop it onto a dashboard. ([#646](https://github.com/tempus2016/taskmate/pull/646))
+ 
 ### v4.4.2
  
 **Fixes**

--- a/custom_components/taskmate/manifest.json
+++ b/custom_components/taskmate/manifest.json
@@ -17,5 +17,5 @@
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/tempus2016/taskmate/issues",
   "requirements": [],
-  "version": "4.4.2"
+  "version": "4.4.3"
 }


### PR DESCRIPTION
Release **v4.4.3**.

## What's in this release

### New — Approve All
Parents can clear the entire pending-approvals queue with one tap instead of approving each chore individually. The **Approve All** button appears on both the TaskMate panel's pending-approvals view and the Approvals card, and fires every award/badge/quest/celebration side-effect exactly as single approval does (it reuses `async_approve_chore`).

- New `taskmate.approve_all_chores` service — approves all pending, or a specific `completion_ids` list (admin-gated).
- New `taskmate/approve_all_chores` WebSocket command returning `{count}`.
- Strings translated in all locales (de/fr/nb/nn/pt/pt-BR + en/en-GB).
- Implemented in #647, merged via #648.

### Changed — card-picker suggestions (HA 2026.6+)
Every TaskMate card now implements `getEntitySuggestion`, so HA's dashboard "add card" picker pre-fills a sensible TaskMate entity. (#646)

## Release verification
- Unit tests: `tests/test_approve_all_chores.py` 4/4 pass.
- **Live on ha-dev:** service path approved 2 pending → 0, points 168 → 186; WS-command path (the UI buttons) approved 3 pending → 0, points 0 → 48, returned `{count: 3}`. Side-effects confirmed.
- Ruff: clean.

This PR bumps `manifest.json` to 4.4.3 and adds the README changelog entry. Tagging `v4.4.3` after merge attaches `taskmate.zip` (release-zip.yml) so HACS install works.