### PR TITLE
fix(panel): gate undo on the shared deny-list so manual adjustments are reversible

### DIFF
--- a/custom_components/taskmate/www/taskmate-panel.js
+++ b/custom_components/taskmate/www/taskmate-panel.js
@@ -330,6 +330,27 @@ class TaskMatePanel extends HTMLElement {
     return fn ? fn(this._hass, key, params) : key;
   }
 
+  // Reason prefixes for *derived* (automatic) transactions, which can't be
+  // undone in isolation — mirrors the backend deny-list in coord_points.py and
+  // the copy in taskmate-activity-card.js. Everything else (penalty, bonus,
+  // gift, manual add/remove) is reversible.
+  //
+  // This is a deny-list, NOT an allow-list (#761): manual adjustments carry
+  // arbitrary or empty reasons, so they cannot be recognised positively.
+  // tests/test_panel_undo_deny_list.py pins all three copies together.
+  static get _UNDO_DENY_PREFIXES() {
+    return [
+      "Weekend bonus", "Streak milestone bonus", "Perfect week bonus",
+      "Allocated to pool:", "Pool refund", "Points decay",
+      "Savings interest", "Badge",
+    ];
+  }
+
+  _txnReversible(reason) {
+    const r = reason || "";
+    return !TaskMatePanel._UNDO_DENY_PREFIXES.some(p => r.startsWith(p));
+  }
+
   // Transaction reasons are stored in English in the DB (e.g. "Penalty: Messy room").
   // Mirror the activity-card mapping so panel views render in the user's language.
   _translateReason(reason) {
@@ -3120,7 +3141,7 @@ class TaskMatePanel extends HTMLElement {
               <tbody>
                 ${[...transactions].reverse().map(t => {
                   const child = childById[t.child_id];
-                  const undoable = typeof t.reason === "string" && (t.reason.startsWith("Penalty: ") || t.reason.startsWith("Bonus: "));
+                  const undoable = this._txnReversible(t.reason);
                   return `
                     <tr class="tm-row">
                       <td class="tm-meta">${this._esc(this._timeAgo(t.created_at))}</td>

--- a/tests/test_panel_undo_deny_list.py
+++ b/tests/test_panel_undo_deny_list.py
@@ -1,0 +1,103 @@
+"""The panel's undo gate must match the backend's, not use its own allow-list (#761).
+
+The Admin Panel used to render its undo button only for reasons starting with
+"Penalty: " or "Bonus: ". That allow-list silently hid undo for manual
+add/remove adjustments, which `PointsMixin.async_undo_transaction` explicitly
+supports and which `taskmate-activity-card` already offers.
+
+There are now three copies of the deny-list — Python, the card, the panel — so
+these tests pin them against each other. The backend's own comment warns that a
+new derived reason must be added to its list; a third copy is a third place to
+forget.
+"""
+from __future__ import annotations
+
+import pathlib
+import re
+
+from custom_components.taskmate.coord_points import PointsMixin
+
+WWW = (
+    pathlib.Path(__file__).resolve().parent.parent
+    / "custom_components" / "taskmate" / "www"
+)
+PANEL = (WWW / "taskmate-panel.js").read_text(encoding="utf-8")
+ACTIVITY_CARD = (WWW / "taskmate-activity-card.js").read_text(encoding="utf-8")
+
+
+def _js_deny_prefixes(src: str, label: str) -> list[str]:
+    """Pull the string literals out of a JS _UNDO_DENY_PREFIXES getter."""
+    block = re.search(
+        r"_UNDO_DENY_PREFIXES\(\)\s*\{\s*return\s*\[(.*?)\]", src, re.S
+    )
+    assert block, f"{label} has no _UNDO_DENY_PREFIXES getter"
+    prefixes = re.findall(r'"([^"]+)"', block.group(1))
+    assert prefixes, f"{label} _UNDO_DENY_PREFIXES is empty"
+    return prefixes
+
+
+def test_panel_no_longer_uses_a_reason_allow_list():
+    # The bug: an allow-list of just these two prefixes. Its absence is the fix.
+    assert 'startsWith("Penalty: ") || t.reason.startsWith("Bonus: ")' not in PANEL, (
+        "the panel is still gating undo on a Penalty:/Bonus: allow-list, which "
+        "hides undo for manual adjustments"
+    )
+
+
+def test_panel_gates_undo_on_reversibility():
+    block = re.search(r"_renderActivityTab\(\) \{(.*?)\n  \}", PANEL, re.S)
+    assert block, "could not find _renderActivityTab"
+    body = block.group(1)
+    assert "_txnReversible(" in body, (
+        "the transactions table must decide undoability via _txnReversible"
+    )
+
+
+def test_panel_has_a_reversibility_helper():
+    block = re.search(r"_txnReversible\(reason\) \{(.*?)\n  \}", PANEL, re.S)
+    assert block, "could not find _txnReversible in the panel"
+    body = block.group(1)
+    assert "_UNDO_DENY_PREFIXES" in body, "must consult the deny-list"
+    assert "startsWith" in body, "deny-list entries are prefixes, not exact matches"
+
+
+def test_all_three_deny_lists_are_identical():
+    backend = list(PointsMixin._UNDO_DENY_PREFIXES)
+    panel = _js_deny_prefixes(PANEL, "taskmate-panel.js")
+    card = _js_deny_prefixes(ACTIVITY_CARD, "taskmate-activity-card.js")
+    assert panel == backend, (
+        "panel deny-list drifted from coord_points.py: "
+        f"panel={panel} backend={backend}"
+    )
+    assert card == backend, (
+        "activity-card deny-list drifted from coord_points.py: "
+        f"card={card} backend={backend}"
+    )
+
+
+def test_manual_adjustments_are_reversible_under_the_deny_list():
+    # The whole point of #761: these reasons must NOT be denied.
+    deny = tuple(PointsMixin._UNDO_DENY_PREFIXES)
+    for reason in (
+        "Admin panel adjustment",   # the #746 quick buttons
+        "Broke a window",           # a free-text reason from the custom dialog
+        "",                         # a bare add_points/remove_points call
+        "Penalty: Messy room",
+        "Bonus: Helped out",
+    ):
+        assert not reason.startswith(deny), f"{reason!r} should be reversible"
+
+
+def test_derived_transactions_are_still_denied():
+    deny = tuple(PointsMixin._UNDO_DENY_PREFIXES)
+    for reason in (
+        "Weekend bonus (×2)",
+        "Streak milestone bonus (7 day streak!)",
+        "Perfect week bonus!",
+        "Allocated to pool: Cinema trip",
+        "Pool refund (reward deleted): Cinema trip",
+        "Points decay",
+        "Savings interest",
+        "Badge: 50 Chores Completed",
+    ):
+        assert reason.startswith(deny), f"{reason!r} must stay non-undoable"


### PR DESCRIPTION
The Admin Panel's transactions table gated its undo button on an **allow-list** of reason prefixes, which silently hid undo for manual point adjustments:

```js
const undoable = typeof t.reason === "string"
  && (t.reason.startsWith("Penalty: ") || t.reason.startsWith("Bonus: "));
```

Every other part of the system uses a **deny-list** of *derived* reasons instead, and treats manual adjustments as reversible:

- `PointsMixin.async_undo_transaction` — *"Reversible: penalties, bonuses, **manual add/remove adjustments**, and gifts"*, refusing only `_UNDO_DENY_PREFIXES`.
- `taskmate-activity-card.js` — mirrors that list, so the Lovelace card already offered undo.

**Closes #761**

## The change

The panel now carries the same `_UNDO_DENY_PREFIXES` / `_txnReversible` pair as the activity card, and the table asks `this._txnReversible(t.reason)`. No backend change — `undo_transaction` already accepted these; only the button was missing.

One behavioural detail worth noting: the old `typeof t.reason === "string"` guard also excluded transactions with a **null/empty** reason, i.e. a bare `add_points`/`remove_points` service call. Those are now undoable too, which matches the backend exactly (`reason = target.reason or ""`, then a prefix check that `""` never trips).

Gifts are likewise not in the deny-list, so they now show an undo button in the panel as they already do in the card. The backend reverses both legs via `link_id`, or raises for pre-`link_id` legacy gifts — in which case the panel surfaces the error as a toast, same as the card.

## Drift guard

This makes a **third** copy of the deny-list (Python, card, panel), and `coord_points.py` already warns that any new derived reason must be added to its list. `tests/test_panel_undo_deny_list.py` pins all three against each other by parsing the two JS getters and comparing them to `PointsMixin._UNDO_DENY_PREFIXES`, so a future divergence fails the suite rather than shipping a quietly wrong undo button.

6 new tests: the allow-list is gone, the table gates on `_txnReversible`, the helper consults the deny-list by prefix, all three lists are identical, manual/free-text/empty/penalty/bonus reasons are reversible, and all eight derived reasons stay refused.

Suite: **1462 passed**, with the same 3 failures + 9 errors that pre-exist on `main`.

## Verified on ha-dev

| Check | Result |
|---|---|
| `+13` with reason `UNDO FIX 761` → row gains an undo button (was 0) | pass |
| All 5 `Manual adjustment` rows now show undo | pass |
| All 6 `Badge` rows still show **no** undo | pass |
| `Allocated to pool:` / `Pool refund (…)` rows still show **no** undo | pass |
| Clicking undo reversed the balance 231 → 218 exactly | pass |
| No console errors | pass |
