### PR TITLE
docs(readme): restore the section rule before Insights

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,6 +475,8 @@ Spend points to unlock something for a while — the TV, the console socket, a w
 - Turning something **off** is never gated by the allowlist — a revert is always safe.
 - Fires `taskmate_unlock_started` and `taskmate_unlock_ended` (`entity_id`, `reward_id`, `reward_name`, `child_id`, `child_name`, `started_at`, `revert_at`).
 
+---
+
 ## Insights — Fairness, Friction, Week Ahead & Health
  
 **TaskMate panel → Insights.** Answers the question the raw numbers don't: *am I dumping everything on the eldest?*


### PR DESCRIPTION
Follow-up to #764.

Removing the external lock-screen shop guide also removed the `---` rule that separated **Timed Unlock Rewards** from **Insights**, which would have left the only section boundary in the README without one (71 rules across 52 `##` headings elsewhere).

Restores the rule. No content change.
