### PR TITLE
chore(deps): bump home-assistant/actions/hassfest to e3fb68eb

### DIFF
--- a/.github/workflows/hassfest.yaml
+++ b/.github/workflows/hassfest.yaml
@@ -18,4 +18,4 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
-      - uses: home-assistant/actions/hassfest@f4ca6f671bd429efb108c0f2fa0ae8af0215986c # master
+      - uses: home-assistant/actions/hassfest@e3fb68ebda13d88a0d695082f471ba2c83d025fb # master

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Hassfest validation
-        uses: home-assistant/actions/hassfest@f4ca6f671bd429efb108c0f2fa0ae8af0215986c # master
+        uses: home-assistant/actions/hassfest@e3fb68ebda13d88a0d695082f471ba2c83d025fb # master
 
   test:
     name: Run tests


### PR DESCRIPTION
Supersedes #714. Closes it.

Dependabot could not rebase #714 cleanly — #713 (checkout 7.0.1) modified `hassfest.yaml` and `tests.yml`, the same two files, which left #714 in a `dirty` (conflicted) state. This applies the identical bump on top of current main.

`home-assistant/actions/hassfest` is pinned to a **branch**, not a tag, so there is no version to bump — only the SHA moves:

```
f4ca6f671bd429efb108c0f2fa0ae8af0215986c  ->  e3fb68ebda13d88a0d695082f471ba2c83d025fb
```

`e3fb68eb` verified via the API as the current head of `home-assistant/actions` `master`, which is the same SHA Dependabot proposed in #714. The trailing `# master` comment stays accurate and needs no change.

Two lines, workflow files only.