### PR TITLE
ci: pin the floor legs whole dependency set

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,12 +54,10 @@ jobs:
             harness: "0.13.144"
             # HA 2024.7 does not pin its whole transitive tree, so pip resolves
             # some of it to today's releases and old code meets new libraries.
-            # josepy 2.0 (Feb 2025) dropped ComparableX509, which the acme
-            # version behind hass_nabucasa touches at import — that alone stops
-            # pytest loading, long before any TaskMate code runs. Nothing to do
-            # with the floor being unsupportable; add pins here as the tree
-            # rots further.
-            constraints: "josepy<2"
+            # Rather than chase each break with another one-off pin, this file
+            # holds the complete set a known-good run resolved. See the header
+            # in it for why, and for how to regenerate.
+            constraints: "ci/constraints-floor.txt"
 
     steps:
       - name: Check out repository
@@ -76,7 +74,9 @@ jobs:
           # requirements file (setup-python keys the cache by Python version
           # too, so the two legs cannot share an entry).
           cache: "pip"
-          cache-dependency-path: requirements_test.txt
+          cache-dependency-path: |
+            requirements_test.txt
+            ci/constraints-floor.txt
 
       - name: Install dependencies
         env:
@@ -85,14 +85,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           if [ -n "$HARNESS" ]; then
-            # Written to a constraints file rather than appended to the command
-            # line: these are specifiers like "josepy<2", and unquoted "<" is a
-            # shell redirect.
-            printf '%s\n' "$CONSTRAINTS" > /tmp/constraints.txt
             # Install the floor harness on its own. Layering it over
             # requirements_test.txt would make pip resolve two conflicting
             # homeassistant pins.
-            pip install -c /tmp/constraints.txt "pytest-homeassistant-custom-component==$HARNESS" pytest-cov
+            pip install -c "$CONSTRAINTS" "pytest-homeassistant-custom-component==$HARNESS" pytest-cov
           else
             pip install -r requirements_test.txt
           fi

--- a/ci/constraints-floor.txt
+++ b/ci/constraints-floor.txt
@@ -1,0 +1,141 @@
+# Pinned dependency set for the CI test matrix's "floor" leg (HA 2024.7.0).
+#
+# Why this file exists
+# --------------------
+# Home Assistant 2024.7 does not pin its whole transitive tree, so pip is free
+# to resolve parts of it to today's releases. Two-year-old code then meets
+# current libraries and breaks in ways that have nothing to do with TaskMate:
+# josepy 2.0 dropped ComparableX509, which the acme behind hass_nabucasa
+# touches at import, and that alone stopped pytest loading its plugins (#777).
+#
+# Chasing those one pin at a time is whack-a-mole — each new break costs a red
+# CI run to discover. This file instead pins the entire set that a known-good
+# floor run resolved, so the leg is reproducible and only goes red for reasons
+# that are actually ours.
+#
+# These are constraints, not requirements: pip applies them to whatever the
+# harness pulls in, and unlisted packages still resolve normally.
+#
+# Regenerating
+# ------------
+# Take the "Successfully installed" line from a green floor-leg job log and
+# rewrite each "name-version" token as "name==version". Deliberately excludes
+# pip and setuptools, which the workflow upgrades separately.
+#
+# Captured from: harness 0.13.144 / homeassistant 2024.7.0 / Python 3.12,
+# the run that first went green on main (1540 passed).
+
+acme==2.10.0
+aiodns==3.2.0
+aiohttp==3.9.5
+aiohttp-cors==0.7.0
+aiohttp-fast-url-dispatcher==0.3.0
+aiohttp-fast-zlib==0.1.1
+aiooui==0.1.9
+aiosignal==1.4.0
+aiozoneinfo==0.2.1
+anyio==4.14.2
+astral==2.2
+async-interrupt==1.1.2
+async-timeout==5.0.1
+atomicwrites-homeassistant==1.4.1
+attrs==23.2.0
+awesomeversion==24.2.0
+bcrypt==4.1.2
+bleak==3.0.2
+bleak-retry-connector==4.6.3
+bluetooth-adapters==2.4.0
+bluetooth-auto-recovery==1.6.4
+bluetooth-data-tools==1.28.4
+boto3==1.43.68
+botocore==1.43.68
+btsocket==0.3.0
+certifi==2026.7.22
+cffi==2.1.1
+charset-normalizer==3.4.9
+ciso8601==2.3.1
+coverage==7.5.3
+cryptography==42.0.8
+dbus-fast==5.0.22
+envs==1.4
+execnet==2.1.2
+fnv-hash-fast==0.5.0
+fnvhash==0.1.0
+freezegun==1.5.0
+frozenlist==1.8.0
+greenlet==3.5.5
+h11==0.16.0
+habluetooth==6.1.0
+hass-nabucasa==0.81.1
+home-assistant-bluetooth==1.12.2
+homeassistant==2024.7.0
+httpcore==1.0.9
+httpx==0.27.0
+idna==3.18
+ifaddr==0.2.0
+iniconfig==2.3.0
+Jinja2==3.1.4
+jmespath==1.1.0
+josepy==1.15.0
+lru-dict==1.3.0
+MarkupSafe==3.0.3
+mock-open==1.4.0
+multidict==6.7.1
+numpy==1.26.0
+orjson==3.9.15
+packaging==26.3
+paho-mqtt==1.6.1
+Pillow==10.3.0
+pipdeptree==2.19.0
+pluggy==1.6.0
+psutil==7.2.2
+psutil-home-assistant==0.0.1
+pycares==5.0.1
+pycognito==2024.5.1
+pycparser==3.0
+pydantic==1.10.17
+PyJWT==2.8.0
+pylint-per-file-ignores==1.3.2
+pyOpenSSL==24.1.0
+pyrfc3339==2.1.0
+PyRIC==0.1.6.3
+pytest==8.2.0
+pytest-aiohttp==1.0.5
+pytest-asyncio==0.23.6
+pytest-cov==5.0.0
+pytest-freezer==0.4.8
+pytest-github-actions-annotate-failures==0.2.0
+pytest-homeassistant-custom-component==0.13.144
+pytest-picked==0.5.0
+pytest-socket==0.7.0
+pytest-sugar==1.0.0
+pytest-timeout==2.3.1
+pytest-unordered==0.6.0
+pytest-xdist==3.6.1
+python-dateutil==2.9.0.post0
+python-slugify==8.0.4
+pytz==2026.3.post1
+PyYAML==6.0.1
+requests==2.32.3
+requests-mock==1.12.1
+respx==0.21.1
+s3transfer==0.19.2
+six==1.17.0
+sniffio==1.3.1
+snitun==0.39.1
+sqlalchemy==2.0.31
+syrupy==4.6.1
+termcolor==3.3.0
+text-unidecode==1.3
+tqdm==4.66.4
+typing-extensions==4.16.0
+tzdata==2026.3
+uart-devices==0.1.1
+ulid-transform==0.9.0
+urllib3==1.26.20
+usb-devices==0.5.1
+uv==0.2.13
+voluptuous==0.13.1
+voluptuous-openapi==0.0.4
+voluptuous-serialize==2.6.0
+yarl==1.9.4


### PR DESCRIPTION
## Why

The floor leg (HA 2024.7.0) carried a single hand-added `josepy<2` pin from #777. That fixed the one break we had actually hit, but HA 2024.7 leaves most of its transitive tree unpinned — so the next rotted dependency would have cost another red CI run to discover, and the one after that too.

## What

`ci/constraints-floor.txt` — the complete set a known-good floor run resolved (114 pins, captured from the first green run on main: harness 0.13.144 / homeassistant 2024.7.0 / Python 3.12, 1540 passed). The leg is now reproducible, and only goes red for reasons that are ours.

These are **constraints, not requirements**: pip applies them to whatever the harness pulls in, and anything unlisted still resolves normally.

## Two placement details

- **Under `ci/`, not the repo root.** Dependabot pip scans `/`, and would treat a root requirements file as something to bump — the exact opposite of what this file is for. The floor pins must stay old.
- **Cache keyed on it.** `cache-dependency-path` now includes the constraints file, so editing it invalidates the floor cache instead of restoring a stale tree.

`pip` and `setuptools` are deliberately excluded, since the workflow upgrades pip separately.

The file header records why it exists and how to regenerate it, so the next person hitting a rotted pin does not have to reconstruct this reasoning.

## Verification

The floor leg passing here is the check that matters — it proves the constraints resolve and still run the suite, rather than merely being syntactically valid.