### PR TITLE
feat(notifications): dismiss mobile approval pushes when reviewed

### DIFF
--- a/custom_components/taskmate/coord_chores.py
+++ b/custom_components/taskmate/coord_chores.py
@@ -857,6 +857,14 @@ class ChoresMixin:
                     completion.points_awarded = total_awarded
                     self.storage.update_completion(completion)
 
+                    # Dismiss the mobile approval push now this completion is
+                    # reviewed (covers single approve AND "approve all", which
+                    # reuses this method per completion).
+                    if getattr(self, "notifications", None):
+                        await self.notifications.clear_approval(
+                            "pending_chore_approval", completion_id
+                        )
+
                     self.hass.bus.async_fire(
                         "taskmate_chore_approved",
                         {
@@ -1067,6 +1075,13 @@ class ChoresMixin:
                 "completion_id": completion_id,
                 "timestamp": dt_util.now().isoformat(),
             })
+            # Dismiss the mobile approval push for this reviewed completion. Also
+            # covers undoing an already-approved chore (whose push was cleared at
+            # approval): re-clearing a stale tag is a harmless no-op.
+            if getattr(self, "notifications", None):
+                await self.notifications.clear_approval(
+                    "pending_chore_approval", completion_id
+                )
 
     async def async_undo_chore_approval(self, completion_id: str) -> None:
         """Undo an accidental approval: reverse the awards and return the

--- a/custom_components/taskmate/coord_notifications.py
+++ b/custom_components/taskmate/coord_notifications.py
@@ -44,6 +44,17 @@ _LOGGER = logging.getLogger(__name__)
 _APPROVE_IN_PANEL_HINT = "Open the TaskMate panel to approve or reject."
 
 
+def _approval_tag(entry_id: str) -> str:
+    """Stable HA companion-app notification tag for an approval (chore/reward).
+
+    Set on the outgoing mobile push so that, once the item is approved or
+    rejected, the same tag can be passed to ``clear_notification`` to dismiss
+    the alert from the phone. Keyed on the completion/claim id, so each pending
+    item owns exactly one push.
+    """
+    return f"taskmate_approval_{entry_id}"
+
+
 @dataclass(frozen=True)
 class NotificationTypeMeta:
     id: str
@@ -287,7 +298,10 @@ class NotificationCoordinator:
             # sending dead buttons we append a hint pointing to the panel.
             if service.startswith("mobile_app"):
                 if entry_id:
+                    # `tag` lets us dismiss this push later (clear_approval) once
+                    # the item is reviewed — see _approval_tag.
                     data["data"] = {
+                        "tag": _approval_tag(entry_id),
                         "actions": [
                             {"action": f"TASKMATE_APPROVE_{entry_id}", "title": "Approve"},
                             {"action": f"TASKMATE_REJECT_{entry_id}",  "title": "Reject"},
@@ -299,6 +313,51 @@ class NotificationCoordinator:
             await self.hass.services.async_call(domain, service, data, blocking=False)
         except Exception as err:  # noqa: BLE001
             _LOGGER.warning("notify call failed for %s: %s", notify_service, err)
+
+    async def clear_approval(self, type_id: str, entry_id: str) -> None:
+        """Dismiss the mobile push for a reviewed approval (chore or reward).
+
+        The pending-approval push carries a stable ``tag`` (:func:`_approval_tag`).
+        Once the item is approved or rejected we send the HA companion app's
+        ``clear_notification`` with the same tag so the alert disappears from the
+        phone — the fix for the "approve all leaves a pile of notifications"
+        problem.
+
+        Gated to ``mobile_app.*`` services only: other backends (Telegram, email,
+        persistent) would render the literal "clear_notification" string as a
+        message, so they are skipped. Clearing a tag that isn't present is a
+        harmless no-op on the app, so no per-recipient bookkeeping is needed.
+        """
+        if not entry_id:
+            return
+        cfg = self.storage.get_notification_config(type_id)
+        if not cfg.master_enabled:
+            return
+        tag = _approval_tag(entry_id)
+        cleared_services: set[str] = set()
+        for recipient_id, route in cfg.routes.items():
+            if not route.enabled:
+                continue
+            notify_service = self._resolve_notify_service(recipient_id)
+            if not notify_service:
+                continue
+            domain, service = (
+                notify_service.split(".", 1) if "." in notify_service
+                else ("notify", notify_service)
+            )
+            if domain != "notify" or not service.startswith("mobile_app"):
+                continue
+            if service in cleared_services:
+                continue
+            cleared_services.add(service)
+            try:
+                await self.hass.services.async_call(
+                    "notify", service,
+                    {"message": "clear_notification", "data": {"tag": tag}},
+                    blocking=False,
+                )
+            except Exception as err:  # noqa: BLE001
+                _LOGGER.warning("clear_notification failed for %s: %s", notify_service, err)
 
     async def _fire_persistent_notification(self, type_id: str, message: str) -> None:
         await self.hass.services.async_call(

--- a/custom_components/taskmate/coord_rewards.py
+++ b/custom_components/taskmate/coord_rewards.py
@@ -403,6 +403,12 @@ class RewardsMixin:
                 await self.storage.async_save()
                 await self.async_refresh()
 
+                # Dismiss the mobile approval push now this claim is reviewed.
+                if getattr(self, "notifications", None):
+                    await self.notifications.clear_approval(
+                        "pending_reward_claim", claim_id
+                    )
+
                 self.hass.bus.async_fire("taskmate_reward_approved", {
                     "child_id": child.id, "child_name": child.name,
                     "reward_id": reward.id, "reward_name": reward.name,
@@ -432,6 +438,11 @@ class RewardsMixin:
                 "reward_name": getattr(reward, "name", ""),
                 "timestamp": dt_util.now().isoformat(),
             })
+            # Dismiss the mobile approval push for this reviewed claim.
+            if getattr(self, "notifications", None):
+                await self.notifications.clear_approval(
+                    "pending_reward_claim", claim_id
+                )
 
     async def async_allocate_points_to_pool(
         self, child_id: str, reward_id: str, points: int

--- a/tests/test_coordinator_rewards.py
+++ b/tests/test_coordinator_rewards.py
@@ -64,6 +64,7 @@ def _make_coord(*, children=None, rewards=None, claims=None):
     coord.async_refresh = AsyncMock()
     notifications = MagicMock()
     notifications.fire = AsyncMock()
+    notifications.clear_approval = AsyncMock()
     coord.notifications = notifications
     return coord
 

--- a/tests/test_notifications_dispatch.py
+++ b/tests/test_notifications_dispatch.py
@@ -129,3 +129,92 @@ async def test_pending_chore_approval_dispatches_actionable(coord, hass):
     data = notify_calls[0][0][2]["data"]
     assert {"action": "TASKMATE_APPROVE_completion-123", "title": "Approve"} in data["actions"]
     assert {"action": "TASKMATE_REJECT_completion-123",  "title": "Reject"} in data["actions"]
+
+
+@pytest.mark.asyncio
+async def test_pending_approval_push_carries_clear_tag(coord, hass):
+    """The mobile approval push must carry a stable `tag` so it can later be
+    dismissed via clear_notification (issue #655)."""
+    hass.services.async_call = AsyncMock()
+    hass.bus.async_fire = AsyncMock()
+    p = ParentRecipient(name="John", notify_service="notify.mobile_app_johns_iphone")
+    coord.storage.upsert_parent_recipient(p)
+    coord.storage.set_notification_master("pending_chore_approval", True)
+    coord.storage.set_notification_route(
+        "pending_chore_approval", p.id, NotificationRoute(enabled=True),
+    )
+
+    await coord.fire(
+        "pending_chore_approval",
+        {
+            "entry_id": "completion-123",
+            "child_name": "Maria", "chore_name": "Bin",
+            "points": 10, "points_name": "Stars",
+        },
+    )
+
+    notify_calls = [c for c in hass.services.async_call.call_args_list if c[0][0] == "notify"]
+    assert len(notify_calls) == 1
+    data = notify_calls[0][0][2]["data"]
+    assert data["tag"] == "taskmate_approval_completion-123"
+
+
+@pytest.mark.asyncio
+async def test_clear_approval_targets_only_mobile_app(coord, hass):
+    """clear_approval must send clear_notification to mobile_app.* services only
+    (with the matching tag) and skip non-mobile backends, which would otherwise
+    render the literal 'clear_notification' string as a message."""
+    hass.services.async_call = AsyncMock()
+    mobile = ParentRecipient(name="John", notify_service="notify.mobile_app_johns_iphone")
+    other = ParentRecipient(name="Lisa", notify_service="notify.telegram_lisa")
+    coord.storage.upsert_parent_recipient(mobile)
+    coord.storage.upsert_parent_recipient(other)
+    coord.storage.set_notification_master("pending_chore_approval", True)
+    coord.storage.set_notification_route(
+        "pending_chore_approval", mobile.id, NotificationRoute(enabled=True),
+    )
+    coord.storage.set_notification_route(
+        "pending_chore_approval", other.id, NotificationRoute(enabled=True),
+    )
+
+    await coord.clear_approval("pending_chore_approval", "completion-123")
+
+    notify_calls = [c for c in hass.services.async_call.call_args_list if c[0][0] == "notify"]
+    assert len(notify_calls) == 1
+    assert notify_calls[0][0][1] == "mobile_app_johns_iphone"
+    assert notify_calls[0][0][2] == {
+        "message": "clear_notification",
+        "data": {"tag": "taskmate_approval_completion-123"},
+    }
+
+
+@pytest.mark.asyncio
+async def test_clear_approval_skips_when_master_disabled(coord, hass):
+    """No push was sent when the type's master is off, so nothing to clear."""
+    hass.services.async_call = AsyncMock()
+    mobile = ParentRecipient(name="John", notify_service="notify.mobile_app_johns_iphone")
+    coord.storage.upsert_parent_recipient(mobile)
+    coord.storage.set_notification_master("pending_chore_approval", False)
+    coord.storage.set_notification_route(
+        "pending_chore_approval", mobile.id, NotificationRoute(enabled=True),
+    )
+
+    await coord.clear_approval("pending_chore_approval", "completion-123")
+
+    assert not [c for c in hass.services.async_call.call_args_list if c[0][0] == "notify"]
+
+
+@pytest.mark.asyncio
+async def test_clear_approval_noop_without_entry_id(coord, hass):
+    """A missing entry_id must not fire any notify call."""
+    hass.services.async_call = AsyncMock()
+    mobile = ParentRecipient(name="John", notify_service="notify.mobile_app_johns_iphone")
+    coord.storage.upsert_parent_recipient(mobile)
+    coord.storage.set_notification_master("pending_chore_approval", True)
+    coord.storage.set_notification_route(
+        "pending_chore_approval", mobile.id, NotificationRoute(enabled=True),
+    )
+
+    await coord.clear_approval("pending_chore_approval", "")
+
+    assert not hass.services.async_call.call_args_list


### PR DESCRIPTION
## Summary

When a parent reviews chore approvals — especially with the **Approve all** button — the push notifications for those approvals stay on their phone. This clears them automatically.

Fixes #655

## How it works

The HA companion app dismisses a push when it receives a notify call with `message: "clear_notification"` and a matching `tag`. TaskMate previously sent approval pushes with **no tag**, so there was nothing to clear against. Two parts:

1. **Tag the push** — `_send_to` now stamps mobile approval notifications with a stable `tag` (`taskmate_approval_<entry_id>`, keyed on the completion/claim id).
2. **Clear on review** — new `NotificationCoordinator.clear_approval(type_id, entry_id)` re-walks the same notification routes and sends `clear_notification` with that tag.

Hooked into `async_approve_chore` (covers single approve **and** "Approve all", which reuses it per completion), `async_reject_chore`, `async_approve_reward`, and `async_reject_reward`.

## On the user's toggle suggestion — not needed

Clearing is gated strictly to `mobile_app.*` services. Telegram/email/persistent recipients never receive a `clear_notification` (which they would render as literal text), so there's no spam risk and **no per-parent toggle, setting, UI, or new translations** were required.

## Testing

**Unit** (`test_notifications_dispatch.py`, 4 new): the approval push carries the clear tag; `clear_approval` sends `clear_notification` with the exact tag to mobile_app services **only** (skips a Telegram recipient); skips when master disabled / no entry_id. Full targeted suite 68 passed; Ruff clean. (The 3 pre-existing `TestOneShotChores` order-pollution failures are unchanged from `main`.)

**Live integration on ha-dev** (restarted to load the change): configured a parent routed to a `mobile_app_*` service, created an approval-required chore, completed it (child) then approved it. The error log confirmed the end-to-end wiring:

```
notify call failed for notify.mobile_app_test: Action ... not found          # approval push (now tagged)
clear_notification failed for notify.mobile_app_test: Action ... not found    # clear_approval fired on approve
```

(The "not found" is only because that is a dummy device name on the dev box — the call being attempted, to the mobile_app service with the `clear_notification` message, is the proof; the exact tag/payload is asserted by the unit tests.) Reject exercised the same path during cleanup.