### PR TITLE
chore(ci): correct pinned-action version comments and drop date suffixes

### DIFF
--- a/.github/workflows/auto-branch.yml
+++ b/.github/workflows/auto-branch.yml
@@ -13,7 +13,7 @@ jobs:
     if: github.event.label.name == 'planned'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0 2026-06-19.0.0
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const { owner, repo } = context.repo;

--- a/.github/workflows/hassfest.yaml
+++ b/.github/workflows/hassfest.yaml
@@ -17,5 +17,5 @@ jobs:
   validate:
     runs-on: "ubuntu-latest"
     steps:
-      - uses: "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0" # v6 2026-06-17
-      - uses: home-assistant/actions/hassfest@f4ca6f671bd429efb108c0f2fa0ae8af0215986c # master 2026-06-11
+      - uses: "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0" # v7.0.0
+      - uses: home-assistant/actions/hassfest@f4ca6f671bd429efb108c0f2fa0ae8af0215986c # master

--- a/.github/workflows/issue-comment-labels.yml
+++ b/.github/workflows/issue-comment-labels.yml
@@ -12,7 +12,7 @@ jobs:
     if: ${{ !github.event.issue.pull_request }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0 2026-06-19.0.0
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const isOwner = context.payload.comment.author_association === 'OWNER';

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Apply path labels
-        uses: actions/labeler@b8dd2d9be0f68b860e7dae5dae7d772984eacd6d # v6.1.0 2026-06-27
+        uses: actions/labeler@b8dd2d9be0f68b860e7dae5dae7d772984eacd6d # v6.2.0
         with:
           configuration-path: .github/labeler.yml
           sync-labels: true

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -20,10 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6 2026-06-17
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Apply labels
-        uses: crazy-max/ghaction-github-labeler@548a7c3603594ec17c819e1239f281a3b801ab4d # v6.0.0 2026-06-27
+        uses: crazy-max/ghaction-github-labeler@548a7c3603594ec17c819e1239f281a3b801ab4d # v6.0.0
         with:
           yaml_file: .github/labels.yml
           # Never delete labels not listed in labels.yml — create/update only.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,10 +21,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6 2026-06-17
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0 2026-06-27
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.12"
 
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6 2026-06-17
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0

--- a/.github/workflows/release-announcement.yml
+++ b/.github/workflows/release-announcement.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Create Discussion Announcement
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9 2026-06-17
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/release-zip.yml
+++ b/.github/workflows/release-zip.yml
@@ -19,7 +19,7 @@ jobs:
   attach-zip:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6 2026-06-17
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.event.release.tag_name }}
 

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,7 +12,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@1e223db275d687790206a7acac4d1a11bd6fe629 # v10.3.0 2026-06-27
+      - uses: actions/stale@1e223db275d687790206a7acac4d1a11bd6fe629 # v10.4.0
         with:
           # Only chase issues that are explicitly waiting on the reporter for
           # information — never sweep the whole tracker.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,10 +21,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6 2026-06-17
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Hassfest validation
-        uses: home-assistant/actions/hassfest@f4ca6f671bd429efb108c0f2fa0ae8af0215986c # master 2026-06-11
+        uses: home-assistant/actions/hassfest@f4ca6f671bd429efb108c0f2fa0ae8af0215986c # master
 
   test:
     name: Run tests
@@ -32,10 +32,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6 2026-06-17
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0 2026-06-27
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.12"
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -17,8 +17,8 @@ jobs:
   hacs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6 2026-06-17
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: HACS validation
-        uses: hacs/action@1ebf01c408f29afcb6406bd431bc98fd8cbb15aa # main 2026-06-08
+        uses: hacs/action@1ebf01c408f29afcb6406bd431bc98fd8cbb15aa # main
         with:
           category: integration


### PR DESCRIPTION
## Problem

Dependabot only rewrites the trailing `# vX.Y.Z` comment on a SHA-pinned action when it can match the version string in it. The `# vX.Y.Z <date>` format this repo used defeats that heuristic in two ways:

1. **Silent staleness** — it leaves the comment alone while bumping the SHA, so the file names the *old* version next to the *new* SHA. Both bumps merged today did this:
   - #667 → `actions/labeler` SHA moved to v6.2.0, comment still said `v6.1.0`
   - #668 → `actions/stale` SHA moved to v10.4.0, comment still said `v10.3.0`
2. **Outright corruption** — it version-matched inside the *date* and produced `# v9.0.0 2026-06-19.0.0` in `auto-branch.yml` and `issue-comment-labels.yml`.

The worst case was already in the tree before today: `actions/checkout` is pinned to `9c091bb2`, which is **v7.0.0**, but every one of its 7 call sites was commented `# v6` — off by a full major version.

This is a follow-up to cb9ffc0, which corrected the same drift once already. It regressed immediately because the date suffix was left in place, so it will keep regressing on every future bump until the format changes.

## Fix

Each comment is now the bare resolved version, with no date. Every value was verified by resolving the pinned SHA against the upstream repo tag list via the GitHub API — not copied from the old comment:

| Action | Pinned SHA | Was | Now |
|---|---|---|---|
| `actions/checkout` | `9c091bb2` | `v6 2026-06-17` | `v7.0.0` |
| `actions/labeler` | `b8dd2d9b` | `v6.1.0 2026-06-27` | `v6.2.0` |
| `actions/stale` | `1e223db2` | `v10.3.0 2026-06-27` | `v10.4.0` |
| `actions/github-script` | `3a2844b7` | `v9 …` / `v9.0.0 2026-06-19.0.0` | `v9.0.0` |
| `actions/setup-python` | `ece7cb06` | `v6.3.0 2026-06-27` | `v6.3.0` |
| `actions/setup-node` | `82076278` | `v7.0.0` | `v7.0.0` |
| `crazy-max/ghaction-github-labeler` | `548a7c36` | `v6.0.0 2026-06-27` | `v6.0.0` |

Branch pins keep their branch name minus the date: `hacs/action@…` → `# main`, `home-assistant/actions/hassfest@…` → `# master`.

## Safety

**No SHA is changed.** Verified mechanically:

- extracted every `@<40-hex>` from `.github/` before and after — the multisets are identical
- every line in the diff is a `uses:` line; nothing else is touched
- all workflow YAML still parses under `yaml.safe_load`

So no action resolves differently and no job behaviour changes — this is a documentation-accuracy fix. 19 comments across 11 workflow files.