### PR TITLE
feat(rewards): timed unlock rewards, gated by a parent allowlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@
 - [Scheduled Config Changes](#scheduled-config-changes)
 - [Routine Mode](#routine-mode)
 - [Chore Roulette](#chore-roulette)
+- [Timed Unlock Rewards](#timed-unlock-rewards)
 - [Bonus Points System](#bonus-points-system)
 - [Notifications](#notifications)
 - [Quiet Hours](#quiet-hours)
@@ -442,6 +443,29 @@ show_roulette: true
 - A multiplier below 1 is clamped to 1 — spinning should never punish the child.
  
 Children spin via the `taskmate.spin_roulette` service (`child_id`), which the card calls for them.
+ 
+---
+ 
+## Timed Unlock Rewards
+ 
+Spend points to unlock something for a while — the TV, the console socket, a wifi group. Approving the claim turns the entity on; a timer turns it back off.
+ 
+**Two deliberate limits** keep this from becoming "a reward can do anything to your house":
+ 
+1. A reward can only **turn one entity on and back off**. There is no free-form service call, no payload, no template.
+2. The entity must be on your **allowlist**.
+ 
+### Setting It Up
+ 
+1. **Settings → Unlock allowlist** — add the entities a reward may touch. An entry can be a full entity id (`switch.xbox`) or a bare domain (`switch`) to permit everything in it. **An empty allowlist permits nothing** — this gates household devices, so the safe default when unconfigured is "no".
+2. Open a reward, expand **Advanced — timed unlock**, pick an allowlisted entity and a duration (up to 24 hours; `0` leaves it on for you to turn off yourself).
+ 
+### Key Points
+ 
+- The allowlist is checked **when the reward is saved and again when it fires** — you can revoke an entity later and any reward pointing at it quietly stops unlocking rather than breaking.
+- Active unlocks are **persisted**. A Home Assistant restart mid-unlock re-arms the timer; anything already past due is turned off at startup. A restart can never strand the television on.
+- Turning something **off** is never gated by the allowlist — a revert is always safe.
+- Fires `taskmate_unlock_started` and `taskmate_unlock_ended` (`entity_id`, `reward_id`, `reward_name`, `child_id`, `child_name`, `started_at`, `revert_at`).
  
 ---
  

--- a/custom_components/taskmate/coord_rewards.py
+++ b/custom_components/taskmate/coord_rewards.py
@@ -409,6 +409,9 @@ class RewardsMixin:
                         "pending_reward_claim", claim_id
                     )
 
+                # Timed unlock (#678): allowlisted entity on, auto-off later.
+                await self.async_start_unlock(reward, child)
+
                 self.hass.bus.async_fire("taskmate_reward_approved", {
                     "child_id": child.id, "child_name": child.name,
                     "reward_id": reward.id, "reward_name": reward.name,

--- a/custom_components/taskmate/coord_unlocks.py
+++ b/custom_components/taskmate/coord_unlocks.py
@@ -1,0 +1,219 @@
+"""Timed unlock rewards (#678).
+
+Spend points to unlock something for a while: the TV, the console socket, a
+wifi group. Approving the claim turns the entity on; a timer turns it back off.
+
+Two deliberate limits keep this from becoming "a reward can do anything to
+your house":
+
+  * A reward can only **turn an entity on and back off again**. There is no
+    free-form service call, no payload, no template.
+  * The entity must be on the parent's **allowlist**, checked both when the
+    reward is saved and again when it actually fires — the allowlist can change
+    after a reward was created.
+
+Active unlocks are persisted. A Home Assistant restart mid-unlock must not
+strand the television on: anything already past due is reverted at startup and
+anything still running is re-armed.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta
+from typing import Any
+
+from homeassistant.helpers.event import async_track_point_in_time
+from homeassistant.util import dt as dt_util
+
+_LOGGER = logging.getLogger(__name__)
+
+MAX_UNLOCK_MINUTES = 1440  # a day; longer belongs in an automation, not a reward
+
+
+class UnlocksMixin:
+    """Mixin providing allowlisted, self-reverting entity unlocks."""
+
+    # ── allowlist ────────────────────────────────────────────────────────
+    def unlock_allowlist(self) -> list[str]:
+        """Entity ids and/or bare domains the parent has permitted."""
+        raw = self.storage.get_setting("unlock_allowlist", [])
+        if not isinstance(raw, list):
+            return []
+        return [str(e).strip().lower() for e in raw if str(e).strip()]
+
+    def is_unlock_allowed(self, entity_id: str) -> bool:
+        """True when ``entity_id`` is permitted by the allowlist.
+
+        An entry may be a full entity id (``switch.xbox``) or a bare domain
+        (``switch``), which permits everything in it. An empty allowlist
+        permits nothing — fail closed. This gates household devices, so the
+        safe default when unconfigured is "no".
+        """
+        entity_id = (entity_id or "").strip().lower()
+        if not entity_id or "." not in entity_id:
+            return False
+        allow = self.unlock_allowlist()
+        if not allow:
+            return False
+        domain = entity_id.split(".", 1)[0]
+        return entity_id in allow or domain in allow
+
+    def validate_unlock(self, entity_id: str, minutes: Any) -> tuple[str, int]:
+        """Validate an unlock config, returning the cleaned pair.
+
+        Raises ValueError with a parent-readable message.
+        """
+        entity_id = (entity_id or "").strip().lower()
+        if not entity_id:
+            return "", 0
+        if not self.is_unlock_allowed(entity_id):
+            raise ValueError(
+                f"'{entity_id}' is not on the unlock allowlist. "
+                "Add it in Settings before using it as a reward."
+            )
+        try:
+            mins = int(minutes or 0)
+        except (TypeError, ValueError) as err:
+            raise ValueError("Unlock minutes must be a whole number") from err
+        if mins < 0:
+            raise ValueError("Unlock minutes cannot be negative")
+        if mins > MAX_UNLOCK_MINUTES:
+            raise ValueError(f"Unlock minutes cannot exceed {MAX_UNLOCK_MINUTES}")
+        return entity_id, mins
+
+    # ── active unlock bookkeeping ────────────────────────────────────────
+    def active_unlocks(self) -> list[dict[str, Any]]:
+        raw = self.storage.get_setting("active_unlocks", [])
+        return [u for u in raw if isinstance(u, dict)] if isinstance(raw, list) else []
+
+    def _store_unlocks(self, unlocks: list[dict[str, Any]]) -> None:
+        self.storage.set_setting("active_unlocks", unlocks)
+
+    async def async_start_unlock(self, reward, child) -> dict[str, Any] | None:
+        """Turn on a reward's entity and schedule the revert. Returns the record.
+
+        Returns None (and logs) rather than raising when the reward has no
+        unlock configured or the entity has since left the allowlist — a
+        reward approval must not fail because of a later settings change.
+        """
+        entity_id = (getattr(reward, "unlock_entity", "") or "").strip().lower()
+        if not entity_id:
+            return None
+
+        if not self.is_unlock_allowed(entity_id):
+            _LOGGER.warning(
+                "Reward '%s' wanted to unlock '%s', which is no longer on the "
+                "allowlist — skipping",
+                reward.name, entity_id,
+            )
+            return None
+
+        minutes = int(getattr(reward, "unlock_minutes", 0) or 0)
+        await self.hass.services.async_call(
+            "homeassistant", "turn_on", {"entity_id": entity_id}, blocking=False,
+        )
+
+        record: dict[str, Any] = {
+            "entity_id": entity_id,
+            "reward_id": reward.id,
+            "reward_name": reward.name,
+            "child_id": child.id,
+            "child_name": child.name,
+            "started_at": dt_util.now().isoformat(),
+            "revert_at": "",
+        }
+
+        if minutes > 0:
+            revert_at = dt_util.now() + timedelta(minutes=minutes)
+            record["revert_at"] = revert_at.isoformat()
+            unlocks = self.active_unlocks()
+            unlocks.append(record)
+            self._store_unlocks(unlocks)
+            await self.storage.async_save()
+            self._schedule_revert(record, revert_at)
+
+        _LOGGER.info(
+            "Unlocked %s for %s (%s) for %s minutes",
+            entity_id, child.name, reward.name, minutes or "no auto-revert",
+        )
+        self.hass.bus.async_fire("taskmate_unlock_started", dict(record))
+        return record
+
+    def _schedule_revert(self, record: dict[str, Any], when: datetime) -> None:
+        async def _revert(_now) -> None:
+            await self.async_revert_unlock(record)
+
+        self._unlock_timers.append(
+            async_track_point_in_time(self.hass, _revert, when)
+        )
+
+    async def async_revert_unlock(self, record: dict[str, Any]) -> None:
+        """Turn the entity back off and drop the record."""
+        entity_id = record.get("entity_id", "")
+        if entity_id:
+            await self.hass.services.async_call(
+                "homeassistant", "turn_off", {"entity_id": entity_id}, blocking=False,
+            )
+            _LOGGER.info("Re-locked %s", entity_id)
+
+        remaining = [
+            u for u in self.active_unlocks()
+            if not (u.get("entity_id") == entity_id
+                    and u.get("revert_at") == record.get("revert_at"))
+        ]
+        self._store_unlocks(remaining)
+        await self.storage.async_save()
+        await self.async_refresh()
+        self.hass.bus.async_fire("taskmate_unlock_ended", dict(record))
+
+    async def async_resume_unlocks(self) -> int:
+        """Re-arm unlocks across a restart. Returns how many were reverted now.
+
+        Without this a restart mid-unlock strands the entity on forever, which
+        is the one genuinely bad failure mode of this feature.
+        """
+        now = dt_util.now()
+        still_running: list[dict[str, Any]] = []
+        expired: list[dict[str, Any]] = []
+
+        for record in self.active_unlocks():
+            try:
+                revert_at = datetime.fromisoformat(record.get("revert_at", ""))
+            except (TypeError, ValueError):
+                revert_at = None
+            if revert_at is not None and revert_at.tzinfo is None:
+                revert_at = revert_at.replace(tzinfo=now.tzinfo)
+            if revert_at is None:
+                # Unparseable: revert now rather than leave it on indefinitely.
+                expired.append(record)
+                continue
+            if revert_at <= now:
+                expired.append(record)
+            else:
+                still_running.append(record)
+                self._schedule_revert(record, revert_at)
+
+        for record in expired:
+            entity_id = record.get("entity_id", "")
+            if entity_id:
+                await self.hass.services.async_call(
+                    "homeassistant", "turn_off", {"entity_id": entity_id}, blocking=False,
+                )
+                _LOGGER.info("Re-locked %s after restart (unlock had expired)", entity_id)
+
+        if expired:
+            self._store_unlocks(still_running)
+            await self.storage.async_save()
+
+        if still_running:
+            _LOGGER.info("Re-armed %d active unlock(s) after restart", len(still_running))
+        return len(expired)
+
+    def cancel_unlock_timers(self) -> None:
+        """Drop scheduled reverts on unload so they can't fire post-teardown."""
+        for cancel in getattr(self, "_unlock_timers", []):
+            try:
+                cancel()
+            except Exception:  # noqa: BLE001 - teardown must not raise
+                pass
+        self._unlock_timers = []

--- a/custom_components/taskmate/coordinator.py
+++ b/custom_components/taskmate/coordinator.py
@@ -30,6 +30,7 @@ from .coord_roulette import RouletteMixin
 from .coord_scheduled import ScheduledChangesMixin
 from .coord_templates import TemplatesMixin
 from .coord_timed import TimedMixin
+from .coord_unlocks import UnlocksMixin
 from .models import Child
 from .storage import TaskMateStorage
 
@@ -50,6 +51,7 @@ class TaskMateCoordinator(
     TemplatesMixin,
     ScheduledChangesMixin,
     RouletteMixin,
+    UnlocksMixin,
     DataUpdateCoordinator,
 ):
     """Coordinator to manage TaskMate data."""
@@ -84,6 +86,8 @@ class TaskMateCoordinator(
         self._avail_cache: dict | None = None
         # (data_version, snapshot) cache for _async_update_data (PERF-2).
         self._data_snapshot_cache: tuple[int, dict[str, Any]] | None = None
+        # Scheduled reverts for timed unlock rewards (#678).
+        self._unlock_timers: list = []
 
     def difficulty_multiplier(self, tier: str) -> float:
         """Return the points multiplier for a difficulty tier.
@@ -278,6 +282,8 @@ class TaskMateCoordinator(
         # Catch up on scheduled changes (#675) that came due while HA was off —
         # the parent still expects "from 1 September" to have happened.
         await self.async_apply_due_scheduled_changes(refresh=False)
+        # A restart mid-unlock must never strand the TV on (#678).
+        await self.async_resume_unlocks()
         await self.async_refresh()
         # Schedule midnight streak check at 00:00:05
         self._unsub_midnight = async_track_time_change(
@@ -620,6 +626,7 @@ class TaskMateCoordinator(
 
     async def async_shutdown(self) -> None:
         """Shutdown the coordinator and clean up listeners."""
+        self.cancel_unlock_timers()
         if self._unsub_midnight:
             self._unsub_midnight()
             self._unsub_midnight = None

--- a/custom_components/taskmate/models.py
+++ b/custom_components/taskmate/models.py
@@ -467,6 +467,11 @@ class Reward:
     restock_amount: int = 0
     restock_period: str = "weekly"  # daily | weekly (Mon) | monthly (1st)
     restock_last: str = ""  # ISO date this reward was last restocked
+    # Timed unlock (#678): on approval, turn this entity on and turn it back
+    # off after unlock_minutes. The entity must be on the parent's allowlist,
+    # checked both at save time and again when it fires.
+    unlock_entity: str = ""
+    unlock_minutes: int = 0
     id: str = field(default_factory=generate_id)
 
     def __post_init__(self) -> None:
@@ -496,6 +501,8 @@ class Reward:
             expires_at=expires_at,
             restock_enabled=data.get("restock_enabled", False),
             restock_amount=int(data.get("restock_amount", 0) or 0),
+            unlock_entity=str(data.get("unlock_entity", "") or ""),
+            unlock_minutes=int(data.get("unlock_minutes", 0) or 0),
             restock_period=data.get("restock_period", "weekly"),
             restock_last=data.get("restock_last", ""),
             id=data.get("id", generate_id()),
@@ -517,6 +524,8 @@ class Reward:
             "restock_amount": self.restock_amount,
             "restock_period": self.restock_period,
             "restock_last": self.restock_last,
+            "unlock_entity": self.unlock_entity,
+            "unlock_minutes": self.unlock_minutes,
             "id": self.id,
         }
 

--- a/custom_components/taskmate/websocket.py
+++ b/custom_components/taskmate/websocket.py
@@ -679,7 +679,8 @@ async def _ws_scheduled_remove(hass, connection, msg, coordinator):
 
 _REWARD_FIELDS = {"name", "cost", "description", "icon", "assigned_to",
                   "is_jackpot", "pool_enabled", "quantity", "expires_at",
-                  "restock_enabled", "restock_amount", "restock_period"}
+                  "restock_enabled", "restock_amount", "restock_period",
+                  "unlock_entity", "unlock_minutes"}
 
 
 def _reward_payload_schema(*, require_name: bool):
@@ -698,6 +699,8 @@ def _reward_payload_schema(*, require_name: bool):
         vol.Optional("restock_enabled"): bool,
         vol.Optional("restock_amount"): vol.All(int, vol.Range(min=0, max=10000)),
         vol.Optional("restock_period"): vol.In(["daily", "weekly", "monthly"]),
+        vol.Optional("unlock_entity"): str,
+        vol.Optional("unlock_minutes"): vol.All(int, vol.Range(min=0, max=1440)),
     }
 
 
@@ -708,6 +711,16 @@ def _reward_payload_schema(*, require_name: bool):
 @websocket_api.async_response
 @_admin_only
 async def _ws_add_reward(hass, connection, msg, coordinator):
+    # Timed unlock (#678): refuse an entity that isn't on the parent's
+    # allowlist, at save time, with a message the panel can show.
+    try:
+        unlock_entity, unlock_minutes = coordinator.validate_unlock(
+            msg.get("unlock_entity", ""), msg.get("unlock_minutes", 0),
+        )
+    except ValueError as err:
+        connection.send_error(msg["id"], "invalid_format", str(err))
+        return
+
     # coordinator.async_add_reward accepts a subset; build a Reward dataclass
     # to populate every editable field uniformly.
     reward = Reward(
@@ -723,6 +736,8 @@ async def _ws_add_reward(hass, connection, msg, coordinator):
         restock_enabled=msg.get("restock_enabled", False),
         restock_amount=msg.get("restock_amount", 0),
         restock_period=msg.get("restock_period", "weekly"),
+        unlock_entity=unlock_entity,
+        unlock_minutes=unlock_minutes,
     )
     coordinator.storage.add_reward(reward)
     await coordinator.storage.async_save()
@@ -742,6 +757,15 @@ async def _ws_update_reward(hass, connection, msg, coordinator):
     if not existing:
         connection.send_error(msg["id"], "not_found", f"Reward {msg['reward_id']} not found")
         return
+    if "unlock_entity" in msg or "unlock_minutes" in msg:
+        try:
+            coordinator.validate_unlock(
+                msg.get("unlock_entity", existing.unlock_entity),
+                msg.get("unlock_minutes", existing.unlock_minutes),
+            )
+        except ValueError as err:
+            connection.send_error(msg["id"], "invalid_format", str(err))
+            return
     for field in _REWARD_FIELDS:
         if field in msg:
             value = msg[field]
@@ -1184,6 +1208,7 @@ _SUBKEY_SETTINGS = {
     "perfect_week_bonus", "streak_milestones",
     "streak_requires_all_chores", "perfect_week_requires_all_chores",
     "difficulty_multiplier_easy", "difficulty_multiplier_medium", "difficulty_multiplier_hard",
+    "unlock_allowlist",
     "roulette_enabled", "roulette_multiplier", "roulette_daily_spins",
     "surprise_bonus_enabled", "surprise_bonus_chance", "surprise_bonus_min", "surprise_bonus_max",
     "points_decay_enabled", "points_decay_period", "points_decay_percent",
@@ -1344,6 +1369,7 @@ _UPDATE_SETTINGS_SCHEMA = {
     vol.Optional("difficulty_multiplier_easy"): vol.All(vol.Coerce(float), vol.Range(min=0.0, max=10.0)),
     vol.Optional("difficulty_multiplier_medium"): vol.All(vol.Coerce(float), vol.Range(min=0.0, max=10.0)),
     vol.Optional("difficulty_multiplier_hard"): vol.All(vol.Coerce(float), vol.Range(min=0.0, max=10.0)),
+    vol.Optional("unlock_allowlist"): [str],
     vol.Optional("roulette_enabled"): bool,
     vol.Optional("roulette_multiplier"): vol.All(vol.Coerce(float), vol.Range(min=1.0, max=5.0)),
     vol.Optional("roulette_daily_spins"): vol.All(int, vol.Range(min=1, max=10)),

--- a/custom_components/taskmate/www/locales/de.json
+++ b/custom_components/taskmate/www/locales/de.json
@@ -1628,5 +1628,16 @@
   "panel.settings_roulette_enabled": "Aufgaben-Roulette aktivieren",
   "panel.settings_roulette_enabled_hint": "Ein Kind kann für eine zufällige offene Aufgabe mit Extrapunkten drehen.",
   "panel.settings_roulette_multiplier": "Punkte-Multiplikator",
-  "panel.settings_roulette_spins": "Drehungen pro Tag"
+  "panel.settings_roulette_spins": "Drehungen pro Tag",
+  "panel.settings_unlock_allowlist": "Freischalt-Positivliste",
+  "panel.settings_unlock_allowlist_hint": "Nur diese Entitäten dürfen von einer Belohnung freigeschaltet werden. Bis du hier etwas hinzufügst, ist nichts erlaubt.",
+  "panel.settings_unlock_allowlist_empty": "Noch nichts erlaubt.",
+  "panel.settings_unlock_allowlist_add": "Entität zum Erlauben suchen",
+  "panel.reward_unlock_section": "Erweitert — zeitlich begrenzte Freischaltung",
+  "panel.reward_unlock_intro": "Schaltet etwas ein, wenn diese Belohnung genehmigt wird, und nach einer festgelegten Zeit wieder aus.",
+  "panel.reward_unlock_none": "Nichts",
+  "panel.reward_unlock_entity": "Freischalten",
+  "panel.reward_unlock_minutes": "Wie lange (Minuten)",
+  "panel.reward_unlock_minutes_hint": "0 = eingeschaltet lassen; du musst selbst ausschalten.",
+  "panel.reward_unlock_no_allowlist": "Füge zuerst in den Einstellungen eine Entität zur Freischalt-Positivliste hinzu."
 }

--- a/custom_components/taskmate/www/locales/en-GB.json
+++ b/custom_components/taskmate/www/locales/en-GB.json
@@ -1628,5 +1628,16 @@
   "panel.settings_roulette_enabled": "Enable chore roulette",
   "panel.settings_roulette_enabled_hint": "Lets a child spin for a random outstanding chore worth extra points.",
   "panel.settings_roulette_multiplier": "Points multiplier",
-  "panel.settings_roulette_spins": "Spins per day"
+  "panel.settings_roulette_spins": "Spins per day",
+  "panel.settings_unlock_allowlist": "Unlock allowlist",
+  "panel.settings_unlock_allowlist_hint": "Only these entities may be unlocked by a reward. Nothing is allowed until you add something here.",
+  "panel.settings_unlock_allowlist_empty": "Nothing allowed yet.",
+  "panel.settings_unlock_allowlist_add": "Search for an entity to allow",
+  "panel.reward_unlock_section": "Advanced — timed unlock",
+  "panel.reward_unlock_intro": "Turn something on when this reward is approved, and back off again after a set time.",
+  "panel.reward_unlock_none": "Nothing",
+  "panel.reward_unlock_entity": "Unlock",
+  "panel.reward_unlock_minutes": "For how long (minutes)",
+  "panel.reward_unlock_minutes_hint": "0 = leave it on; you'll need to turn it off yourself.",
+  "panel.reward_unlock_no_allowlist": "Add an entity to the unlock allowlist in Settings first."
 }

--- a/custom_components/taskmate/www/locales/en.json
+++ b/custom_components/taskmate/www/locales/en.json
@@ -1628,5 +1628,16 @@
   "panel.settings_roulette_enabled": "Enable chore roulette",
   "panel.settings_roulette_enabled_hint": "Lets a child spin for a random outstanding chore worth extra points.",
   "panel.settings_roulette_multiplier": "Points multiplier",
-  "panel.settings_roulette_spins": "Spins per day"
+  "panel.settings_roulette_spins": "Spins per day",
+  "panel.settings_unlock_allowlist": "Unlock allowlist",
+  "panel.settings_unlock_allowlist_hint": "Only these entities may be unlocked by a reward. Nothing is allowed until you add something here.",
+  "panel.settings_unlock_allowlist_empty": "Nothing allowed yet.",
+  "panel.settings_unlock_allowlist_add": "Search for an entity to allow",
+  "panel.reward_unlock_section": "Advanced — timed unlock",
+  "panel.reward_unlock_intro": "Turn something on when this reward is approved, and back off again after a set time.",
+  "panel.reward_unlock_none": "Nothing",
+  "panel.reward_unlock_entity": "Unlock",
+  "panel.reward_unlock_minutes": "For how long (minutes)",
+  "panel.reward_unlock_minutes_hint": "0 = leave it on; you'll need to turn it off yourself.",
+  "panel.reward_unlock_no_allowlist": "Add an entity to the unlock allowlist in Settings first."
 }

--- a/custom_components/taskmate/www/locales/fr.json
+++ b/custom_components/taskmate/www/locales/fr.json
@@ -1628,5 +1628,16 @@
   "panel.settings_roulette_enabled": "Activer la roulette des tâches",
   "panel.settings_roulette_enabled_hint": "Permet à un enfant de tirer une tâche au hasard valant plus de points.",
   "panel.settings_roulette_multiplier": "Multiplicateur de points",
-  "panel.settings_roulette_spins": "Tours par jour"
+  "panel.settings_roulette_spins": "Tours par jour",
+  "panel.settings_unlock_allowlist": "Liste d'autorisation de déverrouillage",
+  "panel.settings_unlock_allowlist_hint": "Seules ces entités peuvent être déverrouillées par une récompense. Rien n'est autorisé tant que vous n'ajoutez rien ici.",
+  "panel.settings_unlock_allowlist_empty": "Rien d'autorisé pour l'instant.",
+  "panel.settings_unlock_allowlist_add": "Rechercher une entité à autoriser",
+  "panel.reward_unlock_section": "Avancé — déverrouillage temporaire",
+  "panel.reward_unlock_intro": "Allume quelque chose quand cette récompense est validée, puis l'éteint après un temps donné.",
+  "panel.reward_unlock_none": "Rien",
+  "panel.reward_unlock_entity": "Déverrouiller",
+  "panel.reward_unlock_minutes": "Pendant combien de temps (minutes)",
+  "panel.reward_unlock_minutes_hint": "0 = laisser allumé ; vous devrez l'éteindre vous-même.",
+  "panel.reward_unlock_no_allowlist": "Ajoutez d'abord une entité à la liste d'autorisation dans les Réglages."
 }

--- a/custom_components/taskmate/www/locales/nb.json
+++ b/custom_components/taskmate/www/locales/nb.json
@@ -1628,5 +1628,16 @@
   "panel.settings_roulette_enabled": "Slå på oppgaveroulette",
   "panel.settings_roulette_enabled_hint": "Lar et barn spinne for en tilfeldig gjenstående oppgave verdt ekstra poeng.",
   "panel.settings_roulette_multiplier": "Poengmultiplikator",
-  "panel.settings_roulette_spins": "Spinn per dag"
+  "panel.settings_roulette_spins": "Spinn per dag",
+  "panel.settings_unlock_allowlist": "Tillatelsesliste for opplåsing",
+  "panel.settings_unlock_allowlist_hint": "Bare disse entitetene kan låses opp av en belønning. Ingenting er tillatt før du legger til noe her.",
+  "panel.settings_unlock_allowlist_empty": "Ingenting tillatt ennå.",
+  "panel.settings_unlock_allowlist_add": "Søk etter en entitet å tillate",
+  "panel.reward_unlock_section": "Avansert — tidsbegrenset opplåsing",
+  "panel.reward_unlock_intro": "Slår på noe når denne belønningen godkjennes, og av igjen etter en angitt tid.",
+  "panel.reward_unlock_none": "Ingenting",
+  "panel.reward_unlock_entity": "Lås opp",
+  "panel.reward_unlock_minutes": "Hvor lenge (minutter)",
+  "panel.reward_unlock_minutes_hint": "0 = la den stå på; du må slå av selv.",
+  "panel.reward_unlock_no_allowlist": "Legg først til en entitet i tillatelseslisten under Innstillinger."
 }

--- a/custom_components/taskmate/www/locales/nn.json
+++ b/custom_components/taskmate/www/locales/nn.json
@@ -1628,5 +1628,16 @@
   "panel.settings_roulette_enabled": "Slå på oppgåveroulette",
   "panel.settings_roulette_enabled_hint": "Lèt eit barn spinne for ei tilfeldig gjenståande oppgåve verdt ekstra poeng.",
   "panel.settings_roulette_multiplier": "Poengmultiplikator",
-  "panel.settings_roulette_spins": "Spinn per dag"
+  "panel.settings_roulette_spins": "Spinn per dag",
+  "panel.settings_unlock_allowlist": "Løyveliste for opplåsing",
+  "panel.settings_unlock_allowlist_hint": "Berre desse entitetane kan låsast opp av ei belønning. Ingenting er tillate før du legg til noko her.",
+  "panel.settings_unlock_allowlist_empty": "Ingenting tillate enno.",
+  "panel.settings_unlock_allowlist_add": "Søk etter ein entitet å tillate",
+  "panel.reward_unlock_section": "Avansert — tidsavgrensa opplåsing",
+  "panel.reward_unlock_intro": "Slår på noko når denne belønninga vert godkjend, og av igjen etter ei fastsett tid.",
+  "panel.reward_unlock_none": "Ingenting",
+  "panel.reward_unlock_entity": "Lås opp",
+  "panel.reward_unlock_minutes": "Kor lenge (minutt)",
+  "panel.reward_unlock_minutes_hint": "0 = la han stå på; du må slå av sjølv.",
+  "panel.reward_unlock_no_allowlist": "Legg først til ein entitet i løyvelista under Innstillingar."
 }

--- a/custom_components/taskmate/www/locales/pt-BR.json
+++ b/custom_components/taskmate/www/locales/pt-BR.json
@@ -1628,5 +1628,16 @@
   "panel.settings_roulette_enabled": "Ativar roleta de tarefas",
   "panel.settings_roulette_enabled_hint": "Permite que uma criança gire por uma tarefa pendente aleatória que vale pontos extras.",
   "panel.settings_roulette_multiplier": "Multiplicador de pontos",
-  "panel.settings_roulette_spins": "Giros por dia"
+  "panel.settings_roulette_spins": "Giros por dia",
+  "panel.settings_unlock_allowlist": "Lista de permissões de desbloqueio",
+  "panel.settings_unlock_allowlist_hint": "Só estas entidades podem ser desbloqueadas por uma recompensa. Nada é permitido até você adicionar algo aqui.",
+  "panel.settings_unlock_allowlist_empty": "Nada permitido ainda.",
+  "panel.settings_unlock_allowlist_add": "Procurar uma entidade para permitir",
+  "panel.reward_unlock_section": "Avançado — desbloqueio temporário",
+  "panel.reward_unlock_intro": "Liga algo quando esta recompensa for aprovada e desliga de novo após um tempo definido.",
+  "panel.reward_unlock_none": "Nada",
+  "panel.reward_unlock_entity": "Desbloquear",
+  "panel.reward_unlock_minutes": "Por quanto tempo (minutos)",
+  "panel.reward_unlock_minutes_hint": "0 = deixar ligado; você terá de desligar.",
+  "panel.reward_unlock_no_allowlist": "Adicione primeiro uma entidade à lista de permissões nas Configurações."
 }

--- a/custom_components/taskmate/www/locales/pt.json
+++ b/custom_components/taskmate/www/locales/pt.json
@@ -1628,5 +1628,16 @@
   "panel.settings_roulette_enabled": "Ativar roleta de tarefas",
   "panel.settings_roulette_enabled_hint": "Permite a uma criança girar por uma tarefa pendente aleatória que vale pontos extra.",
   "panel.settings_roulette_multiplier": "Multiplicador de pontos",
-  "panel.settings_roulette_spins": "Giros por dia"
+  "panel.settings_roulette_spins": "Giros por dia",
+  "panel.settings_unlock_allowlist": "Lista de permissões de desbloqueio",
+  "panel.settings_unlock_allowlist_hint": "Só estas entidades podem ser desbloqueadas por uma recompensa. Nada é permitido até adicionares algo aqui.",
+  "panel.settings_unlock_allowlist_empty": "Nada permitido ainda.",
+  "panel.settings_unlock_allowlist_add": "Procurar uma entidade para permitir",
+  "panel.reward_unlock_section": "Avançado — desbloqueio temporário",
+  "panel.reward_unlock_intro": "Liga algo quando esta recompensa for aprovada e desliga de novo após um tempo definido.",
+  "panel.reward_unlock_none": "Nada",
+  "panel.reward_unlock_entity": "Desbloquear",
+  "panel.reward_unlock_minutes": "Durante quanto tempo (minutos)",
+  "panel.reward_unlock_minutes_hint": "0 = deixar ligado; terás de desligar tu.",
+  "panel.reward_unlock_no_allowlist": "Adiciona primeiro uma entidade à lista de permissões nas Definições."
 }

--- a/custom_components/taskmate/www/taskmate-panel.js
+++ b/custom_components/taskmate/www/taskmate-panel.js
@@ -468,7 +468,16 @@ class TaskMatePanel extends HTMLElement {
     if (act === "close-mobile-nav")  { this._mobileNavOpen = false; this._render(); return; }
     if (act === "close-dialog") { this._closeDialog(); return; }
     if (act === "clear-field") { this._setEntityField(t.dataset.field, ""); this._render(); return; }
-    if (act === "pick-entity") { this._setEntityField(t.dataset.field, t.dataset.value); this._closeEntityDropdown(); this._render(); return; }
+    if (act === "pick-entity") {
+      // The allowlist picker (#678) isn't a dialog field — picking there adds
+      // the entity to the saved list rather than writing into _dialog.data.
+      if (t.dataset.field === "_allowlist_pick") {
+        this._closeEntityDropdown();
+        this._addToAllowlist(t.dataset.value);
+        return;
+      }
+      this._setEntityField(t.dataset.field, t.dataset.value); this._closeEntityDropdown(); this._render(); return;
+    }
     if (act === "scrim") {
       if (e.target === this.querySelector(".tm-scrim")) this._closeDialog();
       return;
@@ -529,6 +538,7 @@ class TaskMatePanel extends HTMLElement {
     if (act === "toggle-depends")    { this._toggleArrayField("depends_on", t.dataset.id); return; }
     if (act === "toggle-calendar")   { this._toggleArrayField("publish_calendar_entities", t.dataset.id); return; }
     if (act === "toggle-weather-condition") { this._toggleArrayField("weather_block_conditions", t.dataset.id); return; }
+    if (act === "remove-allowlist")         { this._removeFromAllowlist(t.dataset.id); return; }
     if (act === "add-scheduled")            { this._addScheduledChange(); return; }
     if (act === "remove-scheduled")         { this._removeScheduledChange(t.dataset.id); return; }
     if (act === "toggle-scheduled-child" || act === "toggle-scheduled-day") {
@@ -1431,7 +1441,8 @@ class TaskMatePanel extends HTMLElement {
     const blank = { name: "", description: "", cost: 50, icon: "mdi:gift",
       assigned_to: [], is_jackpot: false, pool_enabled: false,
       quantity_str: "", expires_at: "",
-      restock_enabled: false, restock_amount: 0, restock_period: "weekly" };
+      restock_enabled: false, restock_amount: 0, restock_period: "weekly",
+      unlock_entity: "", unlock_minutes: 30 };
     if (id) {
       const r = (this._state.rewards || []).find(x => x.id === id);
       if (!r) return;
@@ -1463,6 +1474,8 @@ class TaskMatePanel extends HTMLElement {
       quantity: qty,
       expires_at: (d.expires_at || "").trim() || null,
       restock_enabled: !!d.restock_enabled,
+      unlock_entity: d.unlock_entity || "",
+      unlock_minutes: Math.max(0, Number(d.unlock_minutes) || 0),
       restock_amount: Math.max(0, Number(d.restock_amount) || 0),
       restock_period: d.restock_period || "weekly",
     };
@@ -3871,6 +3884,22 @@ class TaskMatePanel extends HTMLElement {
                 <label>${this._t("panel.settings_surprise_max")}<input type="number" class="tm-input" step="1" min="0" data-setting="surprise_bonus_max" value="${s.surprise_bonus_max ?? 20}"></label>
               </div>
             </div>
+            <div class="tm-setting-row tm-setting-stack">
+              <div class="tm-setting-label">${this._t("panel.settings_unlock_allowlist")}<small>${this._t("panel.settings_unlock_allowlist_hint")}</small></div>
+              <div class="tm-allowlist">
+                ${(s.unlock_allowlist || []).map(e => `
+                  <span class="tm-allow-chip">
+                    ${this._esc(e)}
+                    <button type="button" data-act="remove-allowlist" data-id="${this._esc(e)}" title="${this._t("panel.tooltip_remove")}">✕</button>
+                  </span>
+                `).join("") || `<span class="tm-field-hint">${this._t("panel.settings_unlock_allowlist_empty")}</span>`}
+              </div>
+              <div class="tm-field-row" style="margin-top:8px">
+                ${this._entityPickerField("", "_allowlist_pick", "",
+                  ["switch", "light", "media_player", "input_boolean", "automation", "script", "fan", "climate"],
+                  this._t("panel.settings_unlock_allowlist_add"))}
+              </div>
+            </div>
             <div class="tm-setting-row">
               <div class="tm-setting-label">${this._t("panel.settings_roulette_enabled")}<small>${this._t("panel.settings_roulette_enabled_hint")}</small></div>
               <ha-switch data-setting="roulette_enabled" ${s.roulette_enabled ? "checked" : ""}></ha-switch>
@@ -4812,6 +4841,24 @@ class TaskMatePanel extends HTMLElement {
     this._render();
   }
 
+  async _saveAllowlist(list) {
+    const { ok, err } = await this._callWS({ type: "taskmate/update_settings", unlock_allowlist: list });
+    if (!ok) { this._showToast("err", err); return; }
+    await this._fetchState();
+    this._render();
+  }
+
+  _removeFromAllowlist(entityId) {
+    const current = (this._state.settings || {}).unlock_allowlist || [];
+    this._saveAllowlist(current.filter(e => e !== entityId));
+  }
+
+  _addToAllowlist(entityId) {
+    const current = (this._state.settings || {}).unlock_allowlist || [];
+    if (!entityId || current.includes(entityId)) return;
+    this._saveAllowlist([...current, entityId]);
+  }
+
   async _addScheduledChange() {
     const d = this._dialog.data;
     const draft = this._schedDraft();
@@ -4898,10 +4945,37 @@ class TaskMatePanel extends HTMLElement {
             { v: "monthly", l: this._t("panel.reward_restock_monthly") },
           ])}
         </div>`,
+        this._renderRewardUnlock(d),
       ].join(""),
       `<button type="button" class="tm-btn" data-act="close-dialog">${this._t("panel.btn_cancel")}</button>
        <button type="button" class="tm-btn tm-btn-raised" data-act="save-reward">${this._t("panel.btn_save")}</button>`
     );
+  }
+
+  /**
+   * Timed unlock (#678). Only offers entities the parent has allowlisted in
+   * Settings — a reward must not be able to reach arbitrary devices.
+   */
+  _renderRewardUnlock(d) {
+    const allow = (this._state.settings || {}).unlock_allowlist || [];
+    const open = this._dialog._openAdvanced?.has("unlock");
+    if (!allow.length) {
+      return `<details class="tm-advanced" data-section="unlock"${open ? " open" : ""}>
+        <summary>${this._t("panel.reward_unlock_section")}</summary>
+        <div><span class="tm-field-hint">${this._t("panel.reward_unlock_no_allowlist")}</span></div>
+      </details>`;
+    }
+    const options = [{ v: "", lk: "panel.reward_unlock_none" }]
+      .concat(allow.map(e => ({ v: e, l: e })));
+    return `<details class="tm-advanced" data-section="unlock"${open ? " open" : ""}>
+      <summary>${this._t("panel.reward_unlock_section")}</summary>
+      <div>
+        <span class="tm-field-hint" style="margin-bottom:8px;display:block">${this._t("panel.reward_unlock_intro")}</span>
+        ${this._select(this._t("panel.reward_unlock_entity"), "unlock_entity", d.unlock_entity || "", options)}
+        ${d.unlock_entity ? this._field(this._t("panel.reward_unlock_minutes"), "unlock_minutes",
+          d.unlock_minutes ?? 30, "number", this._t("panel.reward_unlock_minutes_hint")) : ""}
+      </div>
+    </details>`;
   }
 
   _renderAvatarCatalogDialog() {
@@ -6506,6 +6580,20 @@ class TaskMatePanel extends HTMLElement {
       }
 
       /* Chip multi-select */
+      /* Timed unlock allowlist (#678) */
+      .tm-setting-stack { flex-direction: column; align-items: stretch; }
+      .tm-allowlist { display: flex; gap: 6px; flex-wrap: wrap; margin-top: 6px; }
+      .tm-allow-chip {
+        display: inline-flex; align-items: center; gap: 6px;
+        background: var(--tm-surface-0); border: 1px solid var(--tm-border);
+        border-radius: 999px; padding: 4px 6px 4px 12px;
+        font-size: 12.5px; font-family: var(--tm-mono, monospace);
+      }
+      .tm-allow-chip button {
+        background: none; border: 0; cursor: pointer; padding: 0 2px;
+        color: var(--tm-text-muted); font-size: 13px; line-height: 1;
+      }
+
       /* Scheduled config changes (#675) */
       .tm-sched-count {
         display: inline-block; min-width: 18px; padding: 0 5px;

--- a/tests/test_timed_unlocks.py
+++ b/tests/test_timed_unlocks.py
@@ -1,0 +1,235 @@
+"""Timed unlock rewards (#678).
+
+Spend points to unlock the TV for half an hour. Two hard limits keep this from
+becoming "a reward can do anything to your house": a reward can only turn one
+entity on and back off, and that entity must be on the parent's allowlist —
+checked at save time AND again when it actually fires.
+"""
+from __future__ import annotations
+
+from datetime import timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from homeassistant.util import dt as dt_util
+
+from custom_components.taskmate.models import Child, Reward
+
+from .test_coordinator_logic import _make_coord
+
+
+def _coord(allowlist=None, unlocks=None):
+    settings = {}
+    if allowlist is not None:
+        settings["unlock_allowlist"] = allowlist
+    if unlocks is not None:
+        settings["active_unlocks"] = unlocks
+    coord = _make_coord(settings=settings)
+
+    def _set(key, value):
+        settings[key] = value
+    coord.storage.set_setting = MagicMock(side_effect=_set)
+    coord.storage.get_setting = MagicMock(side_effect=lambda k, d="": settings.get(k, d))
+    coord.storage.async_save = AsyncMock()
+    coord.async_refresh = AsyncMock()
+    coord.hass.services.async_call = AsyncMock()
+    coord.hass.bus.async_fire = MagicMock()
+    coord._unlock_timers = []
+    coord._settings = settings
+    return coord
+
+
+def _reward(**kwargs):
+    return Reward(name="TV time", cost=50, **kwargs)
+
+
+class TestAllowlist:
+    def test_empty_allowlist_permits_nothing(self):
+        """Fail closed: this gates household devices."""
+        assert _coord([]).is_unlock_allowed("switch.tv") is False
+
+    def test_unset_allowlist_permits_nothing(self):
+        assert _coord().is_unlock_allowed("switch.tv") is False
+
+    def test_exact_entity_is_permitted(self):
+        assert _coord(["switch.tv"]).is_unlock_allowed("switch.tv") is True
+
+    def test_bare_domain_permits_the_whole_domain(self):
+        coord = _coord(["switch"])
+        assert coord.is_unlock_allowed("switch.tv") is True
+        assert coord.is_unlock_allowed("switch.anything") is True
+
+    def test_domain_entry_does_not_leak_to_other_domains(self):
+        assert _coord(["switch"]).is_unlock_allowed("light.bedroom") is False
+
+    def test_other_entities_are_refused(self):
+        assert _coord(["switch.tv"]).is_unlock_allowed("switch.boiler") is False
+
+    def test_matching_is_case_insensitive(self):
+        assert _coord(["Switch.TV"]).is_unlock_allowed("switch.tv") is True
+
+    @pytest.mark.parametrize("value", ["", "   ", "notanentity", "switch"])
+    def test_malformed_entity_ids_are_refused(self, value):
+        assert _coord(["switch", "switch.tv"]).is_unlock_allowed(value) is False
+
+
+class TestValidation:
+    def test_blank_entity_is_allowed_and_means_no_unlock(self):
+        assert _coord(["switch.tv"]).validate_unlock("", 0) == ("", 0)
+
+    def test_disallowed_entity_is_rejected(self):
+        with pytest.raises(ValueError, match="not on the unlock allowlist"):
+            _coord(["switch.tv"]).validate_unlock("switch.boiler", 30)
+
+    def test_allowed_entity_passes(self):
+        assert _coord(["switch.tv"]).validate_unlock("switch.tv", 30) == ("switch.tv", 30)
+
+    def test_minutes_must_be_a_number(self):
+        with pytest.raises(ValueError, match="whole number"):
+            _coord(["switch.tv"]).validate_unlock("switch.tv", "ages")
+
+    def test_negative_minutes_rejected(self):
+        with pytest.raises(ValueError, match="negative"):
+            _coord(["switch.tv"]).validate_unlock("switch.tv", -1)
+
+    def test_absurd_duration_rejected(self):
+        with pytest.raises(ValueError, match="cannot exceed"):
+            _coord(["switch.tv"]).validate_unlock("switch.tv", 10000)
+
+
+class TestStartingAnUnlock:
+    @pytest.mark.asyncio
+    async def test_unlock_turns_the_entity_on(self):
+        coord = _coord(["switch.tv"])
+        record = await coord.async_start_unlock(
+            _reward(unlock_entity="switch.tv", unlock_minutes=30), Child(name="Kid", id="k1"))
+        assert record["entity_id"] == "switch.tv"
+        coord.hass.services.async_call.assert_awaited_with(
+            "homeassistant", "turn_on", {"entity_id": "switch.tv"}, blocking=False)
+
+    @pytest.mark.asyncio
+    async def test_reward_without_unlock_does_nothing(self):
+        coord = _coord(["switch.tv"])
+        assert await coord.async_start_unlock(_reward(), Child(name="Kid", id="k1")) is None
+        coord.hass.services.async_call.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_entity_removed_from_allowlist_is_refused_at_fire_time(self):
+        """The allowlist can change after a reward was created — re-check."""
+        coord = _coord(["switch.something_else"])
+        result = await coord.async_start_unlock(
+            _reward(unlock_entity="switch.tv", unlock_minutes=30), Child(name="Kid", id="k1"))
+        assert result is None
+        coord.hass.services.async_call.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_unlock_is_persisted_so_a_restart_can_revert_it(self):
+        coord = _coord(["switch.tv"])
+        await coord.async_start_unlock(
+            _reward(unlock_entity="switch.tv", unlock_minutes=30), Child(name="Kid", id="k1"))
+        assert len(coord.active_unlocks()) == 1
+        coord.storage.async_save.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_zero_minutes_does_not_schedule_a_revert(self):
+        coord = _coord(["switch.tv"])
+        record = await coord.async_start_unlock(
+            _reward(unlock_entity="switch.tv", unlock_minutes=0), Child(name="Kid", id="k1"))
+        assert record["revert_at"] == ""
+        assert coord.active_unlocks() == []
+
+    @pytest.mark.asyncio
+    async def test_starting_fires_an_event(self):
+        coord = _coord(["switch.tv"])
+        await coord.async_start_unlock(
+            _reward(unlock_entity="switch.tv", unlock_minutes=30), Child(name="Kid", id="k1"))
+        event, payload = coord.hass.bus.async_fire.call_args[0]
+        assert event == "taskmate_unlock_started"
+        assert payload["child_name"] == "Kid"
+
+
+class TestReverting:
+    @pytest.mark.asyncio
+    async def test_revert_turns_the_entity_off_and_clears_the_record(self):
+        coord = _coord(["switch.tv"])
+        record = await coord.async_start_unlock(
+            _reward(unlock_entity="switch.tv", unlock_minutes=30), Child(name="Kid", id="k1"))
+        await coord.async_revert_unlock(record)
+        coord.hass.services.async_call.assert_awaited_with(
+            "homeassistant", "turn_off", {"entity_id": "switch.tv"}, blocking=False)
+        assert coord.active_unlocks() == []
+
+    @pytest.mark.asyncio
+    async def test_revert_fires_an_event(self):
+        coord = _coord(["switch.tv"])
+        record = await coord.async_start_unlock(
+            _reward(unlock_entity="switch.tv", unlock_minutes=30), Child(name="Kid", id="k1"))
+        coord.hass.bus.async_fire.reset_mock()
+        await coord.async_revert_unlock(record)
+        assert coord.hass.bus.async_fire.call_args[0][0] == "taskmate_unlock_ended"
+
+
+class TestSurvivingARestart:
+    """The one genuinely bad failure mode: a restart leaving the TV on forever."""
+
+    @pytest.mark.asyncio
+    async def test_expired_unlock_is_reverted_on_startup(self):
+        past = (dt_util.now() - timedelta(minutes=5)).isoformat()
+        coord = _coord(["switch.tv"], [{"entity_id": "switch.tv", "revert_at": past}])
+        assert await coord.async_resume_unlocks() == 1
+        coord.hass.services.async_call.assert_awaited_with(
+            "homeassistant", "turn_off", {"entity_id": "switch.tv"}, blocking=False)
+        assert coord.active_unlocks() == []
+
+    @pytest.mark.asyncio
+    async def test_still_running_unlock_is_kept_and_rearmed(self):
+        future = (dt_util.now() + timedelta(minutes=25)).isoformat()
+        coord = _coord(["switch.tv"], [{"entity_id": "switch.tv", "revert_at": future}])
+        assert await coord.async_resume_unlocks() == 0
+        assert len(coord.active_unlocks()) == 1
+        assert len(coord._unlock_timers) == 1
+        coord.hass.services.async_call.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_unparseable_revert_time_is_turned_off_not_left_on(self):
+        coord = _coord(["switch.tv"], [{"entity_id": "switch.tv", "revert_at": "whenever"}])
+        assert await coord.async_resume_unlocks() == 1
+        coord.hass.services.async_call.assert_awaited_with(
+            "homeassistant", "turn_off", {"entity_id": "switch.tv"}, blocking=False)
+
+    @pytest.mark.asyncio
+    async def test_resume_reverts_even_if_no_longer_allowlisted(self):
+        """Turning something OFF is always safe — never gate the revert."""
+        past = (dt_util.now() - timedelta(minutes=5)).isoformat()
+        coord = _coord([], [{"entity_id": "switch.tv", "revert_at": past}])
+        assert await coord.async_resume_unlocks() == 1
+        coord.hass.services.async_call.assert_awaited_with(
+            "homeassistant", "turn_off", {"entity_id": "switch.tv"}, blocking=False)
+
+    @pytest.mark.asyncio
+    async def test_nothing_active_is_a_no_op(self):
+        coord = _coord(["switch.tv"], [])
+        assert await coord.async_resume_unlocks() == 0
+        coord.hass.services.async_call.assert_not_awaited()
+
+    def test_cancelling_timers_is_safe_when_one_raises(self):
+        coord = _coord(["switch.tv"])
+        bad = MagicMock(side_effect=RuntimeError("already gone"))
+        good = MagicMock()
+        coord._unlock_timers = [bad, good]
+        coord.cancel_unlock_timers()  # must not raise during teardown
+        good.assert_called_once()
+        assert coord._unlock_timers == []
+
+
+class TestModel:
+    def test_unlock_fields_round_trip(self):
+        reward = _reward(unlock_entity="switch.tv", unlock_minutes=45)
+        restored = Reward.from_dict(reward.to_dict())
+        assert restored.unlock_entity == "switch.tv"
+        assert restored.unlock_minutes == 45
+
+    def test_legacy_reward_without_unlock_fields(self):
+        restored = Reward.from_dict({"name": "Old reward", "cost": 10})
+        assert restored.unlock_entity == ""
+        assert restored.unlock_minutes == 0


### PR DESCRIPTION
Spend points to unlock something for a while — the TV, the console socket, a wifi group. Approving the claim turns the entity on; a timer turns it back off.

## Two deliberate limits

You asked for this to be restricted to an allowlist you pick, and I tightened it a step further than that:

1. **A reward can only turn ONE entity on and back off again.** No free-form service call, no payload, no template. The original idea ("a reward can call an HA service") would have let a reward do anything to the house; this shape cannot.
2. **The entity must be on your allowlist** — checked when the reward is saved **and again when it actually fires**, because the allowlist can change after a reward was created. Revoke an entity later and any reward pointing at it quietly stops unlocking rather than breaking.

**An empty allowlist permits nothing.** This gates household devices, so the safe default when unconfigured is "no", not "everything". An entry may be a full entity id (`switch.xbox`) or a bare domain (`switch`) to permit everything in it.

## Surviving a restart

The one genuinely bad failure mode here is a Home Assistant restart mid-unlock leaving the television on forever. Active unlocks are therefore **persisted**, and on startup anything already past due is turned off while anything still running gets a fresh timer.

Reverting is **never** gated by the allowlist — turning something off is always safe, including for an entity that has since been revoked or whose `revert_at` is unparseable. Scheduled reverts are also cancelled on unload so they cannot fire after teardown, and cancellation tolerates an already-dead handle.

## Setting it up

1. **Settings → Unlock allowlist** — add the entities a reward may touch.
2. Open a reward → **Advanced — timed unlock** → pick an allowlisted entity and a duration (max 24h; `0` leaves it on).

## Testing

- **33 new tests**: allowlist matching (empty/unset fail closed, exact id, bare domain, domain doesn't leak across domains, case-insensitive, malformed ids), validation (blank means no unlock, disallowed entity, non-numeric/negative/absurd minutes), starting an unlock (turns on, persists, fires an event, zero minutes schedules nothing, **entity removed from the allowlist is refused at fire time**), reverting, and surviving a restart (expired reverted, still-running kept and re-armed, unparseable time turned off rather than left on, **revert works even when no longer allowlisted**, timer cancellation tolerates a raising handle).
- Full suite: **1124 passed** vs **1091** on `main`, identical pre-existing 3 failures / 9 errors.
- `ruff` clean; `eslint` clean.
- **Verified end-to-end on ha-dev** against real `input_boolean` helpers created through HA's own API:
  - empty allowlist → reward save refused
  - non-allowlisted entity → refused
  - 99999 minutes → refused
  - allowlisted reward saved, claimed, approved → **entity turned on**
  - waited out the 1-minute unlock → **entity turned off by the timer, record cleared**
  - started a 30-minute unlock and **restarted Home Assistant mid-unlock** → entity still on, record retained and re-armed

  No console errors; rewards, allowlist and helpers all cleaned up afterwards.

Three earlier e2e attempts failed on test-harness problems worth noting, none of them product bugs: `POST /api/states` creates a virtual state with no integration behind it (so `homeassistant.turn_on` does nothing and it vanishes on restart); leftover helpers made HA suffix new ids so the test measured a stale entity; and browserless idles the tab out across a 72-second wait.

## i18n

All 11 new strings translated into all 8 locales in this PR.

Fixes #678