### PR TITLE
fix(storage): deleting a chore or child drops its pending swap requests (#785)

### DIFF
--- a/custom_components/taskmate/coord_chores.py
+++ b/custom_components/taskmate/coord_chores.py
@@ -530,6 +530,9 @@ class ChoresMixin:
         self.storage.remove_chore_from_task_groups(chore_id)
         # Drop queued scheduled changes (#675) — nothing left to apply them to.
         self.storage.remove_scheduled_changes_for_chore(chore_id)
+        # Drop pending swap requests (#785), else they sit in the parent's
+        # approval queue forever showing "?" for the chore that no longer exists.
+        self.storage.remove_swap_requests_for_chore(chore_id)
         # Remove chore from children's chore_order lists
         for child in self.storage.get_children():
             if chore_id in child.chore_order:

--- a/custom_components/taskmate/coordinator.py
+++ b/custom_components/taskmate/coordinator.py
@@ -824,10 +824,23 @@ class TaskMateCoordinator(
         self.storage.remove_career_score_history_for_child(child_id)
         self.storage.remove_quest_progress_for_child(child_id)
         self.storage.remove_challenge_progress_for_child(child_id)
-        # Remove child from chore assigned_to lists
+        # Drop pending swap requests either side of this child (#785) — a
+        # handover to or from a deleted child can never complete, and the
+        # approval queue would render them as "?".
+        self.storage.remove_swap_requests_for_child(child_id)
+        # Remove child from chore assigned_to lists, and clear any approved swap
+        # override that pointed at them so the chore isn't left assigned to a
+        # child who no longer exists.
         for chore in self.storage.get_chores():
+            dirty = False
             if child_id in chore.assigned_to:
                 chore.assigned_to.remove(child_id)
+                dirty = True
+            if getattr(chore, "assignment_swap_child_id", "") == child_id:
+                chore.assignment_swap_child_id = ""
+                chore.assignment_swap_date = ""
+                dirty = True
+            if dirty:
                 self.storage.update_chore(chore)
         await self.storage.async_save()
         await self.async_refresh()

--- a/custom_components/taskmate/storage.py
+++ b/custom_components/taskmate/storage.py
@@ -121,20 +121,14 @@ class TaskMateStorage:
         if "scheduled_changes" not in self._data:
             self._data["scheduled_changes"] = []
 
-        # Drop settled swap requests (#783). Approval used to only flip a status
-        # flag, so existing installs carry every swap they ever approved — and
-        # nothing reads a request once it leaves "pending". Runs on every load
-        # rather than behind a one-shot flag: it is a cheap list filter, and it
-        # also sweeps up records left by a downgrade to an older version.
-        swap_requests = self._data.get("swap_requests")
-        if swap_requests:
-            still_pending = [r for r in swap_requests if r.get("status") == "pending"]
-            if len(still_pending) != len(swap_requests):
-                _LOGGER.debug(
-                    "Dropped %d settled swap request(s) from storage",
-                    len(swap_requests) - len(still_pending),
-                )
-                self._data["swap_requests"] = still_pending
+        # Drop settled swap requests (#783) and ones pointing at a chore or child
+        # that no longer exists (#785). Approval used to only flip a status flag,
+        # and deletes did not cascade, so existing installs carry both kinds —
+        # the orphans surface in the parent's approval queue as an unclearable
+        # "? wants to swap ?" row. Runs on every load rather than behind a
+        # one-shot flag: it is a cheap list filter, and it also sweeps up records
+        # left by a downgrade to a version without the cascades.
+        self._drop_dead_swap_requests()
 
         # Notifications overhaul (v3.9.0)
         if "parent_recipients" not in self._data:
@@ -992,6 +986,57 @@ class TaskMateStorage:
                 del reqs[i]
                 return True
         return False
+
+    def _drop_dead_swap_requests(self) -> None:
+        """Prune swap requests that are settled or dangling (#783, #785).
+
+        Called from ``async_load``. A request survives only when it is still
+        pending *and* every id it names still resolves — the chore, the
+        requester, and ``from_child_id`` when set (it is "" for a chore with no
+        cached assignee yet, which is a normal request, not a dead reference).
+        """
+        swap_requests = self._data.get("swap_requests")
+        if not swap_requests:
+            return
+
+        chore_ids = {c.get("id") for c in self._data.get("chores", [])}
+        child_ids = {c.get("id") for c in self._data.get("children", [])}
+
+        def _alive(req: dict) -> bool:
+            if req.get("status") != "pending":
+                return False
+            if req.get("chore_id") not in chore_ids:
+                return False
+            if req.get("requester_id") not in child_ids:
+                return False
+            from_id = req.get("from_child_id") or ""
+            return not from_id or from_id in child_ids
+
+        kept = [r for r in swap_requests if _alive(r)]
+        if len(kept) != len(swap_requests):
+            _LOGGER.debug(
+                "Dropped %d settled or orphaned swap request(s) from storage",
+                len(swap_requests) - len(kept),
+            )
+            self._data["swap_requests"] = kept
+
+    def remove_swap_requests_for_chore(self, chore_id: str) -> None:
+        """Drop a deleted chore's swap requests so they can't linger in the
+        approval queue with nothing to approve."""
+        self._data["swap_requests"] = [r for r in self._data.get("swap_requests", []) if r.get("chore_id") != chore_id]
+
+    def remove_swap_requests_for_child(self, child_id: str) -> None:
+        """Drop swap requests a deleted child is either side of.
+
+        Both ends matter: the requester is who the handover goes *to*, and
+        `from_child_id` is who it comes from and is rendered in the queue.
+        Either being gone makes the request undeliverable.
+        """
+        self._data["swap_requests"] = [
+            r
+            for r in self._data.get("swap_requests", [])
+            if r.get("requester_id") != child_id and r.get("from_child_id") != child_id
+        ]
 
     # ── Quests (chore chains) ────────────────────────────────────────────
     def get_quests(self) -> list[Quest]:

--- a/tests/test_chore_swap.py
+++ b/tests/test_chore_swap.py
@@ -130,3 +130,104 @@ def test_approve_twice_is_rejected():
     run(coord.async_approve_swap(rid))
     with pytest.raises(ValueError, match="not found"):
         run(coord.async_approve_swap(rid))
+
+
+# ---------------------------------------------------------------------------
+# Orphan cleanup (#785) — deleting a chore or child must take its pending swap
+# requests with it, or the parent is left with an unclearable "? wants to swap
+# ?" row in the approval queue.
+# ---------------------------------------------------------------------------
+
+
+def _real_system():
+    """A coordinator over real storage — the mock storage above can't exercise
+    the removal cascades, which touch several stores at once."""
+    from tests.test_rotation_quota import _make_system
+
+    return _make_system()
+
+
+def _two_kids_and_chore(coord, _mod, now):
+    from unittest.mock import patch
+
+    with patch.object(_mod.dt_util, "now", return_value=now):
+        alice = run(coord.async_add_child("Alice"))
+        bob = run(coord.async_add_child("Bob"))
+        chore = run(
+            coord.async_add_chore(
+                "Dishes",
+                points=10,
+                assignment_mode="alternating",
+                assigned_to=[alice.id, bob.id],
+            )
+        )
+        active = coord._compute_active_children(chore)[0]
+        other = next(c.id for c in (alice, bob) if c.id != active)
+        run(coord.async_request_swap(chore.id, other))
+    return chore, active, other
+
+
+def test_removing_chore_drops_its_pending_swap_requests():
+    from tests.test_rotation_quota import _now
+
+    coord, storage, _mod = _real_system()
+    chore, _active, _other = _two_kids_and_chore(coord, _mod, _now())
+    assert len(storage.get_swap_requests()) == 1
+
+    run(coord.async_remove_chore(chore.id))
+    assert storage.get_swap_requests() == []
+
+
+def test_removing_child_drops_swap_requests_they_requested():
+    from tests.test_rotation_quota import _now
+
+    coord, storage, _mod = _real_system()
+    _chore, _active, other = _two_kids_and_chore(coord, _mod, _now())
+    assert len(storage.get_swap_requests()) == 1
+
+    run(coord.async_remove_child(other))
+    assert storage.get_swap_requests() == []
+
+
+def test_removing_child_drops_swap_requests_aimed_away_from_them():
+    """The swapped-*away* child matters too: `from_child_id` is rendered in the
+    queue, and the request describes a handover that can no longer happen."""
+    from tests.test_rotation_quota import _now
+
+    coord, storage, _mod = _real_system()
+    _chore, active, _other = _two_kids_and_chore(coord, _mod, _now())
+    run(coord.async_remove_child(active))
+    assert storage.get_swap_requests() == []
+
+
+def test_removing_child_clears_a_swap_override_pointing_at_them():
+    from unittest.mock import patch
+
+    from tests.test_rotation_quota import _now
+
+    coord, storage, _mod = _real_system()
+    now = _now()
+    chore, _active, other = _two_kids_and_chore(coord, _mod, now)
+    with patch.object(_mod.dt_util, "now", return_value=now):
+        run(coord.async_approve_swap(storage.get_swap_requests()[0]["id"]))
+    assert storage.get_chore(chore.id).assignment_swap_child_id == other
+
+    run(coord.async_remove_child(other))
+    stored = storage.get_chore(chore.id)
+    assert stored.assignment_swap_child_id == ""
+    assert stored.assignment_swap_date == ""
+
+
+def test_removing_an_unrelated_child_leaves_the_request_alone():
+    from unittest.mock import patch
+
+    from tests.test_rotation_quota import _now
+
+    coord, storage, _mod = _real_system()
+    now = _now()
+    _chore, _active, _other = _two_kids_and_chore(coord, _mod, now)
+    with patch.object(_mod.dt_util, "now", return_value=now):
+        bystander = run(coord.async_add_child("Cara"))
+
+    run(coord.async_remove_child(bystander.id))
+    assert len(storage.get_swap_requests()) == 1

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -116,19 +116,27 @@ class TestAsyncLoad:
         assert children[0].name == "Alice"
         assert children[0].points == 100
 
+    @staticmethod
+    def _swap_fixture(swap_requests):
+        """Storage seeded with children a/b and chores c1-c4, so a request is
+        only dropped for its status — not for referencing something missing."""
+        return {
+            "children": [{"id": "a", "name": "Alice"}, {"id": "b", "name": "Bob"}],
+            "chores": [{"id": f"c{i}", "name": f"Chore {i}"} for i in range(1, 5)],
+            "swap_requests": swap_requests,
+        }
+
     def test_settled_swap_requests_are_dropped_on_load(self):
         """Existing installs accumulated approved swap requests that nothing
         reads (#783). Load clears them out; pending ones must survive."""
-        existing = {
-            "children": [],
-            "chores": [],
-            "swap_requests": [
+        existing = self._swap_fixture(
+            [
                 {"id": "s1", "chore_id": "c1", "requester_id": "b", "status": "approved"},
                 {"id": "s2", "chore_id": "c2", "requester_id": "a", "status": "pending"},
                 {"id": "s3", "chore_id": "c3", "requester_id": "b", "status": "approved"},
                 {"id": "s4", "chore_id": "c4", "requester_id": "a"},  # legacy: no status
-            ],
-        }
+            ]
+        )
         storage = _make_storage(initial_data=existing)
         run(storage.async_load())
         assert [r["id"] for r in storage.get_swap_requests()] == ["s2"]
@@ -139,17 +147,47 @@ class TestAsyncLoad:
         assert storage.get_swap_requests() == []
 
     def test_load_leaves_all_pending_swap_requests_alone(self):
-        existing = {
-            "children": [],
-            "chores": [],
-            "swap_requests": [
+        existing = self._swap_fixture(
+            [
                 {"id": "s1", "chore_id": "c1", "requester_id": "b", "status": "pending"},
                 {"id": "s2", "chore_id": "c2", "requester_id": "a", "status": "pending"},
-            ],
-        }
+            ]
+        )
         storage = _make_storage(initial_data=existing)
         run(storage.async_load())
         assert [r["id"] for r in storage.get_swap_requests()] == ["s1", "s2"]
+
+    def test_orphaned_pending_swap_requests_are_dropped_on_load(self):
+        """Installs that deleted a chore or child before #785 carry pending
+        requests pointing at nothing; the panel renders them as "? wants to
+        swap ?" and the parent can't clear them."""
+        existing = self._swap_fixture(
+            [
+                {"id": "keep", "chore_id": "c1", "requester_id": "a", "from_child_id": "b", "status": "pending"},
+                {"id": "dead-chore", "chore_id": "gone", "requester_id": "a", "status": "pending"},
+                {"id": "dead-requester", "chore_id": "c2", "requester_id": "gone", "status": "pending"},
+                {
+                    "id": "dead-from",
+                    "chore_id": "c3",
+                    "requester_id": "a",
+                    "from_child_id": "gone",
+                    "status": "pending",
+                },
+            ]
+        )
+        storage = _make_storage(initial_data=existing)
+        run(storage.async_load())
+        assert [r["id"] for r in storage.get_swap_requests()] == ["keep"]
+
+    def test_blank_from_child_id_does_not_count_as_orphaned(self):
+        """`from_child_id` is "" for a chore with no cached assignee yet — that
+        is a normal request, not a dangling reference."""
+        existing = self._swap_fixture(
+            [{"id": "s1", "chore_id": "c1", "requester_id": "a", "from_child_id": "", "status": "pending"}]
+        )
+        storage = _make_storage(initial_data=existing)
+        run(storage.async_load())
+        assert [r["id"] for r in storage.get_swap_requests()] == ["s1"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #785

## Problem

Deleting a chore or a child left its **pending** swap requests behind.

`async_remove_chore` cascaded to completions, last-completed, task groups, scheduled changes and children's `chore_order`. `async_remove_child` cascaded to completions, reward claims, transactions, pool allocations, career history, quest and challenge progress, and stripped the child from `assigned_to`. Neither touched `swap_requests`.

The panel falls back to `"?"` for a name it cannot resolve (`taskmate-panel.js:3187`):

```js
{child: this._esc((req && req.name) || "?"), chore: this._esc((chore && chore.name) || "?")}
```

so the parent was left with a permanent `"? wants to swap ?"` row in the approval queue that only rejecting could clear.

## Fix

Cascade on delete, matching every other cleanup in the codebase.

**Both ends matter for the child cascade.** `requester_id` is who the handover goes *to*; `from_child_id` is who it comes *from* and is rendered in the queue. Either being gone makes the request undeliverable, so `remove_swap_requests_for_child` filters on both.

Child removal also clears a chore's approved swap override when it pointed at the deleted child, so the chore is not left assigned to someone who no longer exists.

**Migration.** The load-time sweep added in #784 is extended to drop dangling pending requests, so installs that already deleted a chore or child get cleaned up instead of carrying the stuck row forever. A request now survives only when it is pending *and* every id it names resolves. `from_child_id` is exempt when blank — that is the normal shape for a request against a chore with no cached assignee yet, not a dead reference, and there is a test pinning it.

## Verification

**Unit** — 7 new tests (5 cascade, 2 sweep). Full suite **1558 passed**.

Two existing tests from #784 needed their fixtures updated: they asserted pending requests survive, but used empty `children` / `chores` lists, so under the new orphan rule every one of their records is dangling. They now seed the referenced entities, which is what they always meant — they were testing the settled/pending filter, not the orphan filter.

**Live instance.** Created two orphans the way a user would — delete the chore out from under a pending request, then delete the requesting child:

```
seed (unpatched main):
  pending swap_requests now visible to the parent: 2
    145875f5 chore=2701e65e requester=0a7b48d0
    9ae04c83 chore=767dc857 requester=9e9a609c

check (this branch):
  pending swap_requests after restart: 0
  PASS — load-time sweep cleared the pre-existing orphans
  PASS — deleting a chore drops its pending swap request immediately
  PASS — deleting a child drops their pending swap request immediately
```

The two cascade assertions run with no restart involved. A full swap-request-approve-complete cycle still passes afterwards.

## Noted, not fixed

`assignment_current_child_id` is *not* cleared when the child it names is deleted, so a rotation chore can point at a ghost until the midnight assignment pass, during which the sensor filter (`assignment_current_child_id != child.id`) matches nobody and the chore is invisible to the whole pool. That predates the swap feature and is a separate defect — happy to open an issue.