### PR TITLE
fix(chores): approved sibling swaps can be completed (#781)

### DIFF
--- a/custom_components/taskmate/coord_assignments.py
+++ b/custom_components/taskmate/coord_assignments.py
@@ -360,12 +360,42 @@ class AssignmentsMixin:
             return cached
         return self._compute_active_children_uncached(chore, today)
 
+    def _swap_override(self, chore: Chore, today: date | None = None) -> str:
+        """The child an approved sibling swap moved this chore to for ``today``.
+
+        Returns "" when there is no swap for that date, or when the swapped-to
+        child is no longer in the chore's pool (removed from `assigned_to`, or
+        deleted). Stamped with a date so it expires on its own — a swap is a
+        one-day arrangement, and probes of other days must stay pure rotation.
+        """
+        swap_date = getattr(chore, "assignment_swap_date", "") or ""
+        swapped_to = getattr(chore, "assignment_swap_child_id", "") or ""
+        if not swap_date or not swapped_to:
+            return ""
+        if today is None:
+            today = dt_util.as_local(dt_util.now()).date()
+        if swap_date != today.isoformat():
+            return ""
+        if swapped_to not in self._chore_assignment_pool(chore):
+            return ""
+        return swapped_to
+
     def _compute_active_children_uncached(self, chore: Chore, today: date | None = None) -> list[str]:
         mode = getattr(chore, "assignment_mode", "everyone")
         require_availability = getattr(chore, "require_availability", False)
 
         if mode == "unassigned":
             return []
+
+        # An approved swap replaces the whole active set for that day, ahead of
+        # every mode's own logic. `require_availability` is deliberately not
+        # re-applied: a parent explicitly approved this child for today, which
+        # outranks an availability entity. "everyone" chores have no single
+        # assignee to move, and async_request_swap already refuses them.
+        if mode != "everyone":
+            swapped_to = self._swap_override(chore, today)
+            if swapped_to:
+                return [swapped_to]
 
         if mode == "first_come":
             # Competitive: every child in the resolved pool sees it until the
@@ -628,8 +658,8 @@ class AssignmentsMixin:
         Runs at midnight. All chores are processed concurrently so the runtime
         is bounded by the slowest single publish, not the sum across chores.
 
-        Also clears stale skip state (skip_date != today) so yesterday's skip
-        doesn't bleed into the new day.
+        Also clears stale skip and swap state (dated != today) so yesterday's
+        skip or approved sibling swap doesn't bleed into the new day.
         """
         today = dt_util.as_local(dt_util.now()).date()
         today_iso = today.isoformat()
@@ -637,11 +667,16 @@ class AssignmentsMixin:
         if not chores:
             return
 
-        # Clear stale skip state in-memory (persisted via update_chore below).
+        # Clear stale skip/swap state in-memory (persisted via update_chore
+        # below). Both are read-time-guarded by their date too, so this is
+        # housekeeping rather than a correctness requirement.
         for chore in chores:
             if getattr(chore, "skip_date", "") and chore.skip_date != today_iso:
                 chore.skip_date = ""
                 chore.skip_count = 0
+            if getattr(chore, "assignment_swap_date", "") and chore.assignment_swap_date != today_iso:
+                chore.assignment_swap_date = ""
+                chore.assignment_swap_child_id = ""
 
         # Group-aware daily assignment map.
         daily = self._compute_daily_assignments(today)
@@ -657,10 +692,14 @@ class AssignmentsMixin:
             await self._publish_chore_to_calendars(chore, today)
             if list(getattr(chore, "publish_calendar_published_dates", []) or []) != before:
                 dirty = True
-            # Always persist if skip state was cleared above.
+            # Always persist if skip/swap state was cleared above.
             if getattr(chore, "skip_date", "") == "" and getattr(chore, "skip_count", 0) == 0:
                 stored = self.storage.get_chore(chore.id)
                 if stored and (stored.skip_date or stored.skip_count):
+                    dirty = True
+            if getattr(chore, "assignment_swap_date", "") == "":
+                stored = self.storage.get_chore(chore.id)
+                if stored and getattr(stored, "assignment_swap_date", ""):
                     dirty = True
             if dirty:
                 self.storage.update_chore(chore)

--- a/custom_components/taskmate/coord_chores.py
+++ b/custom_components/taskmate/coord_chores.py
@@ -181,6 +181,12 @@ class ChoresMixin:
             raise ValueError(f"Swap request {req_id} not found")
         chore = self.get_chore(req["chore_id"])
         if chore:
+            # Stamp the dated override *and* the cached current child. The
+            # override is what every eligibility gate reads (#781); the cached
+            # field keeps the sensors/cards consistent without waiting for the
+            # next assignment pass.
+            chore.assignment_swap_child_id = req["requester_id"]
+            chore.assignment_swap_date = dt_util.as_local(dt_util.now()).date().isoformat()
             chore.assignment_current_child_id = req["requester_id"]
             self.storage.update_chore(chore)
         self.storage.update_swap_request(req_id, status="approved")
@@ -314,6 +320,8 @@ class ChoresMixin:
         data["assignment_current_child_id"] = ""
         data["skip_date"] = ""
         data["skip_count"] = 0
+        data["assignment_swap_child_id"] = ""
+        data["assignment_swap_date"] = ""
         data["publish_calendar_published_dates"] = []
         data["disabled_for"] = []
         data["enabled"] = True
@@ -561,6 +569,12 @@ class ChoresMixin:
             chore.skip_date = today_iso
             chore.skip_count = 0
 
+        # A skip is a deliberate move of today's assignee, so it supersedes any
+        # approved swap — otherwise the swap override would keep winning and the
+        # skip would silently do nothing.
+        chore.assignment_swap_child_id = ""
+        chore.assignment_swap_date = ""
+
         # Cyclical: A → B → … → unassigned → back to A.
         # skip_count < pool_size  → advance to next child
         # skip_count == pool_size → unassigned (no child today)
@@ -624,9 +638,13 @@ class ChoresMixin:
             chore.assigned_to = [child_id] + [c for c in pool if c != child_id]
             chore.assignment_rotation_anchor = today.isoformat()
 
-        # Any previous skip is wiped — manual start is an explicit reset.
+        # Any previous skip or approved swap is wiped — manual start is an
+        # explicit reset, and a lingering swap override would outrank the
+        # child the parent just picked.
         chore.skip_date = ""
         chore.skip_count = 0
+        chore.assignment_swap_child_id = ""
+        chore.assignment_swap_date = ""
 
         chore.assignment_current_child_id = child_id
 
@@ -878,8 +896,12 @@ class ChoresMixin:
         # the "Current" column / child-stats card stops pointing at the
         # original child. The pointer recomputes at the next midnight refresh.
         if getattr(chore, "assignment_mode", "everyone") != "everyone":
-            if getattr(chore, "assignment_current_child_id", ""):
+            if getattr(chore, "assignment_current_child_id", "") or getattr(chore, "assignment_swap_date", ""):
                 chore.assignment_current_child_id = ""
+                # Drop the swap override too, or it would re-point the column
+                # at the swapped-to child on the next assignment pass.
+                chore.assignment_swap_child_id = ""
+                chore.assignment_swap_date = ""
                 self.storage.update_chore(chore)
 
         await self.storage.async_save()

--- a/custom_components/taskmate/models.py
+++ b/custom_components/taskmate/models.py
@@ -329,6 +329,13 @@ class Chore:
     # Skip state (ephemeral: cleared at midnight when skip_date != today)
     skip_date: str = ""  # ISO date the skip applies to ("" = no active skip)
     skip_count: int = 0  # number of times skipped today; added to rotation index
+    # Approved sibling swap (ephemeral, same shape as the skip pair above).
+    # This — not assignment_current_child_id — is the override every read-time
+    # eligibility gate consults, because assignment_current_child_id is itself
+    # *written from* _compute_active_children at midnight; reading it back there
+    # would pin the rotation to whoever it last cached (#781).
+    assignment_swap_child_id: str = ""  # child the chore was swapped to
+    assignment_swap_date: str = ""  # ISO date the swap applies to ("" = no swap)
     # Calendar publish: list of HA calendar entity ids to mirror the chore to. Any number supported.
     publish_calendar_entities: list[str] = field(default_factory=list)
     # ISO dates already written to the configured calendars. Used for both
@@ -400,6 +407,8 @@ class Chore:
             require_availability=data.get("require_availability", False),
             skip_date=data.get("skip_date", ""),
             skip_count=int(data.get("skip_count", 0) or 0),
+            assignment_swap_child_id=data.get("assignment_swap_child_id", ""),
+            assignment_swap_date=data.get("assignment_swap_date", ""),
             publish_calendar_entities=list(data.get("publish_calendar_entities", [])),
             # Back-compat: old records stored a single ISO date in
             # `publish_calendar_last_date`. Seed the new list with it so we
@@ -464,6 +473,8 @@ class Chore:
             "require_availability": self.require_availability,
             "skip_date": self.skip_date,
             "skip_count": self.skip_count,
+            "assignment_swap_child_id": self.assignment_swap_child_id,
+            "assignment_swap_date": self.assignment_swap_date,
             "publish_calendar_entities": self.publish_calendar_entities,
             "publish_calendar_published_dates": self.publish_calendar_published_dates,
             "bonus_subtasks": [b.to_dict() for b in self.bonus_subtasks],

--- a/tests/test_chore_swap.py
+++ b/tests/test_chore_swap.py
@@ -6,6 +6,7 @@ import asyncio
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from homeassistant.util import dt as dt_util
 
 from custom_components.taskmate.coordinator import TaskMateCoordinator
 from custom_components.taskmate.models import Child, Chore
@@ -88,3 +89,18 @@ def test_reject_removes_request():
     run(coord.async_reject_swap(rid))
     assert coord._reqs == []
     assert chore.assignment_current_child_id == "a"  # unchanged
+
+
+def test_approve_stamps_dated_swap_override():
+    """Approval records a *dated* override, not just the cached current child.
+
+    `assignment_current_child_id` is written from `_compute_active_children`
+    at midnight, so it can't be the override's home — reading it back there
+    would pin the rotation. The dated pair is what read-time gates consult.
+    """
+    chore = Chore(name="Bins", assignment_mode="alternating", assignment_current_child_id="a", id="ch1")
+    coord = _coord(chore, [Child(name="A", id="a"), Child(name="B", id="b")])
+    run(coord.async_request_swap("ch1", "b"))
+    run(coord.async_approve_swap(coord._reqs[0]["id"]))
+    assert chore.assignment_swap_child_id == "b"
+    assert chore.assignment_swap_date == dt_util.now().date().isoformat()

--- a/tests/test_rotation_quota.py
+++ b/tests/test_rotation_quota.py
@@ -116,3 +116,73 @@ class TestRotationQuota:
         comps = _parent_completions(storage)
         assert len(comps) == 1
         assert comps[0].child_id == inactive
+
+
+class TestSwappedRotation:
+    """An approved sibling swap must move the *whole* eligibility, not just the
+    card's view of it (#781). Before the fix the swapped-to child saw the chore
+    (the sensor reads `assignment_current_child_id`) but `async_complete_chore`
+    gated on `_compute_active_children`, which is pure date math — so the tap
+    was a silent no-op: no points, no pending approval, and the chore returned
+    on the next 30s coordinator refresh.
+    """
+
+    def _swapped(self, coord, _mod, now):
+        chore, active, inactive = _alternating_chore(coord, _mod, now)
+        with patch.object(_mod.dt_util, "now", return_value=now):
+            req_id = run(coord.async_request_swap(chore.id, inactive))
+            run(coord.async_approve_swap(req_id))
+        return chore, active, inactive
+
+    def test_swapped_to_child_can_complete(self):
+        coord, storage, _mod = _make_system()
+        now = _now()
+        chore, _active, inactive = self._swapped(coord, _mod, now)
+        with patch.object(_mod.dt_util, "now", return_value=now):
+            result = run(coord.async_complete_chore(chore.id, inactive, as_parent=False))
+        assert result is not None
+        comps = _parent_completions(storage)
+        assert len(comps) == 1
+        assert comps[0].child_id == inactive
+        assert coord.get_child(inactive).points > 0
+
+    def test_swapped_away_child_can_no_longer_complete(self):
+        coord, storage, _mod = _make_system()
+        now = _now()
+        chore, active, _inactive = self._swapped(coord, _mod, now)
+        with patch.object(_mod.dt_util, "now", return_value=now):
+            result = run(coord.async_complete_chore(chore.id, active, as_parent=False))
+        assert result is None
+        assert _parent_completions(storage) == []
+
+    def test_swap_still_shares_one_quota(self):
+        coord, storage, _mod = _make_system()
+        now = _now()
+        chore, active, inactive = self._swapped(coord, _mod, now)
+        with patch.object(_mod.dt_util, "now", return_value=now):
+            run(coord.async_complete_chore(chore.id, inactive, as_parent=False))
+            result = run(coord.async_complete_chore(chore.id, active, as_parent=False))
+        assert result is None
+        assert len(_parent_completions(storage)) == 1
+
+    def test_swap_does_not_leak_into_later_days(self):
+        coord, storage, _mod = _make_system()
+        now = _now()
+        chore, active, inactive = self._swapped(coord, _mod, now)
+        stored = storage.get_chore(chore.id)
+        # The override is stamped with today's date only. A 2-child pool
+        # alternates daily, so day+2 must land back on the swapped-away child —
+        # if the override leaked it would still be pinned to the requester.
+        day_after = (now + dt.timedelta(days=2)).date()
+        assert coord._compute_active_children(stored, day_after) == [active]
+        with patch.object(_mod.dt_util, "now", return_value=now + dt.timedelta(days=2)):
+            assert coord._compute_active_children(stored) == [active]
+
+    def test_swapped_chore_is_available_to_new_assignee(self):
+        coord, storage, _mod = _make_system()
+        now = _now()
+        chore, active, inactive = self._swapped(coord, _mod, now)
+        stored = storage.get_chore(chore.id)
+        with patch.object(_mod.dt_util, "now", return_value=now):
+            assert coord.is_chore_available_for_child(stored, inactive) is True
+            assert coord.is_chore_available_for_child(stored, active) is False


### PR DESCRIPTION
Fixes #781

## Root cause

TaskMate had two sources of truth for "whose chore is this today":

- `chore.assignment_current_child_id` — a cached field. `async_approve_swap` wrote it, and the child sensor filters on it (`sensor.py:1147`), so the chore correctly appeared on the swapped-to child's card.
- `_compute_active_children()` — pure rotation date math (`idx = (today - anchor).days % len(pool)`). It never consulted the cached field or the swap requests.

Every eligibility gate uses the second one. So the swapped-to child was shown the chore, tapped it, and `async_complete_chore` returned `None` at a *debug* log level:

```python
if child_id not in self._compute_active_children(chore):
    _LOGGER.debug("complete_chore no-op: %s not assigned to %s today", ...)
    return None
```

Every reported symptom follows from that silent no-op:

| Symptom | Cause |
|---|---|
| Chore dims | Card `_optimisticCompletions` — purely local |
| No points | `return None` before any completion record is written |
| Never reaches parent approval | Same — no `ChoreCompletion` created |
| Reappears ~30s later | `update_interval=timedelta(seconds=30)` reconciles the optimistic dim away |

Broken since **v4.0.0** (`97d8e26`) — sibling swaps have never been completable.

## Fix

`assignment_current_child_id` cannot host the override, because it is itself *written from* `_compute_active_children` during the midnight assignment pass — reading it back there would pin the rotation to whatever it last cached and it would stop alternating.

Instead this adds a **dated** override pair, `assignment_swap_child_id` / `assignment_swap_date`, mirroring the existing `skip_date` / `skip_count` idiom. `_compute_active_children` applies it only on its stamped date, so probes of other days (calendar projection, streak backfill) stay pure rotation and the swap expires on its own.

Fixing the single resolver repairs every downstream gate at once — four of which were silently broken the same way:

- `async_complete_chore` — the reported bug
- `is_chore_available_for_child` — per-chore button entity and todo list also treated the swapped-to child as ineligible
- `_due_chore_ids_for_child` — streak / perfect-day credited the pre-swap child
- `calendar.py` / `coord_calendar.py` — published calendar events named the pre-swap child
- `_async_reevaluate_availability` — silently reverted an approved swap mid-day for `require_availability` chores

Swap-clearing is applied where a parent deliberately moves today's assignee, so a lingering override can't silently outrank them: `async_skip_chore`, manual start, chore clone, and parent-complete-for-pool.

The panel cannot set the new fields — `_CHORE_EDITABLE_FIELDS` is an allowlist, so coordinator-managed runtime state stays coordinator-managed by construction.

## Verification

**Unit** — 6 new tests (`TestSwappedRotation` + a swap-stamp assertion). All fail on `main`, pass here. Full suite: **1546 passed**, no regressions. Ruff, ESLint, translation parity and data-file checks all clean.

Coverage includes the properties that could regress: the swapped-away child can no longer complete, the pool still shares **one** daily quota, and the override does not leak into later days (day+2 lands back on the swapped-away child).

**End-to-end on the live ha-dev instance**, driving `taskmate.complete_chore` over WebSocket — the exact call the child card makes on tap. A/B against the same script:

```
unpatched:  after complete: pending=0  Ben points=0 -> 0     <- the reported bug
            AssertionError: expected 1 pending approval, got 0

patched:    today's assignee: Ana  ->  swapping to: Ben
            swap requested + approved
            after complete: pending=1  Ben points=0 -> 0
            after approval: Ben points=5
            quota holds: Ana points unchanged at 0
            PASS
```

## Note (not fixed here)

Approved swap requests are never pruned from storage (`storage.py:960`). Not user-visible — `_build_state_snapshot` filters to `status == "pending"` — but they accumulate indefinitely. Left out to keep this diff to the one root cause.