### PR TITLE
feat(cards): undo completed bonus sub-tasks by clicking again

### DIFF
--- a/custom_components/taskmate/www/taskmate-child-card.js
+++ b/custom_components/taskmate/www/taskmate-child-card.js
@@ -3301,15 +3301,19 @@ class TaskMateChildCard extends LitElement {
       const isLoading = this._loading[bonusKey];
 
       const handleClick = () => {
-        if (isLoading || bonusDone) return;
-        this._handleCompleteBonusSubtask(chore, subtask, child);
+        if (isLoading) return;
+        if (bonusDone) {
+          this._handleUndoBonusSubtask(chore, subtask, child, todaysCompletions);
+        } else {
+          this._handleCompleteBonusSubtask(chore, subtask, child);
+        }
       };
 
       return html`
         <div
           class="chore-card bonus-subtask ${bonusDone ? 'completed' : ''} ${isLoading ? 'loading' : ''}"
           role="button"
-          tabindex="${bonusDone ? '-1' : '0'}"
+          tabindex="0"
           @click="${handleClick}"
           title="${bonusDone ? this._t('child.click_to_undo') : this._t('child.bonus_tooltip', {name: subtask.name})}"
         >
@@ -3368,6 +3372,66 @@ class TaskMateChildCard extends LitElement {
         this.requestUpdate();
       }
     }, 30000);
+  }
+
+  /**
+   * Undo a completed bonus sub-task (second click on its checkbox). Each
+   * sub-task completion carries its own completion_id, so rejecting it reverses
+   * only that sub-task's points — the parent chore stays done. Mirrors the
+   * parent-only admin gate and reject_chore path used by _handleUndo.
+   */
+  async _handleUndoBonusSubtask(chore, subtask, child, todaysCompletions) {
+    const bonusKey = `${chore.id}_bonus_${subtask.id}_${child.id}`;
+    if (this._loading[bonusKey]) return;
+
+    // Undoing removes already-awarded points, so it is parent-only — short-circuit
+    // for non-admins with one friendly message instead of a doomed service call.
+    if (this.hass.user && !this.hass.user.is_admin) {
+      this._notifyUndo(this._t("child.undo_not_allowed"));
+      return;
+    }
+
+    const clearOptimistic = () => {
+      if (this._optimisticCompletions && this._optimisticCompletions[bonusKey]) {
+        const next = { ...this._optimisticCompletions };
+        delete next[bonusKey];
+        this._optimisticCompletions = next;
+      }
+    };
+
+    // Find the persisted completion record for this sub-task.
+    const completion = (todaysCompletions || []).find(
+      c => c.chore_id === chore.id && c.child_id === child.id && c.bonus_subtask_id === subtask.id
+    );
+    const completionId = completion?.completion_id || completion?.id;
+
+    // Only an optimistic tick and nothing on the server yet — just roll back the
+    // optimistic state; there is no completion to reject.
+    if (!completionId) {
+      clearOptimistic();
+      this.requestUpdate();
+      return;
+    }
+
+    this._loading = { ...this._loading, [bonusKey]: true };
+    this.requestUpdate();
+
+    try {
+      await this.hass.callService("taskmate", "reject_chore", {
+        completion_id: completionId,
+      });
+      this._playSound(this.config.undo_sound || "undo");
+      clearOptimistic();
+    } catch (error) {
+      console.error("Failed to undo bonus sub-task completion:", error);
+      const message = this._isUnauthorized(error)
+        ? this._t("child.undo_not_allowed")
+        : this._t("child.error_undo", { message: error?.message || "" });
+      this._notifyUndo(message);
+    } finally {
+      this._loading = { ...this._loading, [bonusKey]: false };
+      this.requestUpdate();
+    }
   }
 
   _renderCelebration() {


### PR DESCRIPTION
## Summary

Adds an **undo** for completed bonus sub-tasks on the Child Card: clicking a completed sub-task checkbox a second time now un-completes it, mirroring the existing tap-to-undo on parent chores.

Fixes #653

## The problem

Parent chores can be undone by tapping a done chore, but bonus sub-tasks could not. Worse, a completed sub-task tile already showed a **"Click to undo"** tooltip (`child.click_to_undo`) — but the click handler bailed early on `bonusDone`, so the advertised affordance did nothing.

## The fix (frontend only)

- Second click on a completed sub-task now calls `reject_chore` with that sub-task’s **own** `completion_id`.
- Because a bonus completion carries `bonus_subtask_id`, the existing backend (`async_reject_chore` → `is_parent = not bonus_subtask_id`) reverses **only that sub-task’s points** and leaves the parent chore done — no cascade, no streak/one-shot side effects.
- New `_handleUndoBonusSubtask` mirrors `_handleUndo`: parent-only admin gate, undo sound, optimistic rollback, single friendly error toast.
- Done tiles are focusable again (`tabindex="0"`).
- No backend changes and **no new strings** (reuses `child.click_to_undo`, `child.undo_not_allowed`, `child.error_undo`). Applies to classic and all designed styles (they share `_renderBonusSubtasks`).

## Testing — verified on the ha-dev instance

Exercised end-to-end against the live dev HA with the real Child Card in a browser (browserless):

- Parent chore done, **Bonus A completed** (+3), Bonus B pending → child at **216**.
- Clicked the completed Bonus A tile (tooltip "Click to undo").
- Result: **Bonus A checkbox reverts to unchecked**, child drops to **213** (only the +3 reversed), **parent chore stays done**, Bonus B unchanged.

Also confirmed the service-layer path directly: rejecting a bonus completion_id removes just that completion and its points, retaining the parent completion.