### PR TITLE
feat(cards): pre-reader mode — a picture-only child card

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@
 - [Chore Roulette](#chore-roulette)
 - [Timed Unlock Rewards](#timed-unlock-rewards)
 - [Insights — Fairness, Friction, Week Ahead & Health](#insights--fairness-friction-week-ahead--health)
+- [Pre-Reader Mode](#pre-reader-mode)
 - [Bonus Points System](#bonus-points-system)
 - [Notifications](#notifications)
 - [Quiet Hours](#quiet-hours)
@@ -519,6 +520,27 @@ The fourth view checks the setup itself and reports storage size and entity coun
 | A child has no chores; completion records for deleted chores; a very large history | Note |
  
 Every issue carries a plain sentence and a **Show me** button that jumps to where it lives — a diagnostic that only says "3 problems" isn't one you can act on. Notes alone still count as healthy.
+ 
+---
+ 
+## Pre-Reader Mode
+ 
+A picture-only child card for children who can't read yet. No chore names, no numbers — a big icon, a row of stars for the points, and a huge tick when it's done.
+ 
+```yaml
+type: custom:taskmate-child-card
+entity: sensor.taskmate_overview
+child_id: <child_id>
+pre_reader: true
+pre_reader_labels: false   # optional; adds the chore name back under each tile
+```
+ 
+### Key Points
+ 
+- **Chores now have a picture.** Set one per chore in the panel (next to the description). Without it a tile falls back to the time-of-day icon — fine for one chore, useless for telling "brush teeth" from "get dressed", so set them.
+- **Points are shown as stars, not digits** (1–5, scaled from the chore's value). A four-year-old can count pictures.
+- Tiles are at least 128 px with a large tap target, and a **done tile stays tappable** so a mis-tap can be undone, exactly as on the standard card.
+- **Opt-in.** An existing dashboard never turns into pictures on its own, and names stay off unless you ask for them.
  
 ---
  

--- a/custom_components/taskmate/button.py
+++ b/custom_components/taskmate/button.py
@@ -139,7 +139,10 @@ class CompleteChoreButton(TaskMateBaseButton):
     def icon(self) -> str:
         """Return the icon."""
         chore = self.coordinator.get_chore(self.chore_id)
-        return getattr(chore, 'icon', "mdi:check-circle") if chore else "mdi:check-circle"
+        # Chores gained an optional icon in #683, defaulting to "". Fall back on
+        # falsiness, not on the attribute being absent — otherwise every chore
+        # without a picture gets a blank button icon.
+        return (getattr(chore, 'icon', "") or "mdi:check-circle") if chore else "mdi:check-circle"
 
     @property
     def extra_state_attributes(self) -> dict:

--- a/custom_components/taskmate/models.py
+++ b/custom_components/taskmate/models.py
@@ -251,6 +251,9 @@ class Chore:
     claim_allowance_minutes: int = 0  # Grace minutes past period end during which the chore stays claimable; 0 = no grace. Night chores still cap at midnight.
     daily_limit: int = 1
     completion_sound: str = "coin"  # Sound to play on completion
+    # Optional picture for the chore. Text-free pre-reader mode (#683) needs
+    # one per chore; everything else falls back to the time-of-day icon.
+    icon: str = ""
     difficulty: str = "medium"  # easy | medium | hard — scales awarded points by the tier multiplier (medium = ×1.0 baseline)
     # Scheduling
     # schedule_mode: "specific_days" = show on selected days of week (Mode A)
@@ -342,6 +345,7 @@ class Chore:
             claim_allowance_minutes=max(0, int(data.get("claim_allowance_minutes", 0) or 0)),
             daily_limit=data.get("daily_limit", 1),
             completion_sound=data.get("completion_sound", "coin"),
+            icon=str(data.get("icon", "") or ""),
             difficulty=data.get("difficulty", "medium"),
             schedule_mode=schedule_mode,
             due_days=list(data.get("due_days", [])),
@@ -404,6 +408,7 @@ class Chore:
             "claim_allowance_minutes": self.claim_allowance_minutes,
             "daily_limit": self.daily_limit,
             "completion_sound": self.completion_sound,
+            "icon": self.icon,
             "difficulty": self.difficulty,
             "schedule_mode": self.schedule_mode,
             "due_days": self.due_days,

--- a/custom_components/taskmate/sensor.py
+++ b/custom_components/taskmate/sensor.py
@@ -299,6 +299,9 @@ def _build_chores_list(coordinator: TaskMateCoordinator, common: dict) -> list[d
         assignment_current_child_id = getattr(c, 'assignment_current_child_id', '')
         if assignment_current_child_id:
             record["assignment_current_child_id"] = assignment_current_child_id
+        icon = getattr(c, 'icon', '')
+        if icon:
+            record["icon"] = icon
         completion_sound = getattr(c, 'completion_sound', 'coin')
         if completion_sound and completion_sound != 'coin':
             record["completion_sound"] = completion_sound

--- a/custom_components/taskmate/websocket.py
+++ b/custom_components/taskmate/websocket.py
@@ -457,7 +457,7 @@ async def _ws_list_ha_users(hass, connection, msg, coordinator):
 _CHORE_EDITABLE_FIELDS = {
     "name", "description", "points", "assigned_to", "depends_on", "requires_approval",
     "time_category", "claim_allowance_minutes", "daily_limit", "completion_sound",
-    "difficulty",
+    "icon", "difficulty",
     "schedule_mode", "due_days", "recurrence", "recurrence_day",
     "recurrence_start", "first_occurrence_mode", "visibility_entity",
     "visibility_state", "visibility_operator",
@@ -487,6 +487,7 @@ def _chore_payload_schema(*, require_name: bool):
         vol.Optional("claim_allowance_minutes"): vol.All(int, vol.Range(min=0)),
         vol.Optional("daily_limit"): vol.All(int, vol.Range(min=1)),
         vol.Optional("completion_sound"): str,
+        vol.Optional("icon"): str,
         vol.Optional("difficulty"): vol.In(["easy", "medium", "hard"]),
         vol.Optional("schedule_mode"): vol.In(["specific_days", "recurring", "one_shot"]),
         vol.Optional("due_days"): [str],

--- a/custom_components/taskmate/www/locales/de.json
+++ b/custom_components/taskmate/www/locales/de.json
@@ -1708,5 +1708,8 @@
   "panel.health_count_scheduled_changes": "Geplant",
   "panel.health_count_active_unlocks": "Freischaltungen",
   "panel.health_count_mandatory_misses": "Versäumt",
-  "panel.health_count_storage": "Speicher"
+  "panel.health_count_storage": "Speicher",
+  "panel.chore_icon_label": "Bild",
+  "child.editor.pre_reader": "Nur-Bilder-Modus (für kleine Kinder)",
+  "child.editor.pre_reader_labels": "Namen im Bildmodus anzeigen"
 }

--- a/custom_components/taskmate/www/locales/en-GB.json
+++ b/custom_components/taskmate/www/locales/en-GB.json
@@ -1708,5 +1708,8 @@
   "panel.health_count_scheduled_changes": "Scheduled",
   "panel.health_count_active_unlocks": "Unlocks",
   "panel.health_count_mandatory_misses": "Misses",
-  "panel.health_count_storage": "Storage"
+  "panel.health_count_storage": "Storage",
+  "panel.chore_icon_label": "Picture",
+  "child.editor.pre_reader": "Picture-only mode (for young children)",
+  "child.editor.pre_reader_labels": "Show names in picture mode"
 }

--- a/custom_components/taskmate/www/locales/en.json
+++ b/custom_components/taskmate/www/locales/en.json
@@ -1708,5 +1708,8 @@
   "panel.health_count_scheduled_changes": "Scheduled",
   "panel.health_count_active_unlocks": "Unlocks",
   "panel.health_count_mandatory_misses": "Misses",
-  "panel.health_count_storage": "Storage"
+  "panel.health_count_storage": "Storage",
+  "panel.chore_icon_label": "Picture",
+  "child.editor.pre_reader": "Picture-only mode (for young children)",
+  "child.editor.pre_reader_labels": "Show names in picture mode"
 }

--- a/custom_components/taskmate/www/locales/fr.json
+++ b/custom_components/taskmate/www/locales/fr.json
@@ -1708,5 +1708,8 @@
   "panel.health_count_scheduled_changes": "Planifiées",
   "panel.health_count_active_unlocks": "Déverrouillages",
   "panel.health_count_mandatory_misses": "Manquements",
-  "panel.health_count_storage": "Stockage"
+  "panel.health_count_storage": "Stockage",
+  "panel.chore_icon_label": "Image",
+  "child.editor.pre_reader": "Mode images seules (jeunes enfants)",
+  "child.editor.pre_reader_labels": "Afficher les noms en mode images"
 }

--- a/custom_components/taskmate/www/locales/nb.json
+++ b/custom_components/taskmate/www/locales/nb.json
@@ -1708,5 +1708,8 @@
   "panel.health_count_scheduled_changes": "Planlagte",
   "panel.health_count_active_unlocks": "Opplåsinger",
   "panel.health_count_mandatory_misses": "Glemt",
-  "panel.health_count_storage": "Lagring"
+  "panel.health_count_storage": "Lagring",
+  "panel.chore_icon_label": "Bilde",
+  "child.editor.pre_reader": "Kun bilder (for små barn)",
+  "child.editor.pre_reader_labels": "Vis navn i bildemodus"
 }

--- a/custom_components/taskmate/www/locales/nn.json
+++ b/custom_components/taskmate/www/locales/nn.json
@@ -1708,5 +1708,8 @@
   "panel.health_count_scheduled_changes": "Planlagde",
   "panel.health_count_active_unlocks": "Opplåsingar",
   "panel.health_count_mandatory_misses": "Gløymt",
-  "panel.health_count_storage": "Lagring"
+  "panel.health_count_storage": "Lagring",
+  "panel.chore_icon_label": "Bilete",
+  "child.editor.pre_reader": "Berre bilete (for små born)",
+  "child.editor.pre_reader_labels": "Vis namn i biletemodus"
 }

--- a/custom_components/taskmate/www/locales/pt-BR.json
+++ b/custom_components/taskmate/www/locales/pt-BR.json
@@ -1708,5 +1708,8 @@
   "panel.health_count_scheduled_changes": "Agendadas",
   "panel.health_count_active_unlocks": "Desbloqueios",
   "panel.health_count_mandatory_misses": "Falhas",
-  "panel.health_count_storage": "Armazenamento"
+  "panel.health_count_storage": "Armazenamento",
+  "panel.chore_icon_label": "Imagem",
+  "child.editor.pre_reader": "Modo só imagens (crianças pequenas)",
+  "child.editor.pre_reader_labels": "Mostrar nomes no modo imagens"
 }

--- a/custom_components/taskmate/www/locales/pt.json
+++ b/custom_components/taskmate/www/locales/pt.json
@@ -1708,5 +1708,8 @@
   "panel.health_count_scheduled_changes": "Agendadas",
   "panel.health_count_active_unlocks": "Desbloqueios",
   "panel.health_count_mandatory_misses": "Falhas",
-  "panel.health_count_storage": "Armazenamento"
+  "panel.health_count_storage": "Armazenamento",
+  "panel.chore_icon_label": "Imagem",
+  "child.editor.pre_reader": "Modo só imagens (crianças pequenas)",
+  "child.editor.pre_reader_labels": "Mostrar nomes no modo imagens"
 }

--- a/custom_components/taskmate/www/taskmate-child-card.js
+++ b/custom_components/taskmate/www/taskmate-child-card.js
@@ -1193,6 +1193,51 @@ class TaskMateChildCard extends LitElement {
         width: 6px;
         background: var(--fun-red);
       }
+      /* Pre-reader mode (#683) — picture-only, huge targets */
+      .pre-reader-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(128px, 1fr));
+        gap: 14px;
+        padding: 4px 0 8px;
+      }
+      .pre-tile {
+        position: relative;
+        display: flex; flex-direction: column;
+        align-items: center; justify-content: center; gap: 8px;
+        min-height: 140px; padding: 16px 10px;
+        border: 3px solid var(--divider-color, #e0e0e0);
+        border-radius: 26px;
+        background: var(--card-background-color, #fff);
+        font-family: inherit; cursor: pointer;
+        transition: transform 0.12s ease, border-color 0.12s ease;
+      }
+      .pre-tile:active { transform: scale(0.96); }
+      .pre-tile:focus-visible { outline: 4px solid var(--primary-color); outline-offset: 3px; }
+      .pre-tile-icon ha-icon { --mdc-icon-size: 64px; color: var(--primary-color); }
+      .pre-tile-stars { display: flex; gap: 2px; }
+      .pre-tile-stars ha-icon { --mdc-icon-size: 18px; color: #f1c40f; }
+      .pre-tile-label {
+        font-size: 0.85rem; font-weight: 700; text-align: center;
+        color: var(--secondary-text-color); line-height: 1.2;
+      }
+      .pre-tile.done {
+        border-color: var(--success-color, #2ecc71);
+        background: rgba(46, 204, 113, 0.10);
+      }
+      .pre-tile.done .pre-tile-icon ha-icon { opacity: 0.35; }
+      .pre-tile.done .pre-tile-stars { opacity: 0.35; }
+      .pre-tile-tick {
+        position: absolute; inset: 0;
+        display: grid; place-items: center;
+        pointer-events: none;
+      }
+      .pre-tile-tick ha-icon {
+        --mdc-icon-size: 72px;
+        color: var(--success-color, #2ecc71);
+      }
+      .pre-tile.locked { opacity: 0.4; cursor: default; }
+      .pre-tile.loading { opacity: 0.6; }
+
       /* Chore roulette (#677) */
       .roulette {
         display: flex; flex-direction: column; gap: 8px;
@@ -2166,7 +2211,12 @@ class TaskMateChildCard extends LitElement {
                   })() : ''}
                 </div>
                 ${this._renderRoulette(child, childChores, pointsIcon)}
-                ${childChores.map((chore, index) => html`
+                ${this.config.pre_reader === true ? html`
+                  <div class="pre-reader-grid">
+                    ${childChores.map((chore, index) =>
+                      this._renderPreReaderTile(chore, child, todaysCompletions, index))}
+                  </div>
+                ` : childChores.map((chore, index) => html`
                   ${chore.task_type === 'timed'
                     ? this._renderTimedChoreCard(chore, child, pointsIcon, todaysCompletions, index)
                     : html`
@@ -3146,6 +3196,53 @@ class TaskMateChildCard extends LitElement {
       this._spinning = null;
       this.requestUpdate();
     }
+  }
+
+  /**
+   * Pre-reader mode (#683): a picture-only tile for children who can't read
+   * yet. No chore name, no numbers — a big icon, a row of stars for the
+   * points, and a huge tick when it's done.
+   */
+  _renderPreReaderTile(chore, child, todaysCompletions = [], choreIndex = 0) {
+    const dailyLimit = chore.daily_limit || 1;
+    // Counted the same way the standard row does: pending completions hold a
+    // place too, and a parent completing on behalf lands under "__parent__".
+    const childCompletionsToday = todaysCompletions.filter(
+      (comp) => comp.chore_id === chore.id
+        && (comp.child_id === child.id || comp.child_id === "__parent__")
+        && !comp.bonus_subtask_id
+    );
+    const isDone = childCompletionsToday.length >= dailyLimit;
+    const isLoading = this._loading[chore.id];
+    const available = chore._isAvailableForChild !== false && !chore._isLockedPreview;
+
+    // Stars, not digits: a 4-year-old can count pictures, not read "+3".
+    const points = chore.effective_points ?? chore.points ?? 0;
+    const stars = Math.max(1, Math.min(5, Math.round(points / 2) || 1));
+
+    const icon = chore.icon
+      || this._getTimeCategoryIcon(chore.time_category)
+      || 'mdi:checkbox-marked-circle-outline';
+
+    return html`
+      <button
+        class="pre-tile ${isDone ? 'done' : ''} ${isLoading ? 'loading' : ''} ${available ? '' : 'locked'}"
+        ?disabled=${isLoading || !available}
+        aria-label="${chore.name}"
+        title="${chore.name}"
+        @click=${() => (isDone
+          ? this._handleUndo(chore, child, childCompletionsToday)
+          : this._handleComplete(chore, child))}
+      >
+        <div class="pre-tile-icon"><ha-icon icon="${icon}"></ha-icon></div>
+        ${isDone ? html`<div class="pre-tile-tick"><ha-icon icon="mdi:check-bold"></ha-icon></div>` : ''}
+        <div class="pre-tile-stars">
+          ${Array.from({ length: stars }, () => html`<ha-icon icon="mdi:star"></ha-icon>`)}
+        </div>
+        ${this.config.pre_reader_labels === true
+          ? html`<div class="pre-tile-label">${chore.name}</div>` : ''}
+      </button>
+    `;
   }
 
   _renderChoreCard(chore, child, pointsIcon, todaysCompletions = [], choreIndex = 0) {
@@ -4300,6 +4397,8 @@ class TaskMateChildCardEditor extends LitElement {
       },
       { name: 'show_countdown', selector: { boolean: {} } },
       { name: 'show_description', selector: { boolean: {} } },
+      { name: 'pre_reader', selector: { boolean: {} } },
+      { name: 'pre_reader_labels', selector: { boolean: {} } },
       { name: 'debug', selector: { boolean: {} } },
     ];
   }
@@ -4315,6 +4414,8 @@ class TaskMateChildCardEditor extends LitElement {
       elapsed_time_mode: this._t('child.editor.missed_time_chores'),
       show_countdown: this._t('child.editor.show_countdown'),
       show_description: this._t('child.editor.show_description'),
+      pre_reader: this._t('child.editor.pre_reader'),
+      pre_reader_labels: this._t('child.editor.pre_reader_labels'),
       debug: this._t('child.editor.show_debug'),
     };
     return labels[entry.name] ?? entry.name;
@@ -4345,6 +4446,8 @@ class TaskMateChildCardEditor extends LitElement {
       elapsed_time_mode: this.config.elapsed_time_mode || 'dim',
       show_countdown: this.config.show_countdown !== false,
       show_description: this.config.show_description === true,
+      pre_reader: this.config.pre_reader === true,
+      pre_reader_labels: this.config.pre_reader_labels === true,
       debug: this.config.debug === true,
     };
 

--- a/custom_components/taskmate/www/taskmate-panel.js
+++ b/custom_components/taskmate/www/taskmate-panel.js
@@ -1283,6 +1283,7 @@ class TaskMatePanel extends HTMLElement {
       due_days: d.due_days || [],
       daily_limit: Number(d.daily_limit) || 1,
       completion_sound: d.completion_sound || "coin",
+      icon: d.icon || "",
     });
     if (!ok) { this._showToast("err", this._t("panel.toast_bulk_add_failed", {error: err})); return; }
     this._closeDialog(true);
@@ -1355,6 +1356,7 @@ class TaskMatePanel extends HTMLElement {
       assignment_mode: "everyone", assignment_rotation_anchor: "",
       manual_start_child_id: "",
       require_availability: false,
+      icon: "",
       visibility_entity: "", visibility_state: "on", visibility_operator: "none",
       weather_entity: "", weather_block_conditions: [],
       weather_temp_min: "", weather_temp_max: "", weather_wind_max: "",
@@ -4894,7 +4896,10 @@ class TaskMatePanel extends HTMLElement {
     return this._dialogShell(this._dialog.mode === "add" ? this._t("panel.dialog_add_chore") : this._t("panel.dialog_edit_chore"),
       [
         this._field(this._t("panel.chore_name_label"), "name", d.name, "text"),
-        this._field(this._t("panel.chore_description_label"), "description", d.description, "text"),
+        `<div class="tm-field-row">
+          ${this._field(this._t("panel.chore_description_label"), "description", d.description, "text")}
+          ${this._iconPickerField(this._t("panel.chore_icon_label"), "icon", d.icon)}
+        </div>`,
         this._select(this._t("panel.chore_task_type_label"), "task_type", d.task_type || "standard", [
           { v: "standard", l: this._t("panel.chore_task_type_standard") },
           { v: "timed", l: this._t("panel.chore_task_type_timed") },

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -45,7 +45,7 @@ def test_complete_chore_button_identity_and_icon():
     btn = CompleteChoreButton(coord, _entry(), child, chore)
     assert btn._attr_unique_id == "entry1_ch1_cho1_complete"
     assert btn._attr_name == "Malia: Complete Dishes"
-    assert btn.icon == "mdi:check-circle"  # Chore has no icon field -> getattr fallback
+    assert btn.icon == "mdi:check-circle"  # no picture set -> falls back
     attrs = btn.extra_state_attributes
     assert attrs["child_id"] == "ch1"
     assert attrs["chore_id"] == "cho1"

--- a/tests/test_pre_reader_mode.py
+++ b/tests/test_pre_reader_mode.py
@@ -1,0 +1,95 @@
+"""Pre-reader mode and the chore icon it needs (#683).
+
+A picture-only child card for children who can't read yet. The card itself is
+JavaScript; what Python guards is the icon field it depends on — a chore with
+no picture would leave a pre-reader looking at identical tiles.
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+import re
+
+from custom_components.taskmate.models import Chore
+
+WWW = pathlib.Path(__file__).resolve().parent.parent / "custom_components" / "taskmate" / "www"
+CARD = (WWW / "taskmate-child-card.js").read_text(encoding="utf-8")
+
+
+def _tile_source() -> str:
+    """The tile method body — sliced from its definition, not its call site."""
+    start = CARD.index("  _renderPreReaderTile(chore, child, todaysCompletions = [], choreIndex = 0) {")
+    return CARD[start:CARD.index("_renderChoreCard(chore, child, pointsIcon", start)]
+
+
+class TestChoreIcon:
+    def test_defaults_to_empty(self):
+        """Empty means "fall back to the time-of-day icon", not a bad default."""
+        assert Chore(name="Chore").icon == ""
+
+    def test_round_trips(self):
+        restored = Chore.from_dict(Chore(name="Teeth", icon="mdi:tooth").to_dict())
+        assert restored.icon == "mdi:tooth"
+
+    def test_legacy_chore_without_an_icon(self):
+        assert Chore.from_dict({"name": "Old"}).icon == ""
+
+    def test_none_is_coerced_to_empty(self):
+        assert Chore.from_dict({"name": "Odd", "icon": None}).icon == ""
+
+    def test_icon_is_editable_over_the_websocket(self):
+        ws = (WWW.parent / "websocket.py").read_text(encoding="utf-8")
+        block = re.search(r"_CHORE_EDITABLE_FIELDS = \{(.*?)\}", ws, re.S)
+        assert block and '"icon"' in block.group(1)
+
+    def test_button_falls_back_when_no_picture_is_set(self):
+        """The icon default is "", so a fallback keyed on the attribute being
+        absent would leave every button blank."""
+        button = (WWW.parent / "button.py").read_text(encoding="utf-8")
+        assert "getattr(chore, 'icon', \"\") or \"mdi:check-circle\"" in button
+
+    def test_icon_is_exposed_to_the_cards(self):
+        """Cards read chores from the sensor, so an unexposed field is invisible."""
+        sensor = (WWW.parent / "sensor.py").read_text(encoding="utf-8")
+        assert 'record["icon"] = icon' in sensor
+
+
+class TestPreReaderCard:
+    def test_tile_renderer_exists(self):
+        assert "_renderPreReaderTile" in CARD
+
+    def test_grid_is_gated_behind_the_config_flag(self):
+        """An existing dashboard must not suddenly turn into pictures."""
+        assert "this.config.pre_reader === true" in CARD
+
+    def test_labels_are_opt_in(self):
+        """The whole point is no text, so names default to off."""
+        assert "this.config.pre_reader_labels === true" in CARD
+
+    def test_tile_falls_back_to_the_time_category_icon(self):
+        assert "_getTimeCategoryIcon(chore.time_category)" in CARD
+
+    def test_tile_uses_the_real_completion_handlers(self):
+        assert "_handleComplete(chore, child)" in CARD
+        assert "_handleUndo(chore, child, childCompletionsToday)" in CARD
+
+    def test_done_tile_stays_tappable_for_undo(self):
+        """A mis-tap must be recoverable, exactly as on the standard row."""
+        tile = _tile_source()
+        assert "?disabled=${isLoading || !available}" in tile
+
+    def test_tile_shows_stars_rather_than_a_number(self):
+        tile = _tile_source()
+        assert "pre-tile-stars" in tile
+        assert "mdi:star" in tile
+
+    def test_editor_exposes_both_options(self):
+        assert "name: 'pre_reader'" in CARD
+        assert "name: 'pre_reader_labels'" in CARD
+
+    def test_strings_exist_in_every_locale(self):
+        keys = {"panel.chore_icon_label", "child.editor.pre_reader", "child.editor.pre_reader_labels"}
+        for path in sorted((WWW / "locales").glob("*.json")):
+            data = json.loads(path.read_text(encoding="utf-8"))
+            missing = sorted(k for k in keys if k not in data)
+            assert missing == [], f"{path.name} missing {missing}"


### PR DESCRIPTION
A picture-only child card for children who can't read yet. No chore names, no numbers — a big icon, a row of stars for the points, and a huge tick when it's done.

```yaml
type: custom:taskmate-child-card
child_id: <child_id>
pre_reader: true
pre_reader_labels: false   # optional; adds names back
```

## Design

- **Points are stars, not digits** (1–5, scaled from the chore's value). A four-year-old can count pictures but can't read "+3".
- Tiles are ≥128px with a large tap target, and a **done tile stays tappable** so a mis-tap can be undone — exactly as on the standard row.
- **Both options are opt-in.** An existing dashboard never turns into pictures on its own, and names stay off unless asked for.

## A gap this exposed, and a regression it caused

Chores had **no icon field**, so every tile would have looked identical — which defeats the entire feature. Chores now carry an optional icon, editable in the panel beside the description and exposed on the chores sensor, with a fallback to the time-of-day icon.

Adding that field **broke the complete-chore button entity**. It used `getattr(chore, "icon", "mdi:check-circle")` — a fallback keyed on the attribute being *absent*. With the field now present and defaulting to `""`, every button for a chore without a picture would have rendered a **blank icon**.

The existing `test_button.py` caught it immediately (4 failures instead of the usual 3). The fallback now keys on falsiness, and there's a guard test so the same shape can't come back. Worth flagging as a general hazard: `getattr(obj, "x", default)` is a trap the moment `x` gains an empty default.

## Testing

- **16 new tests**: the icon field (default, round-trip, legacy chores, `None` coercion, editable over the websocket, exposed on the sensor), the button fallback guard, and the card (tile renderer exists, grid gated behind the flag, labels opt-in, time-category fallback, real completion handlers, done-tile-stays-tappable, stars not numbers, editor options, strings in every locale).
- Full suite: **1227 passed** vs **1211** on `main`, back to the identical pre-existing 3 failures / 9 errors after fixing the regression.
- `ruff` clean; `eslint` clean.
- **Verified end-to-end on ha-dev**: saved `mdi:tooth` on a chore, mounted the card in pre-reader mode, confirmed the grid replaced the standard rows entirely (0 `.chore-card`), the pictured tile rendered `mdi:tooth` with **2 stars for a 4-point chore**, an unpictured chore fell back to its time-of-day icon, tiles measured **136×140px**, tapping marked it done, and labels appeared only when enabled. No console errors.

One earlier run "failed" for a good reason: an *evening* chore tile was correctly disabled outside its window, which is exactly right — the test needed an always-claimable chore, not a code change.

## i18n

All 3 new strings translated into all 8 locales in this PR.

Fixes #683