### PR TITLE
ci: test both ends of the supported HA range

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,9 +19,39 @@ jobs:
   # every push/PR. It used to be duplicated here as a "validate" job; that ran
   # the same action twice per PR for no extra signal.
 
-  test:
-    name: Run tests
+  matrix-tests:
+    # Both ends of the supported range, because a single version can only ever
+    # prove one of them:
+    #
+    #   * floor   — the oldest HA we claim to support in hacs.json (2024.7.0).
+    #     Before this leg existed that claim was untested, and the previous
+    #     claim (2024.1.0) turned out to be impossible — see #776.
+    #   * current — what HA users are actually on today, and what ha-dev runs.
+    #
+    # The harness pins its own matching homeassistant, so pinning one version
+    # per leg pins the whole HA stack for that leg.
+    name: tests (py${{ matrix.python-version }}, HA ${{ matrix.ha }})
     runs-on: ubuntu-latest
+
+    strategy:
+      # Never cancel the other leg: "old breaks, new fine" and "new breaks, old
+      # fine" are different bugs and we want to see both in one run.
+      fail-fast: false
+      matrix:
+        include:
+          - name: current
+            python-version: "3.14"
+            ha: "2026.7.4"
+            # Empty means "use the pinned requirements_test.txt", which is the
+            # file Dependabot maintains.
+            harness: ""
+          - name: floor
+            python-version: "3.12"
+            ha: "2024.7.0"
+            # Pinned here rather than in a requirements file so Dependabot
+            # leaves it alone: this version is deliberately old, and bumping it
+            # would silently stop testing the floor.
+            harness: "0.13.144"
 
     steps:
       - name: Check out repository
@@ -32,18 +62,31 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version: "3.14"
+          python-version: ${{ matrix.python-version }}
           # The HA test harness pulls in homeassistant and its whole dependency
           # tree — easily the slowest step in CI. Cache it against the pinned
-          # requirements file.
+          # requirements file (setup-python keys the cache by Python version
+          # too, so the two legs cannot share an entry).
           cache: "pip"
           cache-dependency-path: requirements_test.txt
 
       - name: Install dependencies
+        env:
+          HARNESS: ${{ matrix.harness }}
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements_test.txt
+          if [ -n "$HARNESS" ]; then
+            # Install the floor harness on its own. Layering it over
+            # requirements_test.txt would make pip resolve two conflicting
+            # homeassistant pins.
+            pip install "pytest-homeassistant-custom-component==$HARNESS" pytest-cov
+          else
+            pip install -r requirements_test.txt
+          fi
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+
+      - name: Show resolved HA version
+        run: python -c "import homeassistant; print('homeassistant', homeassistant.__version__)"
 
       - name: Run tests
         run: pytest -v --cov --cov-report=term-missing --cov-report=xml --cov-report=html
@@ -86,7 +129,29 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: coverage-html
+          # Artifact names must be unique across matrix legs.
+          name: coverage-html-${{ matrix.name }}
           path: htmlcov/
           retention-days: 14
           if-no-files-found: ignore
+
+  # Aggregate gate. The branch ruleset requires a check named exactly "Run
+  # tests"; matrix legs carry their own per-leg names, so that check would
+  # otherwise never report again and every PR would sit blocked. This job keeps
+  # the name stable and stays red unless every leg passed — note that a
+  # skipped or cancelled leg is not a success either.
+  test:
+    name: Run tests
+    runs-on: ubuntu-latest
+    needs: matrix-tests
+    if: always()
+    steps:
+      - name: Check matrix result
+        env:
+          RESULT: ${{ needs.matrix-tests.result }}
+        run: |
+          echo "matrix-tests result: $RESULT"
+          if [ "$RESULT" != "success" ]; then
+            echo "::error::One or more test matrix legs did not pass ($RESULT)."
+            exit 1
+          fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,6 +52,14 @@ jobs:
             # leaves it alone: this version is deliberately old, and bumping it
             # would silently stop testing the floor.
             harness: "0.13.144"
+            # HA 2024.7 does not pin its whole transitive tree, so pip resolves
+            # some of it to today's releases and old code meets new libraries.
+            # josepy 2.0 (Feb 2025) dropped ComparableX509, which the acme
+            # version behind hass_nabucasa touches at import — that alone stops
+            # pytest loading, long before any TaskMate code runs. Nothing to do
+            # with the floor being unsupportable; add pins here as the tree
+            # rots further.
+            constraints: "josepy<2"
 
     steps:
       - name: Check out repository
@@ -73,13 +81,18 @@ jobs:
       - name: Install dependencies
         env:
           HARNESS: ${{ matrix.harness }}
+          CONSTRAINTS: ${{ matrix.constraints }}
         run: |
           python -m pip install --upgrade pip
           if [ -n "$HARNESS" ]; then
+            # Written to a constraints file rather than appended to the command
+            # line: these are specifiers like "josepy<2", and unquoted "<" is a
+            # shell redirect.
+            printf '%s\n' "$CONSTRAINTS" > /tmp/constraints.txt
             # Install the floor harness on its own. Layering it over
             # requirements_test.txt would make pip resolve two conflicting
             # homeassistant pins.
-            pip install "pytest-homeassistant-custom-component==$HARNESS" pytest-cov
+            pip install -c /tmp/constraints.txt "pytest-homeassistant-custom-component==$HARNESS" pytest-cov
           else
             pip install -r requirements_test.txt
           fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -86,7 +86,8 @@ jobs:
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
       - name: Show resolved HA version
-        run: python -c "import homeassistant; print('homeassistant', homeassistant.__version__)"
+        # HA keeps its version in homeassistant.const, not on the package.
+        run: python -c "from homeassistant.const import __version__; print('homeassistant', __version__)"
 
       - name: Run tests
         run: pytest -v --cov --cov-report=term-missing --cov-report=xml --cov-report=html


### PR DESCRIPTION
## Why

#776 corrected the declared HA floor to `2024.7.0`, but nothing verified it. CI ran a single HA (2026.7.4), so the floor was an argument about which APIs exist rather than a tested claim — and the *previous* floor (`2024.1.0`) was wrong for roughly two years precisely because nothing exercised it.

This adds the second leg so both ends of the supported range are actually run.

## How the floor leg is pinned

The harness pins its own matching `homeassistant`, so one pin per leg fixes that leg's entire HA stack. I walked the harness releases to find the one that lands exactly on our floor:

| harness | pins homeassistant |
|---|---|
| 0.13.136 | 2024.6.4 |
| 0.13.143 | 2024.7.0b9 |
| **0.13.144** | **2024.7.0** |
| 0.13.145 | 2024.7.1 |

So the matrix is:

| leg | Python | HA | source of pin |
|---|---|---|---|
| current | 3.14 | 2026.7.4 | `requirements_test.txt` (Dependabot-maintained) |
| floor | 3.12 | 2024.7.0 | harness `0.13.144`, pinned in the workflow |

The floor pin lives in the workflow rather than a requirements file **so Dependabot leaves it alone**. Bumping it would silently stop testing the floor, which is the one thing that leg exists to do.

## The required-check problem

The branch ruleset requires a check named exactly `Run tests`. Matrix legs carry per-leg names, so that check would never report again and **every PR would sit blocked**.

Rather than repoint the ruleset at names that change whenever the matrix changes, there's a small aggregate job that keeps the `Run tests` name and fails unless every leg succeeded. It treats skipped and cancelled as failures too, so the gate can't go green because a leg silently didn't run. No ruleset change needed.

Other details:

- `fail-fast: false` — "old breaks, new fine" and "new breaks, old fine" are different bugs, and I want both visible in one run
- Coverage artifacts are named per leg, since artifact names must be unique across a matrix
- A `Show resolved HA version` step prints the actual resolved `homeassistant.__version__`, so the log proves which HA each leg tested rather than relying on the pin being right

## Verification

The floor leg is new information — nothing has ever run this suite against HA 2024.7.0, so whether it passes is genuinely open. That result is the point of the PR and I'll report it as it comes back rather than assume it.
