### PR TITLE
fix(badges): detect earned badges from state, not a custom event

### DIFF
--- a/custom_components/taskmate/www/taskmate-attr-resolver.js
+++ b/custom_components/taskmate/www/taskmate-attr-resolver.js
@@ -96,6 +96,23 @@
   window.__taskmate_is_parent = isTaskmateParent;
 
   /**
+   * Stable id of a badge entry from the badges sensor.
+   *
+   * ChildBadgesSensor publishes earned/available entries keyed `badge_id`, but
+   * several card templates were written against `b.id` — undefined on those
+   * entries, so every "is this the badge that was just earned?" test compared
+   * against the string "undefined" and never matched (#752). Read the id
+   * through this helper so both spellings work.
+   */
+  function badgeId(badge) {
+    if (!badge) return "";
+    const id = badge.badge_id != null ? badge.badge_id : badge.id;
+    return id != null ? String(id) : "";
+  }
+
+  window.__taskmate_badge_id = badgeId;
+
+  /**
    * Event-driven update guard for LitElement cards.
    *
    * HA sets a new `hass` object on every card whenever ANY entity changes.

--- a/custom_components/taskmate/www/taskmate-badges-card.js
+++ b/custom_components/taskmate/www/taskmate-badges-card.js
@@ -36,58 +36,54 @@ class TaskMateBadgesCard extends LitElement {
     super();
     this._filterTier = "all";
     this._justEarned = null;
-    this._unsubscribeEvents = null;
-    this._subscribing = false;
+    this._seenBadgeIds = null;
     this._justEarnedTimeout = null;
-  }
-
-  connectedCallback() {
-    super.connectedCallback();
-    this._subscribeEvents();
   }
 
   disconnectedCallback() {
     super.disconnectedCallback();
-    this._unsubscribeEvents?.();
-    this._unsubscribeEvents = null;
     if (this._justEarnedTimeout) {
       clearTimeout(this._justEarnedTimeout);
       this._justEarnedTimeout = null;
     }
   }
 
-  _subscribeEvents() {
-    if (!this.hass) return;
-    if (this._unsubscribeEvents || this._subscribing) return;
-    this._subscribing = true;
-    this.hass.connection.subscribeEvents((event) => {
-      const data = event.data || {};
-      if (data.child_id && this.config?.child_id && String(data.child_id) !== String(this.config.child_id)) return;
-      if (data.badge_id) {
-        this._justEarned = String(data.badge_id);
-        this.requestUpdate();
-        this._justEarnedTimeout = setTimeout(() => {
-          this._justEarned = null;
-          this.requestUpdate();
-        }, 1800);
-      }
-    }, "taskmate_badge_earned").then(unsub => {
-      this._subscribing = false;
-      if (!this.isConnected) {
-        unsub();
-        return;
-      }
-      this._unsubscribeEvents = unsub;
-    }).catch(() => {
-      this._subscribing = false;
-    });
+  /* Newly-earned badges are detected by diffing the badges sensor's `earned`
+     list across hass updates (#752). The card used to subscribe to the custom
+     `taskmate_badge_earned` event, but Home Assistant refuses a custom-event
+     subscription from a non-admin user and logs an error every time — so the
+     highlight never fired for children, and the log filled up. `state_changed`
+     is allowlisted for everyone, so the diff works for every user. */
+  _trackEarnedBadges() {
+    const earned = this.hass?.states?.[this.config?.entity]?.attributes?.earned;
+    if (!Array.isArray(earned)) return false;
+    const ids = new Set(earned.map(b => window.__taskmate_badge_id(b)).filter(Boolean));
+
+    // First observation is the baseline — never flash a badge earned earlier.
+    if (this._seenBadgeIds === null) {
+      this._seenBadgeIds = ids;
+      return false;
+    }
+    const fresh = [...ids].filter(id => !this._seenBadgeIds.has(id));
+    this._seenBadgeIds = ids;
+    if (!fresh.length) return false;
+
+    this._justEarned = fresh[0];
+    clearTimeout(this._justEarnedTimeout);
+    this._justEarnedTimeout = setTimeout(() => {
+      this._justEarned = null;
+      this.requestUpdate();
+    }, 1800);
+    return true;
   }
 
   shouldUpdate(changedProps) {
     if (changedProps.has("hass")) {
-      return window.__taskmate_hasChanged
+      const flashed = this._trackEarnedBadges();
+      const relevant = window.__taskmate_hasChanged
         ? window.__taskmate_hasChanged(changedProps.get("hass"), this.hass, this.config?.entity)
         : true;
+      return flashed || relevant;
     }
     return true;
   }
@@ -557,7 +553,7 @@ class TaskMateBadgesCard extends LitElement {
   }
 
   _renderEarned(b) {
-    const justEarned = this._justEarned && String(this._justEarned) === String(b.id);
+    const justEarned = !!this._justEarned && this._justEarned === window.__taskmate_badge_id(b);
     return html`
       <div class="badge earned tier-${b.tier} ${justEarned ? 'just-earned' : ''}">
         ${b.point_bonus > 0 ? html`<div class="badge-bonus">+${b.point_bonus}</div>` : ''}

--- a/custom_components/taskmate/www/taskmate-child-card.js
+++ b/custom_components/taskmate/www/taskmate-child-card.js
@@ -43,9 +43,11 @@ class TaskMateChildCard extends LitElement {
 
   shouldUpdate(changedProps) {
     if (changedProps.has("hass")) {
-      return window.__taskmate_hasChanged
+      const flashed = this._trackEarnedBadges();
+      const relevant = window.__taskmate_hasChanged
         ? window.__taskmate_hasChanged(changedProps.get("hass"), this.hass, this.config?.entity)
         : true;
+      return flashed || relevant;
     }
     return true;
   }
@@ -66,19 +68,17 @@ class TaskMateChildCard extends LitElement {
     // Badge strip state
     this._earnedBadges = [];
     this._justEarnedBadge = null;
-    this._badgeEventUnsub = null;
-  }
-
-  connectedCallback() {
-    super.connectedCallback();
-    this._subscribeBadgeEvents();
+    this._seenBadgeIds = null;
+    this._justEarnedTimeout = null;
   }
 
   disconnectedCallback() {
     super.disconnectedCallback();
     this._stopTimerTick();
-    this._badgeEventUnsub?.();
-    this._badgeEventUnsub = null;
+    if (this._justEarnedTimeout) {
+      clearTimeout(this._justEarnedTimeout);
+      this._justEarnedTimeout = null;
+    }
     if (this._audioContext) {
       this._audioContext.close().catch(() => {});
       this._audioContext = null;
@@ -118,27 +118,37 @@ class TaskMateChildCard extends LitElement {
     return fn ? fn(this.hass, key, params) : key;
   }
 
-  _subscribeBadgeEvents() {
-    if (this._badgeEventUnsub || this._badgeSubscribing) return;
-    if (!this.hass?.connection) return;
-    this._badgeSubscribing = true;
-    this.hass.connection.subscribeEvents((event) => {
-      const data = event.data || {};
-      const configChild = this.config?.child_id;
-      if (configChild && data.child_id && String(data.child_id) !== String(configChild)) return;
-      if (data.badge_id) {
-        this._justEarnedBadge = String(data.badge_id);
-        this.requestUpdate();
-        setTimeout(() => { this._justEarnedBadge = null; this.requestUpdate(); }, 1800);
-      }
-    }, "taskmate_badge_earned").then(unsub => {
-      this._badgeSubscribing = false;
-      if (!this.isConnected) {
-        unsub();
-        return;
-      }
-      this._badgeEventUnsub = unsub;
-    }).catch(() => { this._badgeSubscribing = false; });
+  /* Newly-earned badges are detected by diffing this child's badges sensor
+     `earned` list across hass updates (#752). The card used to subscribe to the
+     custom `taskmate_badge_earned` event, but Home Assistant refuses a
+     custom-event subscription from a non-admin user — logging an error every
+     time — so the strip never lit up for a child. `state_changed` is
+     allowlisted for everyone, so the diff works for every user. */
+  _trackEarnedBadges() {
+    const attrs = (window.__taskmate_attrs && window.__taskmate_attrs(this.hass, this.config?.entity))
+      || this.hass?.states?.[this.config?.entity]?.attributes || {};
+    const child = (attrs.children || []).find(c => c.id === this.config?.child_id)
+      || (!this.config?.child_id && (attrs.children || [])[0]);
+    const earned = this._resolveBadgesEntity(child)?.attributes?.earned;
+    if (!Array.isArray(earned)) return false;
+    const ids = new Set(earned.map(b => window.__taskmate_badge_id(b)).filter(Boolean));
+
+    // First observation is the baseline — never flash a badge earned earlier.
+    if (this._seenBadgeIds === null) {
+      this._seenBadgeIds = ids;
+      return false;
+    }
+    const fresh = [...ids].filter(id => !this._seenBadgeIds.has(id));
+    this._seenBadgeIds = ids;
+    if (!fresh.length) return false;
+
+    this._justEarnedBadge = fresh[0];
+    clearTimeout(this._justEarnedTimeout);
+    this._justEarnedTimeout = setTimeout(() => {
+      this._justEarnedBadge = null;
+      this.requestUpdate();
+    }, 1800);
+    return true;
   }
 
   _tierColor(tier) {
@@ -2205,7 +2215,7 @@ class TaskMateChildCard extends LitElement {
           <div class="badge-strip" @click=${() => this._openBadgesView()} title="${this._t('badges.label')}">
             <span class="badge-strip-label">${this._t('badges.label')}</span>
             ${earnedBadges.slice(0, 5).map(b => html`
-              <div class="badge-mini tier-${b.tier} ${this._justEarnedBadge && String(this._justEarnedBadge) === String(b.id) ? 'just-earned' : ''}"
+              <div class="badge-mini tier-${b.tier} ${this._justEarnedBadge === window.__taskmate_badge_id(b) ? 'just-earned' : ''}"
                 style="--t: ${this._tierColor(b.tier)}">
                 <ha-icon icon="${b.icon || 'mdi:medal'}"></ha-icon>
               </div>
@@ -2465,7 +2475,7 @@ class TaskMateChildCard extends LitElement {
           <div class="tmd-badges" @click=${() => this._openBadgesView()} title="${this._t("badges.label")}">
             <span class="lbl">${this._t("badges.label")}</span>
             ${earnedBadges.slice(0, 5).map(b => html`
-              <div class="tmd-badge-mini ${this._justEarnedBadge && String(this._justEarnedBadge) === String(b.id) ? "just-earned" : ""}"
+              <div class="tmd-badge-mini ${this._justEarnedBadge === window.__taskmate_badge_id(b) ? "just-earned" : ""}"
                 style="--t:${this._tierColor(b.tier)}">
                 <ha-icon icon="${b.icon || "mdi:medal"}"></ha-icon>
               </div>`)}

--- a/tests/test_badge_highlight_without_events.py
+++ b/tests/test_badge_highlight_without_events.py
@@ -1,0 +1,87 @@
+"""Cards must not subscribe to the custom badge event, and must read `badge_id`.
+
+Two defects, one guard (issue #752):
+
+1. The badges card and the child card subscribed to `taskmate_badge_earned`
+   over the WebSocket. Home Assistant only lets non-admin users subscribe to an
+   allowlisted set of core events, so every child's dashboard logged
+   "Refusing to allow <user> to subscribe to event taskmate_badge_earned" on
+   every load. Newly-earned badges are now detected by diffing the badges
+   sensor's `earned` attribute, which rides on `state_changed` and is allowed
+   for everyone.
+
+2. `ChildBadgesSensor` publishes earned entries keyed `badge_id`, but the
+   templates compared against `b.id` — undefined on those entries — so the
+   "just earned" highlight could never match. Both cards now read the id
+   through `window.__taskmate_badge_id`.
+
+Structural (grep over source) because neither defect is visible to a
+functional test: the cards render perfectly either way.
+"""
+from __future__ import annotations
+
+import pathlib
+import re
+
+WWW = pathlib.Path(__file__).resolve().parent.parent / "custom_components" / "taskmate" / "www"
+
+BADGE_CARDS = ("taskmate-badges-card.js", "taskmate-child-card.js")
+
+
+def _src(name: str) -> str:
+    return (WWW / name).read_text(encoding="utf-8")
+
+
+def test_no_card_subscribes_to_the_badge_event():
+    """A custom-event subscription is refused for non-admins and logs an error."""
+    offenders = []
+    for f in sorted(WWW.glob("*.js")):
+        src = f.read_text(encoding="utf-8")
+        # Comments explaining why we no longer subscribe are fine; a real call
+        # is not.
+        if re.search(r"subscribeEvents\s*\(", src):
+            offenders.append(f.name)
+    assert offenders == [], (
+        "these files call subscribeEvents(); Home Assistant refuses custom-event "
+        f"subscriptions from non-admin users and logs an error each time: {offenders}"
+    )
+
+
+def test_badge_id_helper_exists():
+    src = _src("taskmate-attr-resolver.js")
+    assert "window.__taskmate_badge_id" in src, (
+        "the shared badge-id helper is gone; the cards depend on it"
+    )
+
+
+def test_badge_cards_read_the_id_through_the_helper():
+    for name in BADGE_CARDS:
+        src = _src(name)
+        assert "__taskmate_badge_id" in src, f"{name} does not use the badge-id helper"
+
+
+def test_badge_cards_do_not_compare_against_the_undefined_id_field():
+    """`String(b.id)` on a sensor badge entry is the literal string "undefined"."""
+    offenders = []
+    for name in BADGE_CARDS:
+        for line in _src(name).splitlines():
+            if "just-earned" not in line:
+                continue
+            if re.search(r"String\(\s*b\.id\s*\)", line):
+                offenders.append(f"{name}: {line.strip()[:100]}")
+    assert offenders == [], (
+        "badge entries from ChildBadgesSensor are keyed badge_id, not id — "
+        f"these comparisons can never match: {offenders}"
+    )
+
+
+def test_both_child_card_render_paths_highlight_the_new_badge():
+    """Classic and designed paths each need the highlight (the recurring bug)."""
+    hits = [
+        line for line in _src("taskmate-child-card.js").splitlines()
+        if "just-earned" in line and "__taskmate_badge_id" in line
+    ]
+    assert len(hits) >= 2, (
+        "expected the just-earned highlight on BOTH the classic and designed "
+        f"render paths of the child card, found {len(hits)}"
+    )


### PR DESCRIPTION
Fixes #752

## Problem

Every non-admin dashboard load logged an error, repeatedly:

```
Logger: homeassistant.components.websocket_api.commands
Refusing to allow Louise to subscribe to event taskmate_badge_earned
```

`taskmate-badges-card.js` and `taskmate-child-card.js` both subscribed to the custom `taskmate_badge_earned` event to drive the "just earned" highlight. Home Assistant only permits non-admin users to subscribe to an allowlisted set of core events (`state_changed`, `themes_updated`, …); a custom event is refused with `Unauthorized` and logged as an error. Both cards `.catch()` the rejection, so nothing visibly broke — the log just filled up on every load and reconnect.

## Second defect found while tracing it

**The highlight has never worked, for anyone.** `ChildBadgesSensor` publishes earned entries keyed `badge_id` (`sensor.py:1192`), but all three render sites compared against `b.id`, which is `undefined` on those entries — so the test was always `"<id>" === "undefined"`. The subscription's only observable effect was the log spam.

## Changes

- **`taskmate-attr-resolver.js`** — new `window.__taskmate_badge_id(badge)`, tolerating both `badge_id` and `id`.
- **`taskmate-badges-card.js`** — subscription replaced with `_trackEarnedBadges()`, which diffs the configured badges sensor's `earned` list across `hass` updates. First observation is a baseline, so a previously-earned badge never flashes on mount. Highlight now compares through the helper.
- **`taskmate-child-card.js`** — same treatment against the resolved per-child badges sensor, and the helper applied on **both** render paths (classic `:2218` and designed `:2478`).
- The tracker runs from `shouldUpdate` and ORs its result into the return, so a badge-only change still forces a render even though per-child badges sensors are not in the resolver's `COMPANIONS` watch list.

`state_changed` is allowlisted for every user, so this works for children and parents alike.

## Tests

`tests/test_badge_highlight_without_events.py` (structural — neither defect is visible to a functional test):
- no shipped card calls `subscribeEvents(` at all
- the shared badge-id helper exists and both cards use it
- no `String(b.id)` comparison survives on a `just-earned` line
- the child card highlights on **both** render paths

All 5 fail on `main`, pass here. Full suite: 1415 passed; the 3 failures + 9 errors in `test_coordinator_logic.py` / `test_templates.py` are the known pre-existing order-pollution set. Ruff clean; ESLint warning count unchanged from `main` (11, all pre-existing).

## ha-dev verification

Signed in as the **non-admin** test user, both cards mounted, badge awarded from outside the browser via `taskmate.award_badge_manually`:

| | old code | this PR |
|---|---|---|
| `Refusing to allow …` lines logged | **2** (one per card) | **0** |
| `.just-earned` elements after the award | **0** on both cards | **1** on both cards |

Console errors: none in either run. The awarded badge was revoked afterwards, so ha-dev data is as it was found.