### PR TITLE
feat(notifications): route approvals to whoever is home, or round-robin

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@
 - [Pre-Reader Mode](#pre-reader-mode)
 - [Read Aloud](#read-aloud)
 - [Accessible Design Style](#accessible-design-style)
+- [Multi-Parent Approval Routing](#multi-parent-approval-routing)
 - [Bonus Points System](#bonus-points-system)
 - [Notifications](#notifications)
 - [Quiet Hours](#quiet-hours)
@@ -584,6 +585,31 @@ A fifth per-card design alongside Classic, Playroom, Console and Clean Pro — p
 - **High contrast.** Near-black on white (~19:1, comfortably past WCAG AAA), with heavy borders so meaning never rests on hue alone.
 - **Dyslexia-friendly type.** Atkinson Hyperlegible, drawn for low vision — its letterforms stay distinct where similar glyphs (I/l/1, O/0) usually collapse.
 - **Dark variant included.** `#0A0A0A` rather than pure black, which blooms on OLED and is harsh with astigmatism.
+ 
+---
+ 
+## Multi-Parent Approval Routing
+ 
+By default every approval buzzes every parent. Two other modes are available via the `parent_routing` setting:
+ 
+| Mode | Behaviour |
+|---|---|
+| `all` *(default)* | Every enabled parent, as before |
+| `home` | Only parents whose presence entity says they're here |
+| `round_robin` | One parent per notification, rotating |
+ 
+Give each parent a **presence entity** (`device_tracker.*`, `person.*`, anything that reads `home`/`on`/`true`/`present`) in the notification settings.
+ 
+### Every fallback errs towards over-notifying
+ 
+An unseen approval is worse than a redundant buzz, so:
+ 
+- **Nobody home** → everyone is told, not nobody.
+- **No presence entity set** → that parent counts as available and is never silently cut out.
+- **Broken or unavailable presence sensor** → fails open.
+- **Round-robin state pointing at a deleted parent** → starts from the beginning rather than wedging.
+ 
+Round-robin position is tracked **per notification type**, so a reward claim doesn't advance the chore-approval rotation. Child notifications are never affected by any of this — a reminder for a child must always reach that child.
  
 ---
  

--- a/custom_components/taskmate/coord_notifications.py
+++ b/custom_components/taskmate/coord_notifications.py
@@ -159,7 +159,14 @@ class NotificationCoordinator:
         recipients_fired: list[str] = []
         message = self._render_template(meta, context)
 
+        # Multi-parent routing (#687): thin the PARENT recipients down per the
+        # configured policy. Child routes are never touched — a reminder for a
+        # child must always reach that child.
+        allowed_parents = self._route_parents(type_id, cfg, only_recipients)
+
         for recipient_id, route in cfg.routes.items():
+            if recipient_id.startswith("parent:") and recipient_id not in allowed_parents:
+                continue
             if not route.enabled:
                 continue
             if only_recipients is not None and recipient_id not in only_recipients:
@@ -183,6 +190,68 @@ class NotificationCoordinator:
         # only when a recipient is explicitly routed to notify.persistent_
         # notification, flowing through _send_to like any other channel.
         self._fire_bus_event(type_id, context, recipients_fired)
+
+    # ── Multi-parent routing (#687) ──────────────────────────────────────
+
+    PARENT_ROUTING_MODES = ("all", "home", "round_robin")
+
+    def parent_routing_mode(self) -> str:
+        mode = str(self.storage.get_setting("parent_routing", "all") or "all")
+        return mode if mode in self.PARENT_ROUTING_MODES else "all"
+
+    def _parent_is_home(self, recipient_id: str) -> bool:
+        """True when this parent's presence entity says they're here.
+
+        No entity configured means "always available" — a parent who hasn't
+        set one up shouldn't be silently excluded from every approval.
+        """
+        parent = next(
+            (p for p in self.storage.get_parent_recipients() if p.id == recipient_id), None,
+        )
+        entity_id = (getattr(parent, "presence_entity", "") or "").strip() if parent else ""
+        if not entity_id:
+            return True
+        state = self.hass.states.get(entity_id)
+        if state is None or state.state in ("unavailable", "unknown", None, ""):
+            # Fail open: a broken presence sensor must not stop approvals.
+            return True
+        return str(state.state).lower() in ("home", "on", "true", "present")
+
+    def _route_parents(
+        self, type_id: str, cfg, only_recipients: set[str] | None,
+    ) -> set[str]:
+        """Which parent recipient ids should receive this notification."""
+        candidates = [
+            rid for rid, route in cfg.routes.items()
+            if rid.startswith("parent:") and route.enabled
+            and (only_recipients is None or rid in only_recipients)
+        ]
+        if not candidates:
+            return set()
+
+        mode = self.parent_routing_mode()
+        if mode == "all":
+            return set(candidates)
+
+        if mode == "home":
+            at_home = [rid for rid in candidates if self._parent_is_home(rid)]
+            # Nobody home: tell everyone rather than nobody. An unseen approval
+            # is worse than a redundant buzz.
+            return set(at_home or candidates)
+
+        # round_robin — one parent per notification, rotating.
+        ordered = sorted(candidates)
+        state = self.storage.get_setting("parent_routing_state", {})
+        state = dict(state) if isinstance(state, dict) else {}
+        last = state.get(type_id)
+        try:
+            start = ordered.index(last) + 1 if last in ordered else 0
+        except ValueError:
+            start = 0
+        chosen = ordered[start % len(ordered)]
+        state[type_id] = chosen
+        self.storage.set_setting("parent_routing_state", state)
+        return {chosen}
 
     async def send_test(self, type_id: str) -> list[str]:
         """Send a sample notification of ``type_id`` to its enabled routes.

--- a/custom_components/taskmate/models.py
+++ b/custom_components/taskmate/models.py
@@ -1132,6 +1132,9 @@ class ParentRecipient:
     name: str
     notify_service: str
     enabled: bool = True
+    # Presence entity for "whoever is home" routing (#687). Empty means this
+    # parent is always considered available.
+    presence_entity: str = ""
     id: str = field(default_factory=lambda: f"parent:{generate_id()}")
 
     @classmethod
@@ -1141,6 +1144,7 @@ class ParentRecipient:
             name=data.get("name", ""),
             notify_service=data.get("notify_service", ""),
             enabled=bool(data.get("enabled", True)),
+            presence_entity=str(data.get("presence_entity", "") or ""),
             id=rid,
         )
 
@@ -1148,6 +1152,7 @@ class ParentRecipient:
         return {
             "id": self.id,
             "name": self.name,
+            "presence_entity": self.presence_entity,
             "notify_service": self.notify_service,
             "enabled": self.enabled,
         }

--- a/custom_components/taskmate/websocket.py
+++ b/custom_components/taskmate/websocket.py
@@ -1254,7 +1254,7 @@ _SUBKEY_SETTINGS = {
     "perfect_week_bonus", "streak_milestones",
     "streak_requires_all_chores", "perfect_week_requires_all_chores",
     "difficulty_multiplier_easy", "difficulty_multiplier_medium", "difficulty_multiplier_hard",
-    "unlock_allowlist",
+    "unlock_allowlist", "parent_routing",
     "read_aloud_media_player", "read_aloud_tts_entity", "read_aloud_template",
     "read_aloud_one_template", "read_aloud_done_template", "read_aloud_joiner",
     "roulette_enabled", "roulette_multiplier", "roulette_daily_spins",
@@ -1418,6 +1418,7 @@ _UPDATE_SETTINGS_SCHEMA = {
     vol.Optional("difficulty_multiplier_medium"): vol.All(vol.Coerce(float), vol.Range(min=0.0, max=10.0)),
     vol.Optional("difficulty_multiplier_hard"): vol.All(vol.Coerce(float), vol.Range(min=0.0, max=10.0)),
     vol.Optional("unlock_allowlist"): [str],
+    vol.Optional("parent_routing"): vol.In(["all", "home", "round_robin"]),
     vol.Optional("read_aloud_media_player"): str,
     vol.Optional("read_aloud_tts_entity"): str,
     vol.Optional("read_aloud_template"): vol.All(str, vol.Length(max=300)),
@@ -1925,6 +1926,7 @@ async def ws_notif_set_child_quiet(hass, connection, msg, coordinator):
     vol.Required("name"): str,
     vol.Required("notify_service"): str,
     vol.Optional("enabled", default=True): bool,
+    vol.Optional("presence_entity", default=""): str,
 })
 @websocket_api.async_response
 @_admin_only
@@ -1942,6 +1944,7 @@ async def ws_notif_upsert_parent(hass, connection, msg, coordinator):
         existing.name = msg["name"]
         existing.notify_service = msg["notify_service"]
         existing.enabled = msg["enabled"]
+        existing.presence_entity = msg.get("presence_entity", "")
         await c.notifications.upsert_parent(existing)
         connection.send_result(msg["id"], existing.to_dict())
     else:
@@ -1949,6 +1952,7 @@ async def ws_notif_upsert_parent(hass, connection, msg, coordinator):
             name=msg["name"],
             notify_service=msg["notify_service"],
             enabled=msg["enabled"],
+            presence_entity=msg.get("presence_entity", ""),
         )
         await c.notifications.upsert_parent(p)
         connection.send_result(msg["id"], p.to_dict())

--- a/tests/test_parent_routing.py
+++ b/tests/test_parent_routing.py
@@ -1,0 +1,150 @@
+"""Multi-parent approval routing (#687).
+
+Send approvals to whoever is home, or round-robin between parents, instead of
+buzzing everyone every time. Every fallback errs towards over-notifying: an
+unseen approval is worse than a redundant buzz.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.taskmate.coord_notifications import NotificationCoordinator
+from custom_components.taskmate.models import ParentRecipient
+
+
+def _notifier(parents=(), settings=None, states=None):
+    conf = dict(settings or {})
+    hass = MagicMock()
+    hass.services.async_call = AsyncMock()
+    known = dict(states or {})
+    hass.states.get = MagicMock(
+        side_effect=lambda e: MagicMock(state=known[e]) if e in known else None)
+    storage = MagicMock()
+    storage.get_setting = MagicMock(side_effect=lambda k, d="": conf.get(k, d))
+    storage.set_setting = MagicMock(side_effect=lambda k, v: conf.__setitem__(k, v))
+    storage.get_parent_recipients = MagicMock(return_value=list(parents))
+    n = NotificationCoordinator(hass, storage)
+    n._conf = conf
+    return n
+
+
+def _cfg(*recipient_ids, enabled=True):
+    cfg = MagicMock()
+    cfg.master_enabled = True
+    cfg.routes = {rid: MagicMock(enabled=enabled) for rid in recipient_ids}
+    return cfg
+
+
+DAD = ParentRecipient(name="Dad", notify_service="notify.dad", id="parent:dad",
+                      presence_entity="device_tracker.dad")
+MUM = ParentRecipient(name="Mum", notify_service="notify.mum", id="parent:mum",
+                      presence_entity="device_tracker.mum")
+NOENT = ParentRecipient(name="Gran", notify_service="notify.gran", id="parent:gran")
+
+
+class TestMode:
+    def test_defaults_to_all(self):
+        assert _notifier().parent_routing_mode() == "all"
+
+    def test_unknown_mode_falls_back_to_all(self):
+        assert _notifier(settings={"parent_routing": "telepathy"}).parent_routing_mode() == "all"
+
+
+class TestAllMode:
+    def test_every_enabled_parent_is_chosen(self):
+        n = _notifier([DAD, MUM])
+        assert n._route_parents("t", _cfg("parent:dad", "parent:mum"), None) == {"parent:dad", "parent:mum"}
+
+    def test_disabled_routes_are_skipped(self):
+        n = _notifier([DAD, MUM])
+        cfg = _cfg("parent:dad", "parent:mum")
+        cfg.routes["parent:mum"].enabled = False
+        assert n._route_parents("t", cfg, None) == {"parent:dad"}
+
+    def test_children_are_not_parents(self):
+        n = _notifier([DAD])
+        assert n._route_parents("t", _cfg("child:a", "parent:dad"), None) == {"parent:dad"}
+
+
+class TestHomeMode:
+    def _n(self, states):
+        return _notifier([DAD, MUM], {"parent_routing": "home"}, states)
+
+    def test_only_the_parent_who_is_home(self):
+        n = self._n({"device_tracker.dad": "home", "device_tracker.mum": "not_home"})
+        assert n._route_parents("t", _cfg("parent:dad", "parent:mum"), None) == {"parent:dad"}
+
+    def test_both_home_means_both(self):
+        n = self._n({"device_tracker.dad": "home", "device_tracker.mum": "home"})
+        assert n._route_parents("t", _cfg("parent:dad", "parent:mum"), None) == {"parent:dad", "parent:mum"}
+
+    def test_nobody_home_falls_back_to_everyone(self):
+        """An unseen approval is worse than a redundant buzz."""
+        n = self._n({"device_tracker.dad": "not_home", "device_tracker.mum": "not_home"})
+        assert n._route_parents("t", _cfg("parent:dad", "parent:mum"), None) == {"parent:dad", "parent:mum"}
+
+    def test_missing_presence_entity_counts_as_available(self):
+        """A parent who never configured presence must not be silently cut out."""
+        n = _notifier([NOENT], {"parent_routing": "home"}, {})
+        assert n._route_parents("t", _cfg("parent:gran"), None) == {"parent:gran"}
+
+    def test_broken_presence_sensor_fails_open(self):
+        n = self._n({"device_tracker.dad": "unavailable", "device_tracker.mum": "not_home"})
+        assert "parent:dad" in n._route_parents("t", _cfg("parent:dad", "parent:mum"), None)
+
+    @pytest.mark.parametrize("value", ["home", "on", "true", "present", "HOME"])
+    def test_states_that_count_as_home(self, value):
+        n = self._n({"device_tracker.dad": value, "device_tracker.mum": "not_home"})
+        assert n._route_parents("t", _cfg("parent:dad", "parent:mum"), None) == {"parent:dad"}
+
+
+class TestRoundRobin:
+    def _n(self):
+        return _notifier([DAD, MUM], {"parent_routing": "round_robin"})
+
+    def test_one_parent_at_a_time(self):
+        n = self._n()
+        chosen = n._route_parents("t", _cfg("parent:dad", "parent:mum"), None)
+        assert len(chosen) == 1
+
+    def test_it_actually_rotates(self):
+        n = self._n()
+        cfg = _cfg("parent:dad", "parent:mum")
+        first = n._route_parents("t", cfg, None)
+        second = n._route_parents("t", cfg, None)
+        third = n._route_parents("t", cfg, None)
+        assert first != second
+        assert third == first  # wraps
+
+    def test_rotation_is_per_notification_type(self):
+        """A reward claim shouldn't advance the chore-approval rotation."""
+        n = self._n()
+        cfg = _cfg("parent:dad", "parent:mum")
+        n._route_parents("chore", cfg, None)
+        assert n._conf["parent_routing_state"].keys() == {"chore"}
+        n._route_parents("reward", cfg, None)
+        assert n._conf["parent_routing_state"].keys() == {"chore", "reward"}
+
+    def test_a_removed_parent_does_not_wedge_the_rotation(self):
+        n = self._n()
+        n._conf["parent_routing_state"] = {"t": "parent:gone"}
+        chosen = n._route_parents("t", _cfg("parent:dad", "parent:mum"), None)
+        assert chosen and chosen.issubset({"parent:dad", "parent:mum"})
+
+    def test_single_parent_always_gets_it(self):
+        n = _notifier([DAD], {"parent_routing": "round_robin"})
+        cfg = _cfg("parent:dad")
+        assert n._route_parents("t", cfg, None) == {"parent:dad"}
+        assert n._route_parents("t", cfg, None) == {"parent:dad"}
+
+
+class TestModel:
+    def test_presence_entity_round_trips(self):
+        restored = ParentRecipient.from_dict(DAD.to_dict())
+        assert restored.presence_entity == "device_tracker.dad"
+
+    def test_legacy_parent_without_presence(self):
+        restored = ParentRecipient.from_dict({"name": "Old", "notify_service": "notify.x"})
+        assert restored.presence_entity == ""


### PR DESCRIPTION
By default every approval buzzes every parent. `parent_routing` adds two alternatives:

| Mode | Behaviour |
|---|---|
| `all` *(default)* | Every enabled parent, as before |
| `home` | Only parents whose presence entity says they're here |
| `round_robin` | One parent per notification, rotating |

Parents gain an optional **presence entity** (`device_tracker.*`, `person.*`, anything reading `home`/`on`/`true`/`present`).

## Every fallback errs towards over-notifying

An unseen approval is worse than a redundant buzz, so all four failure modes fail *loud*:

- **Nobody home** → everyone is told, not nobody.
- **No presence entity configured** → that parent counts as available, never silently cut out.
- **Broken/unavailable sensor** → fails open.
- **Round-robin state pointing at a deleted parent** → restarts rather than wedging.

Round-robin position is tracked **per notification type**, so a reward claim doesn't advance the chore-approval rotation.

**Child routes are never touched.** Routing thins the *parent* recipients only — a reminder about a child must always reach that child, and quiet hours continue to apply to them independently.

## Testing

- **22 new tests**: mode defaulting and unknown-mode fallback; all-mode (every enabled parent, disabled routes skipped, children excluded); home-mode (one home, both home, nobody home falls back, missing entity counts available, broken sensor fails open, and each accepted "home" state value); round-robin (one at a time, actually rotates, wraps, per-type state, deleted-parent recovery, single parent always gets it); and model round-trip including legacy parents without the field.
- Full suite: **1293 passed** vs **1271** on `main`, identical pre-existing 3 failures / 9 errors.
- `ruff` clean.
- **Verified end-to-end on ha-dev**: created two parents (one with a presence entity, one without), confirmed `presence_entity` persisted through the websocket round-trip, confirmed all three modes are accepted and `telepathy` is rejected with a clear message listing the valid ones, and confirmed the setting reads back. Both test parents deleted afterwards; no console errors.

Fixes #687