### PR TITLE
feat(notifications): attach the evidence photo to the approval push

### DIFF
--- a/README.md
+++ b/README.md
@@ -988,6 +988,9 @@ See the [Allowance wiki page](https://github.com/tempus2016/taskmate/wiki/Allowa
 ---
 
 ## Photo Proof
+ 
+Evidence photos are attached to the **approval push notification** on the HA companion app, so a parent can approve from the lock screen while actually looking at the tidied room. The URL is signed (24h) because the app fetches attachments without the user's bearer token — an unsigned URL returns 401. Android reads `data.image` and iOS reads `data.attachment.url`; both are sent so one payload works on either. Non-mobile backends (Telegram, email, persistent) get no attachment, since they'd render a raw payload rather than a picture.
+ 
 
 Photo proof lets a chore require evidence before it counts. Turn on **Require photo proof** (`require_photo`) in the chore dialog and that chore's completions **always** go through parent approval — even if Requires Approval is off — and any photo attached is shown to the parent as a thumbnail when they review it.
 

--- a/custom_components/taskmate/coord_chores.py
+++ b/custom_components/taskmate/coord_chores.py
@@ -759,7 +759,10 @@ class ChoresMixin:
 
         # Fire approval notification only if it stays pending
         if not auto_approve:
-            await self._async_notify_pending_approval(child.name, chore.name, chore.points, completion_id=completion.id)
+            await self._async_notify_pending_approval(
+                child.name, chore.name, chore.points,
+                completion_id=completion.id, photo_url=completion.photo_url,
+            )
 
         await self.async_refresh()
 

--- a/custom_components/taskmate/coord_notifications.py
+++ b/custom_components/taskmate/coord_notifications.py
@@ -291,6 +291,18 @@ class NotificationCoordinator:
             return
 
         data: dict[str, Any] = {"title": "TaskMate", "message": message}
+
+        # Evidence photo (#686): attach it so a parent can approve from the
+        # lock screen while actually looking at the tidied room. The URL is
+        # pre-signed by the caller, because the companion app fetches
+        # attachments without the user's bearer token.
+        photo_url = context.get("photo_url") or ""
+        attach_photo = bool(photo_url) and service.startswith("mobile_app")
+
+        # Build the mobile-app payload once: the action buttons and the photo
+        # are independent, so a completion with no entry id still gets its
+        # picture, and a photo-less approval still gets its buttons.
+        push: dict[str, Any] = {}
         if meta.actionable:
             entry_id = context.get("entry_id")
             # Tap actions only render on the HA mobile app. Other backends
@@ -300,15 +312,23 @@ class NotificationCoordinator:
                 if entry_id:
                     # `tag` lets us dismiss this push later (clear_approval) once
                     # the item is reviewed — see _approval_tag.
-                    data["data"] = {
-                        "tag": _approval_tag(entry_id),
-                        "actions": [
-                            {"action": f"TASKMATE_APPROVE_{entry_id}", "title": "Approve"},
-                            {"action": f"TASKMATE_REJECT_{entry_id}",  "title": "Reject"},
-                        ]
-                    }
+                    push["tag"] = _approval_tag(entry_id)
+                    push["actions"] = [
+                        {"action": f"TASKMATE_APPROVE_{entry_id}", "title": "Approve"},
+                        {"action": f"TASKMATE_REJECT_{entry_id}",  "title": "Reject"},
+                    ]
             else:
                 data["message"] = f"{message} {_APPROVE_IN_PANEL_HINT}"
+
+        if attach_photo:
+            # "image" renders inline on Android; iOS needs it under
+            # attachment.url. Sending both keeps one payload working on either.
+            push["image"] = photo_url
+            push["attachment"] = {"url": photo_url, "content-type": "jpeg"}
+
+        if push:
+            data["data"] = push
+
         try:
             await self.hass.services.async_call(domain, service, data, blocking=False)
         except Exception as err:  # noqa: BLE001

--- a/custom_components/taskmate/coord_points.py
+++ b/custom_components/taskmate/coord_points.py
@@ -1013,7 +1013,7 @@ class PointsMixin:
 
     async def _async_notify_pending_approval(
         self, child_name: str, chore_name: str, points: int,
-        completion_id: str | None = None,
+        completion_id: str | None = None, photo_url: str = "",
     ) -> None:
         await self.notifications.fire(
             "pending_chore_approval",
@@ -1023,6 +1023,9 @@ class PointsMixin:
                 "chore_name": chore_name,
                 "points": points,
                 "points_name": self.storage.get_points_name(),
+                # Evidence photo (#686). Signed here rather than in the
+                # notifier so the notifier stays free of photo specifics.
+                "photo_url": photos.sign_photo_url(self.hass, photo_url) if photo_url else "",
             },
         )
 

--- a/custom_components/taskmate/photos.py
+++ b/custom_components/taskmate/photos.py
@@ -123,9 +123,14 @@ def sign_photo_url(hass, photo_url: str, expiration_hours: int = 24) -> str:
         return photo_url
     from datetime import timedelta
 
-    from homeassistant.components.http.auth import async_sign_path
-
     try:
+        # Import inside the try: this is called on the completion path now
+        # (#686 signs the evidence photo for the approval push), and an
+        # ImportError escaping here would fail the completion itself — which
+        # is exactly what "never break delivery over a signing hiccup" is
+        # meant to prevent.
+        from homeassistant.components.http.auth import async_sign_path
+
         return async_sign_path(hass, photo_url, timedelta(hours=expiration_hours))
     except Exception:  # noqa: BLE001 - never break state delivery over a signing hiccup
         _LOGGER.debug("Could not sign photo URL %s", photo_url, exc_info=True)

--- a/tests/test_approval_photo_push.py
+++ b/tests/test_approval_photo_push.py
@@ -1,0 +1,126 @@
+"""Evidence photo in the approval push (#686).
+
+A parent approving "tidy your room" from the lock screen should be able to see
+the room. The photo is signed before it reaches the notifier, because the
+companion app fetches attachments without the user's bearer token.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.taskmate.coord_notifications import NotificationCoordinator
+
+SIGNED = "/api/taskmate/photo/abc.jpg?authSig=tok"
+
+
+def _notifier():
+    hass = MagicMock()
+    hass.services.async_call = AsyncMock()
+    storage = MagicMock()
+    return NotificationCoordinator(hass, storage), hass
+
+
+def _meta(actionable=True):
+    meta = MagicMock()
+    meta.id = "pending_chore_approval"
+    meta.actionable = actionable
+    return meta
+
+
+async def _send(service, context, actionable=True):
+    notifier, hass = _notifier()
+    await notifier._send_to(service, "Ella completed 'Tidy room'", _meta(actionable), context)
+    assert hass.services.async_call.await_count == 1
+    return hass.services.async_call.await_args[0][2]
+
+
+class TestPhotoAttachment:
+    @pytest.mark.asyncio
+    async def test_photo_is_attached_for_the_mobile_app(self):
+        data = await _send("mobile_app_phone", {"entry_id": "c1", "photo_url": SIGNED})
+        assert data["data"]["image"] == SIGNED
+
+    @pytest.mark.asyncio
+    async def test_ios_attachment_form_is_sent_too(self):
+        """Android reads data.image, iOS reads data.attachment.url — send both
+        so one payload works on either platform."""
+        data = await _send("mobile_app_phone", {"entry_id": "c1", "photo_url": SIGNED})
+        assert data["data"]["attachment"]["url"] == SIGNED
+
+    @pytest.mark.asyncio
+    async def test_approve_reject_actions_survive_the_photo(self):
+        data = await _send("mobile_app_phone", {"entry_id": "c1", "photo_url": SIGNED})
+        actions = [a["action"] for a in data["data"]["actions"]]
+        assert actions == ["TASKMATE_APPROVE_c1", "TASKMATE_REJECT_c1"]
+        assert data["data"]["tag"]
+
+    @pytest.mark.asyncio
+    async def test_no_photo_means_no_attachment_keys(self):
+        data = await _send("mobile_app_phone", {"entry_id": "c1", "photo_url": ""})
+        assert "image" not in data["data"]
+        assert "attachment" not in data["data"]
+
+    @pytest.mark.asyncio
+    async def test_non_mobile_backends_get_no_attachment(self):
+        """Telegram/email/persistent would render a raw payload, not a picture."""
+        data = await _send("telegram", {"entry_id": "c1", "photo_url": SIGNED})
+        assert "data" not in data
+
+    @pytest.mark.asyncio
+    async def test_photo_without_an_entry_id_still_attaches(self):
+        """No entry id means no action buttons, but the picture is still useful."""
+        data = await _send("mobile_app_phone", {"photo_url": SIGNED})
+        assert data["data"]["image"] == SIGNED
+
+    @pytest.mark.asyncio
+    async def test_non_actionable_type_can_still_carry_a_photo(self):
+        data = await _send("mobile_app_phone", {"photo_url": SIGNED}, actionable=False)
+        assert data["data"]["image"] == SIGNED
+
+    @pytest.mark.asyncio
+    async def test_message_is_unchanged_by_the_photo(self):
+        data = await _send("mobile_app_phone", {"entry_id": "c1", "photo_url": SIGNED})
+        assert data["message"] == "Ella completed 'Tidy room'"
+
+
+class TestSigning:
+    def test_context_signs_the_photo_url(self):
+        """An unsigned URL 401s for the companion app, so signing must happen
+        before the notifier sees it."""
+        source = (
+            __import__("pathlib").Path(__file__).resolve().parent.parent
+            / "custom_components" / "taskmate" / "coord_points.py"
+        ).read_text(encoding="utf-8")
+        assert "photos.sign_photo_url(self.hass, photo_url)" in source
+
+    def test_completion_photo_is_passed_to_the_notifier(self):
+        source = (
+            __import__("pathlib").Path(__file__).resolve().parent.parent
+            / "custom_components" / "taskmate" / "coord_chores.py"
+        ).read_text(encoding="utf-8")
+        assert "photo_url=completion.photo_url" in source
+
+
+class TestSigningIsNeverFatal:
+    def test_signing_import_is_inside_the_try(self):
+        """sign_photo_url runs on the completion path now. An ImportError
+        escaping it would fail the completion itself, which is precisely what
+        its "never break delivery" contract exists to prevent."""
+        source = (
+            __import__("pathlib").Path(__file__).resolve().parent.parent
+            / "custom_components" / "taskmate" / "photos.py"
+        ).read_text(encoding="utf-8")
+        body = source[source.index("def sign_photo_url"):source.index("async def async_delete_photo")]
+        try_at = body.index("try:")
+        import_at = body.index("from homeassistant.components.http.auth import async_sign_path")
+        assert try_at < import_at, "the HA import must sit inside the try block"
+
+    def test_unsignable_url_falls_back_to_the_original(self):
+        from custom_components.taskmate import photos
+        assert photos.sign_photo_url(None, "/api/taskmate/photo/x.jpg") == "/api/taskmate/photo/x.jpg"
+
+    def test_foreign_urls_are_returned_untouched(self):
+        from custom_components.taskmate import photos
+        assert photos.sign_photo_url(None, "https://evil.example/x.jpg") == "https://evil.example/x.jpg"


### PR DESCRIPTION
A parent approving *"tidy your room"* from the lock screen can now see the room.

## The signing detail that makes it work

The companion app fetches attachments **without the user's bearer token**, so a bare photo URL returns **401**. The URL is therefore signed (24h) before it reaches the notifier — at the call site, so the notifier stays free of photo specifics.

Android reads `data.image`, iOS reads `data.attachment.url`. Both are sent so a single payload works on either platform. Non-mobile backends (Telegram, email, persistent) get **no** attachment — they would render a raw payload rather than a picture.

## Two bugs fixed on the way

**The photo and the buttons were nested.** A completion with no `entry_id` built no `data` block at all, so it lost its picture entirely. The payload build is now flat: buttons and attachment are independent. Caught by a test written specifically for that case.

**`sign_photo_url` had its HA import outside its own `try`.** An `ImportError` escaped despite the docstring promising it "never break[s] state delivery over a signing hiccup". That was harmless while it only ran when building the panel snapshot — but this change puts it on the **completion path**, where an escape would fail the completion itself. Two tests in the suite went red the moment it started running there.

## Testing

- **13 new tests**: attachment present for mobile, iOS form included, action buttons survive, no photo means no attachment keys, non-mobile backends excluded, photo without an entry id still attaches, non-actionable types can carry a photo, message unchanged, signing happens at the call site, the completion photo is passed through, the import sits inside the try, and both fallback paths of `sign_photo_url`.
- Full suite: **1271 passed** vs **1258** on `main`, back to the identical pre-existing 3 failures / 9 errors after fixing the signing bug.
- `ruff` clean.
- **Verified end-to-end on ha-dev** with a real uploaded JPEG and a real approval-required completion. The decisive result:

  | Request | Status |
  |---|---|
  | Signed URL (as the app would fetch it) | **200, `image/jpeg`** |
  | Bare URL | **401** |

  That is the whole reason for signing, demonstrated rather than assumed. Test chore removed afterwards; no console errors.

Fixes #686