### PR TITLE
chore(release): v4.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1434,6 +1434,11 @@ Beyond the sensors above, TaskMate also exposes:
  
 ## Changelog
  
+### v4.5.0
+ 
+**New**
+- **Parent access without admin rights** — you can now give a second parent day-to-day control of TaskMate without making them a Home Assistant admin. In **Settings → Parents (no admin rights)**, tick any existing non-admin Home Assistant user; they can then approve or reject chores, adjust points, confirm rewards and allowance payouts, award badges, complete chores on a child's behalf, and undo — straight from the cards. They still **cannot** open the admin panel or change any configuration, and every parent action is recorded in the audit log. Ideal for a partner who wants to run the daily routine but shouldn't have full Home Assistant admin rights. ([#662](https://github.com/tempus2016/taskmate/pull/662), fixes [#661](https://github.com/tempus2016/taskmate/issues/661))
+ 
 ### v4.4.4
  
 **New**

--- a/custom_components/taskmate/manifest.json
+++ b/custom_components/taskmate/manifest.json
@@ -17,5 +17,5 @@
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/tempus2016/taskmate/issues",
   "requirements": [],
-  "version": "4.4.4"
+  "version": "4.5.0"
 }


### PR DESCRIPTION
Bumps manifest to 4.5.0 and adds the v4.5.0 changelog entry for the non-admin parent role (#662, fixes #661). Release plumbing only — the feature itself already merged in #662.