### PR TITLE
fix(chores): keep a shared chore image until its last reference goes

### DIFF
--- a/custom_components/taskmate/coord_chores.py
+++ b/custom_components/taskmate/coord_chores.py
@@ -456,21 +456,46 @@ class ChoresMixin:
                 chore, cleanup_entities, today, summary_prefixes=extra_prefixes,
             )
         self.storage.update_chore(chore)
-        # Replacing or clearing the picture orphans the old file; delete it.
+        # Replacing or clearing the picture orphans the old file; delete it —
+        # unless a clone still shows it (#768).
         if prev_image and prev_image != (chore.image_url or ""):
-            await images.async_delete_image(self.hass, prev_image)
+            await self._async_release_image(prev_image, excluding_chore_id=chore.id)
         await self._publish_chore_to_calendars(chore, today)
         await self.storage.async_save()
         await self.async_refresh()
+
+    async def _async_release_image(
+        self, image_url: str, *, excluding_chore_id: str = ""
+    ) -> None:
+        """Delete a chore image file, but only if nothing else still shows it.
+
+        `async_clone_chore` copies `image_url` straight from the source, so two
+        chores routinely share one file on disk. Unlinking on the first delete
+        or re-picture would leave the other chore rendering a broken image
+        (#768). `excluding_chore_id` skips the chore being edited or removed —
+        on the update path storage already holds its new value, and on the
+        remove path it is about to go, so neither counts as a reference.
+        """
+        if not image_url:
+            return
+        for other in self.storage.get_chores():
+            if other.id == excluding_chore_id:
+                continue
+            if (getattr(other, "image_url", "") or "") == image_url:
+                return
+        await images.async_delete_image(self.hass, image_url)
 
     async def async_remove_chore(self, chore_id: str) -> None:
         """Remove a chore and all associated data."""
         existing = self.storage.get_chore(chore_id)
         if existing is not None and getattr(existing, "publish_calendar_entities", []):
             await self._cleanup_chore_from_calendars(existing)
-        # Nothing sweeps taskmate_images, so the file has to go with the chore.
+        # Nothing sweeps taskmate_images, so the file has to go with the chore —
+        # unless a clone still shows it (#768).
         if existing is not None and getattr(existing, "image_url", ""):
-            await images.async_delete_image(self.hass, existing.image_url)
+            await self._async_release_image(
+                existing.image_url, excluding_chore_id=chore_id
+            )
         self.storage.remove_chore(chore_id)
         self.storage.remove_completions_for_chore(chore_id)
         self.storage.remove_last_completed_for_chore(chore_id)

--- a/tests/test_chore_image_cleanup.py
+++ b/tests/test_chore_image_cleanup.py
@@ -21,14 +21,14 @@ def _body(name: str) -> str:
 
 def test_removing_a_chore_deletes_its_image():
     body = _body("async_remove_chore")
-    assert "async_delete_image" in body, (
+    assert "_async_release_image" in body, (
         "taskmate_images is never orphan-swept, so an undeleted file leaks forever"
     )
 
 
 def test_replacing_an_image_deletes_the_previous_file():
     body = _body("async_update_chore")
-    assert "async_delete_image" in body
+    assert "_async_release_image" in body
     # Must compare against the pre-update value, which the method already
     # captures as `existing` for the calendar cleanup.
     assert "existing" in body
@@ -39,8 +39,15 @@ def test_cleanup_uses_the_value_captured_before_storage_is_mutated():
     # from the `existing` snapshot taken before that, not re-read afterwards.
     body = _body("async_update_chore")
     existing_at = body.index("existing = self.storage.get_chore")
-    delete_at = body.index("async_delete_image")
+    delete_at = body.index("_async_release_image")
     assert existing_at < delete_at
+
+
+def test_the_release_helper_is_the_only_thing_that_unlinks():
+    # Both cleanup paths must go through _async_release_image so the shared-file
+    # check (#768) can never be bypassed by a new call site.
+    assert SRC.count("images.async_delete_image") == 1
+    assert "async_delete_image" in _body("_async_release_image")
 
 
 def test_the_images_dir_is_not_in_the_photo_sweeper():

--- a/tests/test_chore_image_sharing.py
+++ b/tests/test_chore_image_sharing.py
@@ -1,0 +1,112 @@
+"""A shared chore image survives until the last chore referencing it goes (#768).
+
+`async_clone_chore` copies `image_url` verbatim, so a duplicated chore points at
+the same file on disk as its source. Deleting or re-picturing either copy must
+not unlink a file the other one is still showing.
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from custom_components.taskmate.coordinator import TaskMateCoordinator
+from custom_components.taskmate.models import Chore
+
+IMAGE = "/api/taskmate/image/deadbeef.png"
+OTHER = "/api/taskmate/image/cafebabe.png"
+
+
+def run(coro):
+    """Run a coroutine synchronously."""
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+def _coord(chores: list[Chore]) -> TaskMateCoordinator:
+    """A coordinator whose storage holds exactly `chores`."""
+    coord = object.__new__(TaskMateCoordinator)
+    coord.hass = MagicMock()
+    coord.data = {}
+
+    by_id = {c.id: c for c in chores}
+    storage = MagicMock()
+    storage.get_chores = MagicMock(return_value=chores)
+    storage.get_chore = MagicMock(side_effect=by_id.get)
+    storage.get_children = MagicMock(return_value=[])
+    storage.async_save = AsyncMock()
+    coord.storage = storage
+
+    coord.async_refresh = AsyncMock()
+    coord._compute_daily_assignments = MagicMock(return_value={})
+    coord._compute_active_children = MagicMock(return_value=[])
+    coord._publish_chore_to_calendars = AsyncMock()
+    coord._cleanup_chore_from_calendars = AsyncMock()
+    return coord
+
+
+def _chore(chore_id: str, image_url: str = "") -> Chore:
+    return Chore(id=chore_id, name=f"chore {chore_id}", points=1, image_url=image_url)
+
+
+def test_removing_one_of_two_chores_sharing_an_image_keeps_the_file():
+    a, b = _chore("a", IMAGE), _chore("b", IMAGE)
+    coord = _coord([a, b])
+    with patch(
+        "custom_components.taskmate.coord_chores.images.async_delete_image",
+        new=AsyncMock(),
+    ) as delete:
+        run(coord.async_remove_chore("a"))
+    delete.assert_not_awaited()
+
+
+def test_removing_the_last_chore_using_an_image_deletes_the_file():
+    a = _chore("a", IMAGE)
+    coord = _coord([a])
+    with patch(
+        "custom_components.taskmate.coord_chores.images.async_delete_image",
+        new=AsyncMock(),
+    ) as delete:
+        run(coord.async_remove_chore("a"))
+    delete.assert_awaited_once_with(coord.hass, IMAGE)
+
+
+def test_replacing_an_image_still_used_elsewhere_keeps_the_file():
+    a, b = _chore("a", IMAGE), _chore("b", IMAGE)
+    coord = _coord([a, b])
+    updated = _chore("a", OTHER)
+    with patch(
+        "custom_components.taskmate.coord_chores.images.async_delete_image",
+        new=AsyncMock(),
+    ) as delete:
+        run(coord.async_update_chore(updated))
+    delete.assert_not_awaited()
+
+
+def test_replacing_the_only_reference_to_an_image_deletes_the_file():
+    a = _chore("a", IMAGE)
+    coord = _coord([a])
+    updated = _chore("a", OTHER)
+    with patch(
+        "custom_components.taskmate.coord_chores.images.async_delete_image",
+        new=AsyncMock(),
+    ) as delete:
+        run(coord.async_update_chore(updated))
+    delete.assert_awaited_once_with(coord.hass, IMAGE)
+
+
+def test_the_chore_being_updated_does_not_count_as_its_own_reference():
+    # Storage already holds the *new* value by the time cleanup runs, so a naive
+    # "is anyone using it?" scan must exclude the chore under edit or it would
+    # never delete anything.
+    a = _chore("a", IMAGE)
+    coord = _coord([a])
+    updated = _chore("a", "")
+    with patch(
+        "custom_components.taskmate.coord_chores.images.async_delete_image",
+        new=AsyncMock(),
+    ) as delete:
+        run(coord.async_update_chore(updated))
+    delete.assert_awaited_once_with(coord.hass, IMAGE)


### PR DESCRIPTION
## What changed

Both chore-image cleanup paths now go through a new `_async_release_image` helper, which unlinks the file only when no **other** chore still references it.

- `async_update_chore` — re-picturing or clearing a chore
- `async_remove_chore` — deleting a chore

The chore being edited or removed is excluded from the scan: on the update path storage already holds its new value, and on the remove path it is about to go, so neither counts as a reference.

## Why

`async_clone_chore` builds the clone from `source.to_dict()` and never resets `image_url`, so a duplicated chore points at the *same* file on disk. Unlinking on the first delete or re-picture left the surviving chore rendering a broken-image placeholder, with no error and nothing in the log.

I went with a reference check rather than copying the file on clone, because it also covers any other path that duplicates an `image_url` (template packs, imports) rather than just the clone.

## Validation

Six new behavioural tests in `tests/test_chore_image_sharing.py` — two reproduce the bug (shared file survives delete / re-picture), three pin the still-correct single-reference behaviour, and one guards the case where the edited chore must not count as its own reference. Both bug tests fail on `main` and pass here.

`tests/test_chore_image_cleanup.py` retargeted at the helper, plus a new assertion that `images.async_delete_image` has exactly one call site, so the shared-file check can't be bypassed by a future caller.

- Full suite: **1540 passed** (1534 before)
- `ruff check` clean

Verified live on the ha-dev instance with the exact reproduction from the issue:

```
--- setup ---            set image + cloned -> 8a9a0f48b9114c66   file: HTTP 200
--- delete the CLONE --- deleted the clone                        file: HTTP 200  <-- was 404 before this fix
--- clear the ORIGINAL - cleared the original                     file: HTTP 404  <-- correctly reclaimed, no leak
```

Fixes #768
