### PR TITLE
chore: smoke-test the pre-commit.ci installation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,8 @@
 #
 # pre-commit.ci (the GitHub App) runs the same hooks on PRs and pushes an
 # autofix commit when a hook rewrites a file.
+# The app is installed on this repo; the trailing space at the end of this
+# line is deliberate, as a live check that the autofix path works.   
 
 ci:
   autofix_commit_msg: "style: pre-commit.ci autofixes"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@
 # pre-commit.ci (the GitHub App) runs the same hooks on PRs and pushes an
 # autofix commit when a hook rewrites a file.
 # The app is installed on this repo; the trailing space at the end of this
-# line is deliberate, as a live check that the autofix path works.   
+# line is deliberate, as a live check that the autofix path works.
 
 ci:
   autofix_commit_msg: "style: pre-commit.ci autofixes"


### PR DESCRIPTION
Throwaway PR to confirm the pre-commit.ci app is live on this repo.

The added comment in `.pre-commit-config.yaml` carries deliberate trailing whitespace. If the app is wired up, it fails the `trailing-whitespace` hook, strips it, and pushes a `style: pre-commit.ci autofixes` commit to this branch — proving detection and write access in one go.

Close without merging once the answer is in.