### PR TITLE
fix(tests): use a non-polluting event loop helper

### DIFF
--- a/tests/test_coordinator_logic.py
+++ b/tests/test_coordinator_logic.py
@@ -907,9 +907,7 @@ class TestOneShotChores:
 
         now = _date(2024, 3, 20)  # Today
         with patch.object(_mod.dt_util, "now", return_value=now):
-            asyncio.get_event_loop().run_until_complete(
-                coord._async_expire_one_shot_chores()
-            )
+            run(coord._async_expire_one_shot_chores())
 
         assert chore.enabled is False
         coord.storage.update_chore.assert_called_once_with(chore)
@@ -926,9 +924,7 @@ class TestOneShotChores:
 
         now = _date(2024, 3, 20)
         with patch.object(_mod.dt_util, "now", return_value=now):
-            asyncio.get_event_loop().run_until_complete(
-                coord._async_expire_one_shot_chores()
-            )
+            run(coord._async_expire_one_shot_chores())
 
         assert chore.enabled is True
         coord.storage.update_chore.assert_not_called()
@@ -945,9 +941,7 @@ class TestOneShotChores:
 
         now = _date(2024, 3, 20)
         with patch.object(_mod.dt_util, "now", return_value=now):
-            asyncio.get_event_loop().run_until_complete(
-                coord._async_expire_one_shot_chores()
-            )
+            run(coord._async_expire_one_shot_chores())
 
         coord.storage.update_chore.assert_not_called()
 

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -9,6 +9,15 @@ import pytest
 from custom_components.taskmate.storage import TaskMateStorage
 
 
+def run(coro):
+    """Run a coroutine synchronously."""
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
 @pytest.fixture
 def storage():
     """Create a storage instance with in-memory store."""
@@ -17,7 +26,7 @@ def storage():
     s._store = MagicMock()
     s._store.async_load = AsyncMock(return_value=None)
     s._store.async_save = AsyncMock()
-    asyncio.get_event_loop().run_until_complete(s.async_load())
+    run(s.async_load())
     return s
 
 


### PR DESCRIPTION
## What changed

Replaced `asyncio.get_event_loop().run_until_complete(...)` with the suite's existing `run()` helper in the four remaining places that used it.

- `tests/test_coordinator_logic.py` — the three `TestOneShotChores` midnight-expiry tests. This file **already defined** `run()` at line 95; these tests just weren't using it.
- `tests/test_templates.py` — the `storage` fixture. Added the same helper here.

## Why

`get_event_loop()` only creates a loop if one has never been set on the thread. `asyncio.run()` sets the current loop to `None` on cleanup, so once any earlier test in the session has used it, every later `get_event_loop()` raises `RuntimeError: There is no current event loop in thread 'MainThread'`.

That made the suite order-dependent: 12 tests failed in a full run on Python 3.11 while the same files passed in isolation. The `run()` helper builds its own loop and closes it without touching the thread's current loop, so it can't pollute or be polluted.

CI pins 3.12 and was already green — this fixes latent fragility, not a broken build.

## Validation

| | before | after |
|---|---|---|
| Full suite | 1522 passed, 3 failed, 9 errors | **1534 passed, 0 failed** |
| `tests/test_templates.py` alone | 9 passed | 9 passed |
| `tests/test_coordinator_logic.py` alone | 80 passed | 80 passed |
| `ruff check` on both files | clean | clean |

`grep -rn "get_event_loop" tests/ --include=*.py` now returns nothing, so there are no remaining sites to regress.

Fixes #765
