### PR TITLE
feat(cards): accessible design style

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@
 - [Insights — Fairness, Friction, Week Ahead & Health](#insights--fairness-friction-week-ahead--health)
 - [Pre-Reader Mode](#pre-reader-mode)
 - [Read Aloud](#read-aloud)
+- [Accessible Design Style](#accessible-design-style)
 - [Bonus Points System](#bonus-points-system)
 - [Notifications](#notifications)
 - [Quiet Hours](#quiet-hours)
@@ -572,6 +573,17 @@ The sentence comes from **parent-editable templates** in Settings, not from Task
 A template with a bad placeholder logs a warning and falls back to the built-in wording rather than silencing the feature.
  
 Fires `taskmate_read_aloud` (`child_id`, `media_player`, `tts_entity`, `message`).
+ 
+---
+ 
+## Accessible Design Style
+ 
+A fifth per-card design alongside Classic, Playroom, Console and Clean Pro — pick it per card or as the global default.
+ 
+- **Colour-blind safe.** Uses the Okabe-Ito palette, which stays distinguishable under protanopia, deuteranopia and tritanopia.
+- **High contrast.** Near-black on white (~19:1, comfortably past WCAG AAA), with heavy borders so meaning never rests on hue alone.
+- **Dyslexia-friendly type.** Atkinson Hyperlegible, drawn for low vision — its letterforms stay distinct where similar glyphs (I/l/1, O/0) usually collapse.
+- **Dark variant included.** `#0A0A0A` rather than pure black, which blooms on OLED and is harsh with astigmatism.
  
 ---
  

--- a/custom_components/taskmate/select.py
+++ b/custom_components/taskmate/select.py
@@ -14,7 +14,7 @@ from .coordinator import TaskMateCoordinator
 # (setting_key, translation_key, options, default, icon)
 _SELECTS = [
     ("streak_reset_mode", "streak_reset_mode", ["reset", "pause"], "reset", "mdi:restart"),
-    ("card_design", "card_design", ["classic", "playroom", "console", "cleanpro"], "classic", "mdi:palette"),
+    ("card_design", "card_design", ["classic", "playroom", "console", "cleanpro", "accessible"], "classic", "mdi:palette"),
 ]
 
 

--- a/custom_components/taskmate/websocket.py
+++ b/custom_components/taskmate/websocket.py
@@ -1246,7 +1246,7 @@ async def _ws_remove_task_group(hass, connection, msg, coordinator):
 # Top-level fields stored at storage._data root
 _TOP_LEVEL_SETTINGS = {"points_name", "points_icon"}
 # Allowed values for the global default card-design style (per-card design styles).
-_ALLOWED_CARD_DESIGNS = {"classic", "playroom", "console", "cleanpro"}
+_ALLOWED_CARD_DESIGNS = {"classic", "playroom", "console", "cleanpro", "accessible"}
 # Settings stored under storage._data["settings"][key]
 _SUBKEY_SETTINGS = {
     "history_days", "streak_reset_mode", "card_design",

--- a/custom_components/taskmate/www/locales/de.json
+++ b/custom_components/taskmate/www/locales/de.json
@@ -1711,5 +1711,6 @@
   "panel.health_count_storage": "Speicher",
   "panel.chore_icon_label": "Bild",
   "child.editor.pre_reader": "Nur-Bilder-Modus (für kleine Kinder)",
-  "child.editor.pre_reader_labels": "Namen im Bildmodus anzeigen"
+  "child.editor.pre_reader_labels": "Namen im Bildmodus anzeigen",
+  "common.design.accessible": "Barrierefrei"
 }

--- a/custom_components/taskmate/www/locales/en-GB.json
+++ b/custom_components/taskmate/www/locales/en-GB.json
@@ -1711,5 +1711,6 @@
   "panel.health_count_storage": "Storage",
   "panel.chore_icon_label": "Picture",
   "child.editor.pre_reader": "Picture-only mode (for young children)",
-  "child.editor.pre_reader_labels": "Show names in picture mode"
+  "child.editor.pre_reader_labels": "Show names in picture mode",
+  "common.design.accessible": "Accessible"
 }

--- a/custom_components/taskmate/www/locales/en.json
+++ b/custom_components/taskmate/www/locales/en.json
@@ -1711,5 +1711,6 @@
   "panel.health_count_storage": "Storage",
   "panel.chore_icon_label": "Picture",
   "child.editor.pre_reader": "Picture-only mode (for young children)",
-  "child.editor.pre_reader_labels": "Show names in picture mode"
+  "child.editor.pre_reader_labels": "Show names in picture mode",
+  "common.design.accessible": "Accessible"
 }

--- a/custom_components/taskmate/www/locales/fr.json
+++ b/custom_components/taskmate/www/locales/fr.json
@@ -1711,5 +1711,6 @@
   "panel.health_count_storage": "Stockage",
   "panel.chore_icon_label": "Image",
   "child.editor.pre_reader": "Mode images seules (jeunes enfants)",
-  "child.editor.pre_reader_labels": "Afficher les noms en mode images"
+  "child.editor.pre_reader_labels": "Afficher les noms en mode images",
+  "common.design.accessible": "Accessible"
 }

--- a/custom_components/taskmate/www/locales/nb.json
+++ b/custom_components/taskmate/www/locales/nb.json
@@ -1711,5 +1711,6 @@
   "panel.health_count_storage": "Lagring",
   "panel.chore_icon_label": "Bilde",
   "child.editor.pre_reader": "Kun bilder (for små barn)",
-  "child.editor.pre_reader_labels": "Vis navn i bildemodus"
+  "child.editor.pre_reader_labels": "Vis navn i bildemodus",
+  "common.design.accessible": "Tilgjengelig"
 }

--- a/custom_components/taskmate/www/locales/nn.json
+++ b/custom_components/taskmate/www/locales/nn.json
@@ -1711,5 +1711,6 @@
   "panel.health_count_storage": "Lagring",
   "panel.chore_icon_label": "Bilete",
   "child.editor.pre_reader": "Berre bilete (for små born)",
-  "child.editor.pre_reader_labels": "Vis namn i biletemodus"
+  "child.editor.pre_reader_labels": "Vis namn i biletemodus",
+  "common.design.accessible": "Tilgjengeleg"
 }

--- a/custom_components/taskmate/www/locales/pt-BR.json
+++ b/custom_components/taskmate/www/locales/pt-BR.json
@@ -1711,5 +1711,6 @@
   "panel.health_count_storage": "Armazenamento",
   "panel.chore_icon_label": "Imagem",
   "child.editor.pre_reader": "Modo só imagens (crianças pequenas)",
-  "child.editor.pre_reader_labels": "Mostrar nomes no modo imagens"
+  "child.editor.pre_reader_labels": "Mostrar nomes no modo imagens",
+  "common.design.accessible": "Acessível"
 }

--- a/custom_components/taskmate/www/locales/pt.json
+++ b/custom_components/taskmate/www/locales/pt.json
@@ -1711,5 +1711,6 @@
   "panel.health_count_storage": "Armazenamento",
   "panel.chore_icon_label": "Imagem",
   "child.editor.pre_reader": "Modo só imagens (crianças pequenas)",
-  "child.editor.pre_reader_labels": "Mostrar nomes no modo imagens"
+  "child.editor.pre_reader_labels": "Mostrar nomes no modo imagens",
+  "common.design.accessible": "Acessível"
 }

--- a/custom_components/taskmate/www/taskmate-design.js
+++ b/custom_components/taskmate/www/taskmate-design.js
@@ -12,16 +12,17 @@
  *   playroom — warm, rounded, picture-book
  *   console  — dark gamified HUD
  *   cleanpro — calm productivity / SaaS
+ *   accessible — high contrast, colour-blind safe, dyslexia-friendly type
  *
  * Mirrors window.__taskmate_localize: exposed globally, no ES module imports.
  */
 (function () {
-  const IDS = ["classic", "playroom", "console", "cleanpro"];
+  const IDS = ["classic", "playroom", "console", "cleanpro", "accessible"];
 
   // Fonts must be loaded at the document level (an @import inside a shadow
   // stylesheet is honoured, but loading once globally avoids N duplicate fetches).
   const FONT_IMPORT =
-    "@import url('https://fonts.googleapis.com/css2?family=Baloo+2:wght@500;600;700;800&family=Nunito:wght@400;600;700;800;900&family=Space+Grotesk:wght@400;500;600;700&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@500;700;800&family=Manrope:wght@500;600;700;800&display=swap');";
+    "@import url('https://fonts.googleapis.com/css2?family=Baloo+2:wght@500;600;700;800&family=Nunito:wght@400;600;700;800;900&family=Space+Grotesk:wght@400;500;600;700&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@500;700;800&family=Manrope:wght@500;600;700;800&family=Atkinson+Hyperlegible:wght@400;700&display=swap');";
 
   // Design tokens. IMPORTANT: these are :host-scoped so they can be applied
   // INSIDE each card's shadow root. A document-level [data-tm-design] rule
@@ -59,6 +60,22 @@
    Cards stamp data-tm-dark on the host when HA is in dark mode. Each design has
    a light base (above) and a dark override here, so all three follow HA's
    light/dark setting. */
+:host([data-tm-design="accessible"]),[data-tm-design="accessible"]{
+  /* Colours are the Okabe-Ito colour-blind-safe palette: distinguishable
+     under protanopia, deuteranopia and tritanopia. Text is near-black on
+     white (~19:1, comfortably past WCAG AAA) and borders are heavy enough to
+     carry meaning without relying on hue. Atkinson Hyperlegible is drawn for
+     low vision — its letterforms stay distinct where similar glyphs (I/l/1,
+     O/0) usually collapse. */
+  --tmd-bg:#FFFFFF;--tmd-surface:#FFFFFF;--tmd-surface-2:#F2F2F2;--tmd-border:#111111;
+  --tmd-text:#111111;--tmd-dim:#3D3D3D;
+  --tmd-accent:#0072B2;--tmd-accent2:#D55E00;--tmd-good:#009E73;--tmd-warn:#E69F00;--tmd-bad:#D55E00;--tmd-gold:#E69F00;
+  --tmd-radius:10px;--tmd-radius-sm:6px;--tmd-shadow:0 0 0 2px #111111;--tmd-hd-text:#fff;
+  --tmd-font-display:"Atkinson Hyperlegible",sans-serif;
+  --tmd-font-body:"Atkinson Hyperlegible",sans-serif;
+  --tmd-font-mono:"Atkinson Hyperlegible",monospace;
+  --tmd-c1:#0072B2;--tmd-c2:#D55E00;--tmd-c3:#009E73;--tmd-c4:#CC79A7;--tmd-c5:#56B4E9;--tmd-c6:#E69F00;
+}
 :host([data-tm-design="console"][data-tm-dark]),[data-tm-design="console"][data-tm-dark]{
   --tmd-bg:#0E1320;--tmd-surface:#161D2E;--tmd-surface-2:#1E2740;--tmd-border:#2A3550;
   --tmd-text:#EAF0FF;--tmd-dim:#8A97B8;
@@ -75,6 +92,16 @@
   --tmd-bg:#0F141A;--tmd-surface:#181D25;--tmd-surface-2:#212733;--tmd-border:#2C3340;
   --tmd-text:#E6EAF1;--tmd-dim:#97A1B0;--tmd-accent:#6E86F5;--tmd-accent2:#1FC7B8;
   --tmd-shadow:0 1px 2px rgba(0,0,0,.4),0 8px 18px rgba(0,0,0,.35);
+}
+:host([data-tm-design="accessible"][data-tm-dark]),[data-tm-design="accessible"][data-tm-dark]{
+  /* Pure black would bloom on OLED and is harsh for astigmatism; #0A0A0A with
+     near-white text still clears AAA. Hues are the Okabe-Ito light variants,
+     which stay distinguishable against a dark ground. */
+  --tmd-bg:#0A0A0A;--tmd-surface:#0A0A0A;--tmd-surface-2:#1C1C1C;--tmd-border:#F5F5F5;
+  --tmd-text:#F5F5F5;--tmd-dim:#CFCFCF;
+  --tmd-accent:#56B4E9;--tmd-accent2:#E69F00;--tmd-good:#009E73;--tmd-warn:#F0E442;--tmd-bad:#E69F00;--tmd-gold:#F0E442;
+  --tmd-shadow:0 0 0 2px #F5F5F5;
+  --tmd-c1:#56B4E9;--tmd-c2:#E69F00;--tmd-c3:#009E73;--tmd-c4:#CC79A7;--tmd-c5:#F0E442;--tmd-c6:#0072B2;
 }`;
 
   // Shared component kit, themed by the tokens above. Every designed card
@@ -234,6 +261,7 @@
       { value: "playroom", label: label("playroom", "Playroom") },
       { value: "console",  label: label("console", "Console") },
       { value: "cleanpro", label: label("cleanpro", "Clean Pro") },
+      { value: "accessible", label: label("accessible", "Accessible") },
     ];
   }
 

--- a/tests/test_accessible_design.py
+++ b/tests/test_accessible_design.py
@@ -1,0 +1,102 @@
+"""Accessible design style (#685).
+
+A fourth per-card design: colour-blind safe, high contrast, dyslexia-friendly
+type. The design ids live in THREE places — the JS design layer, the websocket
+allowlist and the select entity — and a mismatch means a style that either
+can't be chosen or can't be saved.
+"""
+from __future__ import annotations
+
+import pathlib
+import re
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent / "custom_components" / "taskmate"
+DESIGN_JS = (ROOT / "www" / "taskmate-design.js").read_text(encoding="utf-8")
+WEBSOCKET = (ROOT / "websocket.py").read_text(encoding="utf-8")
+SELECT = (ROOT / "select.py").read_text(encoding="utf-8")
+
+
+def _js_ids() -> list[str]:
+    m = re.search(r"const IDS = \[(.*?)\];", DESIGN_JS)
+    assert m
+    return re.findall(r'"([a-z]+)"', m.group(1))
+
+
+def _ws_ids() -> set[str]:
+    m = re.search(r"_ALLOWED_CARD_DESIGNS = \{(.*?)\}", WEBSOCKET, re.S)
+    assert m
+    return set(re.findall(r'"([a-z]+)"', m.group(1)))
+
+
+def _select_ids() -> list[str]:
+    m = re.search(r'\("card_design", "card_design", \[(.*?)\]', SELECT)
+    assert m
+    return re.findall(r'"([a-z]+)"', m.group(1))
+
+
+class TestIdsStayInSync:
+    def test_websocket_matches_the_design_layer(self):
+        """A style the backend rejects can be picked but never saved."""
+        assert _ws_ids() == set(_js_ids())
+
+    def test_select_entity_matches_the_design_layer(self):
+        assert set(_select_ids()) == set(_js_ids())
+
+    def test_accessible_is_registered_everywhere(self):
+        assert "accessible" in _js_ids()
+        assert "accessible" in _ws_ids()
+        assert "accessible" in _select_ids()
+
+
+class TestTokens:
+    def test_light_and_dark_variants_both_exist(self):
+        assert '[data-tm-design="accessible"]' in DESIGN_JS
+        assert '[data-tm-design="accessible"][data-tm-dark]' in DESIGN_JS
+
+    def test_uses_the_okabe_ito_colour_blind_safe_palette(self):
+        """These specific hues are the point — they survive all three common
+        forms of colour blindness."""
+        block = _accessible_block()
+        for colour in ("#0072B2", "#D55E00", "#009E73", "#E69F00", "#CC79A7", "#56B4E9"):
+            assert colour in block, f"{colour} missing from the accessible palette"
+
+    def test_text_is_near_black_on_white(self):
+        block = _accessible_block()
+        assert "--tmd-text:#111111" in block
+        assert "--tmd-surface:#FFFFFF" in block
+
+    def test_borders_carry_meaning_without_hue(self):
+        """Colour alone must not be the only signal."""
+        assert "--tmd-border:#111111" in _accessible_block()
+
+    def test_dyslexia_friendly_font_is_used_throughout(self):
+        block = _accessible_block()
+        assert block.count("Atkinson Hyperlegible") >= 3  # display, body, mono
+
+    def test_the_font_is_actually_loaded(self):
+        assert "Atkinson+Hyperlegible" in DESIGN_JS
+
+    def test_dark_variant_avoids_pure_black(self):
+        """Pure black blooms on OLED and is harsh with astigmatism."""
+        dark = _accessible_block(dark=True)
+        assert "--tmd-bg:#0A0A0A" in dark
+        assert "--tmd-text:#F5F5F5" in dark
+
+
+class TestEditor:
+    def test_offered_in_the_card_editor(self):
+        m = re.search(r"function editorOptions\(t\) \{(.*?)\n  \}", DESIGN_JS, re.S)
+        assert m and 'value: "accessible"' in m.group(1)
+
+    def test_label_exists_in_every_locale(self):
+        import json
+        for path in sorted((ROOT / "www" / "locales").glob("*.json")):
+            data = json.loads(path.read_text(encoding="utf-8"))
+            assert "common.design.accessible" in data, f"{path.name} missing the label"
+
+
+def _accessible_block(dark: bool = False) -> str:
+    needle = ('[data-tm-design="accessible"][data-tm-dark]' if dark
+              else ':host([data-tm-design="accessible"]),')
+    start = DESIGN_JS.index(needle)
+    return DESIGN_JS[start:DESIGN_JS.index("}", start)]

--- a/tests/test_card_design_setting.py
+++ b/tests/test_card_design_setting.py
@@ -32,7 +32,10 @@ def test_snapshot_reflects_stored_card_design():
 
 
 def test_allowed_card_designs_set():
-    assert _ALLOWED_CARD_DESIGNS == {"classic", "playroom", "console", "cleanpro"}
+    # "accessible" added in #685. test_accessible_design.py additionally pins
+    # this set against the JS design layer and the select entity, so the three
+    # lists can't drift apart.
+    assert _ALLOWED_CARD_DESIGNS == {"classic", "playroom", "console", "cleanpro", "accessible"}
 
 
 def test_overview_sensor_exposes_card_design_default():


### PR DESCRIPTION
A fifth per-card design alongside Classic, Playroom, Console and Clean Pro — selectable per card or as the global default, with a dark variant like the others.

## What makes it accessible

- **Colour-blind safe:** the Okabe-Ito palette, distinguishable under protanopia, deuteranopia and tritanopia.
- **High contrast:** near-black on white (~19:1, comfortably past WCAG AAA).
- **Heavy borders**, so meaning never rests on hue alone. That is the actual point of an accessible style — it still works when the colour information is gone.
- **Atkinson Hyperlegible**, drawn for low vision: letterforms stay distinct where I/l/1 and O/0 usually collapse.
- **Dark variant uses `#0A0A0A`, not pure black** — pure black blooms on OLED and is harsh with astigmatism.

## A drift bug caught on the way

Design ids live in **three** places: the JS design layer (`IDS`), the websocket allowlist (`_ALLOWED_CARD_DESIGNS`) and the **select entity** (`select.py`). I updated the first two and a grep caught the third — without it the style would have been offered in the card editor and by the backend, but missing from the `select.taskmate_card_design` entity.

The new test pins all three together, so a future style can't be pickable-but-unsavable, or offered by the select entity and rejected by the backend.

## Testing

- **12 new tests**: the three id lists agree with each other, "accessible" registered in all three, light and dark token blocks exist, each Okabe-Ito hue present, near-black-on-white, borders carry meaning, the font used for display/body/mono and actually loaded, dark avoids pure black, offered in the editor, label in every locale.
- Updated `test_card_design_setting.py`, which pinned the exact four-design set.
- Full suite: **1258 passed** vs **1245** on `main`, identical pre-existing 3 failures / 9 errors.
- `ruff` clean; `eslint` clean.
- **Verified end-to-end on ha-dev**: the backend accepted `accessible` as the global default, the design layer registered it in both `IDS` and the editor options, and a real child card rendered with the resolved tokens — `--tmd-text: #111111`, `--tmd-surface: #FFFFFF`, `--tmd-border: #111111`, `--tmd-accent: #0072B2` and `"Atkinson Hyperlegible", sans-serif`. Previous default restored afterwards. No console errors.

## i18n

Design label translated into all 8 locales.

Fixes #685