### PR TITLE
chore(ci): move CI to Python 3.14 and bump the HA test harness

### DIFF
--- a/.github/workflows/data-checks.yml
+++ b/.github/workflows/data-checks.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version: "3.12"
+          python-version: "3.14"
 
       - name: Check every locale matches en.json
         run: python3 scripts/check_translations.py
@@ -50,7 +50,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version: "3.12"
+          python-version: "3.14"
 
       - name: Install PyYAML
         run: python -m pip install --upgrade pip pyyaml

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version: "3.12"
+          python-version: "3.14"
 
       - name: Install ruff
         run: python -m pip install --upgrade pip "ruff==${RUFF_VERSION}"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version: "3.12"
+          python-version: "3.14"
           # The HA test harness pulls in homeassistant and its whole dependency
           # tree — easily the slowest step in CI. Cache it against the pinned
           # requirements file.

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version: "3.12"
+          python-version: "3.14"
 
       - name: Install zizmor
         run: python -m pip install --upgrade pip "zizmor==1.29.0"

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -6,9 +6,10 @@
 # pytest-asyncio + voluptuous + aiohttp + pyyaml, so freezing this one line
 # freezes the whole test stack deterministically.
 #
-# 0.13.205 is the newest release compatible with the CI Python (3.12); 0.13.206+
-# require >=3.13. This is exactly what the previous unpinned install resolved to.
-pytest-homeassistant-custom-component==0.13.205
+# Keep this in step with the CI Python (3.14): 0.13.206+ require >=3.13 and
+# 0.13.317+ require >=3.14, so bumping the harness past those floors means
+# bumping python-version in the workflows too.
+pytest-homeassistant-custom-component==0.13.348
 
 # Coverage reporting for CI (Tests workflow renders a per-module summary).
 pytest-cov

--- a/tests/test_photo_proof.py
+++ b/tests/test_photo_proof.py
@@ -24,6 +24,12 @@ def _coord(chore, child):
     coord.hass = MagicMock()
     coord.hass.bus = MagicMock()
     coord.hass.bus.async_fire = MagicMock()
+    # A real dict, not a MagicMock: completion signs the evidence photo via
+    # HA's async_sign_path, which reads hass.data[...]. Handed a mock it builds
+    # an unserializable JWT payload — sign_photo_url swallows that and returns
+    # the URL unsigned, but the test harness still flags the attempted mock
+    # serialization at teardown. An empty dict makes the lookup miss cleanly.
+    coord.hass.data = {}
     added = []
     storage = MagicMock()
     storage.get_chore = MagicMock(return_value=chore)


### PR DESCRIPTION
## Why

Dependabot PR #773 (`pytest-homeassistant-custom-component` 0.13.205 → 0.13.348) cannot pass. It fails at pip install, not on any test signal:

```
ERROR: No matching distribution found for pytest-homeassistant-custom-component==0.13.348
```

CI runs Python 3.12. The harness dropped 3.12 at 0.13.206 (needs >=3.13) and 3.13 at 0.13.317 (needs >=3.14), so every bump Dependabot proposes is unresolvable on the current interpreter. `requirements_test.txt` already documented the pin as "newest release compatible with the CI Python (3.12)" — this raises that ceiling instead of freezing the harness indefinitely.

## What

- `python-version: "3.12"` → `"3.14"` in `tests.yml`, `lint.yml`, `data-checks.yml` (both jobs) and `workflow-lint.yml`
- `pytest-homeassistant-custom-component` 0.13.205 → 0.13.348 (HA 2026.7.4), with the pin comment rewritten to record both version floors so the next bump does not repeat this

## What deliberately did not change

The ruff `target-version` stays at `py312`. It describes the runtime the shipped integration must support — `hacs.json` still declares a `2024.1.0` HA floor — not the interpreter CI happens to run on. Raising it to `py314` lets pyupgrade rewrite code into 3.14-only syntax, and it reformats 26 files for no benefit (confirmed locally: main is clean under the same ruff, so the churn comes purely from the flag).

## Verification

- Full suite locally: **1540 passed** (Python 3.11, matching the count on main)
- `ruff check` and `ruff format --check` over `custom_components/taskmate tests scripts`: clean
- The 3.14 run is what this PR exists to prove — merge is gated on the "Run tests" check going green here

Supersedes #773, which should auto-close once this lands.
