### PR TITLE
feat(panel): fairness report — who is actually doing the work

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@
 - [Routine Mode](#routine-mode)
 - [Chore Roulette](#chore-roulette)
 - [Timed Unlock Rewards](#timed-unlock-rewards)
+- [Insights — Fairness Report](#insights--fairness-report)
 - [Bonus Points System](#bonus-points-system)
 - [Notifications](#notifications)
 - [Quiet Hours](#quiet-hours)
@@ -466,6 +467,21 @@ Spend points to unlock something for a while — the TV, the console socket, a w
 - Active unlocks are **persisted**. A Home Assistant restart mid-unlock re-arms the timer; anything already past due is turned off at startup. A restart can never strand the television on.
 - Turning something **off** is never gated by the allowlist — a revert is always safe.
 - Fires `taskmate_unlock_started` and `taskmate_unlock_ended` (`entity_id`, `reward_id`, `reward_name`, `child_id`, `child_name`, `started_at`, `revert_at`).
+ 
+---
+ 
+## Insights — Fairness Report
+ 
+**TaskMate panel → Insights.** Answers the question the raw numbers don't: *am I dumping everything on the eldest?*
+ 
+For a chosen window (7, 14 or 30 days) it shows each child's completed chores, points earned, share of the family total, and how many distinct days they were active — with a marker showing where an even split would sit.
+ 
+### Key Points
+ 
+- **Judged on chore count, not points.** A pricier chore shouldn't be able to hide an uneven split. Points are shown alongside because the two can disagree: three quick jobs versus one hard one is balanced by points and lopsided by count, and only you can say which you meant.
+- Flagged as *doing more* / *doing less* when a child is more than **15 percentage points** off an even share. Wide enough that normal week-to-week variation doesn't nag; narrow enough to catch a real imbalance.
+- **Only approved, non-bonus completions count.** Unapproved work isn't yet work you've agreed happened, and bonus sub-tasks hang off a chore that's already counted.
+- Computed on demand, never cached — a stale report is worse than a slow one.
  
 ---
  

--- a/custom_components/taskmate/coord_reports.py
+++ b/custom_components/taskmate/coord_reports.py
@@ -1,0 +1,140 @@
+"""Parent-facing insight reports (#679).
+
+Reports answer questions the raw data doesn't: *am I dumping everything on the
+eldest?* They are computed on demand rather than stored — they are derived
+views over completions, and a stale cached report is worse than a slow one.
+
+Fairness is the first; the shared window/aggregation helpers here are meant to
+carry the friction and projection reports too.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import date, timedelta
+from typing import Any
+
+from homeassistant.util import dt as dt_util
+
+_LOGGER = logging.getLogger(__name__)
+
+DEFAULT_WINDOW_DAYS = 7
+MAX_WINDOW_DAYS = 90
+
+# A child's share of the family workload may sit this many percentage points
+# either side of an even split before it's called out. Wide enough that normal
+# week-to-week variation doesn't trigger it; narrow enough to catch a genuine
+# imbalance. With two children an even split is 50%, so this flags at 65/35.
+FAIR_SHARE_TOLERANCE = 15.0
+
+
+class ReportsMixin:
+    """Mixin providing on-demand parent insight reports."""
+
+    def _report_window(self, days: int | None) -> tuple[date, date, int]:
+        """Clamp the requested window and return (start, end, days) inclusive."""
+        # `None` means "unspecified"; any supplied value is clamped. Using
+        # truthiness here would silently turn a supplied 0 into the default
+        # rather than the 1-day window the caller half-asked for.
+        if days is None:
+            span = DEFAULT_WINDOW_DAYS
+        else:
+            try:
+                span = int(days)
+            except (TypeError, ValueError):
+                span = DEFAULT_WINDOW_DAYS
+        span = max(1, min(span, MAX_WINDOW_DAYS))
+        end = dt_util.as_local(dt_util.now()).date()
+        return end - timedelta(days=span - 1), end, span
+
+    def _completions_in_window(self, start: date, end: date) -> list:
+        """Approved, non-bonus completions inside the window.
+
+        Bonus sub-tasks are excluded: they're extra credit attached to a chore
+        that's already counted, so including them would double-count the effort.
+        Pending completions are excluded too — unapproved work isn't yet work
+        the parent has agreed happened.
+        """
+        out = []
+        for comp in self.storage.get_completions():
+            if not getattr(comp, "approved", False):
+                continue
+            if getattr(comp, "bonus_subtask_id", ""):
+                continue
+            try:
+                when = dt_util.as_local(comp.completed_at).date()
+            except (AttributeError, TypeError, ValueError):
+                continue
+            if start <= when <= end:
+                out.append(comp)
+        return out
+
+    def fairness_report(self, days: int | None = None) -> dict[str, Any]:
+        """Who is actually doing the work, and is it evenly split?
+
+        Reports both a chore count and a points total because they can
+        disagree: one child doing three quick jobs and another doing one hard
+        one is balanced by points and lopsided by count. Showing both lets the
+        parent decide which they meant.
+        """
+        start, end, span = self._report_window(days)
+        children = self.storage.get_children()
+        completions = self._completions_in_window(start, end)
+
+        by_child: dict[str, dict[str, Any]] = {
+            c.id: {"id": c.id, "name": c.name, "completions": 0, "points": 0, "active_days": set()}
+            for c in children
+        }
+        for comp in completions:
+            entry = by_child.get(comp.child_id)
+            if entry is None:
+                continue  # a since-deleted child's history
+            entry["completions"] += 1
+            entry["points"] += int(getattr(comp, "points_awarded", 0) or 0)
+            entry["active_days"].add(dt_util.as_local(comp.completed_at).date().isoformat())
+
+        total_completions = sum(e["completions"] for e in by_child.values())
+        total_points = sum(e["points"] for e in by_child.values())
+        fair_share = 100.0 / len(children) if children else 0.0
+
+        rows = []
+        for entry in by_child.values():
+            share_completions = (
+                entry["completions"] / total_completions * 100 if total_completions else 0.0
+            )
+            share_points = entry["points"] / total_points * 100 if total_points else 0.0
+            # Judge on chore count: it's the closest proxy for "how much did
+            # they actually have to do", independent of how a chore is priced.
+            delta = share_completions - fair_share
+            if not total_completions:
+                status = "idle"
+            elif delta > FAIR_SHARE_TOLERANCE:
+                status = "over"
+            elif delta < -FAIR_SHARE_TOLERANCE:
+                status = "under"
+            else:
+                status = "balanced"
+            rows.append({
+                "id": entry["id"],
+                "name": entry["name"],
+                "completions": entry["completions"],
+                "points": entry["points"],
+                "share_completions": round(share_completions, 1),
+                "share_points": round(share_points, 1),
+                "delta": round(delta, 1),
+                "active_days": len(entry["active_days"]),
+                "status": status,
+            })
+
+        rows.sort(key=lambda r: (-r["completions"], r["name"]))
+        return {
+            "days": span,
+            "start": start.isoformat(),
+            "end": end.isoformat(),
+            "generated_at": dt_util.now().isoformat(),
+            "fair_share": round(fair_share, 1),
+            "tolerance": FAIR_SHARE_TOLERANCE,
+            "total_completions": total_completions,
+            "total_points": total_points,
+            "children": rows,
+            "balanced": all(r["status"] in ("balanced", "idle") for r in rows),
+        }

--- a/custom_components/taskmate/coordinator.py
+++ b/custom_components/taskmate/coordinator.py
@@ -25,6 +25,7 @@ from .coord_mandatory import MandatoryMixin
 from .coord_notifications import NotificationCoordinator
 from .coord_points import PointsMixin
 from .coord_quests import QuestsMixin
+from .coord_reports import ReportsMixin
 from .coord_rewards import RewardsMixin
 from .coord_roulette import RouletteMixin
 from .coord_scheduled import ScheduledChangesMixin
@@ -50,6 +51,7 @@ class TaskMateCoordinator(
     CalendarMixin,
     TemplatesMixin,
     ScheduledChangesMixin,
+    ReportsMixin,
     RouletteMixin,
     UnlocksMixin,
     DataUpdateCoordinator,

--- a/custom_components/taskmate/websocket.py
+++ b/custom_components/taskmate/websocket.py
@@ -77,6 +77,7 @@ WS_ADD_CHORE: Final           = "taskmate/add_chore"
 WS_UPDATE_CHORE: Final        = "taskmate/update_chore"
 WS_REMOVE_CHORE: Final        = "taskmate/remove_chore"
 
+WS_REPORT_FAIRNESS: Final     = "taskmate/reports/fairness"
 WS_SCHEDULED_LIST: Final      = "taskmate/scheduled/list"
 WS_SCHEDULED_ADD: Final       = "taskmate/scheduled/add"
 WS_SCHEDULED_REMOVE: Final    = "taskmate/scheduled/remove"
@@ -182,7 +183,7 @@ WS_CONFIG_IMPORT: Final = "taskmate/config/import"
 _AUDIT_EXCLUDE: Final = {
     WS_GET_STATE, WS_NOTIF_GET_STATE, WS_NOTIF_LIST_NOTIFY,
     WS_TEMPLATES_LIST, WS_TEMPLATES_GET, WS_AUDIT_LIST, WS_AUDIT_CLEAR,
-    WS_CONFIG_EXPORT, WS_SCHEDULED_LIST,
+    WS_CONFIG_EXPORT, WS_SCHEDULED_LIST, WS_REPORT_FAIRNESS,
 }
 
 
@@ -618,6 +619,20 @@ async def _ws_remove_chore(hass, connection, msg, coordinator):
     await coordinator.async_remove_chore(msg["chore_id"])
     connection.send_result(msg["id"], {"id": msg["chore_id"]})
 
+
+
+# ---------------------------------------------------------------------------
+# Insight reports (#679)
+# ---------------------------------------------------------------------------
+
+@websocket_api.websocket_command({
+    vol.Required("type"): WS_REPORT_FAIRNESS,
+    vol.Optional("days"): vol.All(int, vol.Range(min=1, max=90)),
+})
+@websocket_api.async_response
+@_admin_only
+async def _ws_report_fairness(hass, connection, msg, coordinator):
+    connection.send_result(msg["id"], coordinator.fairness_report(msg.get("days")))
 
 
 # ---------------------------------------------------------------------------
@@ -2162,6 +2177,7 @@ _COMMANDS = (
     _ws_add_child, _ws_update_child, _ws_remove_child, _ws_list_ha_users,
     _ws_add_chore, _ws_update_chore, _ws_remove_chore, _ws_clone_chore,
     _ws_scheduled_list, _ws_scheduled_add, _ws_scheduled_remove,
+    _ws_report_fairness,
     _ws_bulk_chore_action, _ws_gift_points,
     _ws_request_swap, _ws_approve_swap, _ws_reject_swap,
     _ws_config_export, _ws_config_import,

--- a/custom_components/taskmate/www/locales/de.json
+++ b/custom_components/taskmate/www/locales/de.json
@@ -1639,5 +1639,20 @@
   "panel.reward_unlock_entity": "Freischalten",
   "panel.reward_unlock_minutes": "Wie lange (Minuten)",
   "panel.reward_unlock_minutes_hint": "0 = eingeschaltet lassen; du musst selbst ausschalten.",
-  "panel.reward_unlock_no_allowlist": "Füge zuerst in den Einstellungen eine Entität zur Freischalt-Positivliste hinzu."
+  "panel.reward_unlock_no_allowlist": "Füge zuerst in den Einstellungen eine Entität zur Freischalt-Positivliste hinzu.",
+  "panel.tab_insights": "Einblicke",
+  "panel.insights_loading": "Wird berechnet…",
+  "panel.insights_fairness_title": "Wer macht die Arbeit?",
+  "panel.insights_fairness_intro": "{start} bis {end}. Gleichmäßig verteilt wären {fair}% pro Kind.",
+  "panel.insights_last_days": "Letzte {days} Tage",
+  "panel.insights_no_data": "In diesem Zeitraum noch keine bestätigten Aufgaben.",
+  "panel.insights_balanced": "Wirkt recht ausgewogen.",
+  "panel.insights_unbalanced": "Die Arbeit ist ungleich verteilt.",
+  "panel.insights_chores": "Aufgaben",
+  "panel.insights_status_over": "Macht mehr",
+  "panel.insights_status_under": "Macht weniger",
+  "panel.insights_status_balanced": "Ausgewogen",
+  "panel.insights_status_idle": "Noch nichts",
+  "panel.insights_fairness_note": "Bewertet nach Anzahl der Aufgaben, nicht nach Punkten, damit eine teurere Aufgabe keine ungleiche Verteilung verdeckt. Markiert, wenn ein Kind mehr als {tolerance} Punkte von einem gleichen Anteil abweicht.",
+  "panel.insights_chore": "Aufgabe"
 }

--- a/custom_components/taskmate/www/locales/en-GB.json
+++ b/custom_components/taskmate/www/locales/en-GB.json
@@ -1639,5 +1639,20 @@
   "panel.reward_unlock_entity": "Unlock",
   "panel.reward_unlock_minutes": "For how long (minutes)",
   "panel.reward_unlock_minutes_hint": "0 = leave it on; you'll need to turn it off yourself.",
-  "panel.reward_unlock_no_allowlist": "Add an entity to the unlock allowlist in Settings first."
+  "panel.reward_unlock_no_allowlist": "Add an entity to the unlock allowlist in Settings first.",
+  "panel.tab_insights": "Insights",
+  "panel.insights_loading": "Working it out…",
+  "panel.insights_fairness_title": "Who's doing the work?",
+  "panel.insights_fairness_intro": "{start} to {end}. An even split would be {fair}% each.",
+  "panel.insights_last_days": "Last {days} days",
+  "panel.insights_no_data": "No approved chores in this period yet.",
+  "panel.insights_balanced": "Looks fairly balanced.",
+  "panel.insights_unbalanced": "The workload is uneven.",
+  "panel.insights_chores": "chores",
+  "panel.insights_status_over": "Doing more",
+  "panel.insights_status_under": "Doing less",
+  "panel.insights_status_balanced": "Balanced",
+  "panel.insights_status_idle": "Nothing yet",
+  "panel.insights_fairness_note": "Judged on chore count, not points, so a pricier chore doesn't hide an uneven split. Flagged when a child is more than {tolerance} points off an even share.",
+  "panel.insights_chore": "chore"
 }

--- a/custom_components/taskmate/www/locales/en.json
+++ b/custom_components/taskmate/www/locales/en.json
@@ -1639,5 +1639,20 @@
   "panel.reward_unlock_entity": "Unlock",
   "panel.reward_unlock_minutes": "For how long (minutes)",
   "panel.reward_unlock_minutes_hint": "0 = leave it on; you'll need to turn it off yourself.",
-  "panel.reward_unlock_no_allowlist": "Add an entity to the unlock allowlist in Settings first."
+  "panel.reward_unlock_no_allowlist": "Add an entity to the unlock allowlist in Settings first.",
+  "panel.tab_insights": "Insights",
+  "panel.insights_loading": "Working it out…",
+  "panel.insights_fairness_title": "Who's doing the work?",
+  "panel.insights_fairness_intro": "{start} to {end}. An even split would be {fair}% each.",
+  "panel.insights_last_days": "Last {days} days",
+  "panel.insights_no_data": "No approved chores in this period yet.",
+  "panel.insights_balanced": "Looks fairly balanced.",
+  "panel.insights_unbalanced": "The workload is uneven.",
+  "panel.insights_chores": "chores",
+  "panel.insights_status_over": "Doing more",
+  "panel.insights_status_under": "Doing less",
+  "panel.insights_status_balanced": "Balanced",
+  "panel.insights_status_idle": "Nothing yet",
+  "panel.insights_fairness_note": "Judged on chore count, not points, so a pricier chore doesn't hide an uneven split. Flagged when a child is more than {tolerance} points off an even share.",
+  "panel.insights_chore": "chore"
 }

--- a/custom_components/taskmate/www/locales/fr.json
+++ b/custom_components/taskmate/www/locales/fr.json
@@ -1639,5 +1639,20 @@
   "panel.reward_unlock_entity": "Déverrouiller",
   "panel.reward_unlock_minutes": "Pendant combien de temps (minutes)",
   "panel.reward_unlock_minutes_hint": "0 = laisser allumé ; vous devrez l'éteindre vous-même.",
-  "panel.reward_unlock_no_allowlist": "Ajoutez d'abord une entité à la liste d'autorisation dans les Réglages."
+  "panel.reward_unlock_no_allowlist": "Ajoutez d'abord une entité à la liste d'autorisation dans les Réglages.",
+  "panel.tab_insights": "Analyses",
+  "panel.insights_loading": "Calcul en cours…",
+  "panel.insights_fairness_title": "Qui fait le travail ?",
+  "panel.insights_fairness_intro": "Du {start} au {end}. Une répartition égale serait de {fair}% chacun.",
+  "panel.insights_last_days": "{days} derniers jours",
+  "panel.insights_no_data": "Aucune tâche validée sur cette période.",
+  "panel.insights_balanced": "Cela semble équilibré.",
+  "panel.insights_unbalanced": "La charge est déséquilibrée.",
+  "panel.insights_chores": "tâches",
+  "panel.insights_status_over": "En fait plus",
+  "panel.insights_status_under": "En fait moins",
+  "panel.insights_status_balanced": "Équilibré",
+  "panel.insights_status_idle": "Rien encore",
+  "panel.insights_fairness_note": "Évalué sur le nombre de tâches, pas les points, pour qu'une tâche mieux payée ne masque pas un déséquilibre. Signalé au-delà de {tolerance} points d'écart avec une part égale.",
+  "panel.insights_chore": "tâche"
 }

--- a/custom_components/taskmate/www/locales/nb.json
+++ b/custom_components/taskmate/www/locales/nb.json
@@ -1639,5 +1639,20 @@
   "panel.reward_unlock_entity": "Lås opp",
   "panel.reward_unlock_minutes": "Hvor lenge (minutter)",
   "panel.reward_unlock_minutes_hint": "0 = la den stå på; du må slå av selv.",
-  "panel.reward_unlock_no_allowlist": "Legg først til en entitet i tillatelseslisten under Innstillinger."
+  "panel.reward_unlock_no_allowlist": "Legg først til en entitet i tillatelseslisten under Innstillinger.",
+  "panel.tab_insights": "Innsikt",
+  "panel.insights_loading": "Regner ut…",
+  "panel.insights_fairness_title": "Hvem gjør jobben?",
+  "panel.insights_fairness_intro": "{start} til {end}. En jevn fordeling ville vært {fair}% hver.",
+  "panel.insights_last_days": "Siste {days} dager",
+  "panel.insights_no_data": "Ingen godkjente oppgaver i denne perioden ennå.",
+  "panel.insights_balanced": "Ser ganske jevnt fordelt ut.",
+  "panel.insights_unbalanced": "Arbeidet er ujevnt fordelt.",
+  "panel.insights_chores": "oppgaver",
+  "panel.insights_status_over": "Gjør mer",
+  "panel.insights_status_under": "Gjør mindre",
+  "panel.insights_status_balanced": "Jevnt",
+  "panel.insights_status_idle": "Ingenting ennå",
+  "panel.insights_fairness_note": "Vurdert på antall oppgaver, ikke poeng, så en dyrere oppgave ikke skjuler en skjev fordeling. Markert når et barn er mer enn {tolerance} poeng unna en lik andel.",
+  "panel.insights_chore": "oppgave"
 }

--- a/custom_components/taskmate/www/locales/nn.json
+++ b/custom_components/taskmate/www/locales/nn.json
@@ -1639,5 +1639,20 @@
   "panel.reward_unlock_entity": "Lås opp",
   "panel.reward_unlock_minutes": "Kor lenge (minutt)",
   "panel.reward_unlock_minutes_hint": "0 = la han stå på; du må slå av sjølv.",
-  "panel.reward_unlock_no_allowlist": "Legg først til ein entitet i løyvelista under Innstillingar."
+  "panel.reward_unlock_no_allowlist": "Legg først til ein entitet i løyvelista under Innstillingar.",
+  "panel.tab_insights": "Innsikt",
+  "panel.insights_loading": "Reknar ut…",
+  "panel.insights_fairness_title": "Kven gjer jobben?",
+  "panel.insights_fairness_intro": "{start} til {end}. Ei jamn fordeling ville vore {fair}% kvar.",
+  "panel.insights_last_days": "Siste {days} dagar",
+  "panel.insights_no_data": "Ingen godkjende oppgåver i denne perioden enno.",
+  "panel.insights_balanced": "Ser ganske jamt fordelt ut.",
+  "panel.insights_unbalanced": "Arbeidet er ujamt fordelt.",
+  "panel.insights_chores": "oppgåver",
+  "panel.insights_status_over": "Gjer meir",
+  "panel.insights_status_under": "Gjer mindre",
+  "panel.insights_status_balanced": "Jamt",
+  "panel.insights_status_idle": "Ingenting enno",
+  "panel.insights_fairness_note": "Vurdert på tal oppgåver, ikkje poeng, så ei dyrare oppgåve ikkje skjuler ei skeiv fordeling. Markert når eit barn er meir enn {tolerance} poeng unna ein lik del.",
+  "panel.insights_chore": "oppgåve"
 }

--- a/custom_components/taskmate/www/locales/pt-BR.json
+++ b/custom_components/taskmate/www/locales/pt-BR.json
@@ -1639,5 +1639,20 @@
   "panel.reward_unlock_entity": "Desbloquear",
   "panel.reward_unlock_minutes": "Por quanto tempo (minutos)",
   "panel.reward_unlock_minutes_hint": "0 = deixar ligado; você terá de desligar.",
-  "panel.reward_unlock_no_allowlist": "Adicione primeiro uma entidade à lista de permissões nas Configurações."
+  "panel.reward_unlock_no_allowlist": "Adicione primeiro uma entidade à lista de permissões nas Configurações.",
+  "panel.tab_insights": "Análises",
+  "panel.insights_loading": "Calculando…",
+  "panel.insights_fairness_title": "Quem está fazendo o trabalho?",
+  "panel.insights_fairness_intro": "{start} a {end}. Uma divisão igual seria {fair}% para cada.",
+  "panel.insights_last_days": "Últimos {days} dias",
+  "panel.insights_no_data": "Ainda sem tarefas aprovadas neste período.",
+  "panel.insights_balanced": "Parece bem equilibrado.",
+  "panel.insights_unbalanced": "A carga está desequilibrada.",
+  "panel.insights_chores": "tarefas",
+  "panel.insights_status_over": "Faz mais",
+  "panel.insights_status_under": "Faz menos",
+  "panel.insights_status_balanced": "Equilibrado",
+  "panel.insights_status_idle": "Ainda nada",
+  "panel.insights_fairness_note": "Avaliado pelo número de tarefas, não por pontos, para que uma tarefa mais cara não esconda uma divisão desigual. Sinalizado quando uma criança está a mais de {tolerance} pontos de uma parte igual.",
+  "panel.insights_chore": "tarefa"
 }

--- a/custom_components/taskmate/www/locales/pt.json
+++ b/custom_components/taskmate/www/locales/pt.json
@@ -1639,5 +1639,20 @@
   "panel.reward_unlock_entity": "Desbloquear",
   "panel.reward_unlock_minutes": "Durante quanto tempo (minutos)",
   "panel.reward_unlock_minutes_hint": "0 = deixar ligado; terás de desligar tu.",
-  "panel.reward_unlock_no_allowlist": "Adiciona primeiro uma entidade à lista de permissões nas Definições."
+  "panel.reward_unlock_no_allowlist": "Adiciona primeiro uma entidade à lista de permissões nas Definições.",
+  "panel.tab_insights": "Análises",
+  "panel.insights_loading": "A calcular…",
+  "panel.insights_fairness_title": "Quem está a fazer o trabalho?",
+  "panel.insights_fairness_intro": "{start} a {end}. Uma divisão igual seria {fair}% para cada.",
+  "panel.insights_last_days": "Últimos {days} dias",
+  "panel.insights_no_data": "Ainda sem tarefas aprovadas neste período.",
+  "panel.insights_balanced": "Parece bastante equilibrado.",
+  "panel.insights_unbalanced": "A carga está desequilibrada.",
+  "panel.insights_chores": "tarefas",
+  "panel.insights_status_over": "Faz mais",
+  "panel.insights_status_under": "Faz menos",
+  "panel.insights_status_balanced": "Equilibrado",
+  "panel.insights_status_idle": "Ainda nada",
+  "panel.insights_fairness_note": "Avaliado pelo número de tarefas, não por pontos, para que uma tarefa mais cara não esconda uma divisão desigual. Assinalado quando uma criança está a mais de {tolerance} pontos de uma parte igual.",
+  "panel.insights_chore": "tarefa"
 }

--- a/custom_components/taskmate/www/taskmate-panel.js
+++ b/custom_components/taskmate/www/taskmate-panel.js
@@ -21,6 +21,7 @@ const PANEL_VERSION = (() => {
 const TABS = [
   { id: "children",  lk: "panel.tab_children" },
   { id: "activity",  lk: "panel.tab_activity" },
+  { id: "insights",  lk: "panel.tab_insights" },
   { id: "chores",    lk: "panel.tab_chores" },
   { id: "rewards",   lk: "panel.tab_rewards" },
   { id: "penalties", lk: "panel.tab_penalties" },
@@ -538,6 +539,12 @@ class TaskMatePanel extends HTMLElement {
     if (act === "toggle-depends")    { this._toggleArrayField("depends_on", t.dataset.id); return; }
     if (act === "toggle-calendar")   { this._toggleArrayField("publish_calendar_entities", t.dataset.id); return; }
     if (act === "toggle-weather-condition") { this._toggleArrayField("weather_block_conditions", t.dataset.id); return; }
+    if (act === "insights-window") {
+      this._insightDays = Number(t.dataset.id);
+      this._fairness = null;
+      this._loadFairness(this._insightDays);
+      return;
+    }
     if (act === "remove-allowlist")         { this._removeFromAllowlist(t.dataset.id); return; }
     if (act === "add-scheduled")            { this._addScheduledChange(); return; }
     if (act === "remove-scheduled")         { this._removeScheduledChange(t.dataset.id); return; }
@@ -2301,6 +2308,7 @@ class TaskMatePanel extends HTMLElement {
     return [
       { head: this._t("panel.nav_today"), items: [
         { id: "activity", label: this._t("panel.tab_activity"), icon: "mdi:pulse" },
+        { id: "insights", label: this._t("panel.tab_insights"), icon: "mdi:chart-box-outline" },
       ]},
       { head: this._t("panel.nav_manage"), items: [
         { id: "children",  label: this._t("panel.tab_children"),  icon: "mdi:account-multiple" },
@@ -2467,6 +2475,7 @@ class TaskMatePanel extends HTMLElement {
     switch (this._activeTab) {
       case "children":  return this._renderChildrenTab();
       case "activity":  return this._renderActivityTab();
+      case "insights":  return this._renderInsightsTab();
       case "chores":    return this._renderChoresTab();
       case "rewards":   return this._renderRewardsTab();
       case "penalties": return this._renderPenBonTab("penalty");
@@ -2481,6 +2490,80 @@ class TaskMatePanel extends HTMLElement {
       case "settings":      return this._renderSettingsTab();
       default:          return `<div class="tm-card">${this._t("panel.tab_unknown")}</div>`;
     }
+  }
+
+  /**
+   * Insight reports (#679). Computed on demand rather than stored — a stale
+   * cached report is worse than a slow one — so the tab fetches when opened
+   * and when the window changes.
+   */
+  _renderInsightsTab() {
+    const days = this._insightDays || 7;
+    const report = this._fairness;
+    if (!report) {
+      this._loadFairness(days);
+      return `<div class="tm-card"><div class="tm-empty">${this._t("panel.insights_loading")}</div></div>`;
+    }
+
+    const windows = [7, 14, 30];
+    const maxShare = Math.max(1, ...report.children.map(c => c.share_completions));
+
+    return `
+      <div class="tm-card">
+        <div class="tm-card-head">
+          <h2>${this._t("panel.insights_fairness_title")}</h2>
+          <div class="tm-chip-row">
+            ${windows.map(d => `
+              <button type="button" class="tm-chip-btn ${d === days ? "tm-chip-on" : ""}"
+                      data-act="insights-window" data-id="${d}">
+                ${this._t("panel.insights_last_days", { days: d })}
+              </button>
+            `).join("")}
+          </div>
+        </div>
+        <span class="tm-field-hint">${this._t("panel.insights_fairness_intro", {
+          start: report.start, end: report.end, fair: report.fair_share,
+        })}</span>
+
+        ${report.total_completions === 0 ? `
+          <div class="tm-empty">${this._t("panel.insights_no_data")}</div>
+        ` : `
+          <div class="tm-verdict tm-verdict-${report.balanced ? "ok" : "warn"}">
+            ${report.balanced
+              ? this._t("panel.insights_balanced")
+              : this._t("panel.insights_unbalanced")}
+          </div>
+          <div class="tm-fairness">
+            ${report.children.map(c => `
+              <div class="tm-fair-row">
+                <div class="tm-fair-name">${this._esc(c.name)}</div>
+                <div class="tm-fair-bar">
+                  <i class="tm-fair-${c.status}" style="width:${Math.round(c.share_completions / maxShare * 100)}%"></i>
+                  <span class="tm-fair-target" style="left:${Math.round(report.fair_share / maxShare * 100)}%"></span>
+                </div>
+                <div class="tm-fair-figs">
+                  <strong>${c.completions}</strong> ${this._t(c.completions === 1 ? "panel.insights_chore" : "panel.insights_chores")}
+                  · ${c.points} ${this._esc(this._state.settings?.points_name || this._t("common.points"))}
+                  · ${c.share_completions}%
+                </div>
+                <div class="tm-fair-status tm-fair-${c.status}">${this._t("panel.insights_status_" + c.status)}</div>
+              </div>
+            `).join("")}
+          </div>
+          <span class="tm-field-hint">${this._t("panel.insights_fairness_note", { tolerance: report.tolerance })}</span>
+        `}
+      </div>
+    `;
+  }
+
+  async _loadFairness(days) {
+    if (this._fairnessLoading) return;
+    this._fairnessLoading = true;
+    const { ok, res, err } = await this._callWS({ type: "taskmate/reports/fairness", days });
+    this._fairnessLoading = false;
+    if (!ok) { this._showToast("err", err); return; }
+    this._fairness = res;
+    this._render();
   }
 
   _searchBox(placeholder) {
@@ -6580,6 +6663,47 @@ class TaskMatePanel extends HTMLElement {
       }
 
       /* Chip multi-select */
+      /* Insight reports (#679) */
+      .tm-verdict {
+        border-radius: 10px; padding: 10px 14px; margin: 10px 0 14px;
+        font-weight: 700; font-size: 13.5px;
+      }
+      .tm-verdict-ok { background: rgba(46, 125, 50, 0.12); color: #2e7d32; }
+      .tm-verdict-warn { background: rgba(239, 108, 0, 0.14); color: #ef6c00; }
+      .tm-fairness { display: flex; flex-direction: column; gap: 14px; }
+      .tm-fair-row { display: grid; grid-template-columns: 120px 1fr auto; gap: 10px 12px; align-items: center; }
+      .tm-fair-name { font-weight: 700; font-size: 14px; }
+      .tm-fair-bar {
+        position: relative; height: 14px; border-radius: 99px;
+        background: var(--tm-surface-0); border: 1px solid var(--tm-border);
+        overflow: visible;
+      }
+      .tm-fair-bar > i {
+        display: block; height: 100%; border-radius: 99px;
+        background: var(--tm-accent); min-width: 2px;
+      }
+      .tm-fair-bar > i.tm-fair-over { background: #ef6c00; }
+      .tm-fair-bar > i.tm-fair-under { background: #7e57c2; }
+      .tm-fair-bar > i.tm-fair-balanced { background: #2e7d32; }
+      /* Marks where an even split would sit, so "fair" is visible not implied. */
+      .tm-fair-target {
+        position: absolute; top: -3px; width: 2px; height: 20px;
+        background: var(--tm-text-muted); opacity: 0.65;
+      }
+      .tm-fair-figs { grid-column: 2; font-size: 12.5px; color: var(--tm-text-muted); }
+      .tm-fair-status {
+        font-size: 11.5px; font-weight: 800; text-transform: uppercase;
+        letter-spacing: 0.03em; white-space: nowrap;
+      }
+      .tm-fair-status.tm-fair-over { color: #ef6c00; }
+      .tm-fair-status.tm-fair-under { color: #7e57c2; }
+      .tm-fair-status.tm-fair-balanced { color: #2e7d32; }
+      .tm-fair-status.tm-fair-idle { color: var(--tm-text-muted); }
+      @media (max-width: 640px) {
+        .tm-fair-row { grid-template-columns: 1fr auto; }
+        .tm-fair-bar { grid-column: 1 / -1; }
+      }
+
       /* Timed unlock allowlist (#678) */
       .tm-setting-stack { flex-direction: column; align-items: stretch; }
       .tm-allowlist { display: flex; gap: 6px; flex-wrap: wrap; margin-top: 6px; }

--- a/tests/test_fairness_report.py
+++ b/tests/test_fairness_report.py
@@ -1,0 +1,162 @@
+"""Fairness report (#679).
+
+Answers "am I dumping everything on the eldest?". Judged on chore count rather
+than points, so a pricier chore can't hide an uneven split.
+"""
+from __future__ import annotations
+
+from datetime import timedelta
+from unittest.mock import MagicMock
+
+from homeassistant.util import dt as dt_util
+
+from custom_components.taskmate.coord_reports import (
+    DEFAULT_WINDOW_DAYS,
+    FAIR_SHARE_TOLERANCE,
+    MAX_WINDOW_DAYS,
+)
+from custom_components.taskmate.models import Child
+
+from .test_coordinator_logic import _make_coord
+
+
+def _completion(child_id, *, days_ago=0, points=10, approved=True, bonus=""):
+    comp = MagicMock()
+    comp.child_id = child_id
+    comp.chore_id = "chore"
+    comp.approved = approved
+    comp.bonus_subtask_id = bonus
+    comp.points_awarded = points
+    comp.completed_at = dt_util.now() - timedelta(days=days_ago)
+    return comp
+
+
+def _coord(children, completions):
+    coord = _make_coord(children=children, completions=completions)
+    coord.storage.get_completions = MagicMock(return_value=list(completions))
+    coord.storage.get_children = MagicMock(return_value=list(children))
+    return coord
+
+
+KIDS = [Child(name="Ella", id="a"), Child(name="Sam", id="b")]
+
+
+class TestWindow:
+    def test_default_window(self):
+        report = _coord(KIDS, []).fairness_report()
+        assert report["days"] == DEFAULT_WINDOW_DAYS
+
+    def test_window_is_clamped(self):
+        coord = _coord(KIDS, [])
+        assert coord.fairness_report(0)["days"] == 1
+        assert coord.fairness_report(9999)["days"] == MAX_WINDOW_DAYS
+
+    def test_garbage_window_falls_back(self):
+        assert _coord(KIDS, []).fairness_report("lots")["days"] == DEFAULT_WINDOW_DAYS
+
+    def test_completions_outside_the_window_are_ignored(self):
+        coord = _coord(KIDS, [_completion("a", days_ago=30)])
+        assert coord.fairness_report(7)["total_completions"] == 0
+
+    def test_completions_inside_the_window_count(self):
+        coord = _coord(KIDS, [_completion("a", days_ago=3)])
+        assert coord.fairness_report(7)["total_completions"] == 1
+
+
+class TestWhatCounts:
+    def test_pending_completions_are_excluded(self):
+        """Unapproved work isn't yet work the parent agreed happened."""
+        coord = _coord(KIDS, [_completion("a", approved=False)])
+        assert coord.fairness_report()["total_completions"] == 0
+
+    def test_bonus_subtasks_are_excluded(self):
+        """They hang off a chore already counted — including them double-counts."""
+        coord = _coord(KIDS, [_completion("a"), _completion("a", bonus="sub1")])
+        assert coord.fairness_report()["total_completions"] == 1
+
+    def test_deleted_child_history_is_ignored(self):
+        coord = _coord(KIDS, [_completion("gone"), _completion("a")])
+        report = coord.fairness_report()
+        assert report["total_completions"] == 1
+        assert {r["id"] for r in report["children"]} == {"a", "b"}
+
+    def test_unparseable_timestamp_is_skipped(self):
+        bad = _completion("a")
+        bad.completed_at = "not a date"
+        coord = _coord(KIDS, [bad, _completion("b")])
+        assert coord.fairness_report()["total_completions"] == 1
+
+
+class TestBalance:
+    def test_even_split_is_balanced(self):
+        coord = _coord(KIDS, [_completion("a"), _completion("a"),
+                              _completion("b"), _completion("b")])
+        report = coord.fairness_report()
+        assert report["balanced"] is True
+        assert {r["status"] for r in report["children"]} == {"balanced"}
+
+    def test_lopsided_split_is_flagged(self):
+        coord = _coord(KIDS, [_completion("a")] * 9 + [_completion("b")])
+        report = coord.fairness_report()
+        assert report["balanced"] is False
+        by_id = {r["id"]: r for r in report["children"]}
+        assert by_id["a"]["status"] == "over"
+        assert by_id["b"]["status"] == "under"
+
+    def test_no_activity_reads_as_idle_not_unbalanced(self):
+        report = _coord(KIDS, []).fairness_report()
+        assert report["balanced"] is True
+        assert {r["status"] for r in report["children"]} == {"idle"}
+
+    def test_just_inside_tolerance_is_balanced(self):
+        """60/40 with a 15-point tolerance is not worth nagging about."""
+        coord = _coord(KIDS, [_completion("a")] * 6 + [_completion("b")] * 4)
+        assert _status(coord, "a") == "balanced"
+
+    def test_just_outside_tolerance_is_flagged(self):
+        coord = _coord(KIDS, [_completion("a")] * 7 + [_completion("b")] * 3)
+        assert _status(coord, "a") == "over"
+
+    def test_tolerance_is_reported_so_the_ui_can_explain_itself(self):
+        assert _coord(KIDS, []).fairness_report()["tolerance"] == FAIR_SHARE_TOLERANCE
+
+
+class TestFigures:
+    def test_points_and_counts_are_tracked_separately(self):
+        """One child doing three quick jobs vs one doing a hard one is
+        balanced by points and lopsided by count — show both."""
+        coord = _coord(KIDS, [_completion("a", points=1)] * 3 + [_completion("b", points=30)])
+        by_id = {r["id"]: r for r in coord.fairness_report()["children"]}
+        assert by_id["a"]["completions"] == 3
+        assert by_id["a"]["points"] == 3
+        assert by_id["b"]["completions"] == 1
+        assert by_id["b"]["points"] == 30
+        assert by_id["b"]["share_points"] > by_id["a"]["share_points"]
+        assert by_id["a"]["share_completions"] > by_id["b"]["share_completions"]
+
+    def test_status_follows_count_not_points(self):
+        coord = _coord(KIDS, [_completion("a", points=1)] * 9 + [_completion("b", points=500)])
+        assert _status(coord, "a") == "over"
+
+    def test_active_days_counts_distinct_days(self):
+        coord = _coord(KIDS, [_completion("a", days_ago=0), _completion("a", days_ago=0),
+                              _completion("a", days_ago=2)])
+        by_id = {r["id"]: r for r in coord.fairness_report()["children"]}
+        assert by_id["a"]["active_days"] == 2
+
+    def test_rows_sorted_by_most_work_first(self):
+        coord = _coord(KIDS, [_completion("b")] * 5 + [_completion("a")])
+        assert [r["id"] for r in coord.fairness_report()["children"]] == ["b", "a"]
+
+    def test_fair_share_reflects_family_size(self):
+        three = [*KIDS, Child(name="Kit", id="c")]
+        assert _coord(three, []).fairness_report()["fair_share"] == 33.3
+
+    def test_no_children_does_not_divide_by_zero(self):
+        report = _coord([], []).fairness_report()
+        assert report["fair_share"] == 0.0
+        assert report["children"] == []
+
+
+def _status(coord, child_id):
+    return {r["id"]: r for r in coord.fairness_report()["children"]}[child_id]["status"]


### PR DESCRIPTION
A new **Insights** tab in the panel, answering the question the raw numbers do not: *am I dumping everything on the eldest?*

For a 7/14/30-day window it shows each child's completed chores, points earned, share of the family total, and how many distinct days they were active — with a marker on each bar showing where an even split would sit, so "fair" is visible rather than implied.

## Design decisions

- **Judged on chore count, not points.** A pricier chore must not be able to hide an uneven split. Points are shown alongside because the two genuinely disagree sometimes — three quick jobs versus one hard one is balanced by points and lopsided by count — and only the parent can say which they meant.
- **Flagged at more than 15 percentage points off an even share.** Wide enough that normal week-to-week variation doesn't nag; narrow enough to catch a real imbalance. With two children that means it stays quiet at 60/40 and speaks up at 70/30.
- **Only approved, non-bonus completions count.** Unapproved work isn't yet work the parent has agreed happened, and bonus sub-tasks hang off a chore that is already counted — including them would double-count the effort.
- **No activity reads as "idle", not "unbalanced"** — a quiet week is not an unfair one.
- **Computed on demand, never cached.** These are derived views over completions; a stale report is worse than a slow one.

`coord_reports.py` holds the shared window/aggregation helpers so the friction (#680) and projection (#681) reports can build on the same foundation rather than each re-deriving a window.

## Testing

- **21 new tests**: window defaulting and clamping (including that a supplied `0` clamps to 1 day rather than silently becoming the 7-day default — fixed while writing the test), what counts (pending excluded, bonus sub-tasks excluded, deleted-child history ignored, unparseable timestamps skipped), balance verdicts (even split, lopsided, idle, just inside and just outside tolerance), and the figures (points and counts tracked separately, status follows count not points, distinct active days, row ordering, fair share reflecting family size, no division by zero with no children).
- Full suite: **1145 passed** vs **1124** on `main`, identical pre-existing 3 failures / 9 errors.
- `ruff` clean; `eslint` clean.
- **Verified end-to-end on ha-dev** against real accumulated data: the 7-day report and the 30-day report return genuinely different pictures (7 days: Vaiha 1 / Malia 0; 30 days: Malia 18 "doing more" / Vaiha 4 "doing less"), shares sum to 100%, an absurd window is rejected by the schema, the Insights tab renders the rows and the even-split marker, and switching the window refetches and re-renders. No console errors.

While reviewing the rendered output I caught **"1 chores"** and added a singular form across all locales.

## i18n

All 15 new strings translated into all 8 locales in this PR.

Fixes #679