### PR TITLE
chore(release): v5.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1819,6 +1819,18 @@ Beyond the sensors above, TaskMate also exposes:
  
 ## Changelog
  
+### v5.0.1
+ 
+A bug-fix release. All of v5.0.0's new features work as documented; upgrade is drop-in with no configuration changes.
+
+**Fixes**
+- **The admin panel's Audit log is reachable again** — the Audit view was fully built but missing from the sidebar navigation, so there was no way to open it. It now appears in the panel's **System** group. ([#726](https://github.com/tempus2016/taskmate/pull/726))
+- **Narrow-width layout fixes in the admin panel** — on a phone the Parent Dashboard card lost its **Points** tab off the edge (it now wraps), entity-id chips tore across two lines (they now truncate cleanly), and the pending-approvals pill is a larger tap target. ([#726](https://github.com/tempus2016/taskmate/pull/726))
+- **Chore roulette now shows on every card design** — the spin button rendered on the Classic child card only. It now appears under Playroom, Console, Clean Pro and Accessible too, taking each design's accent colour. ([#728](https://github.com/tempus2016/taskmate/pull/728))
+- **Pre-reader mode now works on every card design** — `pre_reader: true` was silently ignored on any style but Classic. The picture tiles now render under all five designs, so pre-reader pairs correctly with the Accessible style. ([#728](https://github.com/tempus2016/taskmate/pull/728))
+- **The Photo Gallery and Family Goal cards now follow `card_design`** — both cards ignored the design setting and always rendered in the Classic look. They now take the active design's colours and fonts like every other card. ([#731](https://github.com/tempus2016/taskmate/pull/731))
+- **The avatar picker works on every card design** — tapping a child's avatar to switch it worked on the Classic child card only. It now opens under all five designs. ([#731](https://github.com/tempus2016/taskmate/pull/731))
+ 
 ### v5.0.0
  
 The largest release so far: fourteen new features across chores, rewards, cards, notifications and the admin panel. Nothing is removed and no configuration changes — existing setups upgrade untouched. The major version marks the size of the addition, not a breaking change.

--- a/custom_components/taskmate/manifest.json
+++ b/custom_components/taskmate/manifest.json
@@ -17,5 +17,5 @@
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/tempus2016/taskmate/issues",
   "requirements": [],
-  "version": "5.0.0"
+  "version": "5.0.1"
 }


### PR DESCRIPTION
Bumps `manifest.json` to **5.0.1** and adds the changelog entry.

A bug-fix release. All of v5.0.0's features work as documented; upgrade is drop-in with no configuration changes.

## What is fixed (all merged since v5.0.0)

- **Audit view reachable** (#726) — it was fully built but missing from the sidebar nav, so it could not be opened. Now in the panel's System group.
- **Narrow-width panel faults** (#726) — Parent Dashboard card lost its Points tab off the edge (now wraps); entity-id chips tore across two lines (now truncate); pending-approvals pill enlarged to a usable tap target.
- **Chore roulette on every design** (#728) — rendered on Classic only; now under all five, in each design's accent.
- **Pre-reader mode on every design** (#728) — `pre_reader: true` was ignored except on Classic; tiles now render under all five, so it pairs with Accessible.
- **Photo Gallery + Family Goal follow `card_design`** (#731) — both ignored the setting; now take the active design's colours and fonts.
- **Avatar picker on every design** (#731) — worked on Classic only; now opens under all five.

## Release gate

- Full suite on main: **1384 passed**; the 3 failures + 9 errors are the known pre-existing test-order-pollution baseline (they pass in isolation, unchanged from `main`).
- Ruff clean, ESLint 0 errors, every card JS parses.
- All three PRs were individually verified on the ha-dev instance across all five card designs, with screenshots and zero console errors, before merge.

No new websocket commands, services, entities or settings — nothing to smoke-test beyond what each PR already covered.