### PR TITLE
fix(panel): fill the viewport instead of collapsing to content height

### DIFF
--- a/custom_components/taskmate/www/taskmate-panel.js
+++ b/custom_components/taskmate/www/taskmate-panel.js
@@ -5935,8 +5935,20 @@ class TaskMatePanel extends HTMLElement {
 
   _styles() {
     return `<style>
+      /* Fill the panel area without depending on a percentage-height chain.
+         HA nests us as taskmate-panel → ha-panel-custom → partial-panel-resolver
+         → ha-drawer, and the middle two are display:inline / height:auto. A
+         height:100% here only resolves while some ancestor happens to carry a
+         definite height; where it doesn't, the shell collapses to its content
+         height and the nav column visibly stops partway down every short page
+         (#754). A flex column of exactly 100dvh is immune to the ancestor
+         chain: panel_custom gives the element the whole viewport — HA draws no
+         toolbar above it — so 100dvh is the full panel area, not an overflow.
+         It must be height, not min-height: the shell scrolls its own body,
+         and a floor-only rule would let a long section (Settings) grow the
+         panel past the viewport and scroll the nav column off the page. */
       taskmate-panel {
-        display: block; height: 100%;
+        display: flex; flex-direction: column; height: 100dvh;
 
         --tm-bg:            var(--primary-background-color, #fafafa);
         --tm-surface-0:     var(--card-background-color, #fff);
@@ -6004,7 +6016,11 @@ class TaskMatePanel extends HTMLElement {
       .tm-shell {
         display: grid;
         grid-template-columns: var(--tm-sidebar-w) 1fr;
-        height: 100%;
+        /* Flex to fill the panel rather than height:100% — see the note on
+           taskmate-panel above (#754). min-height:0 lets the grid shrink
+           instead of being forced to its content height. */
+        flex: 1 1 auto;
+        min-height: 0;
         position: relative;
         overflow: hidden;
       }

--- a/tests/test_panel_fills_viewport.py
+++ b/tests/test_panel_fills_viewport.py
@@ -1,0 +1,95 @@
+"""The admin panel must not size itself with a percentage-height chain.
+
+The panel is nested as ``taskmate-panel → ha-panel-custom →
+partial-panel-resolver → ha-drawer``, and the middle two are ``display: inline``
+with ``height: auto``. ``height: 100%`` on the panel therefore only resolves
+while some ancestor happens to carry a definite height. Where it doesn't, the
+shell collapses to its content height and, because the shell is a two-column
+grid, the row becomes as tall as the taller column — so the nav column visibly
+stops partway down every section with little content (issue #754).
+
+Structural (grep over source) because the collapse depends on the surrounding
+Home Assistant frontend, which no unit test instantiates.
+"""
+from __future__ import annotations
+
+import pathlib
+import re
+
+PANEL = (
+    pathlib.Path(__file__).resolve().parent.parent
+    / "custom_components" / "taskmate" / "www" / "taskmate-panel.js"
+)
+
+
+def test_panel_stylesheet_is_not_cut_short_by_a_stray_backtick():
+    """The whole panel stylesheet is one JS template literal.
+
+    A backtick inside it — easily typed when quoting a CSS property in a
+    comment — closes the literal early. The file can still parse, so
+    `node --check` passes and only the running panel breaks: `_styles()`
+    returns a truncated `<style>` with no closing tag, the panel renders
+    with no CSS, and every section looks blank-ish. Catch it statically.
+    """
+    src = PANEL.read_text(encoding="utf-8")
+    start = src.index("return `<style>")
+    body_start = src.index("`", start) + 1
+    end = src.index("`", body_start)
+    css = src[body_start:end]
+    assert "</style>" in css, (
+        "the panel stylesheet template literal ends before its </style> — "
+        "something inside it (usually a backtick in a comment) closed it early"
+    )
+
+
+def _block(selector: str) -> str:
+    """Return the CSS declarations of the first rule for `selector`.
+
+    Comments are stripped so a note *explaining* the old `height: 100%` does
+    not read as the declaration itself.
+    """
+    src = PANEL.read_text(encoding="utf-8")
+    match = re.search(
+        r"(?:^|\n)\s*" + re.escape(selector) + r"\s*\{(.*?)\}",
+        src,
+        re.DOTALL,
+    )
+    assert match, f"no CSS rule found for {selector}"
+    return re.sub(r"/\*.*?\*/", "", match.group(1), flags=re.DOTALL)
+
+
+def test_panel_host_is_exactly_one_viewport_tall():
+    rules = _block("taskmate-panel")
+    assert re.search(r"(?<!min-)height:\s*100dvh", rules), (
+        "the panel host needs a viewport-based height; without it the panel "
+        "collapses to content height wherever the ancestor chain is auto"
+    )
+    assert re.search(r"height:\s*100%", rules) is None, (
+        "the panel host must not fall back on height:100% — that is the "
+        "percentage chain this fix removes"
+    )
+    assert "min-height: 100dvh" not in rules, (
+        "a floor-only rule lets a long section grow the panel past the "
+        "viewport, scrolling the nav column off the page instead of scrolling "
+        "the body — the shell manages its own internal scroll"
+    )
+
+
+def test_panel_host_is_a_flex_column():
+    rules = _block("taskmate-panel")
+    assert "display: flex" in rules and "flex-direction: column" in rules, (
+        "the shell fills the panel via flex; the host has to be the flex column"
+    )
+
+
+def test_shell_flexes_instead_of_claiming_a_percentage_height():
+    rules = _block(".tm-shell")
+    assert re.search(r"height:\s*100%", rules) is None, (
+        ".tm-shell must not use height:100%; it resolves to auto whenever the "
+        "ancestor chain has no definite height"
+    )
+    assert "flex: 1 1 auto" in rules, ".tm-shell must flex to fill the panel"
+    assert "min-height: 0" in rules, (
+        "a flex item defaults to min-height:auto, which would force the grid "
+        "back to its content height"
+    )


### PR DESCRIPTION
Fixes #754

## Problem

In `/taskmate-admin`, the nav column and content area stop partway down the page on every section whose content is shorter than the viewport — Templates, Insights and most others. Long sections (Activity) look fine.

The panel sized itself with a chain of percentage heights:

- `taskmate-panel { display: block; height: 100% }` (`taskmate-panel.js:5937`)
- `.tm-shell { height: 100% }` (`taskmate-panel.js:6005`)

A percentage height only resolves against a containing block with a definite height. HA nests the panel as `taskmate-panel → ha-panel-custom → partial-panel-resolver → ha-drawer`, and the middle two are `display: inline` / `height: auto`. It works only while `ha-drawer` happens to carry an explicit pixel height. Where it does not, `height: 100%` falls back to `auto`, and since `.tm-shell` is a two-column grid the row becomes as tall as the **taller** column — the nav list. That is exactly where the cut-off lands.

## Fix

```css
taskmate-panel { display: flex; flex-direction: column; height: 100dvh; }
.tm-shell      { flex: 1 1 auto; min-height: 0; }   /* was height: 100% */
```

Nothing depends on the ancestor chain any more. `panel_custom` gives the element the whole viewport (HA draws no toolbar above it), so `100dvh` is the panel area rather than an overflow.

It has to be `height`, not `min-height`. A first pass used `min-height: 100dvh` and fixed the short pages, but regressed long ones: the shell grew past the viewport and the **page** scrolled, taking the nav column off-screen, instead of the body scrolling inside a viewport-height shell. Caught on ha-dev before it shipped — Settings measured 5695px tall with 4795px of page overflow.

## Bonus guard

The whole panel stylesheet is a single JS template literal. A backtick used to quote a CSS property inside a comment closes it early: the file still parses, `node --check` passes, and only the running panel breaks — `_styles()` returns a truncated `<style>` and the panel renders with no CSS at all. I hit this twice writing the comment above. `test_panel_stylesheet_is_not_cut_short_by_a_stray_backtick` catches it statically; confirmed it fails on the backticked version that `node --check` waves through.

## ha-dev verification

Four sections × chain intact / chain deliberately broken (`ha-drawer { height: auto }`, which reproduces the reported screenshots exactly):

| chain | tab | viewport | panel | shell | sidebar | page overflow |
|---|---|---|---|---|---|---|
| intact | templates | 900 | 900 | 900 | 900 | 0 |
| intact | insights | 900 | 900 | 900 | 900 | 0 |
| intact | badges | 900 | 900 | 900 | 900 | 0 |
| intact | settings | 900 | 900 | 900 | 900 | 0 |
| **broken** | templates | 900 | 900 | 900 | 900 | 0 |
| **broken** | insights | 900 | 900 | 900 | 900 | 0 |
| **broken** | badges | 900 | 900 | 900 | 900 | 0 |
| **broken** | settings | 900 | 900 | 900 | 900 | 0 |

Before the fix, breaking the chain collapsed the panel from 900px to 760px. Zero page overflow everywhere means the body still scrolls internally as it did. No console errors in any run.

## Tests

`tests/test_panel_fills_viewport.py` — 4 structural tests (the collapse depends on the surrounding HA frontend, which no unit test instantiates). The 3 layout ones fail on `main`. Full suite: 1419 passed, with the known pre-existing order-pollution set unchanged. Ruff clean; ESLint warnings unchanged (2, both pre-existing).