### PR TITLE
chore: correct the minimum Home Assistant version to 2024.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <a href="https://github.com/tempus2016/taskmate/releases"><img src="https://img.shields.io/github/v/release/tempus2016/taskmate" alt="Latest Release"></a>
   <a href="https://github.com/hacs/default"><img src="https://img.shields.io/badge/HACS-Default-41BDF5.svg" alt="HACS Default"></a>
   <a href="https://github.com/tempus2016/taskmate/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue" alt="License"></a>
-  <img src="https://img.shields.io/badge/Home%20Assistant-2024.1+-blue" alt="HA Version">
+  <img src="https://img.shields.io/badge/Home%20Assistant-2024.7+-blue" alt="HA Version">
   <a href="https://github.com/tempus2016/taskmate/releases"><img src="https://img.shields.io/github/downloads/tempus2016/taskmate/total" alt="Downloads"></a>
 </p>
 
@@ -124,7 +124,7 @@ Or use the one-click buttons:
 
 ### Requirements
 
-- **Home Assistant** 2024.1 or newer
+- **Home Assistant** 2024.7 or newer
 - A modern browser for the dashboard cards: current Chrome, Firefox, Edge, or Safari. The cards use Web Components, Web Audio, and ES2020 features and will not work in Internet Explorer or pre-2022 browsers.
 
 ### Privacy

--- a/custom_components/taskmate/frontend.py
+++ b/custom_components/taskmate/frontend.py
@@ -106,7 +106,14 @@ async def async_register_frontend(hass: HomeAssistant) -> None:
         _LOGGER.warning("www directory not found at %s", www_path)
         return
 
-    # Register the www folder as a static path
+    # Register the www folder as a static path.
+    #
+    # This call is what sets our minimum Home Assistant version. Both
+    # async_register_static_paths and StaticPathConfig landed in 2024.7.0 and do
+    # not exist in 2024.6.0, so on anything older setup dies here with an
+    # AttributeError rather than degrading — hence the 2024.7.0 floor in
+    # hacs.json and README.md. Lowering that floor means adding a fallback to
+    # the old (since-removed) hass.http.register_static_path.
     await hass.http.async_register_static_paths([StaticPathConfig(URL_BASE, str(www_path), False)])
 
     _LOGGER.debug("Registered static path: %s -> %s", URL_BASE, www_path)

--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,6 @@
 {
   "name": "TaskMate",
-  "homeassistant": "2024.1.0",
+  "homeassistant": "2024.7.0",
   "render_readme": true,
   "zip_release": true,
   "filename": "taskmate.zip"


### PR DESCRIPTION
## Why

`hacs.json` declared a minimum Home Assistant of `2024.1.0`. That was not achievable — it promised something that never worked.

`frontend.py` registers the www folder with `hass.http.async_register_static_paths([StaticPathConfig(...)])`, unconditionally and with no fallback. Both symbols landed in **HA 2024.7.0**; 2024.6.0 has neither:

| HA tag | `StaticPathConfig` / `async_register_static_paths` |
|---|---|
| 2024.5.0 | absent |
| 2024.6.0 | absent |
| **2024.7.0** | **present** |
| 2024.8.0 | present |

On anything older, setup raises `AttributeError` at that line — the integration does not degrade, it fails to load entirely.

## Why 2024.7.0 specifically, and not a round number

I checked the rest of the imported HA surface against the 2024.7.0 tag to confirm nothing else binds higher:

| API | Status in 2024.7.0 |
|---|---|
| `IconSelector` | present |
| `ServiceValidationError` | present |
| `TodoListEntityFeature.UPDATE_TODO_ITEM` | present |

So `async_register_static_paths` is the single binding constraint, and 2024.7.0 is the true floor.

## What changed

- `hacs.json` — `2024.1.0` → `2024.7.0`
- `README.md` — both places the old number appeared: the badge and the Requirements list
- `frontend.py` — a comment recording *why* the floor is what it is, next to the call that causes it

The comment placement is deliberate. `hacs.json` is strict JSON and cannot carry one, and adding a non-schema key risks the HACS validate check — an unexplained number in a data file is exactly how `2024.1.0` drifted unchallenged. Lowering the floor again would mean adding a fallback to the old (since-removed) `hass.http.register_static_path`, and the comment says so.

## Scope caveat

This is the oldest **loadable** version, not a **tested** one. CI runs a single HA (2026.7.4, Python 3.14), so nothing here verifies behaviour on 2024.7. Making the number mean "tested" would need the test job matrixed across two harness/HA pins — deliberately not done here.

## Verification

- `scripts/check_data_files.py`: PASS (metadata consistent)
- Full suite: **1540 passed**
- `ruff check` + `ruff format --check` over `custom_components/taskmate tests scripts`: clean
- No `2024.1` references remain anywhere in `README.md`, `hacs.json`, or the integration
