### PR TITLE
feat(print): fridge-ready weekly chore chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@
 - [Accessible Design Style](#accessible-design-style)
 - [Multi-Parent Approval Routing](#multi-parent-approval-routing)
 - [Sharing Template Packs](#sharing-template-packs)
+- [Printable Weekly Chart](#printable-weekly-chart)
 - [Bonus Points System](#bonus-points-system)
 - [Notifications](#notifications)
 - [Quiet Hours](#quiet-hours)
@@ -632,6 +633,27 @@ A pack is arbitrary JSON from someone else, so:
 - A pack that fails validation writes **nothing**.
  
 **No URL importing.** Packs are imported from pasted or uploaded JSON only. Fetching arbitrary URLs from inside your home network would make TaskMate an SSRF vector; you can still paste a gist's raw contents.
+ 
+---
+ 
+## Printable Weekly Chart
+ 
+A fridge-ready A4 chore chart with a box to tick against every task.
+ 
+`taskmate/print/weekly_chart` returns a **standalone HTML page** — open it in a tab and print. No external assets, so it prints identically offline.
+ 
+| Option | Values |
+|---|---|
+| `orientation` | `portrait` *(default)* or `landscape` — **your choice**: two children with short names fit portrait, five need the width |
+| `week_start` | ISO date anywhere in the week you want (defaults to this week) |
+| `title` | Heading text (defaults to "This week") |
+ 
+### Key Points
+ 
+- **Schedule only.** A paper chart can't know next Thursday's weather, so entity-driven gates aren't applied — a chart that quietly omitted a chore would be worse than one that lists it.
+- Chores with no assignee appear for every child; assigned ones only for theirs.
+- Children with nothing assigned are left off entirely rather than printing an empty row.
+- Chore names are HTML-escaped: they're user input landing in a document.
  
 ---
  

--- a/custom_components/taskmate/printable.py
+++ b/custom_components/taskmate/printable.py
@@ -1,0 +1,141 @@
+"""Printable weekly chore chart (#689).
+
+Builds a self-contained HTML page sized for a sheet of paper, meant for the
+fridge. Portrait or landscape is the parent's choice — a family with two
+children and short chore names wants portrait; one with five children needs
+the width.
+
+Pure string building with no HA imports, so the layout is unit-testable
+without a Home Assistant install.
+"""
+from __future__ import annotations
+
+from datetime import date, timedelta
+from html import escape
+
+ORIENTATIONS = ("portrait", "landscape")
+DAY_NAMES = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]
+
+
+def week_start(day: date, starts_on: str = "monday") -> date:
+    """The first day of the week containing ``day``."""
+    offset = day.weekday() if starts_on == "monday" else (day.weekday() + 1) % 7
+    return day - timedelta(days=offset)
+
+
+def _falls_on(chore: dict, day: date) -> bool:
+    """Schedule-only: would this chore appear on ``day``?
+
+    Deliberately ignores entity-driven gates. A paper chart can't know next
+    Thursday's weather, and a chart that quietly omitted a chore would be
+    worse than one that lists it.
+    """
+    if not chore.get("enabled", True):
+        return False
+    mode = chore.get("schedule_mode", "specific_days")
+    if mode == "one_shot":
+        return str(chore.get("created_date", "")) == day.isoformat()
+    if mode == "recurring":
+        return True  # shown every day; the exact window depends on completions
+    due = [str(d).lower() for d in (chore.get("due_days") or [])]
+    return not due or day.strftime("%A").lower() in due
+
+
+def build_chart(
+    children: list[dict],
+    chores: list[dict],
+    start: date,
+    *,
+    orientation: str = "portrait",
+    title: str = "This week",
+    points_name: str = "Stars",
+) -> str:
+    """Render the printable chart as a standalone HTML document."""
+    if orientation not in ORIENTATIONS:
+        orientation = "portrait"
+
+    days = [start + timedelta(days=i) for i in range(7)]
+    rows = []
+
+    for child in children:
+        child_id = str(child.get("id", ""))
+        # A chore with an empty assigned_to belongs to everyone.
+        mine = [
+            c for c in chores
+            if not (c.get("assigned_to") or []) or child_id in (c.get("assigned_to") or [])
+        ]
+        if not mine:
+            continue
+
+        cells = []
+        for day in days:
+            todays = [c for c in mine if _falls_on(c, day)]
+            boxes = "".join(
+                f'<div class="task"><span class="tick"></span>'
+                f'<span class="name">{escape(str(c.get("name", "")))}</span></div>'
+                for c in todays
+            )
+            cells.append(f'<td>{boxes or "&nbsp;"}</td>')
+        rows.append(
+            f'<tr><th class="who">{escape(str(child.get("name", "")))}</th>'
+            + "".join(cells) + "</tr>"
+        )
+
+    header = "".join(
+        f'<th><span class="dow">{DAY_NAMES[d.weekday()][:3]}</span>'
+        f'<span class="dom">{d.day}</span></th>'
+        for d in days
+    )
+    week_label = f"{start.strftime('%d %b')} – {(start + timedelta(days=6)).strftime('%d %b %Y')}"
+    body = "".join(rows) or (
+        '<tr><td colspan="8" class="empty">No chores to show for this week.</td></tr>'
+    )
+
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>{escape(title)} — {escape(week_label)}</title>
+<style>
+  /* Sized for a sheet of paper, not a screen: the whole point is the fridge. */
+  @page {{ size: A4 {orientation}; margin: 10mm; }}
+  * {{ box-sizing: border-box; }}
+  body {{
+    margin: 0; padding: 12px;
+    font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+    color: #000; background: #fff;
+  }}
+  header {{ display: flex; align-items: baseline; justify-content: space-between; margin-bottom: 10px; }}
+  h1 {{ font-size: 20px; margin: 0; }}
+  .week {{ font-size: 13px; color: #333; }}
+  table {{ width: 100%; border-collapse: collapse; table-layout: fixed; }}
+  th, td {{ border: 1.5px solid #000; vertical-align: top; padding: 5px; }}
+  thead th {{ background: #eee; text-align: center; padding: 4px; }}
+  .dow {{ display: block; font-size: 12px; font-weight: 800; text-transform: uppercase; }}
+  .dom {{ display: block; font-size: 11px; color: #444; }}
+  .who {{ width: 92px; background: #eee; font-size: 13px; text-align: left; }}
+  .task {{ display: flex; align-items: flex-start; gap: 4px; margin-bottom: 3px; }}
+  /* An empty box to tick with a pen — the entire reason this exists on paper. */
+  .tick {{
+    flex: 0 0 auto; width: 11px; height: 11px;
+    border: 1.5px solid #000; border-radius: 2px; margin-top: 1px;
+  }}
+  .name {{ font-size: 10.5px; line-height: 1.25; }}
+  .empty {{ text-align: center; padding: 24px; font-size: 13px; color: #444; }}
+  footer {{ margin-top: 8px; font-size: 10px; color: #444; }}
+  /* Never carry a browser's header/footer or a stray background into print. */
+  @media print {{ body {{ padding: 0; }} .noprint {{ display: none; }} }}
+</style>
+</head>
+<body>
+<header>
+  <h1>{escape(title)}</h1>
+  <div class="week">{escape(week_label)}</div>
+</header>
+<table>
+  <thead><tr><th class="who">&nbsp;</th>{header}</tr></thead>
+  <tbody>{body}</tbody>
+</table>
+<footer>Tick each box as it's done. {escape(points_name)} are still awarded in TaskMate.</footer>
+</body>
+</html>"""

--- a/custom_components/taskmate/websocket.py
+++ b/custom_components/taskmate/websocket.py
@@ -137,6 +137,7 @@ WS_TEMPLATES_CREATE: Final     = "taskmate/templates/create"
 WS_TEMPLATES_UPDATE: Final     = "taskmate/templates/update"
 WS_TEMPLATES_EXPORT: Final     = "taskmate/templates/export"
 WS_TEMPLATES_IMPORT: Final     = "taskmate/templates/import"
+WS_PRINT_CHART: Final          = "taskmate/print/weekly_chart"
 WS_TEMPLATES_DELETE: Final     = "taskmate/templates/delete"
 
 # Notifications
@@ -187,7 +188,7 @@ WS_CONFIG_IMPORT: Final = "taskmate/config/import"
 # Everything else routed through @_admin_only mutates state and is logged.
 _AUDIT_EXCLUDE: Final = {
     WS_GET_STATE, WS_NOTIF_GET_STATE, WS_NOTIF_LIST_NOTIFY,
-    WS_TEMPLATES_LIST, WS_TEMPLATES_GET, WS_TEMPLATES_EXPORT,
+    WS_TEMPLATES_LIST, WS_TEMPLATES_GET, WS_TEMPLATES_EXPORT, WS_PRINT_CHART,
     WS_AUDIT_LIST, WS_AUDIT_CLEAR,
     WS_CONFIG_EXPORT, WS_SCHEDULED_LIST, WS_REPORT_FAIRNESS, WS_REPORT_FRICTION, WS_REPORT_PROJECTION, WS_REPORT_HEALTH,
 }
@@ -685,6 +686,40 @@ async def _ws_templates_import(hass, connection, msg, coordinator):
         connection.send_error(msg["id"], "invalid_format", str(err))
         return
     connection.send_result(msg["id"], result)
+
+
+@websocket_api.websocket_command({
+    vol.Required("type"): WS_PRINT_CHART,
+    vol.Optional("orientation", default="portrait"): vol.In(["portrait", "landscape"]),
+    vol.Optional("week_start"): str,
+    vol.Optional("title"): vol.All(str, vol.Length(max=80)),
+})
+@websocket_api.async_response
+@_admin_only
+async def _ws_print_chart(hass, connection, msg, coordinator):
+    from datetime import date as _date
+
+    from homeassistant.util import dt as dt_util
+
+    from . import printable
+
+    raw = msg.get("week_start", "")
+    try:
+        anchor = _date.fromisoformat(raw) if raw else dt_util.as_local(dt_util.now()).date()
+    except (TypeError, ValueError):
+        connection.send_error(msg["id"], "invalid_format", "week_start must be an ISO date")
+        return
+
+    data = coordinator.storage.data
+    html = printable.build_chart(
+        children=list(data.get("children", [])),
+        chores=list(data.get("chores", [])),
+        start=printable.week_start(anchor),
+        orientation=msg.get("orientation", "portrait"),
+        title=msg.get("title") or "This week",
+        points_name=coordinator.storage.get_points_name(),
+    )
+    connection.send_result(msg["id"], {"html": html})
 
 
 @websocket_api.websocket_command({vol.Required("type"): WS_REPORT_HEALTH})
@@ -2249,7 +2284,7 @@ _COMMANDS = (
     _ws_add_chore, _ws_update_chore, _ws_remove_chore, _ws_clone_chore,
     _ws_scheduled_list, _ws_scheduled_add, _ws_scheduled_remove,
     _ws_report_fairness, _ws_report_friction, _ws_report_projection, _ws_report_health,
-    _ws_templates_export, _ws_templates_import,
+    _ws_templates_export, _ws_templates_import, _ws_print_chart,
     _ws_bulk_chore_action, _ws_gift_points,
     _ws_request_swap, _ws_approve_swap, _ws_reject_swap,
     _ws_config_export, _ws_config_import,

--- a/tests/test_printable_chart.py
+++ b/tests/test_printable_chart.py
@@ -1,0 +1,133 @@
+"""Printable weekly chore chart (#689).
+
+A sheet for the fridge. Pure string building, so the layout is testable
+without a Home Assistant install.
+"""
+from __future__ import annotations
+
+from datetime import date
+
+from custom_components.taskmate import printable
+
+MON = date(2026, 7, 20)  # a Monday
+
+
+def _child(name="Ella", cid="a"):
+    return {"id": cid, "name": name}
+
+
+def _chore(name="Make bed", **over):
+    chore = {"name": name, "enabled": True, "schedule_mode": "specific_days",
+             "due_days": [], "assigned_to": []}
+    chore.update(over)
+    return chore
+
+
+class TestWeekStart:
+    def test_monday_start_from_midweek(self):
+        assert printable.week_start(date(2026, 7, 22)) == MON
+
+    def test_monday_start_on_a_monday_is_itself(self):
+        assert printable.week_start(MON) == MON
+
+    def test_sunday_start(self):
+        assert printable.week_start(date(2026, 7, 22), "sunday") == date(2026, 7, 19)
+
+
+class TestOrientation:
+    def test_portrait_is_the_default(self):
+        html = printable.build_chart([_child()], [_chore()], MON)
+        assert "size: A4 portrait" in html
+
+    def test_landscape_is_honoured(self):
+        html = printable.build_chart([_child()], [_chore()], MON, orientation="landscape")
+        assert "size: A4 landscape" in html
+
+    def test_an_unknown_orientation_falls_back_to_portrait(self):
+        html = printable.build_chart([_child()], [_chore()], MON, orientation="sideways")
+        assert "size: A4 portrait" in html
+
+
+class TestContent:
+    def test_all_seven_days_are_columns(self):
+        html = printable.build_chart([_child()], [_chore()], MON)
+        for day in ("Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"):
+            assert f">{day}<" in html
+
+    def test_child_names_appear(self):
+        html = printable.build_chart([_child("Ella"), _child("Sam", "b")], [_chore()], MON)
+        assert "Ella" in html and "Sam" in html
+
+    def test_a_chore_is_shown_on_its_days_only(self):
+        html = printable.build_chart([_child()], [_chore("Bins", due_days=["tuesday"])], MON)
+        # One tick box for one day, not seven.
+        assert html.count('class="tick"') == 1
+
+    def test_a_daily_chore_appears_every_day(self):
+        html = printable.build_chart([_child()], [_chore("Teeth")], MON)
+        assert html.count('class="tick"') == 7
+
+    def test_every_task_gets_a_box_to_tick(self):
+        """The entire reason it's on paper."""
+        html = printable.build_chart([_child()], [_chore("Bins", due_days=["monday"])], MON)
+        assert 'class="tick"' in html
+
+    def test_unassigned_chores_belong_to_everyone(self):
+        html = printable.build_chart([_child("Ella"), _child("Sam", "b")],
+                                     [_chore("Teeth", assigned_to=[])], MON)
+        assert html.count("Teeth") == 14  # 7 days x 2 children
+
+    def test_assigned_chores_only_reach_their_child(self):
+        html = printable.build_chart([_child("Ella", "a"), _child("Sam", "b")],
+                                     [_chore("Bins", assigned_to=["a"], due_days=["monday"])], MON)
+        assert html.count("Bins") == 1
+
+    def test_disabled_chores_are_omitted(self):
+        html = printable.build_chart([_child()], [_chore("Old", enabled=False)], MON)
+        assert "Old" not in html
+
+    def test_one_shot_appears_only_on_its_date(self):
+        html = printable.build_chart(
+            [_child()],
+            [_chore("Once", schedule_mode="one_shot", created_date=MON.isoformat())],
+            MON)
+        assert html.count("Once") == 1
+
+    def test_children_with_no_chores_are_skipped(self):
+        html = printable.build_chart([_child("Ella", "a"), _child("Sam", "b")],
+                                     [_chore("Bins", assigned_to=["a"])], MON)
+        assert "Sam" not in html
+
+    def test_empty_chart_says_so(self):
+        html = printable.build_chart([], [], MON)
+        assert "No chores to show" in html
+
+    def test_the_week_range_is_printed(self):
+        html = printable.build_chart([_child()], [_chore()], MON)
+        assert "20 Jul" in html and "26 Jul 2026" in html
+
+    def test_points_name_is_used(self):
+        html = printable.build_chart([_child()], [_chore()], MON, points_name="Gems")
+        assert "Gems" in html
+
+
+class TestSafety:
+    def test_names_are_escaped(self):
+        """A chore name is user input and lands in an HTML document."""
+        html = printable.build_chart(
+            [_child('<script>alert(1)</script>')],
+            [_chore('<img src=x onerror=alert(1)>')], MON)
+        # The payloads must survive only as inert text: no unescaped tag can
+        # appear. "onerror=alert" still occurs as escaped text, which is fine —
+        # what matters is that no "<img"/"<script" is emitted.
+        assert "<script" not in html
+        assert "<img" not in html
+        assert "&lt;script&gt;alert(1)&lt;/script&gt;" in html
+        assert "&lt;img src=x onerror=alert(1)&gt;" in html
+
+    def test_output_is_a_standalone_document(self):
+        """It gets opened in a new tab and printed — no external assets."""
+        html = printable.build_chart([_child()], [_chore()], MON)
+        assert html.startswith("<!DOCTYPE html>")
+        assert "<style>" in html
+        assert "http://" not in html and "https://" not in html


### PR DESCRIPTION
A fridge-ready A4 chore chart with a box to tick against every task. `taskmate/print/weekly_chart` returns a **standalone HTML page** — open in a tab, print.

**Orientation is the user's choice**, as you asked: `portrait` (default) or `landscape`. Two children with short chore names fit portrait; five need the width.

| Option | Values |
|---|---|
| `orientation` | `portrait` / `landscape` |
| `week_start` | ISO date anywhere in the target week (defaults to this week) |
| `title` | Heading (defaults to "This week") |

## Decisions

- **Standalone, no external assets.** It prints identically offline and can't be broken by a missing font or CDN. A test asserts no `http(s)://` appears in the output.
- **Schedule-only.** Weather, visibility and availability are current-state facts a paper chart cannot know for next Thursday. A chart that quietly omitted a chore would be worse than one that lists it, so they aren't applied — and the README says so.
- Unassigned chores appear for every child; assigned ones only for theirs. Children with nothing assigned are left off rather than printing an empty row.
- **Chore names are escaped** — user input landing in a document that gets opened in a browser.
- `printable.py` has **no Home Assistant imports**, so the entire layout is unit-testable without an HA install.

## Testing

- **21 new tests**: week-start maths (midweek, on-the-day, Sunday-start), all three orientation paths, seven day columns, child names, a chore appearing on its days only vs every day, a tick box per task, unassigned-vs-assigned scoping, disabled chores omitted, one-shot on its date only, choreless children skipped, the empty state, week range, points name, HTML escaping, and standalone-document shape.
- Full suite: **1336 passed** vs **1315** on `main`, identical pre-existing 3 failures / 9 errors.
- `ruff` clean.
- **Verified end-to-end on ha-dev**: generated both orientations against real data, rendered the HTML in a browser exactly as a print preview would, and confirmed 7 day columns, both children as rows, **72 tick boxes**, the custom title, and no external assets. Bad orientation and a malformed `week_start` are both rejected. Screenshot attached below shows the actual printed layout.

One test-harness note: the first run reported a console error that turned out to be Home Assistant's own frontend reacting to my test wiping its DOM via `setContent`. Rendering the chart in a fresh page fixed it — the chart itself was never at fault.

Fixes #689