### PR TITLE
feat(children): guest child profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@
 - [Multi-Parent Approval Routing](#multi-parent-approval-routing)
 - [Sharing Template Packs](#sharing-template-packs)
 - [Printable Weekly Chart](#printable-weekly-chart)
+- [Guest Child Profiles](#guest-child-profiles)
 - [Bonus Points System](#bonus-points-system)
 - [Notifications](#notifications)
 - [Quiet Hours](#quiet-hours)
@@ -654,6 +655,22 @@ A fridge-ready A4 chore chart with a box to tick against every task.
 - Chores with no assignee appear for every child; assigned ones only for theirs.
 - Children with nothing assigned are left off entirely rather than printing an empty row.
 - Chore names are HTML-escaped: they're user input landing in a document.
+ 
+---
+ 
+## Guest Child Profiles
+ 
+A visiting cousin gets a temporary child profile that expires on its own and stays out of the family leaderboard.
+ 
+Set **Guest** and an end date on a child (`is_guest`, `guest_expires_on`).
+ 
+### Key Points
+ 
+- **Guests don't compete.** They're excluded from the leaderboard — a cousin here for a week shouldn't win the month, and their leaving shouldn't read as a loss.
+- **No end date means no expiry.** You may not know how long the visit is, and silently archiving someone mid-stay would be worse than leaving the profile up.
+- **Expired guests are archived, not deleted.** The visit's completions stay in history, and next summer the same guest can be reactivated rather than rebuilt. Archiving reuses the existing availability plumbing, so every chore and streak path already treats them as away.
+- **Promoting a guest to a family member** clears the end date and un-archives them — someone who moves in shouldn't stay invisible.
+- Archiving fires `taskmate_guest_archived`.
  
 ---
  

--- a/custom_components/taskmate/coord_guests.py
+++ b/custom_components/taskmate/coord_guests.py
@@ -1,0 +1,116 @@
+"""Guest child profiles (#690).
+
+A visiting cousin gets a temporary child that expires on its own and stays out
+of the family leaderboard, so a week's visit doesn't permanently distort the
+season standings or leave a stale profile behind.
+
+"Archived" rather than deleted: the visit's completions stay in history, and
+next summer the same guest can be reactivated instead of rebuilt.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import date
+
+from homeassistant.util import dt as dt_util
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class GuestsMixin:
+    """Mixin providing guest-profile lifecycle."""
+
+    def is_guest_child(self, child) -> bool:
+        return bool(getattr(child, "is_guest", False))
+
+    def guest_has_expired(self, child, on: date | None = None) -> bool:
+        """True when a guest's stay has ended.
+
+        A guest with no end date never expires — a parent may not know how long
+        the visit will be, and silently archiving them mid-stay would be worse
+        than leaving the profile up.
+        """
+        if not self.is_guest_child(child):
+            return False
+        raw = (getattr(child, "guest_expires_on", "") or "").strip()
+        if not raw:
+            return False
+        try:
+            ends = date.fromisoformat(raw)
+        except (TypeError, ValueError):
+            _LOGGER.warning(
+                "Guest %s has an unparseable expiry %r — treating as open-ended",
+                getattr(child, "name", ""), raw,
+            )
+            return False
+        return (on or dt_util.as_local(dt_util.now()).date()) > ends
+
+    def leaderboard_children(self) -> list:
+        """Children who count towards the family leaderboard.
+
+        Guests are excluded: a cousin here for a week shouldn't win the month,
+        and their absence shouldn't look like a loss when they leave.
+        """
+        return [c for c in self.storage.get_children() if not self.is_guest_child(c)]
+
+    async def async_archive_expired_guests(self, refresh: bool = True) -> list[str]:
+        """Archive guests whose stay has ended. Returns the names archived.
+
+        Archiving disables the profile rather than deleting it, so the visit's
+        history survives and the same guest can be reactivated next time.
+        """
+        today = dt_util.as_local(dt_util.now()).date()
+        archived: list[str] = []
+
+        for child in self.storage.get_children():
+            if not self.guest_has_expired(child, today):
+                continue
+            if getattr(child, "availability_entity", "") == "__guest_archived__":
+                continue  # already archived
+
+            # Mark unavailable via the existing availability plumbing, so every
+            # chore/streak path treats them as away without new special cases.
+            child.availability_entity = "__guest_archived__"
+            child.pause_streak_when_unavailable = True
+            self.storage.update_child(child)
+            archived.append(child.name)
+            _LOGGER.info("Archived guest profile '%s' (stay ended %s)",
+                         child.name, child.guest_expires_on)
+            self.hass.bus.async_fire(
+                "taskmate_guest_archived",
+                {
+                    "child_id": child.id,
+                    "child_name": child.name,
+                    "expired_on": child.guest_expires_on,
+                    "timestamp": dt_util.now().isoformat(),
+                },
+            )
+
+        if archived:
+            await self.storage.async_save()
+            if refresh:
+                await self.async_refresh()
+        return archived
+
+    async def async_set_guest(
+        self, child_id: str, is_guest: bool, expires_on: str = "",
+    ) -> None:
+        """Mark a child as a guest (or back to a family member)."""
+        child = self.storage.get_child(child_id)
+        if not child:
+            raise ValueError(f"Child {child_id} not found")
+
+        if expires_on:
+            try:
+                date.fromisoformat(expires_on)
+            except (TypeError, ValueError) as err:
+                raise ValueError("expires_on must be an ISO date, e.g. 2026-08-31") from err
+
+        child.is_guest = bool(is_guest)
+        child.guest_expires_on = expires_on if is_guest else ""
+        if not is_guest and child.availability_entity == "__guest_archived__":
+            # Promoting an archived guest to a family member un-archives them.
+            child.availability_entity = ""
+        self.storage.update_child(child)
+        await self.storage.async_save()
+        await self.async_refresh()

--- a/custom_components/taskmate/coordinator.py
+++ b/custom_components/taskmate/coordinator.py
@@ -21,6 +21,7 @@ from .coord_badges import BadgeCoordinator
 from .coord_calendar import CalendarMixin
 from .coord_challenges import ChallengesMixin
 from .coord_chores import ChoresMixin
+from .coord_guests import GuestsMixin
 from .coord_mandatory import MandatoryMixin
 from .coord_notifications import NotificationCoordinator
 from .coord_points import PointsMixin
@@ -55,6 +56,7 @@ class TaskMateCoordinator(
     ReportsMixin,
     RouletteMixin,
     ReadAloudMixin,
+    GuestsMixin,
     UnlocksMixin,
     DataUpdateCoordinator,
 ):
@@ -666,6 +668,7 @@ class TaskMateCoordinator(
         steps = [
             self.async_apply_due_scheduled_changes,
             self.async_prune_roulette_state,
+            self.async_archive_expired_guests,
             self._async_check_streaks,
             self._async_expire_one_shot_chores,
             self._async_expire_dated_chores,

--- a/custom_components/taskmate/models.py
+++ b/custom_components/taskmate/models.py
@@ -174,6 +174,10 @@ class Child:
     quiet_hours_start: str = ""  # "HH:MM" — start of do-not-disturb window; empty = no quiet hours
     quiet_hours_end: str = ""    # "HH:MM" — end of do-not-disturb window; start>end means overnight
     level: int = 1  # cached XP level (derived from total_points_earned)
+    # Guest profiles (#690): a visiting cousin gets a temporary child that
+    # expires on its own and stays out of the family leaderboard.
+    is_guest: bool = False
+    guest_expires_on: str = ""  # ISO date; profile auto-archives the day after
     id: str = field(default_factory=generate_id)
 
     @classmethod
@@ -193,6 +197,8 @@ class Child:
             streak_paused=data.get("streak_paused", False),
             streak_milestones_achieved=list(data.get("streak_milestones_achieved", [])),
             awarded_perfect_weeks=list(data.get("awarded_perfect_weeks", [])),
+            is_guest=bool(data.get("is_guest", False)),
+            guest_expires_on=str(data.get("guest_expires_on", "") or ""),
             availability_entity=data.get("availability_entity", ""),
             availability_inverted=data.get("availability_inverted", False),
             unavailability_entity=data.get("unavailability_entity", ""),
@@ -223,6 +229,8 @@ class Child:
             "streak_paused": self.streak_paused,
             "streak_milestones_achieved": self.streak_milestones_achieved,
             "awarded_perfect_weeks": self.awarded_perfect_weeks,
+            "is_guest": self.is_guest,
+            "guest_expires_on": self.guest_expires_on,
             "availability_entity": self.availability_entity,
             "availability_inverted": self.availability_inverted,
             "unavailability_entity": self.unavailability_entity,

--- a/custom_components/taskmate/sensor.py
+++ b/custom_components/taskmate/sensor.py
@@ -159,6 +159,9 @@ def _build_children_summary(coordinator: TaskMateCoordinator, common: dict) -> l
             "name": c.name,
             "points": c.points,
             "pending_points": pending.get(c.id, 0),
+            # Guest profiles (#690): cards filter these out of competitive views.
+            **({"is_guest": True, "guest_expires_on": getattr(c, "guest_expires_on", "")}
+               if getattr(c, "is_guest", False) else {}),
             # Chore roulette (#677): today's pick + spins left, so the card can
             # show the result and disable the button once the allowance is used.
             **(

--- a/custom_components/taskmate/websocket.py
+++ b/custom_components/taskmate/websocket.py
@@ -390,6 +390,8 @@ async def _ws_add_child(hass, connection, msg, coordinator):
     vol.Optional("unavailability_entity"): str,
     vol.Optional("pause_streak_when_unavailable"): bool,
     vol.Optional("linked_user_id"): str,
+    vol.Optional("is_guest"): bool,
+    vol.Optional("guest_expires_on"): str,
 })
 @websocket_api.async_response
 @_admin_only
@@ -412,6 +414,19 @@ async def _ws_update_child(hass, connection, msg, coordinator):
         existing.pause_streak_when_unavailable = bool(msg["pause_streak_when_unavailable"])
     if "linked_user_id" in msg:
         existing.linked_user_id = _opt_str(msg["linked_user_id"])
+    if "is_guest" in msg or "guest_expires_on" in msg:
+        # Routed through the coordinator so the expiry is validated and an
+        # archived guest is un-archived when promoted to a family member.
+        try:
+            await coordinator.async_set_guest(
+                existing.id,
+                bool(msg.get("is_guest", existing.is_guest)),
+                _opt_str(msg.get("guest_expires_on", existing.guest_expires_on)),
+            )
+        except ValueError as err:
+            connection.send_error(msg["id"], "invalid_format", str(err))
+            return
+        existing = coordinator.storage.get_child(msg["child_id"])
     await coordinator.async_update_child(existing)
     connection.send_result(msg["id"], {"id": existing.id})
 

--- a/custom_components/taskmate/www/taskmate-leaderboard-card.js
+++ b/custom_components/taskmate/www/taskmate-leaderboard-card.js
@@ -319,7 +319,7 @@ class TaskMateLeaderboardCard extends LitElement {
     if (entity.state === "unavailable" || entity.state === "unknown") return html`<ha-card><div class="error-state"><ha-icon icon="mdi:alert-circle"></ha-icon><div>${this._t('common.unavailable')}</div></div></ha-card>`;
 
     const attrs = (window.__taskmate_attrs && window.__taskmate_attrs(this.hass, this.config.entity)) || entity.attributes || {};
-    const children = [...(attrs.children || [])];
+    const children = [...(attrs.children || [])].filter(c => !c.is_guest);
     const pointsIcon = attrs.points_icon || "mdi:star";
     const pointsName = attrs.points_name || this._t('common.points');
 
@@ -593,7 +593,7 @@ class TaskMateLeaderboardCard extends LitElement {
     }
 
     const attrs = (window.__taskmate_attrs && window.__taskmate_attrs(this.hass, this.config.entity)) || entity.attributes || {};
-    const children = [...(attrs.children || [])];
+    const children = [...(attrs.children || [])].filter(c => !c.is_guest);
     const pointsName = attrs.points_name || this._t('common.points');
 
     const tz = this.hass?.config?.time_zone || Intl.DateTimeFormat().resolvedOptions().timeZone;

--- a/tests/test_guest_profiles.py
+++ b/tests/test_guest_profiles.py
@@ -1,0 +1,196 @@
+"""Guest child profiles (#690).
+
+A visiting cousin gets a temporary child that expires on its own and stays out
+of the family leaderboard. Archived rather than deleted, so the visit's
+history survives and the same guest can come back next summer.
+"""
+from __future__ import annotations
+
+from datetime import date, timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from homeassistant.util import dt as dt_util
+
+from custom_components.taskmate.models import Child
+
+from .test_coordinator_logic import _make_coord
+
+
+def _today():
+    return dt_util.as_local(dt_util.now()).date()
+
+
+def _coord(children):
+    coord = _make_coord(children=list(children))
+    coord.storage.get_children = MagicMock(return_value=list(children))
+    coord.storage.update_child = MagicMock()
+    coord.storage.async_save = AsyncMock()
+    coord.async_refresh = AsyncMock()
+    coord.hass.bus.async_fire = MagicMock()
+    return coord
+
+
+def _guest(name="Cousin", days=None, **over):
+    expires = "" if days is None else (_today() + timedelta(days=days)).isoformat()
+    return Child(name=name, id=name.lower(), is_guest=True, guest_expires_on=expires, **over)
+
+
+FAMILY = Child(name="Ella", id="ella")
+
+
+class TestExpiry:
+    def test_family_members_never_expire(self):
+        assert _coord([FAMILY]).guest_has_expired(FAMILY) is False
+
+    def test_guest_with_no_end_date_never_expires(self):
+        """A parent may not know how long the visit is; archiving mid-stay
+        would be worse than leaving the profile up."""
+        assert _coord([]).guest_has_expired(_guest()) is False
+
+    def test_guest_still_staying(self):
+        assert _coord([]).guest_has_expired(_guest(days=3)) is False
+
+    def test_guest_on_their_last_day_is_still_here(self):
+        assert _coord([]).guest_has_expired(_guest(days=0)) is False
+
+    def test_guest_past_their_end_date(self):
+        assert _coord([]).guest_has_expired(_guest(days=-1)) is True
+
+    def test_unparseable_expiry_is_treated_as_open_ended(self):
+        assert _coord([]).guest_has_expired(_guest(name="Odd", days=0)) is False
+        broken = Child(name="Broken", id="b", is_guest=True, guest_expires_on="soon")
+        assert _coord([]).guest_has_expired(broken) is False
+
+
+class TestLeaderboard:
+    def test_guests_are_excluded(self):
+        """A cousin here for a week shouldn't win the month."""
+        coord = _coord([FAMILY, _guest()])
+        assert [c.id for c in coord.leaderboard_children()] == ["ella"]
+
+    def test_family_only_setup_is_unchanged(self):
+        coord = _coord([FAMILY])
+        assert len(coord.leaderboard_children()) == 1
+
+
+class TestArchiving:
+    @pytest.mark.asyncio
+    async def test_expired_guest_is_archived(self):
+        guest = _guest(days=-1)
+        coord = _coord([FAMILY, guest])
+        assert await coord.async_archive_expired_guests() == ["Cousin"]
+        assert guest.availability_entity == "__guest_archived__"
+        assert guest.pause_streak_when_unavailable is True
+        coord.storage.async_save.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_current_guest_is_left_alone(self):
+        guest = _guest(days=5)
+        coord = _coord([guest])
+        assert await coord.async_archive_expired_guests() == []
+        assert guest.availability_entity == ""
+
+    @pytest.mark.asyncio
+    async def test_archiving_is_idempotent(self):
+        guest = _guest(days=-1, availability_entity="__guest_archived__")
+        coord = _coord([guest])
+        assert await coord.async_archive_expired_guests() == []
+        coord.storage.async_save.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_family_members_are_never_archived(self):
+        coord = _coord([FAMILY])
+        assert await coord.async_archive_expired_guests() == []
+
+    @pytest.mark.asyncio
+    async def test_archiving_fires_an_event(self):
+        coord = _coord([_guest(days=-1)])
+        await coord.async_archive_expired_guests()
+        event, payload = coord.hass.bus.async_fire.call_args[0]
+        assert event == "taskmate_guest_archived"
+        assert payload["child_name"] == "Cousin"
+
+    @pytest.mark.asyncio
+    async def test_archiving_keeps_the_profile(self):
+        """Deleting would take the visit's history with it."""
+        coord = _coord([_guest(days=-1)])
+        await coord.async_archive_expired_guests()
+        coord.storage.remove_child = MagicMock()
+        coord.storage.remove_child.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_refresh_when_asked_not_to(self):
+        coord = _coord([_guest(days=-1)])
+        await coord.async_archive_expired_guests(refresh=False)
+        coord.async_refresh.assert_not_awaited()
+
+
+class TestSetGuest:
+    @pytest.mark.asyncio
+    async def test_marking_a_child_as_a_guest(self):
+        child = Child(name="Cousin", id="c1")
+        coord = _coord([child])
+        coord.storage.get_child = MagicMock(return_value=child)
+        await coord.async_set_guest("c1", True, (_today() + timedelta(days=7)).isoformat())
+        assert child.is_guest is True
+        assert child.guest_expires_on
+
+    @pytest.mark.asyncio
+    async def test_promoting_a_guest_clears_the_expiry(self):
+        child = _guest(days=3)
+        coord = _coord([child])
+        coord.storage.get_child = MagicMock(return_value=child)
+        await coord.async_set_guest(child.id, False)
+        assert child.is_guest is False
+        assert child.guest_expires_on == ""
+
+    @pytest.mark.asyncio
+    async def test_promoting_un_archives(self):
+        """Someone who moves in shouldn't stay invisible."""
+        child = _guest(days=-1, availability_entity="__guest_archived__")
+        coord = _coord([child])
+        coord.storage.get_child = MagicMock(return_value=child)
+        await coord.async_set_guest(child.id, False)
+        assert child.availability_entity == ""
+
+    @pytest.mark.asyncio
+    async def test_bad_expiry_is_rejected(self):
+        child = Child(name="Cousin", id="c1")
+        coord = _coord([child])
+        coord.storage.get_child = MagicMock(return_value=child)
+        with pytest.raises(ValueError, match="ISO date"):
+            await coord.async_set_guest("c1", True, "next week")
+
+    @pytest.mark.asyncio
+    async def test_unknown_child_is_rejected(self):
+        coord = _coord([])
+        coord.storage.get_child = MagicMock(return_value=None)
+        with pytest.raises(ValueError, match="not found"):
+            await coord.async_set_guest("nope", True)
+
+
+class TestModel:
+    def test_guest_fields_round_trip(self):
+        restored = Child.from_dict(_guest(days=5).to_dict())
+        assert restored.is_guest is True
+        assert restored.guest_expires_on
+
+    def test_legacy_child_is_not_a_guest(self):
+        restored = Child.from_dict({"name": "Old"})
+        assert restored.is_guest is False
+        assert restored.guest_expires_on == ""
+
+
+class TestCardFiltering:
+    def test_leaderboard_card_filters_guests(self):
+        import pathlib
+        card = (pathlib.Path(__file__).resolve().parent.parent / "custom_components"
+                / "taskmate" / "www" / "taskmate-leaderboard-card.js").read_text(encoding="utf-8")
+        assert card.count("filter(c => !c.is_guest)") == 2
+
+    def test_sensor_exposes_the_flag(self):
+        import pathlib
+        sensor = (pathlib.Path(__file__).resolve().parent.parent / "custom_components"
+                  / "taskmate" / "sensor.py").read_text(encoding="utf-8")
+        assert '"is_guest": True' in sensor


### PR DESCRIPTION
A visiting cousin gets a temporary child profile that expires on its own and stays out of the family leaderboard.

## Design

- **Guests don't compete.** Excluded from the leaderboard in both the backend helper and the card — a cousin here for a week shouldn't win the month, and their leaving shouldn't read as a loss for everyone else.
- **No end date means no expiry.** A parent may not know how long the visit is, and silently archiving someone mid-stay would be worse than leaving the profile up. An unparseable date is treated the same way rather than expiring immediately.
- **Expired guests are archived, not deleted.** The visit's completions stay in history and the same guest can be reactivated next summer instead of rebuilt.
- Archiving marks them unavailable through the **existing availability plumbing**, so every chore and streak path already treats them as away — no new special cases threaded through the codebase.
- **Promoting a guest to a family member** clears the end date *and* un-archives them. Someone who moves in shouldn't stay invisible.
- Archiving is idempotent and fires `taskmate_guest_archived`.

## Testing

- **24 new tests**: expiry rules (family never expires, open-ended guest never expires, still-staying, last-day-is-still-here, past end date, unparseable date), leaderboard exclusion, archiving (expired archived, current left alone, idempotent, family never archived, event fired, profile kept, refresh flag), set-guest (marking, promoting clears expiry, promoting un-archives, bad expiry rejected, unknown child rejected), model round-trip including legacy children, and guards that the card filters guests and the sensor exposes the flag.
- Full suite: **1360 passed** vs **1336** on `main`, identical pre-existing 3 failures / 9 errors.
- `ruff` clean; `eslint` clean.
- **Verified end-to-end on ha-dev**: created a child, marked them a guest with an end date, confirmed it persisted and that the overview sensor flags `is_guest` so cards can filter, confirmed a malformed date is rejected (`expires_on must be an ISO date, e.g. 2026-08-31`), then promoted them back and confirmed `is_guest: false`, the expiry cleared and the archive flag removed. Test child deleted afterwards; no console errors.

This is the **last of the 18 features** on milestone v5.0.0.

Fixes #690