### PR TITLE
feat(templates): export and import shareable template packs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@
 - [Read Aloud](#read-aloud)
 - [Accessible Design Style](#accessible-design-style)
 - [Multi-Parent Approval Routing](#multi-parent-approval-routing)
+- [Sharing Template Packs](#sharing-template-packs)
 - [Bonus Points System](#bonus-points-system)
 - [Notifications](#notifications)
 - [Quiet Hours](#quiet-hours)
@@ -610,6 +611,27 @@ An unseen approval is worse than a redundant buzz, so:
 - **Round-robin state pointing at a deleted parent** → starts from the beginning rather than wedging.
  
 Round-robin position is tracked **per notification type**, so a reward claim doesn't advance the chore-approval rotation. Child notifications are never affected by any of this — a reminder for a child must always reach that child.
+ 
+---
+ 
+## Sharing Template Packs
+ 
+Export your custom chore templates as a JSON pack and import one somebody else made.
+ 
+- **Export** — `taskmate/templates/export` returns a pack (all custom templates, or a chosen subset). Built-ins are excluded: they ship with TaskMate, so exporting them would only create duplicates on the other end.
+- **Import** — `taskmate/templates/import` takes a pack object.
+ 
+### Import is treated as untrusted
+ 
+A pack is arbitrary JSON from someone else, so:
+ 
+- **Unknown chore fields are dropped**, not carried through. A shared pack cannot set runtime state (rotation anchors, skip dates) or anything the panel wouldn't let you set by hand.
+- Format and version are checked. A pack from a newer TaskMate says so plainly rather than being half-imported.
+- Sizes are capped (50 templates, 200 chores each) and long names truncated rather than rejected.
+- **A clashing name is suffixed, never overwritten** — `Morning routine (2)`. An import must not silently replace something your family built.
+- A pack that fails validation writes **nothing**.
+ 
+**No URL importing.** Packs are imported from pasted or uploaded JSON only. Fetching arbitrary URLs from inside your home network would make TaskMate an SSRF vector; you can still paste a gist's raw contents.
  
 ---
  

--- a/custom_components/taskmate/coord_templates.py
+++ b/custom_components/taskmate/coord_templates.py
@@ -137,3 +137,132 @@ class TemplatesMixin:
             raise ValueError(f"Cannot delete built-in template '{template_id}'")
         self.storage.remove_custom_template(template_id)
         await self.storage.async_save()
+
+    # ── Pack import / export (#688) ──────────────────────────────────────
+
+    PACK_FORMAT = "taskmate.template-pack"
+    PACK_VERSION = 1
+    MAX_PACK_TEMPLATES = 50
+    MAX_PACK_CHORES = 200
+
+    def export_templates(self, template_ids: list[str] | None = None) -> dict:
+        """Build a shareable pack from custom templates.
+
+        Built-ins are excluded: they ship with TaskMate, so exporting them
+        would just create duplicates on the other end.
+        """
+        wanted = set(template_ids or [])
+        packed = []
+        for tpl in self.storage.get_custom_templates():
+            if wanted and tpl.get("id") not in wanted:
+                continue
+            packed.append({
+                "name": tpl.get("name", ""),
+                "icon": tpl.get("icon", "mdi:clipboard-list-outline"),
+                "chores": [
+                    {k: v for k, v in chore.items() if k in TEMPLATE_CHORE_FIELDS}
+                    for chore in tpl.get("chores", [])
+                ],
+            })
+
+        from homeassistant.util import dt as dt_util
+        return {
+            "format": self.PACK_FORMAT,
+            "version": self.PACK_VERSION,
+            "exported_at": dt_util.now().isoformat(),
+            "templates": packed,
+        }
+
+    def _validate_pack(self, pack: dict) -> list[dict]:
+        """Validate an untrusted pack, returning clean template dicts.
+
+        A pack is arbitrary user-supplied JSON, so everything is checked and
+        every unknown chore field is dropped rather than trusted — a shared
+        pack must not be able to set runtime state or fields the panel
+        wouldn't let you set by hand.
+        """
+        if not isinstance(pack, dict):
+            raise ValueError("That doesn't look like a TaskMate pack")
+        if pack.get("format") != self.PACK_FORMAT:
+            raise ValueError("Not a TaskMate template pack")
+        try:
+            version = int(pack.get("version", 0))
+        except (TypeError, ValueError) as err:
+            raise ValueError("Pack version is not a number") from err
+        if version > self.PACK_VERSION:
+            raise ValueError(
+                f"This pack needs a newer TaskMate (pack version {version}, "
+                f"this one understands {self.PACK_VERSION})"
+            )
+
+        templates = pack.get("templates")
+        if not isinstance(templates, list) or not templates:
+            raise ValueError("Pack contains no templates")
+        if len(templates) > self.MAX_PACK_TEMPLATES:
+            raise ValueError(f"Pack has too many templates (max {self.MAX_PACK_TEMPLATES})")
+
+        clean: list[dict] = []
+        for entry in templates:
+            if not isinstance(entry, dict):
+                raise ValueError("Pack contains a malformed template")
+            name = str(entry.get("name", "")).strip()
+            if not name:
+                raise ValueError("A template in the pack has no name")
+
+            raw_chores = entry.get("chores")
+            if not isinstance(raw_chores, list) or not raw_chores:
+                raise ValueError(f"Template '{name}' has no chores")
+            if len(raw_chores) > self.MAX_PACK_CHORES:
+                raise ValueError(f"Template '{name}' has too many chores")
+
+            chores = []
+            for raw in raw_chores:
+                if not isinstance(raw, dict):
+                    raise ValueError(f"Template '{name}' has a malformed chore")
+                chore_name = str(raw.get("name", "")).strip()
+                if not chore_name:
+                    raise ValueError(f"A chore in '{name}' has no name")
+                # Whitelist: unknown keys are dropped, never carried through.
+                cleaned = {k: v for k, v in raw.items() if k in TEMPLATE_CHORE_FIELDS}
+                cleaned["name"] = chore_name[:200]
+                chores.append(cleaned)
+
+            clean.append({
+                "name": name[:120],
+                "icon": str(entry.get("icon", "") or "mdi:clipboard-list-outline"),
+                "chores": chores,
+            })
+        return clean
+
+    async def async_import_pack(self, pack: dict) -> dict:
+        """Import a validated pack as custom templates. Returns a summary.
+
+        Names that already exist are suffixed rather than overwritten — an
+        import should never silently replace something the family built.
+        """
+        clean = self._validate_pack(pack)
+        existing = {t.get("name", "") for t in self.storage.get_custom_templates()}
+
+        created = []
+        for tpl in clean:
+            name = tpl["name"]
+            if name in existing:
+                suffix = 2
+                while f"{name} ({suffix})" in existing:
+                    suffix += 1
+                name = f"{name} ({suffix})"
+            existing.add(name)
+
+            record = {
+                "id": generate_id(),
+                "name": name,
+                "icon": tpl["icon"],
+                "builtin": False,
+                "chores": tpl["chores"],
+            }
+            self.storage.add_custom_template(record)
+            created.append({"id": record["id"], "name": name, "chores": len(tpl["chores"])})
+
+        await self.storage.async_save()
+        await self.async_refresh()
+        return {"imported": len(created), "templates": created}

--- a/custom_components/taskmate/websocket.py
+++ b/custom_components/taskmate/websocket.py
@@ -135,6 +135,8 @@ WS_TEMPLATES_APPLY: Final      = "taskmate/templates/apply"
 WS_TEMPLATES_SAVE_FROM: Final  = "taskmate/templates/save_from_chores"
 WS_TEMPLATES_CREATE: Final     = "taskmate/templates/create"
 WS_TEMPLATES_UPDATE: Final     = "taskmate/templates/update"
+WS_TEMPLATES_EXPORT: Final     = "taskmate/templates/export"
+WS_TEMPLATES_IMPORT: Final     = "taskmate/templates/import"
 WS_TEMPLATES_DELETE: Final     = "taskmate/templates/delete"
 
 # Notifications
@@ -185,7 +187,8 @@ WS_CONFIG_IMPORT: Final = "taskmate/config/import"
 # Everything else routed through @_admin_only mutates state and is logged.
 _AUDIT_EXCLUDE: Final = {
     WS_GET_STATE, WS_NOTIF_GET_STATE, WS_NOTIF_LIST_NOTIFY,
-    WS_TEMPLATES_LIST, WS_TEMPLATES_GET, WS_AUDIT_LIST, WS_AUDIT_CLEAR,
+    WS_TEMPLATES_LIST, WS_TEMPLATES_GET, WS_TEMPLATES_EXPORT,
+    WS_AUDIT_LIST, WS_AUDIT_CLEAR,
     WS_CONFIG_EXPORT, WS_SCHEDULED_LIST, WS_REPORT_FAIRNESS, WS_REPORT_FRICTION, WS_REPORT_PROJECTION, WS_REPORT_HEALTH,
 }
 
@@ -657,6 +660,31 @@ async def _ws_report_friction(hass, connection, msg, coordinator):
 @_admin_only
 async def _ws_report_projection(hass, connection, msg, coordinator):
     connection.send_result(msg["id"], coordinator.projection_report(msg.get("days")))
+
+
+@websocket_api.websocket_command({
+    vol.Required("type"): WS_TEMPLATES_EXPORT,
+    vol.Optional("template_ids"): [str],
+})
+@websocket_api.async_response
+@_admin_only
+async def _ws_templates_export(hass, connection, msg, coordinator):
+    connection.send_result(msg["id"], coordinator.export_templates(msg.get("template_ids")))
+
+
+@websocket_api.websocket_command({
+    vol.Required("type"): WS_TEMPLATES_IMPORT,
+    vol.Required("pack"): dict,
+})
+@websocket_api.async_response
+@_admin_only
+async def _ws_templates_import(hass, connection, msg, coordinator):
+    try:
+        result = await coordinator.async_import_pack(msg["pack"])
+    except ValueError as err:
+        connection.send_error(msg["id"], "invalid_format", str(err))
+        return
+    connection.send_result(msg["id"], result)
 
 
 @websocket_api.websocket_command({vol.Required("type"): WS_REPORT_HEALTH})
@@ -2221,6 +2249,7 @@ _COMMANDS = (
     _ws_add_chore, _ws_update_chore, _ws_remove_chore, _ws_clone_chore,
     _ws_scheduled_list, _ws_scheduled_add, _ws_scheduled_remove,
     _ws_report_fairness, _ws_report_friction, _ws_report_projection, _ws_report_health,
+    _ws_templates_export, _ws_templates_import,
     _ws_bulk_chore_action, _ws_gift_points,
     _ws_request_swap, _ws_approve_swap, _ws_reject_swap,
     _ws_config_export, _ws_config_import,

--- a/tests/test_template_packs.py
+++ b/tests/test_template_packs.py
@@ -1,0 +1,180 @@
+"""Community template packs (#688).
+
+Export custom templates as a shareable pack; import one that somebody else
+made. A pack is arbitrary user-supplied JSON, so import validates everything
+and drops every field it doesn't recognise.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from .test_coordinator_logic import _make_coord
+
+PACK_FORMAT = "taskmate.template-pack"
+
+
+def _coord(custom=()):
+    coord = _make_coord()
+    store = list(custom)
+    coord.storage.get_custom_templates = MagicMock(return_value=store)
+    coord.storage.add_custom_template = MagicMock(side_effect=store.append)
+    coord.storage.async_save = AsyncMock()
+    coord.async_refresh = AsyncMock()
+    coord._store = store
+    return coord
+
+
+def _tpl(name="Morning", chores=None, tid="t1"):
+    return {
+        "id": tid, "name": name, "icon": "mdi:sun", "builtin": False,
+        "chores": chores or [{"name": "Make bed", "points": 2, "time_category": "morning"}],
+    }
+
+
+def _pack(templates=None, **over):
+    pack = {
+        "format": PACK_FORMAT, "version": 1,
+        "templates": templates if templates is not None else [
+            {"name": "Shared routine", "icon": "mdi:sun",
+             "chores": [{"name": "Make bed", "points": 2}]},
+        ],
+    }
+    pack.update(over)
+    return pack
+
+
+class TestExport:
+    def test_exports_custom_templates(self):
+        pack = _coord([_tpl()]).export_templates()
+        assert pack["format"] == PACK_FORMAT
+        assert pack["version"] == 1
+        assert [t["name"] for t in pack["templates"]] == ["Morning"]
+
+    def test_can_export_a_subset(self):
+        coord = _coord([_tpl(tid="t1"), _tpl(name="Bedtime", tid="t2")])
+        pack = coord.export_templates(["t2"])
+        assert [t["name"] for t in pack["templates"]] == ["Bedtime"]
+
+    def test_unknown_chore_fields_are_stripped(self):
+        """Runtime state must never travel in a shared pack."""
+        tpl = _tpl(chores=[{"name": "Bed", "points": 2, "skip_date": "2026-01-01", "id": "x"}])
+        chore = _coord([tpl]).export_templates()["templates"][0]["chores"][0]
+        assert "skip_date" not in chore
+        assert "id" not in chore
+        assert chore["points"] == 2
+
+    def test_no_custom_templates_exports_an_empty_pack(self):
+        pack = _coord([]).export_templates()
+        assert pack["templates"] == []
+
+
+class TestImportValidation:
+    def _fails(self, coord, pack, match):
+        with pytest.raises(ValueError, match=match):
+            coord._validate_pack(pack)
+
+    def test_rejects_a_non_dict(self):
+        self._fails(_coord(), ["nope"], "doesn't look like")
+
+    def test_rejects_a_foreign_format(self):
+        self._fails(_coord(), _pack(format="someone-elses-app"), "Not a TaskMate")
+
+    def test_rejects_a_future_version(self):
+        """Better to say "you need a newer TaskMate" than to guess."""
+        self._fails(_coord(), _pack(version=99), "newer TaskMate")
+
+    def test_rejects_a_non_numeric_version(self):
+        self._fails(_coord(), _pack(version="two"), "not a number")
+
+    def test_rejects_an_empty_pack(self):
+        self._fails(_coord(), _pack(templates=[]), "no templates")
+
+    def test_rejects_too_many_templates(self):
+        many = [{"name": f"T{i}", "chores": [{"name": "c"}]} for i in range(51)]
+        self._fails(_coord(), _pack(templates=many), "too many templates")
+
+    def test_rejects_a_nameless_template(self):
+        self._fails(_coord(), _pack(templates=[{"chores": [{"name": "c"}]}]), "no name")
+
+    def test_rejects_a_template_with_no_chores(self):
+        self._fails(_coord(), _pack(templates=[{"name": "T", "chores": []}]), "no chores")
+
+    def test_rejects_a_nameless_chore(self):
+        self._fails(_coord(), _pack(templates=[{"name": "T", "chores": [{"points": 1}]}]), "no name")
+
+    def test_rejects_a_malformed_chore(self):
+        self._fails(_coord(), _pack(templates=[{"name": "T", "chores": ["nope"]}]), "malformed chore")
+
+    def test_drops_unknown_chore_fields(self):
+        """A shared pack must not be able to set fields the panel wouldn't."""
+        pack = _pack(templates=[{"name": "T", "chores": [
+            {"name": "c", "points": 3, "assignment_current_child_id": "kid1", "enabled": False},
+        ]}])
+        chore = _coord()._validate_pack(pack)[0]["chores"][0]
+        assert "assignment_current_child_id" not in chore
+        assert chore["points"] == 3
+
+    def test_long_names_are_truncated_not_rejected(self):
+        pack = _pack(templates=[{"name": "N" * 500, "chores": [{"name": "c" * 500}]}])
+        clean = _coord()._validate_pack(pack)[0]
+        assert len(clean["name"]) == 120
+        assert len(clean["chores"][0]["name"]) == 200
+
+
+class TestImport:
+    @pytest.mark.asyncio
+    async def test_imports_a_pack(self):
+        coord = _coord()
+        result = await coord.async_import_pack(_pack())
+        assert result["imported"] == 1
+        assert coord._store[0]["name"] == "Shared routine"
+        assert coord._store[0]["builtin"] is False
+        coord.storage.async_save.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_a_clashing_name_is_suffixed_not_overwritten(self):
+        """An import must never silently replace something the family built."""
+        coord = _coord([_tpl(name="Shared routine")])
+        await coord.async_import_pack(_pack())
+        assert [t["name"] for t in coord._store] == ["Shared routine", "Shared routine (2)"]
+
+    @pytest.mark.asyncio
+    async def test_repeated_imports_keep_counting_up(self):
+        coord = _coord([_tpl(name="Shared routine")])
+        await coord.async_import_pack(_pack())
+        await coord.async_import_pack(_pack())
+        assert [t["name"] for t in coord._store][-1] == "Shared routine (3)"
+
+    @pytest.mark.asyncio
+    async def test_imported_templates_get_fresh_ids(self):
+        coord = _coord()
+        await coord.async_import_pack(_pack())
+        await coord.async_import_pack(_pack())
+        assert coord._store[0]["id"] != coord._store[1]["id"]
+
+    @pytest.mark.asyncio
+    async def test_a_bad_pack_writes_nothing(self):
+        coord = _coord()
+        with pytest.raises(ValueError):
+            await coord.async_import_pack(_pack(format="nope"))
+        assert coord._store == []
+        coord.storage.async_save.assert_not_awaited()
+
+
+class TestRoundTrip:
+    @pytest.mark.asyncio
+    async def test_export_then_import_preserves_the_template(self):
+        source = _coord([_tpl(chores=[
+            {"name": "Make bed", "points": 2, "time_category": "morning",
+             "due_days": ["monday"], "requires_approval": False},
+        ])])
+        pack = source.export_templates()
+
+        target = _coord()
+        await target.async_import_pack(pack)
+        imported = target._store[0]
+        assert imported["name"] == "Morning"
+        assert imported["chores"][0]["points"] == 2
+        assert imported["chores"][0]["due_days"] == ["monday"]


### PR DESCRIPTION
Export your custom chore templates as a JSON pack; import one somebody else made.

## Import is treated as untrusted input

A pack is arbitrary JSON from a stranger, so:

- **Unknown chore fields are dropped**, not carried through. A shared pack cannot set runtime state (rotation anchors, skip dates) or anything the panel wouldn't let you set by hand.
- Format and version are checked — a pack from a newer TaskMate says so plainly instead of half-importing.
- Sizes are capped (50 templates, 200 chores each); long names are truncated rather than rejected.
- **A clashing name is suffixed, never overwritten** (`Morning routine (2)`). An import must not silently replace something your family built.
- A pack that fails validation writes **nothing**.

## No import-from-URL — deliberately

The original idea said "import a pack from a URL or gist". I didn't build that: fetching arbitrary URLs from inside a home network turns TaskMate into an SSRF vector, and it buys very little — a gist's raw contents can simply be pasted. Packs come from pasted or uploaded JSON only, and the README says why.

Built-ins are excluded from export, since they ship with TaskMate and would only create duplicates on the other end.

## Testing

- **22 new tests**: export (all, subset, unknown fields stripped, empty), validation (non-dict, foreign format, future version, non-numeric version, empty pack, too many templates, nameless template, template with no chores, nameless chore, malformed chore, unknown fields dropped, long names truncated), import (basic, clash suffixing, repeated imports counting up, fresh ids, bad pack writes nothing) and a full export→import round trip preserving points and due days.
- Full suite: **1315 passed** vs **1293** on `main`, identical pre-existing 3 failures / 9 errors.
- `ruff` clean.
- **Verified end-to-end on ha-dev.** The two decisive results:
  - Exporting then re-importing the same pack produced `["E2E688 Shared", "E2E688 Shared (2)"]` — suffixed, not overwritten.
  - A **hostile pack** carrying `assignment_current_child_id: "kid1"` and a forced `id: "forced"` imported as exactly `{"name": "c", "points": 1}` — the whitelist holds against real untrusted input, not just a unit test.

  Foreign format, future version and empty packs were all rejected with their intended messages. Test templates removed afterwards; no console errors.

Fixes #688