### PR TITLE
fix(cards): wire the last two cards into the design system + designed avatar picker

### DIFF
--- a/custom_components/taskmate/www/taskmate-child-card.js
+++ b/custom_components/taskmate/www/taskmate-child-card.js
@@ -608,6 +608,23 @@ class TaskMateChildCard extends LitElement {
         width: 18px; height: 18px; border-radius: 50%;
         background: rgba(0,0,0,0.45); display: flex; align-items: center; justify-content: center;
       }
+
+      /* Designed-header avatar wrapper: mirror of the classic avatar-container
+         so the picker works under every design, not just classic. The picker
+         itself (.avatar-picker) is absolute, so the header is the positioned
+         anchor. Base styles here win over the shared kit's .tmd-hd because the
+         card includes them after the kit in static styles(). */
+      .tmd-hd { position: relative; }
+      .tmd-av-wrap { position: relative; display: inline-flex; align-items: center; flex: none; }
+      .tmd-av-wrap.avatar-clickable { cursor: pointer; }
+      .tmd-av-edit {
+        position: absolute; bottom: -2px; right: -2px;
+        width: 15px; height: 15px; border-radius: 50%;
+        background: var(--tmd-accent, #7c3aed); color: #fff;
+        display: grid; place-items: center;
+        box-shadow: 0 1px 3px rgba(0,0,0,0.3);
+      }
+      .tmd-av-edit ha-icon { --mdc-icon-size: 10px; color: #fff; }
       .avatar-edit-dot ha-icon { --mdc-icon-size: 12px; color: white; }
       .avatar-picker {
         position: absolute; z-index: 20; margin-top: 56px;
@@ -2476,13 +2493,25 @@ class TaskMateChildCard extends LitElement {
       ? (child.level ? `${this._t("child.level_label", { level: child.level })} · ${remaining} ACTIVE` : `${remaining} ACTIVE`)
       : design === "cleanpro" ? `${remaining} / ${total}`
       : `${remaining} · ${this._t("child.todays_chores")}`;
+    // Avatar picker: classic makes the avatar tappable; the designed header
+    // must too, or the picker only ever works on classic. Same eligibility
+    // rule (allow_avatar_change + more than one unlocked option).
+    const opts = child.avatar_options || [];
+    const canChange = this.config.allow_avatar_change !== false
+      && opts.filter(o => o.unlocked).length > 1;
     return html`
       <div class="tmd-hd">
-        ${this._av(child, tone, 34)}
+        <div class="tmd-av-wrap ${canChange ? "avatar-clickable" : ""}"
+             @click=${canChange ? () => this._toggleAvatarPicker() : null}
+             title="${canChange ? this._t("child.avatar_change") : ""}">
+          ${this._av(child, tone, 34)}
+          ${canChange ? html`<span class="tmd-av-edit"><ha-icon icon="mdi:pencil"></ha-icon></span>` : ""}
+        </div>
         <span class="tt">${title}<small>${sub}</small></span>
         ${remaining === 0 && total > 0 ? html`<span class="pill">🎉</span>` : ""}
         ${pendingPoints > 0 ? html`<span class="tmd-pending">
           <ha-icon icon="mdi:timer-sand"></ha-icon>+${pendingPoints}</span>` : ""}
+        ${canChange && this._avatarPickerOpen ? this._renderAvatarPicker(child, opts) : ""}
       </div>`;
   }
 

--- a/custom_components/taskmate/www/taskmate-family-goal-card.js
+++ b/custom_components/taskmate/www/taskmate-family-goal-card.js
@@ -3,6 +3,11 @@
  * Shows the shared family co-op goal (combined points across all children) with
  * a progress bar toward the target and the reward. Reads the overview sensor's
  * `family_goal` attribute.
+ *
+ * Single layout, so it consumes the design tokens directly (like the routine
+ * card) rather than carrying a second _renderDesigned() template. Every
+ * --tmd-* reference has the card's original value as its fallback, so classic
+ * — which defines no tokens — renders exactly as it did before.
  */
 
 const LitElement = customElements.get("hui-masonry-view")
@@ -13,6 +18,7 @@ const html = LitElement.prototype.html;
 const css = LitElement.prototype.css;
 
 const _safeColor = (c, d) => (typeof c === "string" && /^#[0-9a-fA-F]{3,8}$/.test(c) ? c : d);
+const DEFAULT_ACCENT = "#16a085";
 
 class TaskMateFamilyGoalCard extends LitElement {
   static get properties() {
@@ -39,18 +45,38 @@ class TaskMateFamilyGoalCard extends LitElement {
     return fn ? fn(this.hass, key, params) : key;
   }
 
+  /**
+   * Resolve the active design, stamp data-tm-design on the host (which is what
+   * makes the :host-scoped token block apply inside this shadow root), and set
+   * the accent. The accent is set as an inline host property, not from a
+   * <style> in the template: a shadow tree's <style> is ordered before
+   * adoptedStyleSheets, so it loses to the :host default in static styles().
+   */
+  _applyDesign() {
+    if (window.__taskmate_design) {
+      window.__taskmate_design.apply(this, this.hass, this.config, this.config.entity);
+    }
+    const configured = this.config.header_color;
+    if (typeof configured === "string" && /^#[0-9a-fA-F]{3,8}$/.test(configured)) {
+      this.style.setProperty("--fg-accent", _safeColor(configured, DEFAULT_ACCENT));
+    } else {
+      this.style.removeProperty("--fg-accent");
+    }
+  }
+
   render() {
     if (!this.hass || !this.config) return html``;
+    this._applyDesign();
     const entity = this.hass.states[this.config.entity];
     if (!entity) {
-      return html`<ha-card><div class="empty"><ha-icon icon="mdi:alert-circle"></ha-icon><div>${this._t("common.entity_not_found", { entity: this.config.entity })}</div></div></ha-card>`;
+      return html`<ha-card><div class="fg-empty"><ha-icon icon="mdi:alert-circle"></ha-icon><div>${this._t("common.entity_not_found", { entity: this.config.entity })}</div></div></ha-card>`;
     }
     const attrs = (window.__taskmate_attrs && window.__taskmate_attrs(this.hass, this.config.entity)) || entity.attributes || {};
     const goal = attrs.family_goal || {};
     const pointsName = attrs.points_name || this._t("common.points");
 
     if (!goal.enabled || !goal.target) {
-      return html`<ha-card><div class="empty"><ha-icon icon="mdi:flag-checkered"></ha-icon><div>${this._t("family_goal.disabled")}</div></div></ha-card>`;
+      return html`<ha-card><div class="fg-empty"><ha-icon icon="mdi:flag-checkered"></ha-icon><div>${this._t("family_goal.disabled")}</div></div></ha-card>`;
     }
 
     const progress = Number(goal.progress) || 0;
@@ -60,21 +86,20 @@ class TaskMateFamilyGoalCard extends LitElement {
 
     return html`
       <ha-card>
-        <style>:host { --tm-goal-accent: ${_safeColor(this.config.header_color, "#16a085")}; }</style>
-        <div class="head">
+        <div class="fg-head">
           <ha-icon icon="${achieved ? "mdi:trophy" : "mdi:flag-checkered"}"></ha-icon>
-          <span class="title">${this.config.title || goal.name || this._t("family_goal.default_title")}</span>
+          <span class="fg-title">${this.config.title || goal.name || this._t("family_goal.default_title")}</span>
         </div>
-        <div class="body">
-          <div class="bar"><div class="fill ${achieved ? "done" : ""}" style="width:${pct}%"></div></div>
-          <div class="stats">
+        <div class="fg-body">
+          <div class="fg-bar"><div class="fg-fill ${achieved ? "done" : ""}" style="width:${pct}%"></div></div>
+          <div class="fg-stats">
             <span>${progress} / ${target} ${pointsName}</span>
             <span>${pct}%</span>
           </div>
           ${achieved
-            ? html`<div class="reward done">🎉 ${this._t("family_goal.reached", { reward: goal.reward || "" })}</div>`
+            ? html`<div class="fg-reward done">🎉 ${this._t("family_goal.reached", { reward: goal.reward || "" })}</div>`
             : goal.reward
-              ? html`<div class="reward">${this._t("family_goal.reward_label", { reward: goal.reward })}</div>`
+              ? html`<div class="fg-reward">${this._t("family_goal.reward_label", { reward: goal.reward })}</div>`
               : ""}
         </div>
       </ha-card>
@@ -82,18 +107,48 @@ class TaskMateFamilyGoalCard extends LitElement {
   }
 
   static get styles() {
-    return css`
-      .head { display: flex; align-items: center; gap: 8px; padding: 14px 16px 6px; font-weight: 600; }
-      .head ha-icon { color: var(--tm-goal-accent); }
-      .body { padding: 4px 16px 16px; }
-      .bar { height: 14px; border-radius: 8px; background: var(--secondary-background-color, #eee); overflow: hidden; }
-      .fill { height: 100%; background: var(--tm-goal-accent); transition: width .4s ease; }
-      .fill.done { background: #d4ac0d; }
-      .stats { display: flex; justify-content: space-between; font-size: 0.82rem; color: var(--secondary-text-color); margin-top: 6px; }
-      .reward { margin-top: 8px; font-size: 0.85rem; color: var(--primary-text-color); }
-      .reward.done { font-weight: 600; color: #d4ac0d; }
-      .empty { display: flex; flex-direction: column; align-items: center; gap: 8px; padding: 28px 16px; color: var(--secondary-text-color); }
+    // Layout classes carry an fg- prefix because the shared design kit defines
+    // its own .bar (and .stat / .grid / …); a bare .bar here would pick up the
+    // kit's rules under a designed style.
+    const base = css`
+      :host { --fg-accent: var(--tmd-accent, #16a085); }
+      ha-card {
+        overflow: hidden;
+        background: var(--tmd-surface, var(--ha-card-background, var(--card-background-color, #fff)));
+        color: var(--tmd-text, var(--primary-text-color));
+        border-radius: var(--tmd-radius, var(--ha-card-border-radius, 12px));
+        font-family: var(--tmd-font-body, inherit);
+      }
+      .fg-head {
+        display: flex; align-items: center; gap: 8px;
+        padding: 14px 16px 6px; font-weight: 600;
+        font-family: var(--tmd-font-display, inherit);
+      }
+      .fg-head ha-icon { color: var(--fg-accent); }
+      .fg-body { padding: 4px 16px 16px; }
+      .fg-bar {
+        height: 14px; border-radius: var(--tmd-radius-sm, 8px);
+        background: var(--tmd-surface-2, var(--secondary-background-color, #eee));
+        border: 1px solid var(--tmd-border, transparent);
+        box-sizing: border-box;
+        overflow: hidden;
+      }
+      .fg-fill { height: 100%; background: var(--fg-accent); transition: width .4s ease; }
+      .fg-fill.done { background: var(--tmd-gold, #d4ac0d); }
+      .fg-stats {
+        display: flex; justify-content: space-between;
+        font-size: 0.82rem; color: var(--tmd-dim, var(--secondary-text-color)); margin-top: 6px;
+      }
+      .fg-reward { margin-top: 8px; font-size: 0.85rem; color: var(--tmd-text, var(--primary-text-color)); }
+      .fg-reward.done { font-weight: 600; color: var(--tmd-gold, #d4ac0d); }
+      .fg-empty {
+        display: flex; flex-direction: column; align-items: center; gap: 8px;
+        padding: 28px 16px; color: var(--tmd-dim, var(--secondary-text-color));
+      }
     `;
+    const tokens = window.__taskmate_design && window.__taskmate_design.styles
+      ? window.__taskmate_design.styles() : null;
+    return tokens ? [tokens, base] : base;
   }
 }
 

--- a/custom_components/taskmate/www/taskmate-photo-gallery-card.js
+++ b/custom_components/taskmate/www/taskmate-photo-gallery-card.js
@@ -4,6 +4,10 @@
  * `photo_gallery` attribute and renders thumbnails. A card's <img> can't send a
  * bearer token, so each photo path is signed via the `auth/sign_path` WS command
  * before use.
+ *
+ * Single layout, so it consumes the design tokens directly (like the routine
+ * card). Every --tmd-* reference has the card's original value as its fallback,
+ * so classic — which defines no tokens — renders exactly as it did before.
  */
 
 const LitElement = customElements.get("hui-masonry-view")
@@ -14,6 +18,7 @@ const html = LitElement.prototype.html;
 const css = LitElement.prototype.css;
 
 const _safeColor = (c, d) => (typeof c === "string" && /^#[0-9a-fA-F]{3,8}$/.test(c) ? c : d);
+const DEFAULT_ACCENT = "#5d6d7e";
 
 class TaskMatePhotoGalleryCard extends LitElement {
   static get properties() {
@@ -44,6 +49,25 @@ class TaskMatePhotoGalleryCard extends LitElement {
   _t(key, params) {
     const fn = window.__taskmate_localize;
     return fn ? fn(this.hass, key, params) : key;
+  }
+
+  /**
+   * Resolve the active design, stamp data-tm-design on the host, and set the
+   * header accent. The accent is an inline host property, not a template
+   * <style>: a shadow tree's <style> is ordered before adoptedStyleSheets, so
+   * it loses to the :host default in static styles(). Header stays full-colour
+   * in every style per the house rule.
+   */
+  _applyDesign() {
+    if (window.__taskmate_design) {
+      window.__taskmate_design.apply(this, this.hass, this.config, this.config.entity);
+    }
+    const configured = this.config.header_color;
+    if (typeof configured === "string" && /^#[0-9a-fA-F]{3,8}$/.test(configured)) {
+      this.style.setProperty("--pg-accent", _safeColor(configured, DEFAULT_ACCENT));
+    } else {
+      this.style.removeProperty("--pg-accent");
+    }
   }
 
   // Open the shared in-page lightbox; fall through to the href if it's absent.
@@ -85,22 +109,22 @@ class TaskMatePhotoGalleryCard extends LitElement {
 
   render() {
     if (!this.hass || !this.config) return html``;
+    this._applyDesign();
     const entity = this.hass.states[this.config.entity];
     if (!entity) {
-      return html`<ha-card><div class="empty"><ha-icon icon="mdi:alert-circle"></ha-icon><div>${this._t("common.entity_not_found", { entity: this.config.entity })}</div></div></ha-card>`;
+      return html`<ha-card><div class="pg-empty"><ha-icon icon="mdi:alert-circle"></ha-icon><div>${this._t("common.entity_not_found", { entity: this.config.entity })}</div></div></ha-card>`;
     }
     const items = this._gallery();
     return html`
       <ha-card>
-        <style>:host { --tm-gallery-header: ${_safeColor(this.config.header_color, "#5d6d7e")}; }</style>
-        <div class="card-header" style="background: var(--tm-gallery-header);">
+        <div class="pg-head">
           <ha-icon icon="mdi:image-multiple"></ha-icon>
           <span>${this.config.title || this._t("gallery.default_title")}</span>
         </div>
         ${items.length === 0
-          ? html`<div class="empty"><ha-icon icon="mdi:camera-off"></ha-icon><div>${this._t("gallery.empty")}</div></div>`
+          ? html`<div class="pg-empty"><ha-icon icon="mdi:camera-off"></ha-icon><div>${this._t("gallery.empty")}</div></div>`
           : html`
-            <div class="grid">
+            <div class="pg-grid">
               ${items.map((it) => this._tile(it))}
             </div>`}
       </ha-card>
@@ -111,12 +135,12 @@ class TaskMatePhotoGalleryCard extends LitElement {
     const src = this._signed[it.photo_url];
     const when = this._formatDate(it.completed_at);
     return html`
-      <div class="tile" title="${it.chore_name} — ${it.child_name}">
+      <div class="pg-tile" title="${it.chore_name} — ${it.child_name}">
         ${src
           ? html`<a href="${src}" target="_blank" rel="noopener"
               @click="${(e) => this._openPhoto(e, src, [it.chore_name, it.child_name, when].filter(Boolean).join(" · "))}"><img src="${src}" alt="${it.chore_name}" loading="lazy"></a>`
-          : html`<div class="ph"><ha-icon icon="mdi:image"></ha-icon></div>`}
-        <div class="cap">
+          : html`<div class="pg-ph"><ha-icon icon="mdi:image"></ha-icon></div>`}
+        <div class="pg-cap">
           <span class="who">${it.child_name}</span>
           <span class="what">${it.chore_name}</span>
           <span class="when">${when}${it.approved ? "" : " · " + this._t("gallery.pending")}</span>
@@ -134,27 +158,51 @@ class TaskMatePhotoGalleryCard extends LitElement {
   }
 
   static get styles() {
-    return css`
-      ha-card { overflow: hidden; }
-      .card-header {
-        display: flex; align-items: center; gap: 8px;
-        padding: 12px 16px; color: #fff; font-weight: 600;
+    // Layout classes carry a pg- prefix because the shared design kit defines
+    // its own .grid; a bare .grid here would pick up the kit's rules under a
+    // designed style. Base styles come after the kit in static styles(), so
+    // they win at equal specificity.
+    const base = css`
+      :host { --pg-accent: var(--tmd-accent, #5d6d7e); }
+      ha-card {
+        overflow: hidden;
+        background: var(--tmd-surface, var(--ha-card-background, var(--card-background-color, #fff)));
+        color: var(--tmd-text, var(--primary-text-color));
+        border-radius: var(--tmd-radius, var(--ha-card-border-radius, 12px));
+        font-family: var(--tmd-font-body, inherit);
       }
-      .grid {
+      .pg-head {
+        display: flex; align-items: center; gap: 8px;
+        padding: 12px 16px; color: var(--tmd-hd-text, #fff); font-weight: 600;
+        background: var(--pg-accent);
+        font-family: var(--tmd-font-display, inherit);
+      }
+      .pg-grid {
         display: grid; gap: 10px; padding: 14px;
         grid-template-columns: repeat(auto-fill, minmax(110px, 1fr));
       }
-      .tile { display: flex; flex-direction: column; border-radius: 8px; overflow: hidden; background: var(--secondary-background-color, #f5f5f5); }
-      .tile img, .tile .ph {
+      .pg-tile {
+        display: flex; flex-direction: column;
+        border-radius: var(--tmd-radius-sm, 8px); overflow: hidden;
+        background: var(--tmd-surface-2, var(--secondary-background-color, #f5f5f5));
+        border: 1px solid var(--tmd-border, transparent);
+      }
+      .pg-tile img, .pg-tile .pg-ph {
         width: 100%; aspect-ratio: 1 / 1; object-fit: cover; display: block;
       }
-      .tile .ph { display: flex; align-items: center; justify-content: center; color: var(--secondary-text-color); }
-      .cap { padding: 6px 8px; display: flex; flex-direction: column; gap: 1px; font-size: 0.72rem; }
-      .cap .who { font-weight: 600; }
-      .cap .what { color: var(--primary-text-color); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-      .cap .when { color: var(--secondary-text-color); }
-      .empty { display: flex; flex-direction: column; align-items: center; gap: 8px; padding: 32px 16px; color: var(--secondary-text-color); }
+      .pg-tile .pg-ph { display: flex; align-items: center; justify-content: center; color: var(--tmd-dim, var(--secondary-text-color)); }
+      .pg-cap { padding: 6px 8px; display: flex; flex-direction: column; gap: 1px; font-size: 0.72rem; }
+      .pg-cap .who { font-weight: 600; }
+      .pg-cap .what { color: var(--tmd-text, var(--primary-text-color)); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+      .pg-cap .when { color: var(--tmd-dim, var(--secondary-text-color)); }
+      .pg-empty {
+        display: flex; flex-direction: column; align-items: center; gap: 8px;
+        padding: 32px 16px; color: var(--tmd-dim, var(--secondary-text-color));
+      }
     `;
+    const tokens = window.__taskmate_design && window.__taskmate_design.styles
+      ? window.__taskmate_design.styles() : null;
+    return tokens ? [tokens, base] : base;
   }
 }
 

--- a/tests/test_all_cards_use_design_system.py
+++ b/tests/test_all_cards_use_design_system.py
@@ -1,0 +1,68 @@
+"""Every shipped Lovelace card must wire into the per-card design system.
+
+The photo-gallery and family-goal cards shipped ignoring `card_design`
+entirely (issue #725) — the same gap the routine card had (#721). Nothing
+failed; the cards just rendered identically under every style. This guard
+makes a card that skips the design layer a test failure rather than a
+silently-inconsistent card discovered months later.
+
+The check is structural (grep over source) because the behaviour is invisible
+to a functional test — a card that ignores the design tokens renders perfectly,
+just always in the classic look.
+"""
+from __future__ import annotations
+
+import pathlib
+
+WWW = pathlib.Path(__file__).resolve().parent.parent / "custom_components" / "taskmate" / "www"
+
+# Cards that legitimately do not reference __taskmate_design directly:
+#   the two incentive wrappers delegate their whole render to
+#   createIncentiveCard(), which lives in taskmate-incentive-card.js and does
+#   wire the design system.
+_WRAPPER_EXEMPT = {"taskmate-bonuses-card.js", "taskmate-penalties-card.js"}
+
+
+def _card_files() -> list[pathlib.Path]:
+    return sorted(WWW.glob("taskmate-*-card.js"))
+
+
+def test_there_are_card_files_to_check():
+    assert _card_files(), "expected to find *-card.js files"
+
+
+def test_every_card_wires_the_design_system():
+    missing = []
+    for f in _card_files():
+        src = f.read_text(encoding="utf-8")
+        if f.name in _WRAPPER_EXEMPT:
+            # Must actually be a thin wrapper, or the exemption is a lie.
+            assert "createIncentiveCard" in src, f"{f.name} is exempt but not a wrapper"
+            continue
+        if "__taskmate_design" not in src:
+            missing.append(f.name)
+    assert missing == [], (
+        f"these cards never reference the design system, so they ignore "
+        f"card_design and render identically under every style: {missing}"
+    )
+
+
+def test_cards_that_name_the_design_layer_actually_use_it():
+    """A card that mentions __taskmate_design but never resolves or applies a
+    design, nor pulls in the token styles, is not really wired in."""
+    offenders = []
+    for f in _card_files():
+        if f.name in _WRAPPER_EXEMPT:
+            continue
+        src = f.read_text(encoding="utf-8")
+        if "__taskmate_design" not in src:
+            continue
+        uses_it = (
+            ".styles()" in src
+            or "editorOptions" in src
+            or ".apply(" in src
+            or ".resolve(" in src
+        )
+        if not uses_it:
+            offenders.append(f.name)
+    assert offenders == [], f"cards that name the design layer but never use it: {offenders}"

--- a/tests/test_avatars.py
+++ b/tests/test_avatars.py
@@ -95,3 +95,41 @@ def test_update_catalog_filters_iconless_rows():
     assert len(cat) == 1
     assert cat[0]["icon"] == "mdi:star"
     assert cat[0]["unlock_value"] == 4
+
+
+class TestAvatarPickerOnEveryDesign:
+    """The avatar picker was wired into the classic child-card only.
+
+    `render()` (classic) makes the avatar clickable and renders
+    `_renderAvatarPicker`. `_renderDesigned` builds its header with `_av(...)`,
+    a plain non-interactive element, and never opens the picker — so on
+    playroom / console / cleanpro / accessible, tapping the avatar does
+    nothing even though the same feature works on classic.
+    """
+
+    import pathlib as _pathlib
+
+    SOURCE = (
+        _pathlib.Path(__file__).resolve().parent.parent
+        / "custom_components" / "taskmate" / "www" / "taskmate-child-card.js"
+    ).read_text(encoding="utf-8")
+
+    def _designed_region(self) -> str:
+        start = self.SOURCE.index("_renderDesigned(design) {")
+        end = self.SOURCE.index("\n  _designChoreMeta(", start)
+        return self.SOURCE[start:end]
+
+    def test_classic_opens_the_picker(self):
+        classic = self.SOURCE[self.SOURCE.index("  render() {"):self.SOURCE.index("_renderDesigned(design) {")]
+        assert "_toggleAvatarPicker()" in classic
+        assert "_renderAvatarPicker(" in classic
+
+    def test_designed_header_opens_the_picker(self):
+        region = self._designed_region()
+        assert "_toggleAvatarPicker()" in region, (
+            "the designed header never wires the avatar to the picker, so it "
+            "does nothing on any style but classic"
+        )
+
+    def test_designed_header_renders_the_picker(self):
+        assert "_renderAvatarPicker(" in self._designed_region()


### PR DESCRIPTION
Resolves the two card-design gaps left open after the earlier passes, both reproduced on the dev instance first.

## Photo gallery and family goal ignored `card_design` (#725)

Neither card referenced the design system — no `data-tm-design` stamp, no tokens — so both rendered identically under every style, confirmed live: header background and stamp identical across classic/playroom/accessible.

Both are single-layout cards, so they consume the tokens directly like the routine card. Every `--tmd-*` has the card's original value as its fallback, so **classic is byte-for-byte unchanged** — photo gallery keeps its slate-grey header, family goal keeps its teal bar and its header-less layout (that card never had a coloured banner; only the icon and bar are accented, and they now follow the design).

Layout classes are prefixed `pg-` / `fg-` because the shared kit defines its own `.grid` and `.bar`, which would otherwise capture these cards' elements under a designed style — the same collision the routine card hit.

| | classic | playroom | console | cleanpro | accessible |
|---|---|---|---|---|---|
| photo-gallery header | slate (unchanged) | purple | cyan | indigo | Okabe-Ito blue |
| family-goal accent | teal (unchanged) | purple | cyan | indigo | blue |

## Avatar picker only worked on classic (#730)

The classic header makes the avatar `.avatar-container` tappable (`@click=_toggleAvatarPicker`) and renders the picker. The designed header built a plain `_av()` with no handler, so on the four designed styles tapping the avatar did nothing. Reproduced live: picker opened on classic only.

The designed header now wraps the avatar the same way — same eligibility (`allow_avatar_change` + more than one unlocked option), same `_renderAvatarPicker`, with an edit dot in the active design's accent. Verified: picker opens under all four designed styles.

## Two non-bugs, confirmed not bugs

While reproducing, I checked the two things I had earlier called *inconclusive* rather than claim as broken:

- **Bonus sub-tasks** render fine in the designed path via `_designBonus()` — my earlier probe never completed the parent chore, so the subtasks were correctly locked. Not a bug.
- The three classic-only helpers (`_renderChoreCard` / `_renderTimedChoreCard` / `_renderEmptyState`) are classic-only *by design* — the designed path has its own row builders.

## Guard test

`test_all_cards_use_design_system.py` asserts every shipped `*-card.js` wires the design system (the two incentive wrappers are exempt because they delegate to `createIncentiveCard`, which does). It fails on `main` for photo-gallery and family-goal — so the next un-wired card is a failing test, not a months-later discovery. This is the check that would have caught #721, #725, #727, #729 and #730 up front.

## Verification

ha-dev across all five designs, with screenshots. `scripts/screenshots/check-cards.js` reports zero console errors and no regressions on the other cards. Full suite: 1384 passed, same 3 failures + 9 errors that pre-exist on `main` from test-order pollution.

Fixes #725
Fixes #730