### PR TITLE
feat(cards): in-page lightbox for chore evidence photos

### DIFF
--- a/custom_components/taskmate/www/locales/de.json
+++ b/custom_components/taskmate/www/locales/de.json
@@ -282,6 +282,7 @@
   "common.approve": "Genehmigen",
   "common.approved": "Genehmigt",
   "common.cancel": "Stornieren",
+  "common.close": "Schließen",
   "common.chores": "Hausarbeiten",
   "common.d_streak": "{count}d Serie",
   "common.day_streak": "Tagessträhne",

--- a/custom_components/taskmate/www/locales/en-GB.json
+++ b/custom_components/taskmate/www/locales/en-GB.json
@@ -284,6 +284,7 @@
   "common.approve": "Approve",
   "common.approved": "Approved",
   "common.cancel": "Cancel",
+  "common.close": "Close",
   "common.chores": "Chores",
   "common.complete_on_behalf": "Complete",
   "common.complete_on_behalf_all_done": "All chores done today",

--- a/custom_components/taskmate/www/locales/en.json
+++ b/custom_components/taskmate/www/locales/en.json
@@ -284,6 +284,7 @@
   "common.approve": "Approve",
   "common.approved": "Approved",
   "common.cancel": "Cancel",
+  "common.close": "Close",
   "common.chores": "Chores",
   "common.complete_on_behalf": "Complete",
   "common.complete_on_behalf_all_done": "All chores done today",

--- a/custom_components/taskmate/www/locales/fr.json
+++ b/custom_components/taskmate/www/locales/fr.json
@@ -282,6 +282,7 @@
   "common.approve": "Approuver",
   "common.approved": "Approuvé",
   "common.cancel": "Annuler",
+  "common.close": "Fermer",
   "common.chores": "Tâches",
   "common.d_streak": "série de {count} j",
   "common.day_streak": "jours de suite",

--- a/custom_components/taskmate/www/locales/nb.json
+++ b/custom_components/taskmate/www/locales/nb.json
@@ -282,6 +282,7 @@
   "common.approve": "Godkjenn",
   "common.approved": "Godkjent",
   "common.cancel": "Avbryt",
+  "common.close": "Lukk",
   "common.chores": "Oppgaver",
   "common.d_streak": "{count}d rekke",
   "common.day_streak": "dagers rekke",

--- a/custom_components/taskmate/www/locales/nn.json
+++ b/custom_components/taskmate/www/locales/nn.json
@@ -282,6 +282,7 @@
   "common.approve": "Godkjenn",
   "common.approved": "Godkjend",
   "common.cancel": "Avbryt",
+  "common.close": "Lukk",
   "common.chores": "Oppgåver",
   "common.d_streak": "{count}d rekke",
   "common.day_streak": "dagars rekke",

--- a/custom_components/taskmate/www/locales/pt-BR.json
+++ b/custom_components/taskmate/www/locales/pt-BR.json
@@ -282,6 +282,7 @@
   "common.approve": "Aprovar",
   "common.approved": "Aprovado",
   "common.cancel": "Cancelar",
+  "common.close": "Fechar",
   "common.chores": "Tarefas",
   "common.d_streak": "{count} dias seguidos",
   "common.day_streak": "dias seguidos",

--- a/custom_components/taskmate/www/locales/pt.json
+++ b/custom_components/taskmate/www/locales/pt.json
@@ -282,6 +282,7 @@
   "common.approve": "Aprovar",
   "common.approved": "Aprovado",
   "common.cancel": "Cancelar",
+  "common.close": "Fechar",
   "common.chores": "Tarefas",
   "common.complete_on_behalf": "Concluir",
   "common.complete_on_behalf_all_done": "Todas as tarefas concluídas hoje",

--- a/custom_components/taskmate/www/taskmate-approvals-card.js
+++ b/custom_components/taskmate/www/taskmate-approvals-card.js
@@ -791,8 +791,30 @@ class TaskMateApprovalsCard extends LitElement {
         ? html`<div class="${cls}"><ha-icon icon="${it.icon}"></ha-icon></div>`
         : "";
     }
+    const cap = this._photoCaption(it.title, it.childName, it.completedAt);
     return html`<a class="ap-d-photo-link" href="${photoUrl}" target="_blank" rel="noopener"
+      @click="${(e) => this._openPhoto(e, photoUrl, cap)}"
       title="${this._t('approvals.view_photo') || 'View photo'}"><div class="${cls}"><img src="${photoUrl}" alt=""></div></a>`;
+  }
+
+  // Build "Chore · Child · date" for the lightbox caption from whatever row
+  // fields are present (any missing part is dropped).
+  _photoCaption(chore, child, iso) {
+    let when = "";
+    if (iso) {
+      const d = new Date(iso);
+      if (!isNaN(d)) when = d.toLocaleString([], { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" });
+    }
+    return [chore, child, when].filter(Boolean).join(" · ");
+  }
+
+  // Open the shared in-page lightbox; fall through to the href (new tab) if the
+  // shared design layer somehow isn't loaded.
+  _openPhoto(e, url, caption) {
+    if (window.__taskmate_lightbox) {
+      e.preventDefault();
+      window.__taskmate_lightbox(url, caption, this._t("common.close"));
+    }
   }
 
   _apPlayroom(it, i) {
@@ -1294,6 +1316,7 @@ class TaskMateApprovalsCard extends LitElement {
           </div>
           ${tmSafePhotoUrl(completion.photo_url) ? html`
             <a class="approval-photo" href="${tmSafePhotoUrl(completion.photo_url)}" target="_blank" rel="noopener"
+               @click="${(e) => this._openPhoto(e, tmSafePhotoUrl(completion.photo_url), this._photoCaption(completion.chore_name, completion.child_name, completion.completed_at))}"
                title="${this._t('approvals.view_photo') || 'View photo'}">
               <img src="${tmSafePhotoUrl(completion.photo_url)}" alt="" loading="lazy">
             </a>

--- a/custom_components/taskmate/www/taskmate-design.js
+++ b/custom_components/taskmate/www/taskmate-design.js
@@ -314,4 +314,81 @@
     } catch (e) { stub = {}; }
     return { config: Object.assign({}, stub, { type: "custom:" + type, entity: entityId }) };
   };
+
+  // ── Chore-photo lightbox ───────────────────────────────────────────────────
+  // A single shared, design-AGNOSTIC image viewer for evidence photos. It is
+  // mounted on document.body (NOT inside any card's shadow root), so it paints
+  // above every card, the admin panel, and HA's own stacking contexts no matter
+  // how deeply the trigger is nested or whether an ancestor clips overflow.
+  // Callers pass an ALREADY safety-checked URL (tmSafePhotoUrl/_safePhotoUrl),
+  // an optional caption string, and an optional localised close label. Closes on
+  // backdrop click, the ✕ button, or Escape. Deliberately uses no --tmd-* tokens
+  // so it looks right under all four design styles.
+  window.__taskmate_lightbox = window.__taskmate_lightbox || (function () {
+    let overlay = null, imgEl = null, capEl = null, closeBtn = null, lastFocus = null;
+
+    function onKey(e) { if (e.key === "Escape") { e.stopPropagation(); close(); } }
+
+    function close() {
+      if (!overlay) return;
+      overlay.classList.remove("open");
+      document.body.style.overflow = "";
+      document.removeEventListener("keydown", onKey, true);
+      window.setTimeout(() => { if (overlay) overlay.style.display = "none"; if (imgEl) imgEl.src = ""; }, 180);
+      if (lastFocus && typeof lastFocus.focus === "function") { try { lastFocus.focus(); } catch (e) {} }
+      lastFocus = null;
+    }
+
+    function build() {
+      overlay = document.createElement("div");
+      overlay.className = "tm-lightbox";
+      overlay.setAttribute("role", "dialog");
+      overlay.setAttribute("aria-modal", "true");
+      overlay.innerHTML =
+        "<style>" +
+        ".tm-lightbox{position:fixed;inset:0;z-index:2147483000;display:none;flex-direction:column;" +
+        "align-items:center;justify-content:center;gap:14px;box-sizing:border-box;" +
+        "padding:max(16px,env(safe-area-inset-top)) 16px max(16px,env(safe-area-inset-bottom));" +
+        "background:rgba(8,10,14,.86);opacity:0;transition:opacity .18s ease;" +
+        "font-family:'Inter',system-ui,-apple-system,'Segoe UI',sans-serif;}" +
+        ".tm-lightbox.open{opacity:1;}" +
+        ".tm-lightbox img{max-width:92vw;max-height:80vh;object-fit:contain;border-radius:10px;" +
+        "background:#111;box-shadow:0 18px 60px rgba(0,0,0,.6);}" +
+        ".tm-lightbox .tm-lb-cap{color:#f4f6fb;font-size:14px;font-weight:600;text-align:center;" +
+        "max-width:92vw;line-height:1.4;text-shadow:0 1px 2px rgba(0,0,0,.6);}" +
+        ".tm-lightbox .tm-lb-close{position:absolute;top:14px;right:16px;width:42px;height:42px;border:none;" +
+        "border-radius:50%;background:rgba(255,255,255,.14);color:#fff;font-size:22px;line-height:1;" +
+        "cursor:pointer;transition:background .15s;}" +
+        ".tm-lightbox .tm-lb-close:hover{background:rgba(255,255,255,.28);}" +
+        "@media (prefers-reduced-motion:reduce){.tm-lightbox{transition:none;}}" +
+        "</style>" +
+        "<button class=\"tm-lb-close\" type=\"button\">✕</button>" +
+        "<img alt=\"\">" +
+        "<div class=\"tm-lb-cap\"></div>";
+      document.body.appendChild(overlay);
+      imgEl = overlay.querySelector("img");
+      capEl = overlay.querySelector(".tm-lb-cap");
+      closeBtn = overlay.querySelector(".tm-lb-close");
+      closeBtn.addEventListener("click", close);
+      // Only a click on the dimmed backdrop itself (not image/caption/button) closes.
+      overlay.addEventListener("click", (e) => { if (e.target === overlay) close(); });
+    }
+
+    return function (src, caption, closeLabel) {
+      if (!src) return;
+      if (!overlay) build();
+      lastFocus = document.activeElement;
+      imgEl.src = src;
+      if (caption) { capEl.textContent = caption; capEl.style.display = ""; }
+      else { capEl.textContent = ""; capEl.style.display = "none"; }
+      closeBtn.setAttribute("aria-label", closeLabel || "Close");
+      closeBtn.title = closeLabel || "Close";
+      overlay.style.display = "flex";
+      void overlay.offsetWidth; // force reflow so the opacity transition runs from 0
+      overlay.classList.add("open");
+      document.body.style.overflow = "hidden";
+      document.addEventListener("keydown", onKey, true);
+      closeBtn.focus();
+    };
+  })();
 })();

--- a/custom_components/taskmate/www/taskmate-panel.js
+++ b/custom_components/taskmate/www/taskmate-panel.js
@@ -424,6 +424,10 @@ class TaskMatePanel extends HTMLElement {
     if (act === "switch-to-activity") { this._activeTab = "activity"; this._render(); return; }
     if (act === "toggle-ha-menu") { this.dispatchEvent(new CustomEvent("hass-toggle-menu", { bubbles: true, composed: true })); return; }
     if (act === "copy-id") { navigator.clipboard.writeText(t.dataset.id).then(() => this._showToast("ok", this._t("panel.toast_copied"))); return; }
+    if (act === "view-photo") {
+      if (window.__taskmate_lightbox) { e.preventDefault(); window.__taskmate_lightbox(t.dataset.photo, t.dataset.cap, this._t("common.close")); }
+      return;
+    }
 
     // Children
     if (act === "add-child")    { this._openChildDialog(null); return; }
@@ -2511,10 +2515,11 @@ class TaskMatePanel extends HTMLElement {
                   chorePoints = Math.floor(c.timed_duration_seconds / rateSeconds) * (chore.timed_rate_points || 0);
                 }
               }
+              const photoCap = [choreName, (child && child.name) || "", c.completed_at ? new Date(c.completed_at).toLocaleString([], { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" }) : ""].filter(Boolean).join(" · ");
               return `
                 <div class="tm-approval-item">
                   <div class="tm-approval-icon"><ha-icon icon="${c.bonus_subtask_id ? 'mdi:star-plus' : 'mdi:checkbox-marked-circle-outline'}"></ha-icon></div>
-                  ${this._safePhotoUrl(c.photo_url) ? `<a class="tm-approval-photo" href="${this._esc(this._safePhotoUrl(c.photo_url))}" target="_blank" rel="noopener" title="${this._t("panel.activity_view_photo")}"><img src="${this._esc(this._safePhotoUrl(c.photo_url))}" alt="" loading="lazy"></a>` : ""}
+                  ${this._safePhotoUrl(c.photo_url) ? `<a class="tm-approval-photo" href="${this._esc(this._safePhotoUrl(c.photo_url))}" target="_blank" rel="noopener" data-act="view-photo" data-photo="${this._esc(this._safePhotoUrl(c.photo_url))}" data-cap="${this._esc(photoCap)}" title="${this._t("panel.activity_view_photo")}"><img src="${this._esc(this._safePhotoUrl(c.photo_url))}" alt="" loading="lazy"></a>` : ""}
                   <div class="tm-approval-body">
                     <div class="tm-approval-line">${this._t("panel.activity_completed_text", {child: this._esc((child && child.name) || "?"), chore: this._esc(choreName)})}</div>
                     <div class="tm-meta">${this._timeAgo(c.completed_at)} · ${chorePoints} ${this._t("panel.activity_points")}</div>

--- a/custom_components/taskmate/www/taskmate-parent-dashboard-card.js
+++ b/custom_components/taskmate/www/taskmate-parent-dashboard-card.js
@@ -46,6 +46,24 @@ class TaskMateParentDashboardCard extends LitElement {
     return fn ? fn(this.hass, key, params) : key;
   }
 
+  // Build "Chore · Child · date" for the lightbox caption (missing parts drop).
+  _photoCaption(chore, child, iso) {
+    let when = "";
+    if (iso) {
+      const d = new Date(iso);
+      if (!isNaN(d)) when = d.toLocaleString([], { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" });
+    }
+    return [chore, child, when].filter(Boolean).join(" · ");
+  }
+
+  // Open the shared in-page lightbox; fall through to the href if it's absent.
+  _openPhoto(e, url, caption) {
+    if (window.__taskmate_lightbox) {
+      e.preventDefault();
+      window.__taskmate_lightbox(url, caption, this._t("common.close"));
+    }
+  }
+
   constructor() {
     super();
     this._loading = {};
@@ -790,8 +808,10 @@ class TaskMateParentDashboardCard extends LitElement {
         ? new Date(comp.completed_at).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" }) : "";
       const pts = comp.points || choreMap[comp.chore_id]?.points || 0;
       const photoUrl = tmSafePhotoUrl(comp.photo_url);
+      const photoCap = this._photoCaption(comp.chore_name, child && child.name, comp.completed_at);
       const photo = photoUrl
         ? html`<a class="pd-photo-link" href="${photoUrl}" target="_blank" rel="noopener"
+            @click="${(e) => this._openPhoto(e, photoUrl, photoCap)}"
             title="${this._t('approvals.view_photo') || 'View photo'}"><div class="pd-photo"><img src="${photoUrl}" alt=""></div></a>`
         : "";
       const acts = html`
@@ -1122,6 +1142,7 @@ class TaskMateParentDashboardCard extends LitElement {
               </div>
               ${tmSafePhotoUrl(comp.photo_url) ? html`
                 <a class="approval-photo" href="${tmSafePhotoUrl(comp.photo_url)}" target="_blank" rel="noopener"
+                   @click="${(e) => this._openPhoto(e, tmSafePhotoUrl(comp.photo_url), this._photoCaption(comp.chore_name || chore?.name, child && child.name, comp.completed_at))}"
                    title="${this._t('approvals.view_photo') || 'View photo'}">
                   <img src="${tmSafePhotoUrl(comp.photo_url)}" alt="" loading="lazy">
                 </a>

--- a/custom_components/taskmate/www/taskmate-photo-gallery-card.js
+++ b/custom_components/taskmate/www/taskmate-photo-gallery-card.js
@@ -46,6 +46,14 @@ class TaskMatePhotoGalleryCard extends LitElement {
     return fn ? fn(this.hass, key, params) : key;
   }
 
+  // Open the shared in-page lightbox; fall through to the href if it's absent.
+  _openPhoto(e, url, caption) {
+    if (window.__taskmate_lightbox) {
+      e.preventDefault();
+      window.__taskmate_lightbox(url, caption, this._t("common.close"));
+    }
+  }
+
   _gallery() {
     const entity = this.hass && this.hass.states[this.config.entity];
     const items = (entity && entity.attributes && entity.attributes.photo_gallery) || [];
@@ -105,7 +113,8 @@ class TaskMatePhotoGalleryCard extends LitElement {
     return html`
       <div class="tile" title="${it.chore_name} — ${it.child_name}">
         ${src
-          ? html`<a href="${src}" target="_blank" rel="noopener"><img src="${src}" alt="${it.chore_name}" loading="lazy"></a>`
+          ? html`<a href="${src}" target="_blank" rel="noopener"
+              @click="${(e) => this._openPhoto(e, src, [it.chore_name, it.child_name, when].filter(Boolean).join(" · "))}"><img src="${src}" alt="${it.chore_name}" loading="lazy"></a>`
           : html`<div class="ph"><ha-icon icon="mdi:image"></ha-icon></div>`}
         <div class="cap">
           <span class="who">${it.child_name}</span>


### PR DESCRIPTION
## What

Clicking a chore **evidence photo** now opens an in-page **lightbox** instead of jumping to the raw image in a new browser tab.

Applies to every surface that shows evidence photos:
- **Approvals card** (classic + all designed styles)
- **Parent Dashboard card** (classic + designed)
- **TaskMate panel** pending-approvals
- **Photo Gallery card**

## How

- New shared, **design-agnostic** viewer in `taskmate-design.js`: `window.__taskmate_lightbox(src, caption, closeLabel)`. It mounts a single overlay on `document.body` (not inside any card shadow root), so it paints above every card, the panel, and HA's own stacking contexts no matter how deeply nested the trigger is or whether an ancestor clips overflow. Closes on backdrop click, the ✕ button, or **Escape**, and locks body scroll while open. Respects `prefers-reduced-motion`.
- Each surface passes its **already safety-checked** photo URL (reusing `tmSafePhotoUrl` / `_safePhotoUrl` — no new URL-trust surface) and a `Chore · Child · date` caption assembled from fields already on the row. The original `href`/`target="_blank"` is kept as a graceful fallback if the shared layer somehow isn't loaded.
- One new string, `common.close`, translated into all locales (de/fr/nb/nn/pt/pt-BR + en/en-GB).

## Verification

- **Live on ha-dev via browserless**, loading the real shipped `taskmate-design.js`: overlay mounts on `document.body`, `z-index` 2147483000, caption renders, body scroll locks, and **Escape closes it** (scroll restored). Screenshot confirmed visually.
- ESLint: 0 errors (only pre-existing warnings).
- ha-dev served-content checks confirm all four card/panel files carry the new wiring.

No version bump — lands on `main` for the next release to pick up.