### PR TITLE
fix(deps): resolve two high-severity dev-dependency advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -322,9 +322,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -769,9 +769,9 @@
       "license": "ISC"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Clears both open Dependabot security alerts on the repo.

| Alert | Package | Severity | Change |
|---|---|---|---|
| [#1](https://github.com/advisories/GHSA-3jxr-9vmj-r5cp) | `brace-expansion` | High | 1.1.15 → 1.1.16 |
| [#2](https://github.com/advisories/GHSA-52cp-r559-cp3m) | `js-yaml` | High | 4.2.0 → 4.3.0 |

- `brace-expansion` — DoS via exponential-time expansion of consecutive non-expanding `{}` groups (CVE-2026-13149). Pulled in transitively by `minimatch` (`^1.1.7`).
- `js-yaml` — YAML merge-key chains can force quadratic CPU consumption (CVE-2026-59869). Pulled in transitively by `@eslint/eslintrc` (`^4.1.1`).

## Scope of the change

`npm audit fix`, **lockfile only** — `package.json` is byte-identical, because both patched versions already satisfy the existing semver ranges. The diff is 6 lines in `package-lock.json`.

## Actual exposure

Worth being clear that the practical risk here was low, despite the High rating. Both packages are **development** dependencies of `eslint`. They are not shipped in the integration — nothing under `custom_components/taskmate/` imports them, and the HACS zip does not include `node_modules`. The only place they execute is the ESLint CI job, on this repo's own source. Both advisories are algorithmic-complexity DoS, which needs attacker-controlled input to be meaningful; here the input is our own JS and our own eslint config.

So: correct to fix, no reason for alarm, and no user-facing impact.

## Verification

- `npm audit` → **0 vulnerabilities** (was 2 high)
- `rm -rf node_modules && npm ci` → clean install from the updated lockfile
- `npm run lint` → exits 0, 44 warnings, all pre-existing and unchanged from main

## Note on why these sat unnoticed

`.github/dependabot.yml` only registers the `github-actions` ecosystem — there is no `npm` entry, so Dependabot never opens routine version-update PRs for `package.json`/`package-lock.json`. These surfaced only because security alerting is separate from version updates. Adding an `npm` block would catch this class automatically in future; not included here to keep this PR to the security fix.