### PR TITLE
fix(storage): drop settled swap requests instead of keeping them forever (#783)

### DIFF
--- a/custom_components/taskmate/coord_chores.py
+++ b/custom_components/taskmate/coord_chores.py
@@ -189,7 +189,12 @@ class ChoresMixin:
             chore.assignment_swap_date = dt_util.as_local(dt_util.now()).date().isoformat()
             chore.assignment_current_child_id = req["requester_id"]
             self.storage.update_chore(chore)
-        self.storage.update_swap_request(req_id, status="approved")
+        # Consume the request, exactly as rejection does (#783). Nothing reads a
+        # request once it leaves "pending" — both readers filter on it — so
+        # keeping it would grow the store forever. The approval stays observable
+        # through the event below and the chore's own dated override. `req` is
+        # already captured, so the payload survives the removal.
+        self.storage.remove_swap_request(req_id)
         self.hass.bus.async_fire(
             "taskmate_swap_approved",
             {

--- a/custom_components/taskmate/storage.py
+++ b/custom_components/taskmate/storage.py
@@ -121,6 +121,21 @@ class TaskMateStorage:
         if "scheduled_changes" not in self._data:
             self._data["scheduled_changes"] = []
 
+        # Drop settled swap requests (#783). Approval used to only flip a status
+        # flag, so existing installs carry every swap they ever approved — and
+        # nothing reads a request once it leaves "pending". Runs on every load
+        # rather than behind a one-shot flag: it is a cheap list filter, and it
+        # also sweeps up records left by a downgrade to an older version.
+        swap_requests = self._data.get("swap_requests")
+        if swap_requests:
+            still_pending = [r for r in swap_requests if r.get("status") == "pending"]
+            if len(still_pending) != len(swap_requests):
+                _LOGGER.debug(
+                    "Dropped %d settled swap request(s) from storage",
+                    len(swap_requests) - len(still_pending),
+                )
+                self._data["swap_requests"] = still_pending
+
         # Notifications overhaul (v3.9.0)
         if "parent_recipients" not in self._data:
             self._data["parent_recipients"] = []

--- a/tests/test_chore_swap.py
+++ b/tests/test_chore_swap.py
@@ -77,7 +77,6 @@ def test_approve_reassigns_today():
     run(coord.async_request_swap("ch1", "b"))
     run(coord.async_approve_swap(coord._reqs[0]["id"]))
     assert chore.assignment_current_child_id == "b"
-    assert coord._reqs[0]["status"] == "approved"
     assert any(c[0][0] == "taskmate_swap_approved" for c in coord.hass.bus.async_fire.call_args_list)
 
 
@@ -104,3 +103,30 @@ def test_approve_stamps_dated_swap_override():
     run(coord.async_approve_swap(coord._reqs[0]["id"]))
     assert chore.assignment_swap_child_id == "b"
     assert chore.assignment_swap_date == dt_util.now().date().isoformat()
+
+
+def test_approve_removes_request():
+    """Approval consumes the request, the same way rejection does (#783).
+
+    Nothing reads a request once it leaves `pending` — both readers filter on
+    it — so keeping the record would just grow the store forever. The approval
+    is still observable via the `taskmate_swap_approved` event and the chore's
+    own dated override.
+    """
+    chore = Chore(name="Bins", assignment_mode="alternating", assignment_current_child_id="a", id="ch1")
+    coord = _coord(chore, [Child(name="A", id="a"), Child(name="B", id="b")])
+    run(coord.async_request_swap("ch1", "b"))
+    run(coord.async_approve_swap(coord._reqs[0]["id"]))
+    assert coord._reqs == []
+
+
+def test_approve_twice_is_rejected():
+    """The second approval finds no pending request and raises, rather than
+    re-firing the event or re-stamping the override."""
+    chore = Chore(name="Bins", assignment_mode="alternating", assignment_current_child_id="a", id="ch1")
+    coord = _coord(chore, [Child(name="A", id="a"), Child(name="B", id="b")])
+    run(coord.async_request_swap("ch1", "b"))
+    rid = coord._reqs[0]["id"]
+    run(coord.async_approve_swap(rid))
+    with pytest.raises(ValueError, match="not found"):
+        run(coord.async_approve_swap(rid))

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -116,6 +116,41 @@ class TestAsyncLoad:
         assert children[0].name == "Alice"
         assert children[0].points == 100
 
+    def test_settled_swap_requests_are_dropped_on_load(self):
+        """Existing installs accumulated approved swap requests that nothing
+        reads (#783). Load clears them out; pending ones must survive."""
+        existing = {
+            "children": [],
+            "chores": [],
+            "swap_requests": [
+                {"id": "s1", "chore_id": "c1", "requester_id": "b", "status": "approved"},
+                {"id": "s2", "chore_id": "c2", "requester_id": "a", "status": "pending"},
+                {"id": "s3", "chore_id": "c3", "requester_id": "b", "status": "approved"},
+                {"id": "s4", "chore_id": "c4", "requester_id": "a"},  # legacy: no status
+            ],
+        }
+        storage = _make_storage(initial_data=existing)
+        run(storage.async_load())
+        assert [r["id"] for r in storage.get_swap_requests()] == ["s2"]
+
+    def test_load_without_swap_requests_is_harmless(self):
+        storage = _make_storage(initial_data={"children": [], "chores": []})
+        run(storage.async_load())
+        assert storage.get_swap_requests() == []
+
+    def test_load_leaves_all_pending_swap_requests_alone(self):
+        existing = {
+            "children": [],
+            "chores": [],
+            "swap_requests": [
+                {"id": "s1", "chore_id": "c1", "requester_id": "b", "status": "pending"},
+                {"id": "s2", "chore_id": "c2", "requester_id": "a", "status": "pending"},
+            ],
+        }
+        storage = _make_storage(initial_data=existing)
+        run(storage.async_load())
+        assert [r["id"] for r in storage.get_swap_requests()] == ["s1", "s2"]
+
 
 # ---------------------------------------------------------------------------
 # _migrate_assigned_to_child_ids


### PR DESCRIPTION
Fixes #783

## Problem

`async_approve_swap` flipped the request's status to `"approved"` and left the record in storage forever. Nothing ever reads it — both readers filter to pending:

- `websocket.py:367` — `[r for r in get_swap_requests() if r.get("status") == "pending"]`
- `coord_chores.py:177` — matches on `id` **and** `status == "pending"`

The panel's only swap UI is the pending-approval queue (`taskmate-panel.js:3185`); there is no approved-swap history view. `fairness_report` is built from completions, which after a swap are already recorded against the swapped-to child, so it reflects the outcome without the request record.

The lifecycle asymmetry gave away the original intent: `async_reject_swap` deleted the record outright, while approve merely annotated it.

## Fix

Approval consumes the request, matching rejection. Nothing is lost — the approval remains observable through the `taskmate_swap_approved` event (carrying `chore_id`, `requester_id`, `from_child_id`, `timestamp`) and, since #782, through the chore's own dated `assignment_swap_child_id` / `assignment_swap_date` override.

**Why not a prune job.** `async_prune_history` keeps completions for 90 days because they are real history someone might want. These records are read by nothing, so a retention policy would just mean holding dead data for 90 days instead of forever.

**Migration.** Existing installs are swept at load, otherwise the fix would only stop *new* records accumulating. It runs on every load rather than behind a one-shot flag — it is a cheap list filter over a small list, and it also cleans up after a downgrade to a version that still wrote the records. Pending requests are preserved, including legacy records with no `status` key (dropped, since only an explicit `"pending"` is actionable).

## Verification

**Unit** — 5 new tests: approval removes the request, double-approve still raises, and three covering the load-time sweep (settled dropped / pending preserved / absent list harmless). The two behavioural ones fail on `main`. Full suite **1551 passed**.

**Live instance.** Ran three swap-and-approve cycles on unpatched `main` to accumulate records, then restarted on this branch with debug logging enabled:

```
DEBUG [custom_components.taskmate.storage] Dropped 8 settled swap request(s) from storage
```

Eight — the three I had just made plus five genuinely accumulated from earlier testing, which is the bug in miniature. Then a fresh swap-approve-complete cycle passed end to end, and the next restart reported **nothing left to drop**, confirming new approvals leave no residue.

## Noted, not fixed

Removing a chore does not cascade to its *pending* swap requests, so a deleted chore can leave an orphan in the approval queue. Separate from this change; happy to open an issue if you want it chased.