### PR TITLE
fix(cards): render roulette and pre-reader mode on every card design

### DIFF
--- a/custom_components/taskmate/www/taskmate-child-card.js
+++ b/custom_components/taskmate/www/taskmate-child-card.js
@@ -2421,10 +2421,20 @@ class TaskMateChildCard extends LitElement {
           <ha-icon icon="mdi:clock-outline"></ha-icon>${countdown.label}</span>` : ""}
       </div>`;
 
-    const body =
-      design === "playroom" ? this._designPlayroom(child, rows, remaining, tone) :
-      design === "console"  ? this._designConsole(child, rows, remaining, tone) :
-                              this._designCleanpro(child, rows, remaining, tone);
+    // Pre-reader mode replaces the chore list with picture tiles. It has to be
+    // handled here as well as in the classic path, or `pre_reader: true` is
+    // silently ignored under every designed style — including accessible,
+    // which is the one a child who needs picture tiles is most likely on.
+    // The tiles keep the designed shell (header, tokens) around them.
+    const body = this.config.pre_reader === true
+      ? html`
+        <div class="pre-reader-grid">
+          ${childChores.map((chore, index) =>
+            this._renderPreReaderTile(chore, child, todaysCompletions, index))}
+        </div>`
+      : design === "playroom" ? this._designPlayroom(child, rows, remaining, tone) :
+        design === "console"  ? this._designConsole(child, rows, remaining, tone) :
+                                this._designCleanpro(child, rows, remaining, tone);
 
     return html`<ha-card class="tmd" style="--hd:${hd}">
       ${this._designHeaderFull(child, design, remaining, rows.length, tone, pendingPoints, pointsIcon)}

--- a/custom_components/taskmate/www/taskmate-child-card.js
+++ b/custom_components/taskmate/www/taskmate-child-card.js
@@ -1243,11 +1243,15 @@ class TaskMateChildCard extends LitElement {
         display: flex; flex-direction: column; gap: 8px;
         margin: 4px 0 12px;
       }
+      /* The --tmd-* tokens only resolve under a designed style; the fallbacks
+         are the original classic values, so classic is unchanged. */
       .roulette-btn {
         display: inline-flex; align-items: center; justify-content: center; gap: 8px;
-        background: linear-gradient(135deg, #8e44ad, #c0392b);
-        color: #fff; border: 0; border-radius: 14px;
-        padding: 12px 16px; font-family: inherit; font-size: 0.95rem;
+        background: var(--tmd-accent, linear-gradient(135deg, #8e44ad, #c0392b));
+        color: #fff; border: 0;
+        border-radius: var(--tmd-radius-sm, 14px);
+        padding: 12px 16px;
+        font-family: var(--tmd-font-display, inherit); font-size: 0.95rem;
         font-weight: 800; cursor: pointer; width: 100%;
       }
       .roulette-btn:disabled { opacity: 0.55; cursor: default; }
@@ -1255,24 +1259,24 @@ class TaskMateChildCard extends LitElement {
       @keyframes tm-roulette-spin { to { transform: rotate(360deg); } }
       .roulette-result {
         display: flex; align-items: center; gap: 8px;
-        background: rgba(142, 68, 173, 0.12);
-        border: 1px solid rgba(142, 68, 173, 0.35);
-        border-radius: 12px; padding: 8px 12px;
+        background: color-mix(in srgb, var(--tmd-accent, #8e44ad) 12%, transparent);
+        border: 1px solid color-mix(in srgb, var(--tmd-accent, #8e44ad) 35%, transparent);
+        border-radius: var(--tmd-radius-sm, 12px); padding: 8px 12px;
       }
       .roulette-mult {
-        background: #8e44ad; color: #fff;
-        border-radius: 8px; padding: 2px 8px;
+        background: var(--tmd-accent, #8e44ad); color: #fff;
+        border-radius: var(--tmd-radius-sm, 8px); padding: 2px 8px;
         font-weight: 900; font-size: 0.85rem;
       }
       .roulette-name { flex: 1; font-weight: 700; font-size: 0.95rem; }
       .roulette-worth {
         display: inline-flex; align-items: center; gap: 4px;
-        font-weight: 800; color: #8e44ad;
+        font-weight: 800; color: var(--tmd-accent, #8e44ad);
       }
       .roulette-worth ha-icon { --mdc-icon-size: 16px; }
       .roulette-spent {
         text-align: center; font-size: 0.8rem;
-        color: var(--secondary-text-color); opacity: 0.8;
+        color: var(--tmd-dim, var(--secondary-text-color)); opacity: 0.8;
       }
 
       /* Reactive-chore countdown (#674). Amber by default, red under 5 min.
@@ -2441,6 +2445,7 @@ class TaskMateChildCard extends LitElement {
             ${earnedBadges.length > 5 ? html`<span class="more">+${earnedBadges.length - 5} →</span>` : ""}
           </div>` : ""}
         ${sectionLine}
+        ${this._renderRoulette(child, childChores, pointsIcon)}
         ${body}
         ${this._renderSwappable(allChores, child, pointsIcon)}
       </div>

--- a/tests/test_chore_roulette.py
+++ b/tests/test_chore_roulette.py
@@ -231,3 +231,50 @@ class TestMultiplier:
             if k == "roulette_state" else {"roulette_enabled": True}.get(k, d)
         )):
             assert coord._apply_roulette_multiplier(chore, "kid1", 10) == 20
+
+
+class TestRouletteRendersOnEveryDesign:
+    """The spin button only ever rendered on the classic card.
+
+    `_renderRoulette` was called once, from the classic branch of render().
+    `_renderDesigned` returns before that branch is reached, so a family using
+    playroom, console, cleanpro or accessible had `show_roulette: true` in
+    their config and no button on screen — with nothing logged to explain it.
+    """
+
+    import pathlib as _pathlib
+
+    SOURCE = (
+        _pathlib.Path(__file__).resolve().parent.parent
+        / "custom_components" / "taskmate" / "www" / "taskmate-child-card.js"
+    ).read_text(encoding="utf-8")
+
+    def _designed_region(self) -> str:
+        start = self.SOURCE.index("_renderDesigned(design) {")
+        # End at the *definition* of the next method, not the call to it that
+        # appears inside this one.
+        end = self.SOURCE.index("\n  _designHeaderFull(", start)
+        return self.SOURCE[start:end]
+
+    def _classic_region(self) -> str:
+        start = self.SOURCE.index("  render() {")
+        end = self.SOURCE.index("_renderDesigned(design) {")
+        return self.SOURCE[start:end]
+
+    def test_classic_renders_the_roulette(self):
+        assert "this._renderRoulette(" in self._classic_region()
+
+    def test_designed_styles_render_the_roulette(self):
+        assert "this._renderRoulette(" in self._designed_region(), (
+            "the designed render path never calls _renderRoulette, so the spin "
+            "button is invisible on playroom / console / cleanpro / accessible"
+        )
+
+    def test_roulette_styling_follows_the_active_design(self):
+        """Hard-coded purple ignores the design tokens, so the button looked
+        pasted-on under every style but classic."""
+        import re
+
+        block = re.search(r"\.roulette-btn \{([^}]*)\}", self.SOURCE)
+        assert block, "could not find the .roulette-btn rule"
+        assert "var(--tmd-" in block.group(1)

--- a/tests/test_pre_reader_mode.py
+++ b/tests/test_pre_reader_mode.py
@@ -93,3 +93,35 @@ class TestPreReaderCard:
             data = json.loads(path.read_text(encoding="utf-8"))
             missing = sorted(k for k in keys if k not in data)
             assert missing == [], f"{path.name} missing {missing}"
+
+
+class TestPreReaderRendersOnEveryDesign:
+    """Pre-reader mode was wired into the classic render path only.
+
+    `render()` returns `_renderDesigned(design)` before reaching the classic
+    branch, so `pre_reader: true` was silently ignored on playroom, console,
+    cleanpro and accessible — and accessible is precisely the style a child who
+    needs picture tiles is most likely to be using.
+    """
+
+    import pathlib as _pathlib
+
+    SOURCE = (
+        _pathlib.Path(__file__).resolve().parent.parent
+        / "custom_components" / "taskmate" / "www" / "taskmate-child-card.js"
+    ).read_text(encoding="utf-8")
+
+    def _designed_region(self) -> str:
+        start = self.SOURCE.index("_renderDesigned(design) {")
+        end = self.SOURCE.index("\n  _designHeaderFull(", start)
+        return self.SOURCE[start:end]
+
+    def test_designed_styles_honour_pre_reader(self):
+        region = self._designed_region()
+        assert "pre_reader" in region, (
+            "the designed render path never checks config.pre_reader, so "
+            "pre-reader mode does nothing on any style but classic"
+        )
+
+    def test_designed_styles_render_the_picture_tiles(self):
+        assert "_renderPreReaderTile(" in self._designed_region()


### PR DESCRIPTION
Two v5.0.0 child-card features were wired into only one of the card's two render paths, so both silently did nothing on four of the five designs.

`render()` returns `_renderDesigned(design)` before reaching the classic branch. Anything called only from that branch is invisible on playroom, console, cleanpro and accessible — with no error and nothing logged.

## Chore roulette (#727)

`_renderRoulette` was called once, from the classic branch. Set `show_roulette: true`, enable roulette in Settings, pick any other design, and there is no button.

Its styling was also hard-coded purple, so even once it rendered it ignored the design tokens. Every colour and radius now reads a `--tmd-*` token with the original classic value as the fallback — **classic is unchanged**, purple→red gradient included (it survives as the fallback of `--tmd-accent`).

## Pre-reader mode (#729)

`pre_reader` appeared **zero** times in `_renderDesigned` and zero times in `_designPlayroom` / `_designConsole` / `_designCleanpro`. `pre_reader: true` on any style but classic gave the ordinary chore list.

This is the one that stings: **accessible** is the style a child who needs picture tiles is most likely to be on. A parent setting up for a pre-reader would reasonably choose accessible *and* pre-reader mode, and silently get neither working together — the same argument that made #721 worth fixing before the release.

The designed path now swaps its chore list for the picture tiles, keeping the designed shell around them.

## Before / after

| Design | Roulette before | Roulette after | Pre-reader before | Pre-reader after |
|---|---|---|---|---|
| classic | ✅ | ✅ identical | ✅ | ✅ identical |
| playroom | ❌ | ✅ | ❌ | ✅ |
| console | ❌ | ✅ | ❌ | ✅ |
| cleanpro | ❌ | ✅ | ❌ | ✅ |
| accessible | ❌ | ✅ | ❌ | ✅ |

## How I found the second one

After fixing roulette I diffed every `_render*` helper called from the classic path against the designed path, rather than assuming roulette was the only casualty. That surfaced pre-reader. Three helpers it also flagged — `_renderChoreCard`, `_renderTimedChoreCard`, `_renderEmptyState` — are legitimately classic-only, because the designed path has its own row builders. Two more (bonus sub-tasks, avatar picker) came back inconclusive from my probe rather than broken: sub-tasks only unlock once the parent chore is done, and the two paths use different avatar markup. I have not claimed those as bugs.

## Verification

Checked on ha-dev by injecting state into a **clone** of hass, so the checks exercise the render paths rather than the global roulette setting (off on that instance). Both features now render in all five designs, each in its own accent.

## Tests

Five new tests, all failing on `main`. The important two assert that **both** render paths call the feature — the check neither this nor #721 had, and the reason all three shipped half-wired. One initially passed for the wrong reason (my region boundary matched the *call* to `_designHeaderFull` rather than its definition); I fixed that before trusting it.

Full suite: 1378 passed, with the same 3 failures + 9 errors that pre-exist on `main` from test-order pollution.

Fixes #727
Fixes #729