### PR TITLE
fix(roles): let TaskMate parents apply bonuses and penalties

### DIFF
--- a/custom_components/taskmate/__init__.py
+++ b/custom_components/taskmate/__init__.py
@@ -306,11 +306,13 @@ async def _async_require_admin(hass: HomeAssistant, call: ServiceCall) -> None:
 async def _async_require_parent(hass: HomeAssistant, call: ServiceCall) -> None:
     """Reject user-initiated calls that aren't from an admin or a TaskMate parent.
 
-    Day-to-day parent actions (approve/reject, gift/adjust points, confirm
-    rewards/allowance, award badges, complete-as-parent) accept non-admin HA
-    users listed in ``parent_user_ids`` (issue #661). Context-less calls
-    (automations, scripts) pass. Structural config stays on
-    ``_async_require_admin``.
+    Day-to-day parent actions (approve/reject, gift/adjust points, apply a
+    bonus or penalty, confirm rewards/allowance, award badges,
+    complete-as-parent) accept non-admin HA users listed in ``parent_user_ids``
+    (issue #661). Context-less calls (automations, scripts) pass. Structural
+    config — including *defining* bonuses and penalties — stays on
+    ``_async_require_admin``; only applying an existing one is a parent action
+    (issue #749).
     """
     if not call.context.user_id:
         return
@@ -1324,7 +1326,7 @@ async def _async_register_services(hass: HomeAssistant) -> None:
     hass.services.async_register(
         DOMAIN,
         SERVICE_REMOVE_POINTS,
-        _admin(handle_remove_points),
+        _parent(handle_remove_points),
         schema=vol.Schema(
             {
                 vol.Required(ATTR_CHILD_ID): cv.string,
@@ -1399,7 +1401,7 @@ async def _async_register_services(hass: HomeAssistant) -> None:
     hass.services.async_register(
         DOMAIN,
         SERVICE_APPLY_PENALTY,
-        _admin(handle_apply_penalty),
+        _parent(handle_apply_penalty),
         schema=vol.Schema({
             vol.Required(ATTR_PENALTY_ID): cv.string,
             vol.Required(ATTR_CHILD_ID): cv.string,
@@ -1443,7 +1445,7 @@ async def _async_register_services(hass: HomeAssistant) -> None:
     hass.services.async_register(
         DOMAIN,
         SERVICE_APPLY_BONUS,
-        _admin(handle_apply_bonus),
+        _parent(handle_apply_bonus),
         schema=vol.Schema({
             vol.Required(ATTR_BONUS_ID): cv.string,
             vol.Required(ATTR_CHILD_ID): cv.string,

--- a/custom_components/taskmate/www/taskmate-incentive-card.js
+++ b/custom_components/taskmate/www/taskmate-incentive-card.js
@@ -466,6 +466,28 @@ export function createIncentiveCard(P) {
       return this._getAttrs().points_name || this._t("common.stars");
     }
 
+    /* ── Roles (#749) ──────────────────────────────────────────────────────
+       Applying an existing bonus/penalty is a day-to-day parent action, so
+       admins *and* TaskMate parents get the Apply buttons. Defining one is
+       structural config, so the manage controls (pencil, add/edit/delete) are
+       admin-only — matching the `_parent` / `_admin` service gates. A child on
+       a shared tablet sees the list with no buttons. */
+
+    _canApply() {
+      return window.__taskmate_is_parent(this.hass);
+    }
+
+    _canManage() {
+      return !!this.hass?.user?.is_admin;
+    }
+
+    _toggleEditMode() {
+      if (!this._canManage()) return;
+      this._editMode = !this._editMode;
+      this._editingBonus = null;
+      this._showNewForm = false;
+    }
+
     _getVisibleBonuses() {
       const child = this._getSelectedChild();
       if (!child) return this._getBonuses();
@@ -482,7 +504,7 @@ export function createIncentiveCard(P) {
 
     async _applyBonus(bonus) {
       const child = this._getSelectedChild();
-      if (!child) return;
+      if (!child || !this._canApply()) return;
       const key = bonus.id;
       if (this._loading[key]) return;
       this._loading = { ...this._loading, [key]: true };
@@ -630,7 +652,7 @@ export function createIncentiveCard(P) {
                 <ha-icon icon="mdi:trash-can-outline"></ha-icon>
               </button>
             </div>
-          ` : html`
+          ` : this._canApply() ? html`
             <button class="apply-btn"
                     ?disabled=${isLoading || !child}
                     @click=${() => this._applyBonus(b)}>
@@ -639,7 +661,7 @@ export function createIncentiveCard(P) {
                 : html`<ha-icon icon="${P.applyIcon}"></ha-icon> ${this._t('common.apply')}`
               }
             </button>
-          `}
+          ` : ""}
         </div>
         ${isEditing ? this._renderEditForm() : ""}
       `;
@@ -745,10 +767,12 @@ export function createIncentiveCard(P) {
               ${bonuses.length ? html`
                 <span class="bonus-count">${bonuses.length}</span>
               ` : ""}
-              <button class="icon-btn ${this._editMode ? "active" : ""}" title="${this._tp('manage_title')}"
-                      @click=${() => { this._editMode = !this._editMode; this._editingBonus = null; this._showNewForm = false; }}>
-                <ha-icon icon="mdi:pencil"></ha-icon>
-              </button>
+              ${this._canManage() ? html`
+                <button class="icon-btn ${this._editMode ? "active" : ""}" title="${this._tp('manage_title')}"
+                        @click=${this._toggleEditMode}>
+                  <ha-icon icon="mdi:pencil"></ha-icon>
+                </button>
+              ` : ""}
             </div>
           </div>
 
@@ -776,7 +800,7 @@ export function createIncentiveCard(P) {
                 `}
             ` : ""}
 
-            ${child && !this._editMode ? html`
+            ${child && !this._editMode && this._canApply() ? html`
               <div style="text-align:center; font-size:0.8rem; color:var(--text-secondary); padding-top:4px;">
                 ${this._tp('applying_to', { childName: child.name, points: child.points, pointsName: this._getPointsName() })}
               </div>
@@ -831,6 +855,7 @@ export function createIncentiveCard(P) {
     }
 
     _designApplyBtn(b, klass) {
+      if (!this._canApply()) return "";
       const child = this._getSelectedChild();
       const isLoading = this._loading[b.id];
       return html`
@@ -955,11 +980,13 @@ export function createIncentiveCard(P) {
           <span class="ic">${icon}</span>
           <span class="tt">${this.config.title || this._tp('default_title')}${
             bonuses.length ? html`<small>${bonuses.length}</small>` : ""}</span>
-          <button class="btn ghost sm" style="margin-left:auto"
-                  title="${this._tp('manage_title')}"
-                  @click=${() => { this._editMode = !this._editMode; this._editingBonus = null; this._showNewForm = false; }}>
-            <ha-icon icon="mdi:pencil"></ha-icon>
-          </button>
+          ${this._canManage() ? html`
+            <button class="btn ghost sm" style="margin-left:auto"
+                    title="${this._tp('manage_title')}"
+                    @click=${this._toggleEditMode}>
+              <ha-icon icon="mdi:pencil"></ha-icon>
+            </button>
+          ` : ""}
         </div>`;
 
       const rows = design === "playroom"
@@ -984,7 +1011,7 @@ export function createIncentiveCard(P) {
                   <ha-icon icon="mdi:plus"></ha-icon> ${this._tp('new_bonus')}
                 </button>`)
           : ""}
-        ${child && !this._editMode
+        ${child && !this._editMode && this._canApply()
           ? html`<div class="d-foot">${this._tp('applying_to', { childName: child.name, points: child.points, pointsName: this._getPointsName() })}</div>`
           : ""}`;
 

--- a/tests/test_service_parent_gate.py
+++ b/tests/test_service_parent_gate.py
@@ -70,3 +70,93 @@ async def test_rejects_unknown_user(monkeypatch):
     _coord_with_parents(["uid-mum"], monkeypatch)
     with pytest.raises(tm.Unauthorized):
         await tm._async_require_parent(_hass(None), _call("uid-ghost"))
+
+
+# ---------------------------------------------------------------------------
+# Which gate each service is actually wired to (#749)
+#
+# The gate function above was correct all along; three day-to-day actions were
+# just never moved onto it, so a TaskMate parent tapping Apply on a bonus got
+# "Failed to perform the action taskmate/apply_bonus. Unauthorized" while the
+# quick +points buttons on the same card worked.
+# ---------------------------------------------------------------------------
+
+
+class _Services:
+    """Capture the registered handler for each service name."""
+
+    def __init__(self):
+        self.handlers = {}
+
+    def async_register(self, domain, name, handler, schema=None):
+        self.handlers[name] = handler
+
+
+async def _handlers(user, parent_ids, monkeypatch):
+    """Register the real services against a fake hass and a fake coordinator."""
+    coordinator = MagicMock()
+    coordinator.storage.get_parent_user_ids = MagicMock(return_value=list(parent_ids))
+    coordinator.async_record_audit = AsyncMock()
+    for method in (
+        "async_apply_bonus", "async_apply_penalty", "async_remove_points",
+        "async_add_bonus", "async_update_bonus", "async_remove_bonus",
+    ):
+        setattr(coordinator, method, AsyncMock())
+    monkeypatch.setattr(tm, "_get_coordinator", lambda hass: coordinator)
+
+    services = _Services()
+    hass = MagicMock()
+    hass.services = services
+    hass.auth.async_get_user = AsyncMock(return_value=user)
+    await tm._async_register_services(hass)
+    return services.handlers, coordinator
+
+
+def _service_call(user_id, data):
+    call = MagicMock()
+    call.context.user_id = user_id
+    call.data = data
+    return call
+
+
+PARENT_ACTIONS = [
+    (tm.SERVICE_APPLY_BONUS, {"bonus_id": "b1", "child_id": "c1"}, "async_apply_bonus"),
+    (tm.SERVICE_APPLY_PENALTY, {"penalty_id": "p1", "child_id": "c1"}, "async_apply_penalty"),
+    (tm.SERVICE_REMOVE_POINTS, {"child_id": "c1", "points": 5, "reason": ""}, "async_remove_points"),
+]
+
+
+@pytest.mark.parametrize(("service", "data", "method"), PARENT_ACTIONS)
+@pytest.mark.asyncio
+async def test_parent_may_apply_incentives(service, data, method, monkeypatch):
+    """A non-admin TaskMate parent can apply a bonus/penalty and deduct points."""
+    mum = MagicMock(is_admin=False)
+    handlers, coordinator = await _handlers(mum, ["uid-mum"], monkeypatch)
+
+    await handlers[service](_service_call("uid-mum", data))
+
+    getattr(coordinator, method).assert_awaited()
+
+
+@pytest.mark.parametrize(("service", "data", "method"), PARENT_ACTIONS)
+@pytest.mark.asyncio
+async def test_non_parent_may_not_apply_incentives(service, data, method, monkeypatch):
+    """A child (non-admin, not a listed parent) is still rejected."""
+    kid = MagicMock(is_admin=False)
+    handlers, coordinator = await _handlers(kid, ["uid-mum"], monkeypatch)
+
+    with pytest.raises(tm.Unauthorized):
+        await handlers[service](_service_call("uid-child", data))
+
+    getattr(coordinator, method).assert_not_awaited()
+
+
+@pytest.mark.parametrize("service", ["add_bonus", "update_bonus", "remove_bonus"])
+@pytest.mark.asyncio
+async def test_defining_incentives_stays_admin_only(service, monkeypatch):
+    """Creating/editing/deleting a bonus is structural config: admin only."""
+    mum = MagicMock(is_admin=False)
+    handlers, _ = await _handlers(mum, ["uid-mum"], monkeypatch)
+
+    with pytest.raises(tm.Unauthorized):
+        await handlers[service](_service_call("uid-mum", {"bonus_id": "b1", "name": "x", "points": 5}))


### PR DESCRIPTION
Fixes #749

## Problem

A non-admin HA user designated as a TaskMate **parent** taps **Apply** on a bonus and gets:

```
Failed to perform the action taskmate/apply_bonus. Unauthorized
```

Issue #661 added the parent role and moved day-to-day parent actions onto the `_parent` service gate, but three were left on the strict `_admin` gate: `apply_bonus`, `apply_penalty`, `remove_points`. The result was inconsistent on a single card — the quick **+points** buttons worked (`add_points` is `_parent`) while **Apply** on any bonus or penalty failed.

Separately, `taskmate-incentive-card.js` (shared base for the Bonuses and Penalties cards) had **no role check at all**. It rendered Apply, the manage pencil and the add/edit/delete controls to every user, including a child on a shared tablet — controls that could only ever error.

## Changes

**Backend** (`custom_components/taskmate/__init__.py`)
- `apply_bonus`, `apply_penalty`, `remove_points`: `_admin` → `_parent`.
- Defining a bonus/penalty (`add_*`, `update_*`, `remove_*`) stays `_admin` — structural config. Applying an existing one is the day-to-day action.
- `_async_require_parent` docstring updated to describe the real split.

**Frontend** (`custom_components/taskmate/www/taskmate-incentive-card.js`)
- `_canApply()` → `window.__taskmate_is_parent()` (admins included) gates the Apply buttons and the "Applying to …" footer.
- `_canManage()` → `hass.user.is_admin` gates the manage pencil and everything behind it.
- `_toggleEditMode()` refuses for non-admins, so edit mode cannot be entered even if the button is reached another way; `_applyBonus()` bails for non-parents.
- Applied on **both** render paths (classic and designed), so the gate holds on all five card designs.

## Tests

`tests/test_service_parent_gate.py` gains wiring tests that register the real services and invoke the captured handlers:
- a non-admin parent can call all three (verified against `main`: these three fail without the fix)
- a non-admin non-parent is still refused
- `add_bonus` / `update_bonus` / `remove_bonus` remain admin-only

Full suite: 1410 passed. The 3 failures + 9 errors in `test_coordinator_logic.py` / `test_templates.py` are the known pre-existing order-pollution set on `main`. Ruff clean.

## ha-dev verification

Backend, over the WebSocket `call_service` path:

| scenario | result | balance |
|---|---|---|
| test user listed in `parent_user_ids` | `success: true` | 208 → 218 (bonus = +10) |
| same user removed from `parent_user_ids` | `Unauthorized` | 218 → 218 |

Card rendered for admin / parent / child across classic, playroom, console, cleanpro and accessible — Apply present for admin+parent only, pencil for admin only, child gets a clean read-only list. No console errors in any of the 15 combinations.