### PR TITLE
chore(ci): register the npm ecosystem with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,20 @@ updates:
     labels:
       - "dependencies"
       - "ci"
+
+  # Dev tooling only (eslint) — nothing here ships in the integration.
+  # Grouped so routine bumps arrive as one PR rather than one per package.
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "ci"
+    groups:
+      npm-dev-dependencies:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
Follow-up to #711. That PR fixed two high-severity npm advisories; this closes the gap that let them sit unnoticed.

## Problem

`.github/dependabot.yml` declared only the `github-actions` ecosystem. `package.json` / `package-lock.json` were never scanned for **version updates**, so no PR ever chased them. The `brace-expansion` (CVE-2026-13149) and `js-yaml` (CVE-2026-59869) advisories surfaced purely through **security alerting**, which is a separate channel — by the time they appeared they were already rated High, with nothing open against them.

## Change

Adds an `npm` block mirroring the existing `github-actions` one: `/`, weekly, limit 5, labelled `dependencies` + `ci` (both labels already exist in the repo).

Minor and patch **development** bumps are grouped into a single `npm-dev-dependencies` PR, so a typical week is one PR rather than one per transitive package. Majors are deliberately left ungrouped so they arrive on their own and get reviewed individually — the `setup-node` v6→v7 bump in #672 is the kind of thing that deserves its own PR.

## Scope

Config only, no code. Everything in `package.json` is eslint dev tooling — none of it ships in the integration, and `node_modules` is not part of the HACS zip. So this changes what gets *proposed*, never what gets *released*.

Validated: file parses as YAML, `version: 2`, both ecosystem blocks well-formed, and every referenced label exists in the repo.

## Not included

`requirements_test.txt` and `pyproject.toml` have the same gap — the `pip` ecosystem is not registered either, so the Python test dependencies get no update PRs. Left out of this PR to keep it to the npm gap discussed; happy to add it as a follow-up.