### PR TITLE
fix(panel,cards): make the audit view reachable and fix narrow-width faults

### DIFF
--- a/custom_components/taskmate/www/taskmate-panel.js
+++ b/custom_components/taskmate/www/taskmate-panel.js
@@ -2351,6 +2351,10 @@ class TaskMatePanel extends HTMLElement {
       ]},
       { head: this._t("panel.nav_system"), items: [
         { id: "notifications", label: this._t("panel.tab_notifications"), icon: "mdi:bell-outline" },
+        // The audit view has always been implemented (and documented in the
+        // wiki), but it was never listed here — and the nav is built solely
+        // from this list, so there was no way to open it.
+        { id: "audit", label: this._t("panel.tab_audit"), icon: "mdi:history" },
         { id: "settings", label: this._t("panel.tab_settings"), icon: "mdi:cog-outline" },
       ]},
     ].map(g => ({
@@ -2882,7 +2886,7 @@ class TaskMatePanel extends HTMLElement {
           <div class="tm-child-name">
             <h3>${this._esc(child.name || this._t("panel.child_unnamed"))}</h3>
             ${this._idBadge(child.id)}
-            <div class="tm-meta">${child.availability_entity ? `<code>${this._esc(child.availability_entity)}</code>${child.availability_inverted ? ` <em>${this._t("panel.child_inverted")}</em>` : ""}` : `${this._t("panel.child_no_availability")}`}${child.unavailability_entity ? ` · ${this._t("panel.child_busy_label")} <code>${this._esc(child.unavailability_entity)}</code>` : ""}</div>
+            <div class="tm-meta">${child.availability_entity ? `<code title="${this._esc(child.availability_entity)}">${this._esc(child.availability_entity)}</code>${child.availability_inverted ? ` <em>${this._t("panel.child_inverted")}</em>` : ""}` : `${this._t("panel.child_no_availability")}`}${child.unavailability_entity ? ` · ${this._t("panel.child_busy_label")} <code title="${this._esc(child.unavailability_entity)}">${this._esc(child.unavailability_entity)}</code>` : ""}</div>
           </div>
         </div>
         <div class="tm-stats-row" style="grid-template-columns: 1fr 1fr;">
@@ -6131,6 +6135,10 @@ class TaskMatePanel extends HTMLElement {
         background: var(--tm-warning-soft);
         color: var(--tm-warning);
         border: 1px solid var(--tm-warning-border);
+        /* 24px high is too small to hit reliably on a phone; this is the
+           panel's only route to the pending-approvals queue. */
+        min-height: 32px;
+        box-sizing: border-box;
         padding: 4px 12px 4px 10px;
         border-radius: 999px;
         font-size: 12px; font-weight: 500;
@@ -6318,7 +6326,10 @@ class TaskMatePanel extends HTMLElement {
       .tm-child-name { min-width: 0; flex: 1; }
       .tm-child-name h3 { margin: 0; font-size: 15px; font-weight: 600; letter-spacing: -0.01em; }
       .tm-meta { color: var(--tm-text-faint); font-size: 12px; margin-top: 2px; word-break: break-word; }
-      .tm-meta code { font-family: ui-monospace, "SF Mono", Menlo, monospace; background: var(--tm-surface-2); padding: 1px 6px; border-radius: 4px; font-size: 11px; color: var(--tm-text-muted); }
+      /* Entity ids are long and unbreakable. Left to wrap they split mid-token
+         and tear the pill background across two lines, so truncate instead —
+         the full value is on the title attribute. */
+      .tm-meta code { font-family: ui-monospace, "SF Mono", Menlo, monospace; background: var(--tm-surface-2); padding: 1px 6px; border-radius: 4px; font-size: 11px; color: var(--tm-text-muted); display: inline-block; max-width: 100%; vertical-align: bottom; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
       .tm-text-muted { color: var(--tm-text-muted); }
 
       .tm-stats-row {

--- a/custom_components/taskmate/www/taskmate-parent-dashboard-card.js
+++ b/custom_components/taskmate/www/taskmate-parent-dashboard-card.js
@@ -109,10 +109,19 @@ class TaskMateParentDashboardCard extends LitElement {
         display: flex;
         border-bottom: 1px solid var(--divider-color, #e0e0e0);
         background: var(--secondary-background-color, #f5f5f5);
+        /* Flex items refuse to shrink below their content, so on a narrow card
+           the last tab used to be clipped off the edge with no way to reach it.
+           Wrapping keeps every tab visible without asking the parent to
+           discover a horizontal swipe on a card that doesn't look scrollable. */
+        flex-wrap: wrap;
       }
 
       .tab-btn {
-        flex: 1; padding: 10px 8px;
+        /* Grow to fill a wide card, but keep the label intact when narrow. */
+        flex: 1 0 auto;
+        min-width: 0;
+        white-space: nowrap;
+        padding: 10px 8px;
         background: none; border: none;
         font-size: 0.78rem; font-weight: 600;
         color: var(--secondary-text-color);

--- a/tests/test_panel_navigation.py
+++ b/tests/test_panel_navigation.py
@@ -1,0 +1,96 @@
+"""Every panel view must be reachable from the sidebar.
+
+The audit view shipped fully implemented — render function, clear-log button,
+styles, websocket commands and a wiki page — but it was missing from
+`_sidebarGroups()`. The nav is built solely from that list, so there was no way
+to open it. Nothing failed; the tab was simply invisible.
+"""
+from __future__ import annotations
+
+import pathlib
+import re
+
+WWW = pathlib.Path(__file__).resolve().parent.parent / "custom_components" / "taskmate" / "www"
+PANEL = (WWW / "taskmate-panel.js").read_text(encoding="utf-8")
+
+
+def _tab_ids() -> list[str]:
+    """The ids declared in the TABS constant."""
+    block = re.search(r"const TABS = \[(.*?)\n\];", PANEL, re.S)
+    assert block, "could not find the TABS constant"
+    return re.findall(r'id:\s*"([a-z_]+)"', block.group(1))
+
+
+def _rendered_ids() -> set[str]:
+    """Ids the render switch actually has a case for."""
+    return set(re.findall(r'case "([a-z_]+)":\s*return this\._render', PANEL))
+
+
+def _sidebar_ids() -> set[str]:
+    """Ids listed in the sidebar groups — the only source the nav renders from."""
+    start = PANEL.index("_sidebarGroups() {")
+    end = PANEL.index("_sidebar() {", start)
+    return set(re.findall(r'\{\s*id:\s*"([a-z_]+)"', PANEL[start:end]))
+
+
+class TestEveryViewIsReachable:
+    def test_audit_is_in_the_sidebar(self):
+        assert "audit" in _sidebar_ids(), (
+            "the audit view has a render case but no sidebar entry, so it "
+            "cannot be opened"
+        )
+
+    def test_every_rendered_view_has_a_sidebar_entry(self):
+        rendered = _rendered_ids()
+        sidebar = _sidebar_ids()
+        assert rendered, "expected to find render cases"
+        unreachable = sorted(rendered - sidebar)
+        assert unreachable == [], (
+            f"views with a render case but no way to navigate to them: {unreachable}"
+        )
+
+    def test_no_sidebar_entry_points_at_a_missing_view(self):
+        """The mirror image: a nav item that renders nothing."""
+        dangling = sorted(_sidebar_ids() - _rendered_ids())
+        assert dangling == [], f"sidebar entries with no render case: {dangling}"
+
+    def test_every_sidebar_label_key_exists_in_every_locale(self):
+        import json
+
+        start = PANEL.index("_sidebarGroups() {")
+        end = PANEL.index("_sidebar() {", start)
+        keys = set(re.findall(r'this\._t\("(panel\.tab_[a-z_]+)"\)', PANEL[start:end]))
+        assert keys, "expected sidebar labels to come from translation keys"
+
+        for path in sorted((WWW / "locales").glob("*.json")):
+            data = json.loads(path.read_text(encoding="utf-8"))
+            missing = sorted(k for k in keys if k not in data)
+            assert missing == [], f"{path.name} is missing {missing}"
+
+
+class TestNarrowWidthAffordances:
+    """Faults found auditing the panel and cards down to a 320px viewport."""
+
+    def test_entity_id_chips_truncate_rather_than_wrap(self):
+        """An entity id left to wrap splits mid-token and tears the pill
+        background across two lines."""
+        rule = re.search(r"\.tm-meta code \{([^}]*)\}", PANEL)
+        assert rule, "could not find the .tm-meta code rule"
+        body = rule.group(1)
+        assert "text-overflow: ellipsis" in body
+        assert "white-space: nowrap" in body
+
+    def test_the_approval_pill_is_a_usable_tap_target(self):
+        """It is the panel's only route into the pending-approvals queue."""
+        rule = re.search(r"\.tm-approval-pill \{([^}]*)\}", PANEL)
+        assert rule
+        m = re.search(r"min-height:\s*(\d+)px", rule.group(1))
+        assert m and int(m.group(1)) >= 32, "approval pill is too small to tap"
+
+    def test_parent_dashboard_tabs_stay_reachable_when_narrow(self):
+        """Flex items refuse to shrink below their content, so the last tab was
+        clipped off the card edge with no way to scroll to it."""
+        src = (WWW / "taskmate-parent-dashboard-card.js").read_text(encoding="utf-8")
+        rule = re.search(r"\.tab-nav \{([^}]*)\}", src)
+        assert rule
+        assert "flex-wrap: wrap" in rule.group(1)


### PR DESCRIPTION
Swept every admin-panel tab and every card from 320px to 1440px, probing for content that escapes its container, is clipped with no way to scroll to it, or is too small to tap.

## The audit view could not be opened

`taskmate-panel.js` has always implemented the audit view in full — render function, clear-log button, styles, websocket commands, translations in all eight locales, and an [Admin Audit Log](https://github.com/tempus2016/taskmate/wiki/Admin-Audit-Log) wiki page. But it was missing from `_sidebarGroups()`, and the nav renders solely from that list. Nothing errored; the tab was simply invisible.

Forcing `_activeTab = "audit"` renders 101 rows of real data, so this was only ever a missing nav entry.

## The parent dashboard card lost a tab when narrow

`.tab-nav` is a flex row, and flex items refuse to shrink below their content. At 320px the **Points** tab was clipped off the card edge — no scroll, no wrap, no way to reach it.

It now wraps. Making the strip scrollable was the other option, but a card doesn't look scrollable, so a parent would have had to discover the swipe. Wrapping keeps every tab visible. 400px and above are unchanged.

## Entity-id chips tore across two lines

`.tm-meta` sets `word-break: break-word`, and an entity id has no break opportunities, so the pill split mid-token and left an orphan fragment carrying its own torn background. They now truncate with an ellipsis and put the full value on the `title` attribute.

## The approval pill was a 24px tap target

It is the panel's only route into the pending-approvals queue. Now 32px minimum.

## One reported fault that was not real

The sweep also flagged every badge overflowing its grid cell by exactly 4px at every width. That turned out to be **my harness's fault, not the card's**: it matched badge entities with `/taskmate_badges/`, which never matches `sensor.taskmate_malia_badges`, so the card was rendering with the wrong entity. Re-probed with a real badges sensor, `clientWidth == scrollWidth` and nothing overflows — with or without a `box-sizing` change. I had already written the fix and a test for it; both are reverted, and the harness now matches `/^sensor\.taskmate_.*_badges$/`.

## Verification

On ha-dev: the panel sweep reports **zero faults at 320px and 390px** (was six), and the parent dashboard's three card faults are gone. Remaining card findings are all `text-overflow: ellipsis` truncations, which are deliberate.

Tests parse the panel source for structure rather than behaviour, because the audit bug was invisible to every functional test — the view worked perfectly, it just had no door. The rule now enforced in both directions: no view may have a render case without a nav entry, and no nav entry may point at a missing view. All six new assertions fail on `main`.

Full suite: 1373 passed, with the same 3 failures + 9 errors that pre-exist on `main` from test-order pollution.