### PR TITLE
fix(chores): save the chore picture and show it on the child card

### DIFF
--- a/custom_components/taskmate/www/taskmate-child-card.js
+++ b/custom_components/taskmate/www/taskmate-child-card.js
@@ -884,7 +884,7 @@ class TaskMateChildCard extends LitElement {
         overflow: hidden;
       }
 
-      /* Chore number wrapper (icon removed) */
+      /* Chore number wrapper — holds the number-or-picture badge */
       .chore-number-wrapper {
         display: flex;
         align-items: center;
@@ -910,6 +910,14 @@ class TaskMateChildCard extends LitElement {
         transition: transform 0.2s ease;
         font-family: 'Comic Sans MS', 'Chalkboard SE', 'Marker Felt', sans-serif;
         flex-shrink: 0;
+      }
+
+      /* A chore picture sits where the digit would, so it has to carry the
+         same white-on-colour weight the numeral gets from its text-shadow. */
+      .chore-number-badge ha-icon {
+        --mdc-icon-size: 22px;
+        color: #fff;
+        filter: drop-shadow(1px 1px 2px rgba(0, 0, 0, 0.25));
       }
 
       .chore-card:hover .chore-number-badge {
@@ -1145,10 +1153,6 @@ class TaskMateChildCard extends LitElement {
           rgba(46, 204, 113, 0.25) 0%,
           rgba(39, 174, 96, 0.35) 100%) !important;
         filter: saturate(0.7);
-      }
-
-      .chore-card.completed .chore-icon-container {
-        background: rgba(255, 255, 255, 0.8);
       }
 
       .chore-card.completed .chore-name {
@@ -1618,6 +1622,7 @@ class TaskMateChildCard extends LitElement {
         .chore-card { padding: 10px 12px; gap: 8px; min-height: 54px; flex-wrap: nowrap; }
         .chore-info { flex: 1; min-width: 0; overflow: hidden; }
         .chore-number-badge { width: 30px; height: 30px; min-width: 30px; font-size: 1rem; }
+        .chore-number-badge ha-icon { --mdc-icon-size: 18px; }
         .chore-name { font-size: 0.95rem; }
         .chore-points { font-size: 0.82rem; }
         .chore-checkbox { width: 34px; height: 34px; min-width: 34px; border-radius: 8px; }
@@ -1978,6 +1983,15 @@ class TaskMateChildCard extends LitElement {
       .tmd-undochip:hover { filter: brightness(0.97); }
       .tmd-undochip[disabled] { opacity: 0.6; cursor: default; }
       .q-undo { background: var(--tmd-surface-2); color: var(--tmd-dim); border: 1px solid var(--tmd-border); padding: 7px 10px; font-size: 14px; }
+
+      /* Designed: an explicit chore picture in the glyph slot. The emoji it
+         replaces is sized by font-size, which an ha-icon ignores, so each row
+         type restates its own size. Inherits the row accent so the icon reads
+         as part of the style rather than a pasted-in glyph. */
+      .tmd-glyph-icon { color: var(--ac, var(--tmd-accent)); display: block; }
+      .tmd-chore .ch-emoji .tmd-glyph-icon { --mdc-icon-size: 22px; }
+      .tmd-quest .q-emoji .tmd-glyph-icon { --mdc-icon-size: 19px; }
+      .tmd-check .c-emoji .tmd-glyph-icon { --mdc-icon-size: 18px; }
 
       /* Designed: pending-points + countdown chips on the header/section */
       .tmd-pending {
@@ -2342,6 +2356,20 @@ class TaskMateChildCard extends LitElement {
     return "⭐";
   }
 
+  /** What a designed chore row shows in its glyph slot.
+   *
+   * An explicit picture wins over the keyword guess (#745) — otherwise
+   * choosing mdi:watering-can changed nothing, because _choreEmoji only ever
+   * matched on words. The guess stays as the fallback so chores with no
+   * picture, which is all of them until someone sets one, look as they did.
+   * The icon inherits the row's accent so it reads as part of the style.
+   */
+  _choreGlyph(chore) {
+    return chore.icon
+      ? html`<ha-icon icon="${chore.icon}" class="tmd-glyph-icon"></ha-icon>`
+      : this._choreEmoji(chore);
+  }
+
   /** Mirror of _renderChoreCard's "completed today" detection, designed branch only. */
   _isChoreDone(chore, child, todaysCompletions) {
     const childCompletionsToday = (todaysCompletions || []).filter(
@@ -2421,7 +2449,7 @@ class TaskMateChildCard extends LitElement {
       return {
         chore, child, done, loading, onAct, index: i, dimmed,
         tone: this._designTone(i),
-        emoji: this._choreEmoji(chore),
+        glyph: this._choreGlyph(chore),
         points: chore.effective_points ?? chore.points,
         timed: chore.task_type === "timed",
         mandatory: chore.mandatory === true,
@@ -2579,7 +2607,7 @@ class TaskMateChildCard extends LitElement {
       ${rows.map(r => r.timed ? this._designTimed(r) : html`
         <div class="tmd-chore ${r.done ? "done" : ""} ${r.mandatory ? "mandatory" : ""} ${r.dimmed ? "dimmed" : ""}" style="--ac:${r.tone}">
           <div class="num-badge" style="${r.done ? "--ac:var(--tmd-good)" : ""}">${r.done ? "✓" : r.index + 1}</div>
-          <span class="ch-emoji">${r.emoji}</span>
+          <span class="ch-emoji">${r.glyph}</span>
           <div class="ch-mid">
             <div class="ch-name">${r.chore.name}</div>
             ${r.done ? "" : html`<div class="chip soft" style="margin-top:3px">+${r.points} ⭐</div>`}
@@ -2599,7 +2627,7 @@ class TaskMateChildCard extends LitElement {
       ${rows.map(r => r.timed ? this._designTimed(r) : html`
         <div class="tmd-quest ${r.done ? "done" : ""} ${r.mandatory ? "mandatory" : ""} ${r.dimmed ? "dimmed" : ""}" style="--ac:${r.tone}">
           <div class="num q-num" style="${r.done ? "color:var(--tmd-good)" : ""}">${r.done ? "✓" : String(r.index + 1).padStart(2, "0")}</div>
-          <span class="q-emoji">${r.emoji}</span>
+          <span class="q-emoji">${r.glyph}</span>
           <div class="q-mid">
             <div class="q-name">${r.chore.name}</div>
             ${r.done
@@ -2621,7 +2649,7 @@ class TaskMateChildCard extends LitElement {
       ${rows.map(r => r.timed ? this._designTimed(r) : html`
         <div class="tmd-check ${r.done ? "done" : ""} ${r.mandatory ? "mandatory" : ""} ${r.dimmed ? "dimmed" : ""}" style="--ac:${r.tone}">
           <div class="c-num" style="${r.done ? "--ac:var(--tmd-good)" : ""}">${r.done ? "✓" : r.index + 1}</div>
-          <span class="c-emoji">${r.emoji}</span>
+          <span class="c-emoji">${r.glyph}</span>
           <div class="c-mid">
             <div class="c-name">${r.chore.name}</div>
             ${this._designChoreMeta(r)}
@@ -3299,6 +3327,23 @@ class TaskMateChildCard extends LitElement {
     `;
   }
 
+  /** The coloured badge at the head of a chore row.
+   *
+   * A chore's picture takes the digit's place when one is set (#745) — the
+   * number is only positional, whereas the icon is what a child actually
+   * recognises. Chores with no picture keep their number, which is every
+   * chore that predates the field. Shared by the standard and timed rows so
+   * a picture can't work on one and be invisible on the other.
+   */
+  _choreNumberBadge(chore, colorClass, choreNumber) {
+    return html`
+      <div class="chore-number-badge ${colorClass}">
+        ${chore.icon
+          ? html`<ha-icon icon="${chore.icon}"></ha-icon>`
+          : choreNumber}
+      </div>`;
+  }
+
   _renderChoreCard(chore, child, pointsIcon, todaysCompletions = [], choreIndex = 0) {
     const isLoading = this._loading[chore.id];
     const isCelebrating = this._celebrating === chore.id;
@@ -3408,7 +3453,7 @@ class TaskMateChildCard extends LitElement {
       >
         <div class="chore-info">
           <div class="chore-number-wrapper">
-            <div class="chore-number-badge ${colorClass}">${choreNumber}</div>
+            ${this._choreNumberBadge(chore, colorClass, choreNumber)}
           </div>
           <div class="chore-details">
             <div class="chore-name">${chore.name}${chore.mandatory ? html`<span class="mandatory-badge">⚠ ${this._t('child.mandatory')}</span>` : ''}</div>
@@ -3535,7 +3580,7 @@ class TaskMateChildCard extends LitElement {
       <div class="timed-chore-card ${state} ${isLoading ? 'loading' : ''}">
         <div class="timed-top-row">
           <div class="chore-number-wrapper">
-            <div class="chore-number-badge ${colorClass}">${choreNumber}</div>
+            ${this._choreNumberBadge(chore, colorClass, choreNumber)}
           </div>
           <div class="chore-details">
             <div class="chore-name">${chore.name}</div>

--- a/custom_components/taskmate/www/taskmate-panel.js
+++ b/custom_components/taskmate/www/taskmate-panel.js
@@ -1403,12 +1403,14 @@ class TaskMatePanel extends HTMLElement {
   }
 
   async _doSaveChore() {
+    this._syncIconPickers();
     const d = this._dialog.data;
     if (!d.name || !d.name.trim()) { this._showToast("err", this._t("panel.toast_name_required")); return; }
     const wasAdd = this._dialog.mode === "add";
     const base = {
       name: d.name.trim(),
       description: d.description || "",
+      icon: d.icon || "",
       points: Number(d.points) || 0,
       assigned_to: d.assigned_to || [],
       requires_approval: !!d.requires_approval,

--- a/tests/test_chore_icon.py
+++ b/tests/test_chore_icon.py
@@ -1,0 +1,148 @@
+"""The chore Picture actually saves, and actually shows up (#745).
+
+Two independent faults sat behind that issue:
+
+1. The panel's chore save built an explicit payload and `icon` was missing from
+   it, so the picked icon was dropped in the browser and never reached the
+   backend. The backend has always accepted it.
+2. Even once saved, no standard chore row rendered it. Classic showed a
+   numbered badge; the designed styles showed an emoji guessed by regex from
+   the chore *name*, so an explicit icon changed nothing.
+
+The panel and the cards are JavaScript, so what Python can guard is the source
+itself — these assertions are what stop either half silently regressing.
+"""
+from __future__ import annotations
+
+import pathlib
+import re
+
+WWW = pathlib.Path(__file__).resolve().parent.parent / "custom_components" / "taskmate" / "www"
+PANEL = (WWW / "taskmate-panel.js").read_text(encoding="utf-8")
+CARD = (WWW / "taskmate-child-card.js").read_text(encoding="utf-8")
+
+
+def _method_source(source: str, start_marker: str, end_marker: str) -> str:
+    """Slice a method body out by its definition, not one of its call sites."""
+    start = source.index(start_marker)
+    return source[start:source.index(end_marker, start)]
+
+
+def _save_chore_source() -> str:
+    return _method_source(PANEL, "  async _doSaveChore() {", "  _addBonusSubtask() {")
+
+
+def _chore_card_source() -> str:
+    return _method_source(
+        CARD,
+        "  _renderChoreCard(chore, child, pointsIcon, todaysCompletions = [], choreIndex = 0) {",
+        "  _renderTimedChoreCard(",
+    )
+
+
+class TestPanelSendsTheIcon:
+    """The half that made the issue title true: it never saved."""
+
+    def test_payload_carries_the_icon(self):
+        assert "icon: d.icon" in _save_chore_source()
+
+    def test_picker_is_synced_before_the_payload_is_built(self):
+        """`ha-icon-picker` writes into the draft via a `value-changed` event.
+        Every other dialog re-reads the live pickers first as a safety net; the
+        chore dialog was the only one that did not."""
+        save = _save_chore_source()
+        assert "this._syncIconPickers();" in save
+        assert save.index("this._syncIconPickers();") < save.index("icon: d.icon")
+
+    def test_every_icon_picker_dialog_syncs_before_saving(self):
+        """A blanket guard so no new dialog reintroduces this bug.
+
+        The invariant is about the *widget*, not the field: only
+        `_iconPickerField` renders an `<ha-icon-picker>`, and only those need
+        `_syncIconPickers`. Two savers send an `icon` without one and are
+        exempt — the bulk-add dialog has no picture field at all, and the
+        template dialog uses a plain text input, which reports through the
+        ordinary `input` handler.
+        """
+        no_picker = {"BulkChores", "CreatedTemplate", "EditedTemplate"}
+        # Keep the exemption honest: the template dialog is exempt only for as
+        # long as it really is a text input.
+        assert 'data-field="icon" value="${this._esc(d.icon)}"' in PANEL
+        savers = re.findall(r"  async _doSave(\w+)\(\) \{(.*?)\n  \}", PANEL, re.S)
+        assert savers, "no _doSave* methods found — did the panel get restructured?"
+        checked = 0
+        for name, body in savers:
+            if "icon: d.icon" in body and name not in no_picker:
+                checked += 1
+                assert "this._syncIconPickers();" in body, (
+                    f"_doSave{name} sends an icon without syncing the pickers first"
+                )
+        assert checked, "no picker-backed savers matched — the guard has stopped guarding"
+
+
+class TestClassicRowShowsTheIcon:
+    """Option A: the icon takes the digit's place in the existing badge."""
+
+    def _badge_source(self) -> str:
+        return _method_source(
+            CARD,
+            "  _choreNumberBadge(chore, colorClass, choreNumber) {",
+            "  _renderChoreCard(",
+        )
+
+    def test_badge_renders_the_icon_when_one_is_set(self):
+        assert "chore.icon" in self._badge_source()
+
+    def test_badge_falls_back_to_the_number(self):
+        """Chores with no picture — i.e. every chore that exists today — must
+        keep their number, or the fix is a visual regression for everyone."""
+        badge = self._badge_source()
+        assert "chore-number-badge" in badge
+        assert "choreNumber" in badge
+
+    def test_standard_and_timed_rows_share_the_badge(self):
+        """Two copies is how a picture ends up working on one row type and
+        invisible on the other."""
+        assert CARD.count("this._choreNumberBadge(chore, colorClass, choreNumber)") == 2
+        for marker, end in (
+            ("  _renderChoreCard(chore, child, pointsIcon,", "  _renderTimedChoreCard("),
+            ("  _renderTimedChoreCard(chore, child, pointsIcon,", "\n  _renderBonusSubtasks("),
+        ):
+            assert "this._choreNumberBadge(" in _method_source(CARD, marker, end)
+
+    def test_the_dead_icon_container_css_is_gone(self):
+        """`.chore-icon-container` styled an element removed long ago; leaving
+        it behind is what made the row look intentionally icon-free."""
+        assert ".chore-icon-container" not in CARD
+
+    def test_icon_is_sized_for_the_badge(self):
+        """ha-icon ignores the badge's font-size, so without an explicit size
+        it renders at the 24px default and overflows the 30px mobile badge."""
+        assert ".chore-number-badge ha-icon" in CARD
+
+
+class TestDesignedRowsPreferTheExplicitIcon:
+    """playroom / console / cleanpro rendered a guessed emoji regardless."""
+
+    def test_rows_render_a_resolved_glyph(self):
+        """All three designed renderers must go through the same resolver, or
+        the icon works on one style and is invisible on the other two."""
+        for cls in (".tmd-chore ", ".tmd-quest ", ".tmd-check "):
+            assert cls in CARD
+        assert CARD.count("r.glyph") >= 3
+
+    def test_resolver_prefers_the_icon_over_the_guess(self):
+        assert "_choreGlyph(chore)" in CARD
+        glyph = _method_source(CARD, "  _choreGlyph(chore) {", "  /** Mirror of _renderChoreCard")
+        assert "chore.icon" in glyph
+        assert "_choreEmoji(chore)" in glyph
+
+    def test_designed_icon_is_sized_per_row_type(self):
+        """The emoji it replaces is sized by font-size, which ha-icon ignores."""
+        for slot in (".ch-emoji .tmd-glyph-icon", ".q-emoji .tmd-glyph-icon", ".c-emoji .tmd-glyph-icon"):
+            assert slot in CARD
+
+    def test_emoji_guess_survives_as_the_fallback(self):
+        """Existing chores have no icon, so the guess still has to run."""
+        assert "_choreEmoji(chore) {" in CARD
+        assert '"⭐"' in CARD


### PR DESCRIPTION
## The bug

The Picture dropdown in the chore editor did nothing — the icon neither saved nor appeared on any chore card. Two independent faults sat behind it.

### 1. The panel dropped the icon on save

`_doSaveChore` builds an explicit payload object for `taskmate/add_chore` / `taskmate/update_chore`, and `icon` was simply not in the list. It also skipped `_syncIconPickers()`, which every other icon-picker dialog in the panel calls first. So the picked icon was discarded in the browser and never reached the integration.

The backend was never at fault — `icon` is already on the `Chore` model, in `_CHORE_EDITABLE_FIELDS`, in the websocket schema, and emitted by the chores sensor. `_doSaveReward` does both things correctly, which is why reward icons have always worked.

### 2. No standard chore row rendered it

Even once saved, the icon had nowhere to appear:

- the classic chore row rendered a numbered colour badge and never read `chore.icon`
- the playroom / console / cleanpro rows rendered `_choreEmoji()`, a keyword regex over the chore **name**, so `mdi:watering-can` changed nothing and anything unusual fell through to ⭐
- only pre-reader tiles and the reorder / routine / activity cards actually consumed the field

The field was added for pre-reader mode (#683) and the mainline rows were never wired up.

## The fix

- `_doSaveChore` syncs the live pickers and sends `icon`.
- Classic renders the picture **in place of the digit** inside the existing coloured badge — no layout change, no extra row width, and the colour cycle, tilt and completed ✓ state are all preserved. Done through a `_choreNumberBadge` helper shared by the standard and timed rows, so a picture cannot work on one and be invisible on the other.
- The designed styles go through `_choreGlyph`, which prefers an explicit icon and keeps the emoji guess as the fallback. The icon inherits the row accent so it reads as part of the style.
- Removes the dead `.chore-icon-container` CSS, which styled an element deleted long ago and is why the row looked deliberately icon-free.

**Chores with no picture — i.e. every chore that predates this — render exactly as they do today.** Classic keeps its number, the designed styles keep their emoji.

## Verification

Driven end-to-end against the real dialog on the ha-dev instance, injecting this branch's panel and card:

| | main | this branch |
|---|---|---|
| picker value after picking | `mdi:tooth-outline` | `mdi:tooth-outline` |
| dialog draft | `mdi:tooth-outline` | `mdi:tooth-outline` |
| **stored on the chore** | **`""`** | **`mdi:tooth-outline`** |
| re-opened in the editor | `""` | `mdi:tooth-outline` |

Rendering confirmed across classic, playroom, console and cleanpro, with a deliberately icon-less chore in each list to prove the fallback. No console errors.

12 new tests in `tests/test_chore_icon.py`, including a blanket guard that any picker-backed saver syncs before reading `d.icon`, so this shape of bug cannot come back. Full suite shows the same 12 pre-existing failures as `main` — none new. Ruff clean, eslint 0 errors and no new warnings.

## Not included

The reporter also asked for uploaded **image files** for chores and rewards. That is a much larger piece of work (storage, authenticated serving, upload UI, rendering across all five styles), so it is split out into #750.

Fixes #745