### PR TITLE
feat(panel): week-ahead points projection

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@
 - [Routine Mode](#routine-mode)
 - [Chore Roulette](#chore-roulette)
 - [Timed Unlock Rewards](#timed-unlock-rewards)
-- [Insights — Fairness & Friction](#insights--fairness--friction)
+- [Insights — Fairness, Friction & Week Ahead](#insights--fairness-friction--week-ahead)
 - [Bonus Points System](#bonus-points-system)
 - [Notifications](#notifications)
 - [Quiet Hours](#quiet-hours)
@@ -470,7 +470,7 @@ Spend points to unlock something for a while — the TV, the console socket, a w
  
 ---
  
-## Insights — Fairness & Friction
+## Insights — Fairness, Friction & Week Ahead
  
 **TaskMate panel → Insights.** Answers the question the raw numbers don't: *am I dumping everything on the eldest?*
  
@@ -497,6 +497,14 @@ The second Insights view judges each **chore** rather than each child: how often
 Chores with outstanding mandatory misses show a ⚠ count, and the report leads with a **suggestion** rather than just a diagnosis — a stalling chore that already pays well doesn't need more points, it needs a different child.
  
 **What it can't tell you:** TaskMate deletes a completion when you reject it, and removes a mandatory miss once you resolve it, so neither rejection counts nor historical miss counts exist to be reported. The report says so rather than quietly omitting them. Expected counts are approximate — they don't replay rotation, dependencies, weather or vacations.
+ 
+### Week ahead — what's coming up
+ 
+The third view projects the next 7 / 14 / 28 days from each chore's schedule: how many chores and points are heading each child's way, what balance they'd reach, and a day-by-day grid.
+ 
+Rotation is projected using the same daily-assignment computation the integration itself uses, so alternating / random / balanced picks match what will really happen rather than an independent guess that could drift.
+ 
+**It's a ceiling, not a forecast.** A chore open to everyone is counted for *each* eligible child, because the schedule cannot know who'll get there first. Weather, dependencies and availability aren't projected either — they depend on the day. Points that aren't assigned to anyone are called out separately.
  
 ---
  

--- a/custom_components/taskmate/coord_reports.py
+++ b/custom_components/taskmate/coord_reports.py
@@ -19,6 +19,8 @@ _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_WINDOW_DAYS = 7
 FRICTION_WINDOW_DAYS = 30
+PROJECTION_DAYS = 7
+MAX_PROJECTION_DAYS = 28
 MAX_WINDOW_DAYS = 90
 
 # A child's share of the family workload may sit this many percentage points
@@ -295,3 +297,136 @@ class ReportsMixin:
         if verdict == "struggling":
             return "reprice"
         return "keep"
+
+    # ── Projection (#681) ────────────────────────────────────────────────
+
+    def _chore_falls_on(self, chore, day: date) -> bool:
+        """Would this chore come up on ``day`` under its schedule alone?
+
+        Schedule only. Entity-driven gates (weather, visibility, availability)
+        are current-state facts that can't be known for a future date, so the
+        projection is explicitly "what the calendar says", not a promise.
+        """
+        mode = getattr(chore, "schedule_mode", "specific_days")
+        if mode == "one_shot":
+            created = getattr(chore, "created_date", "")
+            try:
+                return bool(created) and date.fromisoformat(created) == day
+            except (TypeError, ValueError):
+                return False
+
+        expires = getattr(chore, "expires_on", "")
+        if expires:
+            try:
+                if day > date.fromisoformat(expires):
+                    return False
+            except (TypeError, ValueError):
+                pass
+
+        if mode == "recurring":
+            period_days = {
+                "every_2_days": 2, "weekly": 7, "every_2_weeks": 14,
+                "monthly": 30, "every_3_months": 91, "every_6_months": 182,
+            }.get(getattr(chore, "recurrence", "weekly"), 7)
+            anchor_raw = getattr(chore, "recurrence_start", "") or ""
+            try:
+                anchor = date.fromisoformat(anchor_raw) if anchor_raw else None
+            except (TypeError, ValueError):
+                anchor = None
+            if anchor is None:
+                # No anchor: fall back to the weekday, or treat weekly as "once
+                # a week from today" so the projection isn't silently empty.
+                wanted = (getattr(chore, "recurrence_day", "") or "").lower()
+                if wanted:
+                    return day.strftime("%A").lower() == wanted
+                return ((day - dt_util.as_local(dt_util.now()).date()).days % period_days) == 0
+            return ((day - anchor).days % period_days) == 0
+
+        due_days = [d.lower() for d in (getattr(chore, "due_days", []) or [])]
+        if not due_days:
+            return True
+        return day.strftime("%A").lower() in due_days
+
+    def projection_report(self, days: int | None = None) -> dict[str, Any]:
+        """What the week ahead looks like: who gets what, and worth how much.
+
+        Rotation is projected with the coordinator's own daily-assignment
+        computation per day, so alternating/random/balanced picks match what
+        will really happen rather than an independent guess that could drift.
+        """
+        try:
+            span = int(days) if days is not None else PROJECTION_DAYS
+        except (TypeError, ValueError):
+            span = PROJECTION_DAYS
+        span = max(1, min(span, MAX_PROJECTION_DAYS))
+
+        today = dt_util.as_local(dt_util.now()).date()
+        children = self.storage.get_children()
+        chores = [c for c in self.storage.get_chores() if getattr(c, "enabled", True)]
+
+        totals = {c.id: {"id": c.id, "name": c.name, "points": 0, "chores": 0} for c in children}
+        unassigned_points = 0
+        day_rows = []
+
+        for offset in range(span):
+            day = today + timedelta(days=offset)
+            daily_assignments = self._compute_daily_assignments(day)
+            per_day = {c.id: {"points": 0, "chores": 0} for c in children}
+            day_unassigned = 0
+
+            for chore in chores:
+                if not self._chore_falls_on(chore, day):
+                    continue
+                value = self.effective_chore_points(chore)
+                mode = getattr(chore, "assignment_mode", "everyone")
+
+                if mode in ("everyone", "first_come"):
+                    # Anyone in the pool may do it; credit the pool rather than
+                    # inventing a winner the schedule can't know.
+                    pool = list(getattr(chore, "assigned_to", []) or []) or [c.id for c in children]
+                    for child_id in pool:
+                        if child_id in per_day:
+                            per_day[child_id]["points"] += value
+                            per_day[child_id]["chores"] += 1
+                elif mode == "unassigned":
+                    day_unassigned += value
+                else:
+                    child_id = daily_assignments.get(chore.id, "")
+                    if child_id and child_id in per_day:
+                        per_day[child_id]["points"] += value
+                        per_day[child_id]["chores"] += 1
+                    else:
+                        day_unassigned += value
+
+            for child_id, figures in per_day.items():
+                totals[child_id]["points"] += figures["points"]
+                totals[child_id]["chores"] += figures["chores"]
+            unassigned_points += day_unassigned
+
+            day_rows.append({
+                "date": day.isoformat(),
+                "weekday": day.strftime("%A").lower(),
+                "children": [
+                    {"id": cid, "points": f["points"], "chores": f["chores"]}
+                    for cid, f in per_day.items()
+                ],
+                "unassigned_points": day_unassigned,
+            })
+
+        for child in children:
+            entry = totals[child.id]
+            entry["current_points"] = int(getattr(child, "points", 0) or 0)
+            entry["projected_total"] = entry["current_points"] + entry["points"]
+
+        return {
+            "days": span,
+            "start": today.isoformat(),
+            "end": (today + timedelta(days=span - 1)).isoformat(),
+            "generated_at": dt_util.now().isoformat(),
+            "children": sorted(totals.values(), key=lambda r: (-r["points"], r["name"])),
+            "by_day": day_rows,
+            "unassigned_points": unassigned_points,
+            # Shared-pool chores are credited to every eligible child, so the
+            # per-child figures are a ceiling, not a forecast. Say so.
+            "is_ceiling": True,
+        }

--- a/custom_components/taskmate/websocket.py
+++ b/custom_components/taskmate/websocket.py
@@ -79,6 +79,7 @@ WS_REMOVE_CHORE: Final        = "taskmate/remove_chore"
 
 WS_REPORT_FAIRNESS: Final     = "taskmate/reports/fairness"
 WS_REPORT_FRICTION: Final     = "taskmate/reports/friction"
+WS_REPORT_PROJECTION: Final   = "taskmate/reports/projection"
 WS_SCHEDULED_LIST: Final      = "taskmate/scheduled/list"
 WS_SCHEDULED_ADD: Final       = "taskmate/scheduled/add"
 WS_SCHEDULED_REMOVE: Final    = "taskmate/scheduled/remove"
@@ -184,7 +185,7 @@ WS_CONFIG_IMPORT: Final = "taskmate/config/import"
 _AUDIT_EXCLUDE: Final = {
     WS_GET_STATE, WS_NOTIF_GET_STATE, WS_NOTIF_LIST_NOTIFY,
     WS_TEMPLATES_LIST, WS_TEMPLATES_GET, WS_AUDIT_LIST, WS_AUDIT_CLEAR,
-    WS_CONFIG_EXPORT, WS_SCHEDULED_LIST, WS_REPORT_FAIRNESS, WS_REPORT_FRICTION,
+    WS_CONFIG_EXPORT, WS_SCHEDULED_LIST, WS_REPORT_FAIRNESS, WS_REPORT_FRICTION, WS_REPORT_PROJECTION,
 }
 
 
@@ -644,6 +645,16 @@ async def _ws_report_fairness(hass, connection, msg, coordinator):
 @_admin_only
 async def _ws_report_friction(hass, connection, msg, coordinator):
     connection.send_result(msg["id"], coordinator.friction_report(msg.get("days")))
+
+
+@websocket_api.websocket_command({
+    vol.Required("type"): WS_REPORT_PROJECTION,
+    vol.Optional("days"): vol.All(int, vol.Range(min=1, max=28)),
+})
+@websocket_api.async_response
+@_admin_only
+async def _ws_report_projection(hass, connection, msg, coordinator):
+    connection.send_result(msg["id"], coordinator.projection_report(msg.get("days")))
 
 
 # ---------------------------------------------------------------------------
@@ -2188,7 +2199,7 @@ _COMMANDS = (
     _ws_add_child, _ws_update_child, _ws_remove_child, _ws_list_ha_users,
     _ws_add_chore, _ws_update_chore, _ws_remove_chore, _ws_clone_chore,
     _ws_scheduled_list, _ws_scheduled_add, _ws_scheduled_remove,
-    _ws_report_fairness, _ws_report_friction,
+    _ws_report_fairness, _ws_report_friction, _ws_report_projection,
     _ws_bulk_chore_action, _ws_gift_points,
     _ws_request_swap, _ws_approve_swap, _ws_reject_swap,
     _ws_config_export, _ws_config_import,

--- a/custom_components/taskmate/www/locales/de.json
+++ b/custom_components/taskmate/www/locales/de.json
@@ -1680,5 +1680,14 @@
   "panel.insights_suggest_reassign": "Jemand anderem geben",
   "panel.insights_suggest_keep": "So lassen",
   "panel.insights_outstanding_misses": "Offene versäumte Pflichtaufgaben",
-  "panel.insights_friction_note": "Ablehnungen sind nicht aufgeführt: TaskMate löscht eine Erledigung, wenn du sie ablehnst, es gibt also keinen Verlauf dazu. Die erwarteten Werte sind Näherungen — Rotation, Abhängigkeiten und Wetter werden nicht nachgestellt."
+  "panel.insights_friction_note": "Ablehnungen sind nicht aufgeführt: TaskMate löscht eine Erledigung, wenn du sie ablehnst, es gibt also keinen Verlauf dazu. Die erwarteten Werte sind Näherungen — Rotation, Abhängigkeiten und Wetter werden nicht nachgestellt.",
+  "panel.insights_view_projection": "Kommende Woche",
+  "panel.insights_projection_title": "Was steht an?",
+  "panel.insights_projection_intro": "{start} bis {end}, basierend auf dem Zeitplan jeder Aufgabe.",
+  "panel.insights_next_days": "Nächste {days} Tage",
+  "panel.insights_col_day": "Tag",
+  "panel.insights_projected_earn": "bis zu {points} {name}",
+  "panel.insights_projected_total": "käme auf {total}",
+  "panel.insights_projection_unassigned": "{points} Punkte sind niemandem zugewiesen.",
+  "panel.insights_projection_note": "Eine Obergrenze, keine Prognose: Aufgaben für alle werden jedem berechtigten Kind angerechnet, da der Zeitplan nicht wissen kann, wer zuerst da ist. Wetter, Abhängigkeiten und Verfügbarkeit werden nicht vorhergesagt — sie hängen vom Tag ab."
 }

--- a/custom_components/taskmate/www/locales/en-GB.json
+++ b/custom_components/taskmate/www/locales/en-GB.json
@@ -1680,5 +1680,14 @@
   "panel.insights_suggest_reassign": "Give it to someone else",
   "panel.insights_suggest_keep": "Leave it alone",
   "panel.insights_outstanding_misses": "Outstanding mandatory misses",
-  "panel.insights_friction_note": "Rejections aren't listed: TaskMate deletes a completion when you reject it, so there's no rejection history to count. Expected counts are approximate — they don't replay rotation, dependencies or weather."
+  "panel.insights_friction_note": "Rejections aren't listed: TaskMate deletes a completion when you reject it, so there's no rejection history to count. Expected counts are approximate — they don't replay rotation, dependencies or weather.",
+  "panel.insights_view_projection": "Week ahead",
+  "panel.insights_projection_title": "What's coming up?",
+  "panel.insights_projection_intro": "{start} to {end}, based on each chore's schedule.",
+  "panel.insights_next_days": "Next {days} days",
+  "panel.insights_col_day": "Day",
+  "panel.insights_projected_earn": "up to {points} {name}",
+  "panel.insights_projected_total": "would reach {total}",
+  "panel.insights_projection_unassigned": "{points} points aren't assigned to anyone.",
+  "panel.insights_projection_note": "A ceiling, not a forecast: chores open to everyone are counted for each eligible child, since the schedule can't know who'll get there first. Weather, dependencies and availability aren't projected — they depend on the day."
 }

--- a/custom_components/taskmate/www/locales/en.json
+++ b/custom_components/taskmate/www/locales/en.json
@@ -1680,5 +1680,14 @@
   "panel.insights_suggest_reassign": "Give it to someone else",
   "panel.insights_suggest_keep": "Leave it alone",
   "panel.insights_outstanding_misses": "Outstanding mandatory misses",
-  "panel.insights_friction_note": "Rejections aren't listed: TaskMate deletes a completion when you reject it, so there's no rejection history to count. Expected counts are approximate — they don't replay rotation, dependencies or weather."
+  "panel.insights_friction_note": "Rejections aren't listed: TaskMate deletes a completion when you reject it, so there's no rejection history to count. Expected counts are approximate — they don't replay rotation, dependencies or weather.",
+  "panel.insights_view_projection": "Week ahead",
+  "panel.insights_projection_title": "What's coming up?",
+  "panel.insights_projection_intro": "{start} to {end}, based on each chore's schedule.",
+  "panel.insights_next_days": "Next {days} days",
+  "panel.insights_col_day": "Day",
+  "panel.insights_projected_earn": "up to {points} {name}",
+  "panel.insights_projected_total": "would reach {total}",
+  "panel.insights_projection_unassigned": "{points} points aren't assigned to anyone.",
+  "panel.insights_projection_note": "A ceiling, not a forecast: chores open to everyone are counted for each eligible child, since the schedule can't know who'll get there first. Weather, dependencies and availability aren't projected — they depend on the day."
 }

--- a/custom_components/taskmate/www/locales/fr.json
+++ b/custom_components/taskmate/www/locales/fr.json
@@ -1680,5 +1680,14 @@
   "panel.insights_suggest_reassign": "La confier à un autre",
   "panel.insights_suggest_keep": "Ne rien changer",
   "panel.insights_outstanding_misses": "Manquements obligatoires en attente",
-  "panel.insights_friction_note": "Les refus ne sont pas listés : TaskMate supprime une validation quand vous la refusez, il n'y a donc pas d'historique. Les valeurs attendues sont approximatives — rotation, dépendances et météo ne sont pas rejouées."
+  "panel.insights_friction_note": "Les refus ne sont pas listés : TaskMate supprime une validation quand vous la refusez, il n'y a donc pas d'historique. Les valeurs attendues sont approximatives — rotation, dépendances et météo ne sont pas rejouées.",
+  "panel.insights_view_projection": "Semaine à venir",
+  "panel.insights_projection_title": "Qu'est-ce qui arrive ?",
+  "panel.insights_projection_intro": "Du {start} au {end}, d'après le planning de chaque tâche.",
+  "panel.insights_next_days": "{days} prochains jours",
+  "panel.insights_col_day": "Jour",
+  "panel.insights_projected_earn": "jusqu'à {points} {name}",
+  "panel.insights_projected_total": "atteindrait {total}",
+  "panel.insights_projection_unassigned": "{points} points ne sont attribués à personne.",
+  "panel.insights_projection_note": "Un plafond, pas une prévision : les tâches ouvertes à tous sont comptées pour chaque enfant éligible, le planning ne pouvant savoir qui arrivera en premier. Météo, dépendances et disponibilité ne sont pas projetées — elles dépendent du jour."
 }

--- a/custom_components/taskmate/www/locales/nb.json
+++ b/custom_components/taskmate/www/locales/nb.json
@@ -1680,5 +1680,14 @@
   "panel.insights_suggest_reassign": "Gi den til noen andre",
   "panel.insights_suggest_keep": "La den være",
   "panel.insights_outstanding_misses": "Uavklarte glemte pliktoppgaver",
-  "panel.insights_friction_note": "Avvisninger er ikke listet: TaskMate sletter en fullføring når du avviser den, så det finnes ingen historikk. Forventede tall er omtrentlige — rotasjon, avhengigheter og vær spilles ikke av på nytt."
+  "panel.insights_friction_note": "Avvisninger er ikke listet: TaskMate sletter en fullføring når du avviser den, så det finnes ingen historikk. Forventede tall er omtrentlige — rotasjon, avhengigheter og vær spilles ikke av på nytt.",
+  "panel.insights_view_projection": "Uka som kommer",
+  "panel.insights_projection_title": "Hva står for tur?",
+  "panel.insights_projection_intro": "{start} til {end}, basert på timeplanen til hver oppgave.",
+  "panel.insights_next_days": "Neste {days} dager",
+  "panel.insights_col_day": "Dag",
+  "panel.insights_projected_earn": "opptil {points} {name}",
+  "panel.insights_projected_total": "ville nå {total}",
+  "panel.insights_projection_unassigned": "{points} poeng er ikke tildelt noen.",
+  "panel.insights_projection_note": "Et tak, ikke en prognose: oppgaver åpne for alle telles for hvert aktuelt barn, siden timeplanen ikke kan vite hvem som rekker først. Vær, avhengigheter og tilgjengelighet framskrives ikke — de avhenger av dagen."
 }

--- a/custom_components/taskmate/www/locales/nn.json
+++ b/custom_components/taskmate/www/locales/nn.json
@@ -1680,5 +1680,14 @@
   "panel.insights_suggest_reassign": "Gje henne til nokon andre",
   "panel.insights_suggest_keep": "La henne vere",
   "panel.insights_outstanding_misses": "Uavklarte gløymde pliktoppgåver",
-  "panel.insights_friction_note": "Avvisingar er ikkje lista: TaskMate slettar ei fullføring når du avviser henne, så det finst ingen historikk. Venta tal er omtrentlege — rotasjon, avhengnader og ver vert ikkje spelte av på nytt."
+  "panel.insights_friction_note": "Avvisingar er ikkje lista: TaskMate slettar ei fullføring når du avviser henne, så det finst ingen historikk. Venta tal er omtrentlege — rotasjon, avhengnader og ver vert ikkje spelte av på nytt.",
+  "panel.insights_view_projection": "Veka som kjem",
+  "panel.insights_projection_title": "Kva står for tur?",
+  "panel.insights_projection_intro": "{start} til {end}, basert på timeplanen til kvar oppgåve.",
+  "panel.insights_next_days": "Neste {days} dagar",
+  "panel.insights_col_day": "Dag",
+  "panel.insights_projected_earn": "opptil {points} {name}",
+  "panel.insights_projected_total": "ville nå {total}",
+  "panel.insights_projection_unassigned": "{points} poeng er ikkje tildelte nokon.",
+  "panel.insights_projection_note": "Eit tak, ikkje ein prognose: oppgåver opne for alle vert talde for kvart aktuelt barn, sidan timeplanen ikkje kan vite kven som rekk først. Ver, avhengnader og tilgjenge vert ikkje framskrivne — dei kjem an på dagen."
 }

--- a/custom_components/taskmate/www/locales/pt-BR.json
+++ b/custom_components/taskmate/www/locales/pt-BR.json
@@ -1680,5 +1680,14 @@
   "panel.insights_suggest_reassign": "Dar para outra pessoa",
   "panel.insights_suggest_keep": "Deixar como está",
   "panel.insights_outstanding_misses": "Falhas obrigatórias pendentes",
-  "panel.insights_friction_note": "As rejeições não são listadas: o TaskMate apaga a conclusão quando você a rejeita, então não há histórico. Os valores esperados são aproximados — rotação, dependências e clima não são reproduzidos."
+  "panel.insights_friction_note": "As rejeições não são listadas: o TaskMate apaga a conclusão quando você a rejeita, então não há histórico. Os valores esperados são aproximados — rotação, dependências e clima não são reproduzidos.",
+  "panel.insights_view_projection": "Semana seguinte",
+  "panel.insights_projection_title": "O que vem por aí?",
+  "panel.insights_projection_intro": "{start} a {end}, com base na programação de cada tarefa.",
+  "panel.insights_next_days": "Próximos {days} dias",
+  "panel.insights_col_day": "Dia",
+  "panel.insights_projected_earn": "até {points} {name}",
+  "panel.insights_projected_total": "chegaria a {total}",
+  "panel.insights_projection_unassigned": "{points} pontos não estão atribuídos a ninguém.",
+  "panel.insights_projection_note": "Um teto, não uma previsão: tarefas abertas a todos são contadas para cada criança elegível, já que a programação não sabe quem chega primeiro. Clima, dependências e disponibilidade não são projetados — dependem do dia."
 }

--- a/custom_components/taskmate/www/locales/pt.json
+++ b/custom_components/taskmate/www/locales/pt.json
@@ -1680,5 +1680,14 @@
   "panel.insights_suggest_reassign": "Dar a outra pessoa",
   "panel.insights_suggest_keep": "Deixar como está",
   "panel.insights_outstanding_misses": "Falhas obrigatórias por resolver",
-  "panel.insights_friction_note": "As rejeições não são listadas: o TaskMate apaga a conclusão quando a rejeitas, por isso não há histórico. Os valores esperados são aproximados — rotação, dependências e meteorologia não são reproduzidas."
+  "panel.insights_friction_note": "As rejeições não são listadas: o TaskMate apaga a conclusão quando a rejeitas, por isso não há histórico. Os valores esperados são aproximados — rotação, dependências e meteorologia não são reproduzidas.",
+  "panel.insights_view_projection": "Semana seguinte",
+  "panel.insights_projection_title": "O que vem aí?",
+  "panel.insights_projection_intro": "{start} a {end}, com base no horário de cada tarefa.",
+  "panel.insights_next_days": "Próximos {days} dias",
+  "panel.insights_col_day": "Dia",
+  "panel.insights_projected_earn": "até {points} {name}",
+  "panel.insights_projected_total": "chegaria a {total}",
+  "panel.insights_projection_unassigned": "{points} pontos não estão atribuídos a ninguém.",
+  "panel.insights_projection_note": "Um teto, não uma previsão: tarefas abertas a todos são contadas para cada criança elegível, já que o horário não sabe quem chega primeiro. Meteorologia, dependências e disponibilidade não são projetadas — dependem do dia."
 }

--- a/custom_components/taskmate/www/taskmate-panel.js
+++ b/custom_components/taskmate/www/taskmate-panel.js
@@ -544,6 +544,12 @@ class TaskMatePanel extends HTMLElement {
       this._render();
       return;
     }
+    if (act === "projection-window") {
+      this._projectionDays = Number(t.dataset.id);
+      this._projection = null;
+      this._loadProjection(this._projectionDays);
+      return;
+    }
     if (act === "friction-window") {
       this._frictionDays = Number(t.dataset.id);
       this._friction = null;
@@ -2512,14 +2518,16 @@ class TaskMatePanel extends HTMLElement {
     const view = this._insightView || "fairness";
     const switcher = `
       <div class="tm-chip-row" style="margin-bottom:14px">
-        ${["fairness", "friction"].map(v => `
+        ${["fairness", "friction", "projection"].map(v => `
           <button type="button" class="tm-chip-btn ${v === view ? "tm-chip-on" : ""}"
                   data-act="insights-view" data-id="${v}">
             ${this._t("panel.insights_view_" + v)}
           </button>
         `).join("")}
       </div>`;
-    return switcher + (view === "friction" ? this._renderFrictionReport() : this._renderFairnessReport());
+    if (view === "friction") return switcher + this._renderFrictionReport();
+    if (view === "projection") return switcher + this._renderProjectionReport();
+    return switcher + this._renderFairnessReport();
   }
 
   /**
@@ -2587,6 +2595,88 @@ class TaskMatePanel extends HTMLElement {
         `}
       </div>
     `;
+  }
+
+  /**
+   * Projection (#681): what the week ahead looks like. A ceiling rather than
+   * a forecast — shared-pool chores are credited to every eligible child,
+   * because the schedule can't know who will actually get there first.
+   */
+  _renderProjectionReport() {
+    const report = this._projection;
+    if (!report) {
+      this._loadProjection(this._projectionDays || 7);
+      return `<div class="tm-card"><div class="tm-empty">${this._t("panel.insights_loading")}</div></div>`;
+    }
+    const days = this._projectionDays || 7;
+    const kids = report.children;
+    const maxPoints = Math.max(1, ...kids.map(k => k.points));
+    const pointsName = this._state.settings?.points_name || this._t("common.points");
+
+    return `
+      <div class="tm-card">
+        <div class="tm-card-head">
+          <h2>${this._t("panel.insights_projection_title")}</h2>
+          <div class="tm-chip-row">
+            ${[7, 14, 28].map(d => `
+              <button type="button" class="tm-chip-btn ${d === days ? "tm-chip-on" : ""}"
+                      data-act="projection-window" data-id="${d}">
+                ${this._t("panel.insights_next_days", { days: d })}
+              </button>
+            `).join("")}
+          </div>
+        </div>
+        <span class="tm-field-hint">${this._t("panel.insights_projection_intro", { start: report.start, end: report.end })}</span>
+
+        <div class="tm-proj-totals">
+          ${kids.map(k => `
+            <div class="tm-proj-kid">
+              <div class="tm-fair-name">${this._esc(k.name)}</div>
+              <div class="tm-fair-bar"><i style="width:${Math.round(k.points / maxPoints * 100)}%"></i></div>
+              <div class="tm-fair-figs">
+                ${this._t("panel.insights_projected_earn", { points: k.points, name: this._esc(pointsName) })}
+                · ${k.chores} ${this._t(k.chores === 1 ? "panel.insights_chore" : "panel.insights_chores")}
+                · ${this._t("panel.insights_projected_total", { total: k.projected_total })}
+              </div>
+            </div>
+          `).join("")}
+        </div>
+
+        ${report.unassigned_points > 0 ? `
+          <div class="tm-verdict tm-verdict-warn">
+            ${this._t("panel.insights_projection_unassigned", { points: report.unassigned_points })}
+          </div>` : ""}
+
+        <table class="tm-table tm-projection">
+          <thead><tr>
+            <th>${this._t("panel.insights_col_day")}</th>
+            ${kids.map(k => `<th>${this._esc(k.name)}</th>`).join("")}
+          </tr></thead>
+          <tbody>
+            ${report.by_day.map(d => `
+              <tr>
+                <td><strong>${this._t("panel.day_" + d.weekday.slice(0, 3))}</strong> <span class="tm-proj-date">${d.date.slice(5)}</span></td>
+                ${kids.map(k => {
+                  const cell = d.children.find(c => c.id === k.id) || { points: 0, chores: 0 };
+                  return `<td>${cell.chores ? `${cell.points} <span class="tm-proj-count">(${cell.chores})</span>` : "—"}</td>`;
+                }).join("")}
+              </tr>
+            `).join("")}
+          </tbody>
+        </table>
+        <span class="tm-field-hint">${this._t("panel.insights_projection_note")}</span>
+      </div>
+    `;
+  }
+
+  async _loadProjection(days) {
+    if (this._projectionLoading) return;
+    this._projectionLoading = true;
+    const { ok, res, err } = await this._callWS({ type: "taskmate/reports/projection", days });
+    this._projectionLoading = false;
+    if (!ok) { this._showToast("err", err); return; }
+    this._projection = res;
+    this._render();
   }
 
   async _loadFriction(days) {
@@ -6805,6 +6895,15 @@ class TaskMatePanel extends HTMLElement {
         .tm-fair-row { grid-template-columns: 1fr auto; }
         .tm-fair-bar { grid-column: 1 / -1; }
       }
+
+      /* Projection report (#681) */
+      .tm-proj-totals { display: flex; flex-direction: column; gap: 12px; margin: 12px 0 16px; }
+      .tm-proj-kid { display: grid; grid-template-columns: 120px 1fr; gap: 6px 12px; align-items: center; }
+      .tm-proj-kid .tm-fair-figs { grid-column: 2; }
+      .tm-projection td, .tm-projection th { font-size: 13px; text-align: center; }
+      .tm-projection td:first-child, .tm-projection th:first-child { text-align: left; }
+      .tm-proj-date { color: var(--tm-text-muted); font-size: 11.5px; }
+      .tm-proj-count { color: var(--tm-text-muted); font-size: 11.5px; }
 
       /* Friction report (#680) */
       .tm-friction td, .tm-friction th { font-size: 13px; }

--- a/tests/test_projection_report.py
+++ b/tests/test_projection_report.py
@@ -1,0 +1,187 @@
+"""Points projection (#681).
+
+"Show me next week": who gets which chore and what it's worth. A ceiling
+rather than a forecast — shared-pool chores are credited to every eligible
+child, because the schedule cannot know who will get there first.
+"""
+from __future__ import annotations
+
+from datetime import date, timedelta
+from unittest.mock import MagicMock
+
+from homeassistant.util import dt as dt_util
+
+from custom_components.taskmate.coord_reports import MAX_PROJECTION_DAYS, PROJECTION_DAYS
+from custom_components.taskmate.models import Child, Chore
+
+from .test_coordinator_logic import _make_coord
+
+KIDS = [Child(name="Ella", id="a", points=100), Child(name="Sam", id="b", points=50)]
+
+
+def _coord(chores=(), children=KIDS, assignments=None):
+    coord = _make_coord(children=list(children))
+    coord.storage.get_chores = MagicMock(return_value=list(chores))
+    coord.storage.get_children = MagicMock(return_value=list(children))
+    coord._compute_daily_assignments = MagicMock(return_value=dict(assignments or {}))
+    return coord
+
+
+def _today():
+    return dt_util.as_local(dt_util.now()).date()
+
+
+def _for(report, child_id):
+    return next(r for r in report["children"] if r["id"] == child_id)
+
+
+class TestWindow:
+    def test_default_span(self):
+        assert _coord().projection_report()["days"] == PROJECTION_DAYS
+
+    def test_span_is_clamped(self):
+        coord = _coord()
+        assert coord.projection_report(0)["days"] == 1
+        assert coord.projection_report(999)["days"] == MAX_PROJECTION_DAYS
+
+    def test_garbage_span_falls_back(self):
+        assert _coord().projection_report("soon")["days"] == PROJECTION_DAYS
+
+    def test_day_rows_match_the_span(self):
+        assert len(_coord().projection_report(5)["by_day"]) == 5
+
+    def test_starts_today(self):
+        assert _coord().projection_report()["start"] == _today().isoformat()
+
+
+class TestScheduleMatching:
+    def test_daily_chore_appears_every_day(self):
+        chore = Chore(name="Daily", id="c", points=5, schedule_mode="specific_days", due_days=[])
+        report = _coord([chore]).projection_report(3)
+        assert _for(report, "a")["chores"] == 3
+        assert _for(report, "a")["points"] == 15
+
+    def test_specific_weekday_only_appears_then(self):
+        target = _today() + timedelta(days=2)
+        chore = Chore(name="Weekly", id="c", points=5, schedule_mode="specific_days",
+                      due_days=[target.strftime("%A").lower()])
+        report = _coord([chore]).projection_report(7)
+        assert _for(report, "a")["chores"] == 1
+
+    def test_disabled_chores_are_skipped(self):
+        chore = Chore(name="Off", id="c", points=5, enabled=False,
+                      schedule_mode="specific_days", due_days=[])
+        assert _for(_coord([chore]).projection_report(3), "a")["chores"] == 0
+
+    def test_expired_chore_stops_appearing(self):
+        yesterday = (_today() - timedelta(days=1)).isoformat()
+        chore = Chore(name="Done", id="c", points=5, schedule_mode="specific_days",
+                      due_days=[], expires_on=yesterday)
+        assert _for(_coord([chore]).projection_report(3), "a")["chores"] == 0
+
+    def test_one_shot_only_on_its_created_date(self):
+        chore = Chore(name="Once", id="c", points=5, schedule_mode="one_shot",
+                      created_date=_today().isoformat())
+        assert _for(_coord([chore]).projection_report(5), "a")["chores"] == 1
+
+    def test_recurring_every_two_days_from_an_anchor(self):
+        chore = Chore(name="Rec", id="c", points=5, schedule_mode="recurring",
+                      recurrence="every_2_days", recurrence_start=_today().isoformat())
+        # days 0, 2, 4, 6 of a 7-day window
+        assert _for(_coord([chore]).projection_report(7), "a")["chores"] == 4
+
+    def test_recurring_weekly_on_a_named_day(self):
+        target = _today() + timedelta(days=3)
+        chore = Chore(name="Rec", id="c", points=5, schedule_mode="recurring",
+                      recurrence="weekly", recurrence_day=target.strftime("%A").lower())
+        assert _for(_coord([chore]).projection_report(7), "a")["chores"] == 1
+
+    def test_malformed_dates_do_not_crash(self):
+        chore = Chore(name="Odd", id="c", points=5, schedule_mode="recurring",
+                      recurrence="weekly", recurrence_start="not-a-date")
+        assert isinstance(_coord([chore]).projection_report(3)["children"], list)
+
+
+class TestAssignment:
+    def test_everyone_chore_credits_the_whole_pool(self):
+        """A ceiling: the schedule can't know who gets there first."""
+        chore = Chore(name="Open", id="c", points=10, assignment_mode="everyone",
+                      schedule_mode="specific_days", due_days=[])
+        report = _coord([chore]).projection_report(1)
+        assert _for(report, "a")["points"] == 10
+        assert _for(report, "b")["points"] == 10
+        assert report["is_ceiling"] is True
+
+    def test_everyone_chore_respects_an_explicit_pool(self):
+        chore = Chore(name="Open", id="c", points=10, assignment_mode="everyone",
+                      assigned_to=["a"], schedule_mode="specific_days", due_days=[])
+        report = _coord([chore]).projection_report(1)
+        assert _for(report, "a")["points"] == 10
+        assert _for(report, "b")["points"] == 0
+
+    def test_rotation_credits_only_the_days_assignee(self):
+        chore = Chore(name="Rota", id="c", points=10, assignment_mode="alternating",
+                      schedule_mode="specific_days", due_days=[])
+        report = _coord([chore], assignments={"c": "b"}).projection_report(1)
+        assert _for(report, "a")["points"] == 0
+        assert _for(report, "b")["points"] == 10
+
+    def test_rotation_with_no_assignee_counts_as_unassigned(self):
+        chore = Chore(name="Rota", id="c", points=10, assignment_mode="alternating",
+                      schedule_mode="specific_days", due_days=[])
+        report = _coord([chore], assignments={}).projection_report(1)
+        assert report["unassigned_points"] == 10
+
+    def test_unassigned_mode_is_counted_separately(self):
+        chore = Chore(name="Spare", id="c", points=7, assignment_mode="unassigned",
+                      schedule_mode="specific_days", due_days=[])
+        report = _coord([chore]).projection_report(1)
+        assert report["unassigned_points"] == 7
+        assert _for(report, "a")["points"] == 0
+
+
+class TestTotals:
+    def test_projected_total_adds_to_the_current_balance(self):
+        chore = Chore(name="Daily", id="c", points=5, schedule_mode="specific_days", due_days=[])
+        row = _for(_coord([chore]).projection_report(2), "a")
+        assert row["current_points"] == 100
+        assert row["points"] == 10
+        assert row["projected_total"] == 110
+
+    def test_children_sorted_by_most_to_earn(self):
+        chore = Chore(name="Rota", id="c", points=10, assignment_mode="alternating",
+                      schedule_mode="specific_days", due_days=[])
+        report = _coord([chore], assignments={"c": "b"}).projection_report(1)
+        assert report["children"][0]["id"] == "b"
+
+    def test_per_day_rows_carry_each_child(self):
+        chore = Chore(name="Daily", id="c", points=5, schedule_mode="specific_days", due_days=[])
+        day = _coord([chore]).projection_report(1)["by_day"][0]
+        assert {c["id"] for c in day["children"]} == {"a", "b"}
+        assert day["weekday"] == _today().strftime("%A").lower()
+
+    def test_no_chores_produces_zeroes_not_an_error(self):
+        report = _coord([]).projection_report(3)
+        assert all(r["points"] == 0 for r in report["children"])
+        assert report["unassigned_points"] == 0
+
+    def test_difficulty_multiplier_is_applied(self):
+        """Projection must value a chore the same way completion will."""
+        chore = Chore(name="Hard", id="c", points=10, difficulty="hard",
+                      schedule_mode="specific_days", due_days=[])
+        coord = _coord([chore])
+        coord.effective_chore_points = MagicMock(return_value=20)
+        assert _for(coord.projection_report(1), "a")["points"] == 20
+
+
+class TestFallsOn:
+    def test_recurring_without_anchor_or_day_uses_the_period(self):
+        coord = _coord()
+        chore = Chore(name="Rec", id="c", schedule_mode="recurring", recurrence="every_2_days")
+        today = _today()
+        assert coord._chore_falls_on(chore, today) is True
+        assert coord._chore_falls_on(chore, today + timedelta(days=1)) is False
+
+    def test_one_shot_without_a_created_date_never_falls(self):
+        coord = _coord()
+        assert coord._chore_falls_on(Chore(name="X", id="c", schedule_mode="one_shot"), date.today()) is False


### PR DESCRIPTION
A third **Insights** view: what the next 7 / 14 / 28 days look like. Per child — how many chores and points are heading their way and what balance they would reach — plus a day-by-day grid.

## Design

- **Rotation is projected with the coordinator's own daily-assignment computation**, run per day, so alternating / random / balanced picks match what will really happen rather than an independent guess that could drift from the real thing.
- **It is a ceiling, not a forecast — and says so.** A chore open to everyone is credited to *every* eligible child, because the schedule cannot know who will get there first. Inventing a winner would be a more precise-looking lie.
- **Entity-driven gates aren't projected.** Weather, visibility and availability are current-state facts that can't be known for a future date. The note in the UI states this rather than letting the number imply more certainty than it has.
- Points assigned to **nobody** are surfaced separately rather than silently dropped.
- Chore values go through `effective_chore_points`, so a projection values a chore exactly the way completing it will — difficulty multiplier included. (There's a test pinning this, because a projection that disagrees with reality is worse than none.)

## Testing

- **25 new tests**: window defaulting/clamping/garbage, schedule matching (daily, specific weekday, disabled, expired, one-shot on its created date, every-2-days from an anchor, weekly on a named day, malformed dates), assignment (everyone credits the pool, explicit pool respected, rotation credits only the day's assignee, rotation with no assignee counts unassigned, unassigned mode separate), totals (projected total adds to the current balance, ordering, per-day rows, empty case, difficulty multiplier applied), and the `_chore_falls_on` edge cases.
- Full suite: **1193 passed** vs **1168** on `main`, identical pre-existing 3 failures / 9 errors.
- `ruff` clean; `eslint` clean (also removed an unused helper the linter caught).
- **Verified end-to-end on ha-dev**: the report returns a real 7-day grid (e.g. `Mon 07-27 — Malia 26 (8) · Vaiha 6 (4)`), the table renders a column per child, the ceiling caveat is shown, all three Insights views switch cleanly, and switching back to Fairness still works. No console errors.

## i18n

All 9 new strings translated into all 8 locales in this PR.

Fixes #681