### PR TITLE
fix(notifications): point tap default at /taskmate-admin and vet tap targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1824,9 +1824,9 @@ Beyond the sensors above, TaskMate also exposes:
 Adds a navigation target to notifications, so tapping one opens a place of your choosing.
 
 **New**
-- **Tap a notification to jump straight to a screen** — TaskMate mobile notifications now carry a navigation target. Set a global default under **Notifications → When tapped, open** (defaults to the TaskMate panel, `/taskmate`), and override it per notification type — for example, send pending-approval alerts straight to a parents' approval dashboard. Accepts a Lovelace path like `/taskmate` or `/lovelace/parents`, a full URL, or `noAction` to disable navigation. Works on the Home Assistant companion app (Android `clickAction` + iOS `url`) and sits alongside the existing Approve/Reject buttons. Strings are translated into all supported languages. ([#735](https://github.com/tempus2016/taskmate/pull/735), closes [#734](https://github.com/tempus2016/taskmate/issues/734))
+- **Tap a notification to jump straight to a screen** — TaskMate mobile notifications now carry a navigation target. Set a global default under **Notifications → When tapped, open** (defaults to the TaskMate panel, `/taskmate-admin`), and override it per notification type — for example, send pending-approval alerts straight to a parents' approval dashboard. Accepts a Lovelace path like `/taskmate-admin` or `/lovelace/parents`, a full URL, or `noAction` to disable navigation. Works on the Home Assistant companion app (Android `clickAction` + iOS `url`) and sits alongside the existing Approve/Reject buttons. Strings are translated into all supported languages. ([#735](https://github.com/tempus2016/taskmate/pull/735), closes [#734](https://github.com/tempus2016/taskmate/issues/734))
 
-**Note on upgrade:** notification taps now open the TaskMate panel (`/taskmate`) by default. If you preferred the previous behaviour (open wherever the app was last), clear the **When tapped, open** field or set it to `noAction`.
+**Note on upgrade:** notification taps now open the TaskMate panel (`/taskmate-admin`) by default. If you preferred the previous behaviour (open wherever the app was last), clear the **When tapped, open** field or set it to `noAction`.
 
 ### v5.0.1
  

--- a/custom_components/taskmate/const.py
+++ b/custom_components/taskmate/const.py
@@ -392,3 +392,7 @@ NOTIF_TYPE_MANDATORY_PARENT_ALERT:  Final = "mandatory_parent_alert"
 NOTIF_TYPE_MONTHLY_REPORT:          Final = "monthly_report"
 NOTIF_TYPE_SEASON_CHAMPION:         Final = "season_champion"
 NOTIF_TYPE_FAMILY_GOAL_REACHED:     Final = "family_goal_reached"
+
+# Default notification tap target. Must match PANEL_URL_PATH in panel.py —
+# a bare /taskmate is the static-files prefix and returns 403, not the panel.
+DEFAULT_NOTIFICATION_NAV_URL:       Final = "/taskmate-admin"

--- a/custom_components/taskmate/coord_notifications.py
+++ b/custom_components/taskmate/coord_notifications.py
@@ -19,6 +19,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.event import async_track_time_change
 
 from .const import (
+    DEFAULT_NOTIFICATION_NAV_URL,
     NOTIF_TYPE_ALL_CHORES_DONE,
     NOTIF_TYPE_BADGE_EARNED,
     NOTIF_TYPE_BEDTIME_REMINDER,
@@ -86,6 +87,27 @@ NOTIFICATION_TYPES: list[NotificationTypeMeta] = [
 NOTIFICATION_TYPES_BY_ID: dict[str, NotificationTypeMeta] = {
     t.id: t for t in NOTIFICATION_TYPES
 }
+
+
+def _validate_nav_url(value: str) -> str:
+    """Normalise and vet a notification tap target.
+
+    The tap target is opened on the *recipient's* device, so only dashboard
+    paths, web URLs and the companion app's noAction sentinel are allowed —
+    never intent:// / app:// / homeassistant:// style deep links.
+    """
+    value = (value or "").strip()
+    if value in ("", "noAction"):
+        return value
+    if value.lower().startswith(("http://", "https://")):
+        return value
+    if (
+        value.startswith("/")
+        and not value.startswith("//")
+        and not any(ord(c) <= 32 or ord(c) == 127 for c in value)
+    ):
+        return value
+    raise ValueError("nav_url must be a /path, an http(s) URL, or noAction")
 
 
 def _parse_hhmm(value: str) -> tuple[int, int] | None:
@@ -315,7 +337,11 @@ class NotificationCoordinator:
         per_type = (getattr(cfg, "nav_url", "") or "").strip()
         if per_type:
             return per_type
-        return str(self.storage.get_setting("notification_nav_url", "/taskmate") or "").strip()
+        return str(
+            self.storage.get_setting(
+                "notification_nav_url", DEFAULT_NOTIFICATION_NAV_URL
+            ) or ""
+        ).strip()
 
     def _resolve_notify_service(self, recipient_id: str) -> str:
         if recipient_id.startswith("child:"):
@@ -711,8 +737,10 @@ class NotificationCoordinator:
 
     async def set_nav_url(self, type_id: str | None, nav_url: str) -> None:
         """Set the tap target — global (type_id falsy) or per notification type."""
-        nav_url = (nav_url or "").strip()
+        nav_url = _validate_nav_url(nav_url)
         if type_id:
+            if type_id not in NOTIFICATION_TYPES_BY_ID:
+                raise ValueError(f"Unknown notification type {type_id}")
             self.storage.set_notification_nav_url(type_id, nav_url)
         else:
             self.storage.set_setting("notification_nav_url", nav_url)

--- a/custom_components/taskmate/storage.py
+++ b/custom_components/taskmate/storage.py
@@ -8,7 +8,7 @@ from typing import Any
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.storage import Store
 
-from .const import DOMAIN
+from .const import DEFAULT_NOTIFICATION_NAV_URL, DOMAIN
 from .models import (
     AwardedBadge,
     Badge,
@@ -130,6 +130,8 @@ class TaskMateStorage:
         if "notifications_migration_done" not in self._data:
             self._run_notifications_migration()
             self._data["notifications_migration_done"] = True
+
+        self._migrate_nav_url_default()
 
         # Badge migration / seeding
         self._seed_builtin_badges(is_fresh=is_fresh)
@@ -663,6 +665,20 @@ class TaskMateStorage:
 
         if is_fresh:
             self._data["badges_backfill_pending"] = True
+
+    def _migrate_nav_url_default(self) -> None:
+        """Rewrite the broken v5.0.2 notification tap target.
+
+        v5.0.2 shipped "/taskmate" as the default, but the panel lives at
+        /taskmate-admin (/taskmate is the static-files prefix and 403s), so a
+        persisted "/taskmate" is broken for every install. Idempotent.
+        """
+        settings = self._data.get("settings", {}) or {}
+        if settings.get("notification_nav_url") == "/taskmate":
+            settings["notification_nav_url"] = DEFAULT_NOTIFICATION_NAV_URL
+        for cfg in (self._data.get("notification_config", {}) or {}).values():
+            if isinstance(cfg, dict) and cfg.get("nav_url") == "/taskmate":
+                cfg["nav_url"] = DEFAULT_NOTIFICATION_NAV_URL
 
     def _run_notifications_migration(self) -> None:
         """Seed parent_recipients + notification_config from legacy notify_service.

--- a/custom_components/taskmate/websocket.py
+++ b/custom_components/taskmate/websocket.py
@@ -57,7 +57,13 @@ from homeassistant.components import websocket_api
 from homeassistant.core import HomeAssistant
 
 from . import photos
-from .const import DEFAULT_TIME_PERIODS, DOMAIN, MAX_TIME_PERIODS, TIME_CATEGORY_ICONS
+from .const import (
+    DEFAULT_NOTIFICATION_NAV_URL,
+    DEFAULT_TIME_PERIODS,
+    DOMAIN,
+    MAX_TIME_PERIODS,
+    TIME_CATEGORY_ICONS,
+)
 from .coordinator import TaskMateCoordinator
 from .models import BonusSubTask, Reward
 
@@ -1910,7 +1916,9 @@ async def ws_notif_get_state(hass, connection, msg, coordinator):
             "streak_at_risk_cutoff_time": c.storage.get_streak_at_risk_cutoff(),
             "mandatory_escalation_reminder_minutes": c.storage.get_escalation_reminder_minutes(),
             "mandatory_escalation_parent_minutes": c.storage.get_escalation_parent_minutes(),
-            "notification_nav_url": c.storage.get_setting("notification_nav_url", "/taskmate"),
+            "notification_nav_url": c.storage.get_setting(
+                "notification_nav_url", DEFAULT_NOTIFICATION_NAV_URL
+            ),
         },
     }
     connection.send_result(msg["id"], state)

--- a/custom_components/taskmate/www/locales/de.json
+++ b/custom_components/taskmate/www/locales/de.json
@@ -867,7 +867,7 @@
   "panel.notif_section_recipients_desc": "Weise jedem Kind und Elternteil einen Home Assistant Benachrichtigungsdienst zu. Leer lassen, um Benachrichtigungen für diese Person zu überspringen.",
   "panel.notif_streak_cutoff_label": "Frist",
   "panel.notif_nav_url_global_label": "Beim Tippen öffnen",
-  "panel.notif_nav_url_global_hint": "Wohin eine angetippte Benachrichtigung führt: ein Pfad wie /taskmate oder /lovelace/parents, eine vollständige URL oder noAction. Gilt für alle Benachrichtigungen, sofern unten nicht pro Typ überschrieben.",
+  "panel.notif_nav_url_global_hint": "Wohin eine angetippte Benachrichtigung führt: ein Pfad wie /taskmate-admin oder /lovelace/parents, eine vollständige URL oder noAction. Gilt für alle Benachrichtigungen, sofern unten nicht pro Typ überschrieben.",
   "panel.notif_nav_url_row_placeholder": "Nutzt globalen Standard",
   "panel.notif_tab_title": "Benachrichtigungen",
   "panel.template_assignment_mode_label": "Zuweisungsmodus",

--- a/custom_components/taskmate/www/locales/en-GB.json
+++ b/custom_components/taskmate/www/locales/en-GB.json
@@ -917,7 +917,7 @@
   "panel.notif_section_recipients_desc": "Map each child and parent to a Home Assistant notify service. Leave blank to skip notifications for that person.",
   "panel.notif_streak_cutoff_label": "Cutoff",
   "panel.notif_nav_url_global_label": "When tapped, open",
-  "panel.notif_nav_url_global_hint": "Where a tapped notification opens: a path like /taskmate or /lovelace/parents, a full URL, or noAction. Applies to all notifications unless overridden per type below.",
+  "panel.notif_nav_url_global_hint": "Where a tapped notification opens: a path like /taskmate-admin or /lovelace/parents, a full URL, or noAction. Applies to all notifications unless overridden per type below.",
   "panel.notif_nav_url_row_placeholder": "Uses global default",
   "panel.notif_send_test": "Send test",
   "panel.notif_test_sent": "Test sent to {count} recipient(s) + persistent notification",

--- a/custom_components/taskmate/www/locales/en.json
+++ b/custom_components/taskmate/www/locales/en.json
@@ -917,7 +917,7 @@
   "panel.notif_section_recipients_desc": "Map each child and parent to a Home Assistant notify service. Leave blank to skip notifications for that person.",
   "panel.notif_streak_cutoff_label": "Cutoff",
   "panel.notif_nav_url_global_label": "When tapped, open",
-  "panel.notif_nav_url_global_hint": "Where a tapped notification opens: a path like /taskmate or /lovelace/parents, a full URL, or noAction. Applies to all notifications unless overridden per type below.",
+  "panel.notif_nav_url_global_hint": "Where a tapped notification opens: a path like /taskmate-admin or /lovelace/parents, a full URL, or noAction. Applies to all notifications unless overridden per type below.",
   "panel.notif_nav_url_row_placeholder": "Uses global default",
   "panel.notif_send_test": "Send test",
   "panel.notif_test_sent": "Test sent to {count} recipient(s) + persistent notification",

--- a/custom_components/taskmate/www/locales/fr.json
+++ b/custom_components/taskmate/www/locales/fr.json
@@ -867,7 +867,7 @@
   "panel.notif_section_recipients_desc": "Associez chaque enfant et parent à un service de notification Home Assistant. Laisser vide pour ignorer les notifications pour cette personne.",
   "panel.notif_streak_cutoff_label": "Limite",
   "panel.notif_nav_url_global_label": "Au toucher, ouvrir",
-  "panel.notif_nav_url_global_hint": "Où mène une notification touchée : un chemin comme /taskmate ou /lovelace/parents, une URL complète ou noAction. S'applique à toutes les notifications sauf remplacement par type ci-dessous.",
+  "panel.notif_nav_url_global_hint": "Où mène une notification touchée : un chemin comme /taskmate-admin ou /lovelace/parents, une URL complète ou noAction. S'applique à toutes les notifications sauf remplacement par type ci-dessous.",
   "panel.notif_nav_url_row_placeholder": "Utilise la valeur globale",
   "panel.notif_tab_title": "Notifications",
   "panel.template_assignment_mode_label": "Mode d'assignation",

--- a/custom_components/taskmate/www/locales/nb.json
+++ b/custom_components/taskmate/www/locales/nb.json
@@ -867,7 +867,7 @@
   "panel.notif_section_recipients_desc": "Koble hvert barn og foresatt til en Home Assistant-varslingstjeneste. La stå tomt for å hoppe over varsler for den personen.",
   "panel.notif_streak_cutoff_label": "Grense",
   "panel.notif_nav_url_global_label": "Ved trykk, åpne",
-  "panel.notif_nav_url_global_hint": "Hvor et trykk på et varsel åpner: en sti som /taskmate eller /lovelace/parents, en full URL, eller noAction. Gjelder alle varsler med mindre det overstyres per type nedenfor.",
+  "panel.notif_nav_url_global_hint": "Hvor et trykk på et varsel åpner: en sti som /taskmate-admin eller /lovelace/parents, en full URL, eller noAction. Gjelder alle varsler med mindre det overstyres per type nedenfor.",
   "panel.notif_nav_url_row_placeholder": "Bruker global standard",
   "panel.notif_tab_title": "Varsler",
   "panel.template_assignment_mode_label": "Tildelingsmodus",

--- a/custom_components/taskmate/www/locales/nn.json
+++ b/custom_components/taskmate/www/locales/nn.json
@@ -867,7 +867,7 @@
   "panel.notif_section_recipients_desc": "Kople kvart born og kvar føresett til ein Home Assistant-varslingsteneste. La stå tomt for å hoppa over varsel for den personen.",
   "panel.notif_streak_cutoff_label": "Grense",
   "panel.notif_nav_url_global_label": "Ved trykk, opne",
-  "panel.notif_nav_url_global_hint": "Kvar eit trykk på eit varsel opnar: ein sti som /taskmate eller /lovelace/parents, ein full URL, eller noAction. Gjeld alle varsel med mindre det vert overstyrt per type nedanfor.",
+  "panel.notif_nav_url_global_hint": "Kvar eit trykk på eit varsel opnar: ein sti som /taskmate-admin eller /lovelace/parents, ein full URL, eller noAction. Gjeld alle varsel med mindre det vert overstyrt per type nedanfor.",
   "panel.notif_nav_url_row_placeholder": "Brukar global standard",
   "panel.notif_tab_title": "Varsel",
   "panel.template_assignment_mode_label": "Tildelingsmodus",

--- a/custom_components/taskmate/www/locales/pt-BR.json
+++ b/custom_components/taskmate/www/locales/pt-BR.json
@@ -867,7 +867,7 @@
   "panel.notif_section_recipients_desc": "Associe cada criança e responsável a um serviço de notificação do Home Assistant. Deixe em branco para pular notificações para essa pessoa.",
   "panel.notif_streak_cutoff_label": "Limite",
   "panel.notif_nav_url_global_label": "Ao tocar, abrir",
-  "panel.notif_nav_url_global_hint": "Para onde uma notificação tocada abre: um caminho como /taskmate ou /lovelace/parents, uma URL completa ou noAction. Aplica-se a todas as notificações, exceto se substituída por tipo abaixo.",
+  "panel.notif_nav_url_global_hint": "Para onde uma notificação tocada abre: um caminho como /taskmate-admin ou /lovelace/parents, uma URL completa ou noAction. Aplica-se a todas as notificações, exceto se substituída por tipo abaixo.",
   "panel.notif_nav_url_row_placeholder": "Usa o padrão global",
   "panel.notif_tab_title": "Notificações",
   "panel.template_assignment_mode_label": "Modo de atribuição",

--- a/custom_components/taskmate/www/locales/pt.json
+++ b/custom_components/taskmate/www/locales/pt.json
@@ -872,7 +872,7 @@
   "panel.notif_section_recipients_desc": "Associe cada criança e encarregado a um serviço de notificação do Home Assistant. Deixe em branco para ignorar notificações para essa pessoa.",
   "panel.notif_streak_cutoff_label": "Limite",
   "panel.notif_nav_url_global_label": "Ao tocar, abrir",
-  "panel.notif_nav_url_global_hint": "Para onde uma notificação tocada abre: um caminho como /taskmate ou /lovelace/parents, um URL completo ou noAction. Aplica-se a todas as notificações, salvo substituição por tipo abaixo.",
+  "panel.notif_nav_url_global_hint": "Para onde uma notificação tocada abre: um caminho como /taskmate-admin ou /lovelace/parents, um URL completo ou noAction. Aplica-se a todas as notificações, salvo substituição por tipo abaixo.",
   "panel.notif_nav_url_row_placeholder": "Usa o padrão global",
   "panel.notif_tab_title": "Notificações",
   "panel.template_assignment_mode_label": "Modo de atribuição",

--- a/custom_components/taskmate/www/taskmate-panel.js
+++ b/custom_components/taskmate/www/taskmate-panel.js
@@ -4599,7 +4599,7 @@ class TaskMatePanel extends HTMLElement {
           <label style="font-weight:500">${this._t("panel.notif_nav_url_global_label")}</label>
           <input type="text" class="tm-input" style="flex:1;min-width:180px"
                  value="${this._esc((ns.settings && ns.settings.notification_nav_url) || "")}"
-                 data-act="notif-set-nav-url-global" placeholder="/taskmate">
+                 data-act="notif-set-nav-url-global" placeholder="/taskmate-admin">
           <div class="tm-meta" style="flex-basis:100%">${this._t("panel.notif_nav_url_global_hint")}</div>
         </div>
         <div class="tm-table-wrap">

--- a/tests/test_notifications_dispatch.py
+++ b/tests/test_notifications_dispatch.py
@@ -236,8 +236,8 @@ async def test_nav_url_global_default_applied(coord, hass):
     coord.storage.set_notification_route("badge_earned", p.id, NotificationRoute(enabled=True))
     await coord.fire("badge_earned", {"child_name": "M", "badge_name": "Star"})
     data = _notify_data(hass)["data"]
-    assert data["clickAction"] == "/taskmate"
-    assert data["url"] == "/taskmate"
+    assert data["clickAction"] == "/taskmate-admin"
+    assert data["url"] == "/taskmate-admin"
 
 
 @pytest.mark.asyncio
@@ -296,5 +296,5 @@ async def test_nav_url_coexists_with_action_buttons(coord, hass):
         "points": 10, "points_name": "Stars",
     })
     data = _notify_data(hass)["data"]
-    assert data["clickAction"] == "/taskmate"
+    assert data["clickAction"] == "/taskmate-admin"
     assert "actions" in data

--- a/tests/test_notifications_storage.py
+++ b/tests/test_notifications_storage.py
@@ -103,5 +103,22 @@ async def test_custom_notification_crud(storage):
 
 @pytest.mark.asyncio
 async def test_set_notification_nav_url(storage):
-    storage.set_notification_nav_url("badge_earned", "/taskmate")
-    assert storage.get_notification_config("badge_earned").nav_url == "/taskmate"
+    storage.set_notification_nav_url("badge_earned", "/taskmate-admin")
+    assert storage.get_notification_config("badge_earned").nav_url == "/taskmate-admin"
+
+
+@pytest.mark.asyncio
+async def test_migration_rewrites_broken_v502_nav_url(hass):
+    s = TaskMateStorage(hass, "navmig")
+    s._data = {
+        "settings": {"notification_nav_url": "/taskmate"},
+        "notification_config": {
+            "badge_earned": {"type_id": "badge_earned", "nav_url": "/taskmate"},
+            "level_up": {"type_id": "level_up", "nav_url": "/lovelace/kids"},
+        },
+    }
+    s._migrate_nav_url_default()
+    assert s._data["settings"]["notification_nav_url"] == "/taskmate-admin"
+    assert s._data["notification_config"]["badge_earned"]["nav_url"] == "/taskmate-admin"
+    # A deliberate non-default choice is left alone
+    assert s._data["notification_config"]["level_up"]["nav_url"] == "/lovelace/kids"

--- a/tests/test_notifications_test_send.py
+++ b/tests/test_notifications_test_send.py
@@ -72,4 +72,4 @@ async def test_send_test_carries_nav_url(coord, hass):
     await coord.send_test("badge_earned")
     calls = [c for c in hass.services.async_call.call_args_list
              if c[0][0] == "notify" and c[0][1].startswith("mobile_app")]
-    assert calls and calls[0][0][2]["data"]["clickAction"] == "/taskmate"
+    assert calls and calls[0][0][2]["data"]["clickAction"] == "/taskmate-admin"

--- a/tests/test_notifications_ws.py
+++ b/tests/test_notifications_ws.py
@@ -323,9 +323,58 @@ async def test_set_nav_url_per_type(setup, hass):
 
 
 @pytest.mark.asyncio
+async def test_set_nav_url_rejects_dangerous_schemes(setup, hass):
+    coord = setup
+    for bad in (
+        "javascript:alert(1)",
+        "intent://scan/#Intent;scheme=zxing;end",
+        "app://com.evil.app",
+        "homeassistant://call_service/light.turn_off",
+        "//evil.example/phish",
+        "ftp://evil.example",
+    ):
+        connection = MagicMock()
+        msg = {"id": 23, "type": "taskmate/notifications/set_nav_url", "nav_url": bad}
+        await ws.ws_notif_set_nav_url(hass, connection, msg)
+        connection.send_result.assert_not_called()
+        args, _ = connection.send_error.call_args
+        assert args[1] == "invalid", bad
+    assert not coord.storage.get_setting("notification_nav_url")
+
+
+@pytest.mark.asyncio
+async def test_set_nav_url_accepts_noaction_and_https(setup, hass):
+    coord = setup
+    connection = MagicMock()
+    msg = {"id": 24, "type": "taskmate/notifications/set_nav_url",
+           "nav_url": "noAction"}
+    await ws.ws_notif_set_nav_url(hass, connection, msg)
+    assert coord.storage.get_setting("notification_nav_url") == "noAction"
+
+    connection = MagicMock()
+    msg = {"id": 25, "type": "taskmate/notifications/set_nav_url",
+           "nav_url": "https://example.com/dash"}
+    await ws.ws_notif_set_nav_url(hass, connection, msg)
+    assert coord.storage.get_setting("notification_nav_url") == "https://example.com/dash"
+
+
+@pytest.mark.asyncio
+async def test_set_nav_url_rejects_unknown_type_id(setup, hass):
+    coord = setup
+    connection = MagicMock()
+    msg = {"id": 26, "type": "taskmate/notifications/set_nav_url",
+           "type_id": "not_a_type", "nav_url": "/lovelace/x"}
+    await ws.ws_notif_set_nav_url(hass, connection, msg)
+    connection.send_result.assert_not_called()
+    args, _ = connection.send_error.call_args
+    assert args[1] == "invalid"
+    assert "not_a_type" not in coord.storage.get_all_notification_configs()
+
+
+@pytest.mark.asyncio
 async def test_get_state_includes_nav_url(setup, hass):
     connection = MagicMock()
     msg = {"id": 22, "type": "taskmate/notifications/get_state"}
     await ws.ws_notif_get_state(hass, connection, msg)
     state = connection.send_result.call_args[0][1]
-    assert state["settings"]["notification_nav_url"] == "/taskmate"
+    assert state["settings"]["notification_nav_url"] == "/taskmate-admin"


### PR DESCRIPTION
Fixes the three findings from the post-v5.0.2 security review of the notification navigation-URL feature (#735).

## What was wrong

1. **The shipped default tap target was broken.** The feature defaulted to `/taskmate`, but the panel is registered at `/taskmate-admin` — `/taskmate` is the static-files prefix and returns 403. Every upgraded install sent notification taps to a dead path, and the new tests locked the wrong value in.
2. **`nav_url` accepted any string.** The value is executed on the *recipient's* device via `clickAction`/`url`, where the companion app honours `intent://`, `app://` and `homeassistant://call_service/...` deep links — an unnecessary phishing/persistence primitive even behind the admin gate.
3. **`type_id` was unvalidated**, letting arbitrary junk keys grow `notification_config` storage.

## Changes

- Default is now `/taskmate-admin`, defined once as `DEFAULT_NOTIFICATION_NAV_URL` in `const.py` and shared by the dispatcher, the WS `get_state` snapshot, the panel placeholder, all eight locale hints and the README.
- One-time storage migration rewrites a persisted `/taskmate` (global or per-type) to `/taskmate-admin`; any deliberately different value is left alone.
- `set_nav_url` now vets the value: dashboard paths (`/...`, protocol-relative `//host` excluded), `http(s)://` URLs, or `noAction` only — everything else raises and surfaces as a WS `invalid` error. Unknown `type_id`s are rejected.
- Tests: updated default assertions plus new coverage for scheme rejection, unknown-`type_id` rejection and the migration.

## Verification

- `pytest tests/` — 1400 passed; the only failures/errors are the 12 pre-existing order-pollution ones on `main`.
- Ruff clean; `node --check` clean on the panel.
- Live on the dev HA over WebSocket: default resolves to `/taskmate-admin`; `javascript:`, `intent://` and an unknown `type_id` are rejected with `invalid`; stored `/taskmate` was migrated to `/taskmate-admin` across a real restart.