### PR TITLE
chore(release): v5.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1819,6 +1819,15 @@ Beyond the sensors above, TaskMate also exposes:
  
 ## Changelog
  
+### v5.0.2
+ 
+Adds a navigation target to notifications, so tapping one opens a place of your choosing.
+
+**New**
+- **Tap a notification to jump straight to a screen** — TaskMate mobile notifications now carry a navigation target. Set a global default under **Notifications → When tapped, open** (defaults to the TaskMate panel, `/taskmate`), and override it per notification type — for example, send pending-approval alerts straight to a parents' approval dashboard. Accepts a Lovelace path like `/taskmate` or `/lovelace/parents`, a full URL, or `noAction` to disable navigation. Works on the Home Assistant companion app (Android `clickAction` + iOS `url`) and sits alongside the existing Approve/Reject buttons. Strings are translated into all supported languages. ([#735](https://github.com/tempus2016/taskmate/pull/735), closes [#734](https://github.com/tempus2016/taskmate/issues/734))
+
+**Note on upgrade:** notification taps now open the TaskMate panel (`/taskmate`) by default. If you preferred the previous behaviour (open wherever the app was last), clear the **When tapped, open** field or set it to `noAction`.
+
 ### v5.0.1
  
 A bug-fix release. All of v5.0.0's new features work as documented; upgrade is drop-in with no configuration changes.

--- a/custom_components/taskmate/manifest.json
+++ b/custom_components/taskmate/manifest.json
@@ -17,5 +17,5 @@
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/tempus2016/taskmate/issues",
   "requirements": [],
-  "version": "5.0.1"
+  "version": "5.0.2"
 }


### PR DESCRIPTION
Bumps the manifest to **5.0.2** and adds the README changelog entry for the notification tap-navigation feature merged in #735.

Closes #734 (tracking); the feature code landed in #735.

No code changes beyond the version bump + changelog.