### PR TITLE
feat(cards): show progress toward the next badge on the child card (#780)

### DIFF
--- a/README.md
+++ b/README.md
@@ -878,13 +878,15 @@ Empty criteria = manual-award only (parent presses "Award to..." to grant it).
 
 - **`taskmate-badges-card`** — full grid view per child. Earned tiles in tier colour, locked tiles greyed with progress bars showing closest-criterion completion percentage.
 - **`taskmate-child-card`** — inline strip of up to 5 most-recently-earned badges below the points readout (auto-hidden when zero earned). Tap → opens the admin panel's badges section. Disable with `show_badges: false`.
+- **`taskmate-child-card` — "Next up" line** — progress toward the single closest unearned badge (icon, name, bar and an `840 / 1000` count), so the journey is visible without opening the badge grid. Hidden when nothing is started or every remaining badge sits at 0%. Tap → badges section. Disable with `show_next_badge: false`.
 - **Admin panel — Badges section** — Catalogue / Custom / Award History tabs. Award History shows AUTO / MANUAL / SILENT source pills and supports one-click revoke (auto-reverses any point bonus credited).
 
 ### Sensor
 
 Each child gets `sensor.taskmate_badges_<slug>`:
 - State: count of earned badges
-- Attributes: `earned[]` (with `earned_at`, `tier`, etc.), `available[]` (with `progress_pct`), `total_badges`
+- Attributes: `earned[]` (with `earned_at`, `tier`, etc.), `available[]` (with `progress_pct` and `closest_criterion: {metric, current, target}`), `total_badges`
+- `progress_pct` / `closest_criterion` track the criterion that actually gates the award: the weakest one for an `AND` badge, the strongest for an `OR` badge
 
 ### Retroactive Backfill
 

--- a/custom_components/taskmate/sensor.py
+++ b/custom_components/taskmate/sensor.py
@@ -1226,15 +1226,23 @@ class ChildBadgesSensor(TaskMateBaseSensor):
                     }
                 )
             else:
-                if not b.criteria:
+                # The criterion that actually gates the award: for an AND badge
+                # that is the weakest one, for an OR badge the strongest. Using
+                # min() for both understated OR badges (and could report <100%
+                # for one already earned) — see coord_badges.BadgeEvaluator.
+                combinator = (getattr(b, "combinator", "AND") or "AND").upper()
+                scored = []
+                for c in b.criteria:
+                    cur = resolve_metric(c.metric, child, storage)
+                    pct = min(100, int(100 * cur / max(c.value, 1)))
+                    scored.append((pct, c.metric, cur, c.value))
+                if not scored:
                     progress_pct = 0
+                    closest = None
                 else:
-                    pcts = []
-                    for c in b.criteria:
-                        cur = resolve_metric(c.metric, child, storage)
-                        target = max(c.value, 1)
-                        pcts.append(min(100, int(100 * cur / target)))
-                    progress_pct = min(pcts) if pcts else 0
+                    pick = max(scored) if combinator == "OR" else min(scored)
+                    progress_pct = pick[0]
+                    closest = {"metric": pick[1], "current": pick[2], "target": pick[3]}
                 available.append(
                     {
                         "badge_id": b.id,
@@ -1242,6 +1250,7 @@ class ChildBadgesSensor(TaskMateBaseSensor):
                         "icon": b.icon,
                         "tier": b.tier,
                         "progress_pct": progress_pct,
+                        "closest_criterion": closest,
                         "criteria_summary": ", ".join(f"{c.metric} >= {c.value}" for c in b.criteria),
                     }
                 )

--- a/custom_components/taskmate/www/locales/de.json
+++ b/custom_components/taskmate/www/locales/de.json
@@ -153,6 +153,7 @@
   "badges.editor_help": "Konfigurieren Sie per YAML: Setzen Sie entity auf Ihren Badges-Sensor (z.B. sensor.taskmate_badges_mia).",
   "badges.entity_not_found": "{entity} nicht gefunden",
   "badges.label": "Abzeichen",
+  "badges.next_up": "Als Nächstes",
   "badges.title_with_name": "Abzeichen von {name}",
   "bonuses.add_bonus": "Bonus hinzufügen",
   "bonuses.applying_to": "Beantragung bei {childName} – aktuelles Guthaben: {points} {pointsName}",

--- a/custom_components/taskmate/www/locales/en-GB.json
+++ b/custom_components/taskmate/www/locales/en-GB.json
@@ -154,6 +154,7 @@
   "badges.editor_help": "Configure via YAML: set entity to your badges sensor (e.g. sensor.taskmate_badges_mia).",
   "badges.entity_not_found": "{entity} not found",
   "badges.label": "Badges",
+  "badges.next_up": "Next up",
   "badges.title_with_name": "{name}'s Badges",
   "bonuses.add_bonus": "Add Bonus",
   "bonuses.applying_to": "Applying to {childName} — current balance: {points} {pointsName}",

--- a/custom_components/taskmate/www/locales/en.json
+++ b/custom_components/taskmate/www/locales/en.json
@@ -154,6 +154,7 @@
   "badges.editor_help": "Configure via YAML: set entity to your badges sensor (e.g. sensor.taskmate_badges_mia).",
   "badges.entity_not_found": "{entity} not found",
   "badges.label": "Badges",
+  "badges.next_up": "Next up",
   "badges.title_with_name": "{name}'s Badges",
   "bonuses.add_bonus": "Add Bonus",
   "bonuses.applying_to": "Applying to {childName} — current balance: {points} {pointsName}",

--- a/custom_components/taskmate/www/locales/fr.json
+++ b/custom_components/taskmate/www/locales/fr.json
@@ -153,6 +153,7 @@
   "badges.editor_help": "Configurez via YAML : définissez entity sur votre capteur de badges (ex. sensor.taskmate_badges_mia).",
   "badges.entity_not_found": "{entity} introuvable",
   "badges.label": "Badges",
+  "badges.next_up": "Prochain",
   "badges.title_with_name": "Badges de {name}",
   "bonuses.add_bonus": "Ajouter un bonus",
   "bonuses.applying_to": "Application à {childName} — solde actuel : {points} {pointsName}",

--- a/custom_components/taskmate/www/locales/nb.json
+++ b/custom_components/taskmate/www/locales/nb.json
@@ -153,6 +153,7 @@
   "badges.editor_help": "Konfigurer via YAML: sett entity til din badge-sensor (f.eks. sensor.taskmate_badges_mia).",
   "badges.entity_not_found": "{entity} ikke funnet",
   "badges.label": "Merker",
+  "badges.next_up": "Neste",
   "badges.title_with_name": "{name}s merker",
   "bonuses.add_bonus": "Legg til bonus",
   "bonuses.applying_to": "Brukes på {childName} — nåværende saldo: {points} {pointsName}",

--- a/custom_components/taskmate/www/locales/nn.json
+++ b/custom_components/taskmate/www/locales/nn.json
@@ -153,6 +153,7 @@
   "badges.editor_help": "Konfigurer via YAML: sett entity til din badge-sensor (t.d. sensor.taskmate_badges_mia).",
   "badges.entity_not_found": "{entity} ikkje funne",
   "badges.label": "Merke",
+  "badges.next_up": "Neste",
   "badges.title_with_name": "Merka til {name}",
   "bonuses.add_bonus": "Legg til bonus",
   "bonuses.applying_to": "Vert brukt på {childName} — noverande saldo: {points} {pointsName}",

--- a/custom_components/taskmate/www/locales/pt-BR.json
+++ b/custom_components/taskmate/www/locales/pt-BR.json
@@ -153,6 +153,7 @@
   "badges.editor_help": "Configure via YAML: defina entity para o sensor de emblemas (ex. sensor.taskmate_badges_mia).",
   "badges.entity_not_found": "{entity} não encontrado",
   "badges.label": "Conquistas",
+  "badges.next_up": "A seguir",
   "badges.title_with_name": "Conquistas de {name}",
   "bonuses.add_bonus": "Adicionar Bónus",
   "bonuses.applying_to": "A aplicar a {childName} — saldo atual: {points} {pointsName}",

--- a/custom_components/taskmate/www/locales/pt.json
+++ b/custom_components/taskmate/www/locales/pt.json
@@ -153,6 +153,7 @@
   "badges.editor_help": "Configure via YAML: defina entity para o sensor de emblemas (ex. sensor.taskmate_badges_mia).",
   "badges.entity_not_found": "{entity} não encontrado",
   "badges.label": "Conquistas",
+  "badges.next_up": "A seguir",
   "badges.title_with_name": "Conquistas de {name}",
   "bonuses.add_bonus": "Adicionar Bónus",
   "bonuses.applying_to": "A aplicar a {childName} — saldo atual: {points} {pointsName}",

--- a/custom_components/taskmate/www/taskmate-child-card.js
+++ b/custom_components/taskmate/www/taskmate-child-card.js
@@ -160,6 +160,13 @@ class TaskMateChildCard extends LitElement {
     }[tier] || '#888';
   }
 
+  _badgeKeydown(e) {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      this._openBadgesView();
+    }
+  }
+
   _openBadgesView() {
     const slug = this.config?.child_id
       ? String(this.config.child_id).toLowerCase().replace(/\s+/g, '_')
@@ -1906,6 +1913,74 @@ class TaskMateChildCard extends LitElement {
         white-space: nowrap;
       }
 
+      /* ── Next badge progress (#780) ── */
+      .next-badge {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        padding: 10px 16px;
+        cursor: pointer;
+        border-bottom: 1px solid var(--divider-color, #e0e0e0);
+      }
+      .next-badge:hover { background: var(--secondary-background-color, rgba(0,0,0,0.03)); }
+      .next-badge:focus-visible {
+        outline: 2px solid var(--primary-color);
+        outline-offset: -2px;
+      }
+      .next-badge-icon {
+        width: 28px;
+        height: 28px;
+        border-radius: 50%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        --mdc-icon-size: 16px;
+        color: #1a1a1a;
+        border: 2px dashed var(--t);
+        background: transparent;
+        flex-shrink: 0;
+        opacity: 0.85;
+      }
+      .next-badge-body { flex: 1; min-width: 0; }
+      .next-badge-top {
+        display: flex;
+        align-items: baseline;
+        gap: 6px;
+        margin-bottom: 5px;
+      }
+      .next-badge-label {
+        font-size: 11px;
+        color: var(--secondary-text-color);
+        white-space: nowrap;
+      }
+      .next-badge-name {
+        font-size: 12.5px;
+        font-weight: 700;
+        color: var(--primary-text-color);
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+      .next-badge-count {
+        margin-left: auto;
+        font-size: 11px;
+        font-weight: 700;
+        color: var(--secondary-text-color);
+        white-space: nowrap;
+      }
+      .next-badge-bar {
+        height: 6px;
+        border-radius: 3px;
+        background: var(--divider-color, #e0e0e0);
+        overflow: hidden;
+      }
+      .next-badge-bar i {
+        display: block;
+        height: 100%;
+        border-radius: 3px;
+        transition: width 0.4s ease;
+      }
+
       /* ══════════════════════════════════════════════════════════════════
          DESIGNED STYLES (playroom / console / cleanpro)
          Shared .tmd kit + tokens come from taskmate-design.js styles().
@@ -2042,6 +2117,49 @@ class TaskMateChildCard extends LitElement {
       .tmd-badge-mini ha-icon { --mdc-icon-size: 16px; color: #fff; }
       .tmd-badges .more { font-size: 11px; font-weight: 800; color: var(--tmd-accent); }
 
+      /* Designed: next badge progress (#780) */
+      .tmd-next-badge {
+        display: flex; align-items: center; gap: 9px;
+        padding: 9px 11px; margin-bottom: 11px;
+        background: var(--tmd-surface-2); border: 1px solid var(--tmd-border);
+        border-radius: var(--tmd-radius-sm); cursor: pointer;
+      }
+      .tmd-next-badge:focus-visible { outline: 2px solid var(--tmd-accent); outline-offset: 1px; }
+      .tmd-next-badge .ic {
+        width: 26px; height: 26px; border-radius: 50%; display: grid; place-items: center;
+        border: 2px dashed var(--t, var(--tmd-accent)); color: var(--tmd-dim); flex-shrink: 0;
+      }
+      .tmd-next-badge .ic ha-icon { --mdc-icon-size: 15px; }
+      .tmd-next-badge .bd { flex: 1; min-width: 0; }
+      .tmd-next-badge .top { display: flex; align-items: baseline; gap: 6px; margin-bottom: 5px; }
+      .tmd-next-badge .lbl {
+        font-size: 11px; font-weight: 800; color: var(--tmd-dim);
+        text-transform: uppercase; letter-spacing: .04em; white-space: nowrap;
+      }
+      .tmd-next-badge .nm {
+        font-size: 12.5px; font-weight: 700; color: var(--tmd-text);
+        overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+      }
+      .tmd-next-badge .cnt {
+        margin-left: auto; font-size: 11px; font-weight: 800;
+        color: var(--tmd-dim); white-space: nowrap;
+      }
+      .tmd-next-badge .bar {
+        height: 6px; border-radius: 999px; background: var(--tmd-border); overflow: hidden;
+      }
+      .tmd-next-badge .bar i {
+        display: block; height: 100%; border-radius: 999px; transition: width .4s ease;
+      }
+      /* Playroom is chunkier, console squares everything off, accessible needs
+         a solid ring rather than a dashed one to stay legible. */
+      :host([data-tm-design="playroom"]) .tmd-next-badge .bar { height: 8px; }
+      :host([data-tm-design="console"]) .tmd-next-badge .bar,
+      :host([data-tm-design="console"]) .tmd-next-badge .bar i { border-radius: 0; }
+      :host([data-tm-design="accessible"]) .tmd-next-badge .ic { border-style: solid; }
+      :host([data-tm-design="accessible"]) .tmd-next-badge .bar { height: 10px; }
+      :host([data-tm-design="accessible"]) .tmd-next-badge .nm,
+      :host([data-tm-design="accessible"]) .tmd-next-badge .cnt { font-size: 14px; }
+
       /* Designed: vacation banner + swappable section */
       .tmd-vacation {
         display: flex; align-items: center; gap: 7px; padding: 9px 11px; margin-bottom: 11px;
@@ -2072,6 +2190,7 @@ class TaskMateChildCard extends LitElement {
       show_countdown: true,          // Show midnight reset countdown below section title
       show_due_days_only: true,      // Whether to apply due_days filtering at all
       show_badges: true,             // Show badge strip between points and chores
+      show_next_badge: true,         // Show progress toward the closest unearned badge
             header_color: '#9b59b6',
     ...config,
     };
@@ -2172,6 +2291,7 @@ class TaskMateChildCard extends LitElement {
     const badgesEntity = this._resolveBadgesEntity(child);
     const earnedBadges = (badgesEntity?.attributes?.earned) || [];
     const showBadges = this.config.show_badges !== false && earnedBadges.length > 0;
+    const nextBadge = this._nextBadge(badgesEntity);
 
     // Get pending points for this child
     const pendingPoints = child.pending_points || 0;
@@ -2253,6 +2373,28 @@ class TaskMateChildCard extends LitElement {
               </div>
             `)}
             ${earnedBadges.length > 5 ? html`<span class="badge-strip-more">+${earnedBadges.length - 5} →</span>` : ''}
+          </div>
+        ` : ''}
+
+        ${nextBadge ? html`
+          <div class="next-badge" role="button" tabindex="0"
+            aria-label="${this._t('badges.next_up')} — ${nextBadge.name} ${nextBadge.label}"
+            @click=${() => this._openBadgesView()}
+            @keydown=${(e) => this._badgeKeydown(e)}>
+            <div class="next-badge-icon" style="--t: ${this._tierColor(nextBadge.badge.tier)}">
+              <ha-icon icon="${nextBadge.badge.icon || 'mdi:trophy-outline'}"></ha-icon>
+            </div>
+            <div class="next-badge-body">
+              <div class="next-badge-top">
+                <span class="next-badge-label">${this._t('badges.next_up')}</span>
+                <span class="next-badge-name">${nextBadge.name}</span>
+                <span class="next-badge-count">${nextBadge.label}</span>
+              </div>
+              <div class="next-badge-bar" role="progressbar"
+                aria-valuenow="${nextBadge.pct}" aria-valuemin="0" aria-valuemax="100">
+                <i style="width: ${nextBadge.pct}%; background: ${this._tierColor(nextBadge.badge.tier)}"></i>
+              </div>
+            </div>
           </div>
         ` : ''}
 
@@ -2344,6 +2486,39 @@ class TaskMateChildCard extends LitElement {
       }
     }
     return null;
+  }
+
+  /* The single closest unearned badge (#780) — the kid-facing "next up" line.
+     `available[]` is already sorted by nothing in particular, so pick the
+     highest progress_pct. Badges nobody has started (0%) are skipped: a bar
+     stuck at zero is noise, not motivation. Returns null when there is
+     nothing worth showing. */
+  _nextBadge(badgesEntity) {
+    if (this.config.show_next_badge === false) return null;
+    const available = badgesEntity?.attributes?.available || [];
+    let best = null;
+    for (const b of available) {
+      const pct = Math.max(0, Math.min(100, Number(b.progress_pct) || 0));
+      if (pct <= 0) continue;
+      if (!best || pct > best.pct) best = { badge: b, pct };
+    }
+    if (!best) return null;
+    const c = best.badge.closest_criterion;
+    // Older backends (and criteria-free, manual-award badges) have no
+    // closest_criterion — fall back to the percentage.
+    best.label = c && c.target ? `${c.current} / ${c.target}` : `${best.pct}%`;
+    best.name = this._badgeName(best.badge);
+    return best;
+  }
+
+  // Built-in badge names arrive from the sensor in English; the localised
+  // name lives under badge.name_<suffix> (same scheme as the panel).
+  _badgeName(b) {
+    const id = b.badge_id || "";
+    if (!id.startsWith("builtin.")) return b.name;
+    const key = "badge.name_" + id.slice("builtin.".length);
+    const t = this._t(key);
+    return t !== key ? t : b.name;
   }
 
   _designTone(i) { return `var(--tmd-c${(i % 6) + 1})`; }
@@ -2489,6 +2664,7 @@ class TaskMateChildCard extends LitElement {
     const badgesEntity = this._resolveBadgesEntity(child);
     const earnedBadges = (badgesEntity?.attributes?.earned) || [];
     const showBadges = this.config.show_badges !== false && earnedBadges.length > 0;
+    const nextBadge = this._nextBadge(badgesEntity);
     const pendingPoints = child.pending_points || 0;
     const countdown = this.config.show_countdown !== false ? this._getMidnightCountdown() : null;
 
@@ -2531,6 +2707,26 @@ class TaskMateChildCard extends LitElement {
                 <ha-icon icon="${b.icon || "mdi:medal"}"></ha-icon>
               </div>`)}
             ${earnedBadges.length > 5 ? html`<span class="more">+${earnedBadges.length - 5} →</span>` : ""}
+          </div>` : ""}
+        ${nextBadge ? html`
+          <div class="tmd-next-badge" role="button" tabindex="0"
+            aria-label="${this._t("badges.next_up")} — ${nextBadge.name} ${nextBadge.label}"
+            @click=${() => this._openBadgesView()}
+            @keydown=${(e) => this._badgeKeydown(e)}>
+            <div class="ic" style="--t:${this._tierColor(nextBadge.badge.tier)}">
+              <ha-icon icon="${nextBadge.badge.icon || "mdi:trophy-outline"}"></ha-icon>
+            </div>
+            <div class="bd">
+              <div class="top">
+                <span class="lbl">${this._t("badges.next_up")}</span>
+                <span class="nm">${nextBadge.name}</span>
+                <span class="cnt">${nextBadge.label}</span>
+              </div>
+              <div class="bar" role="progressbar"
+                aria-valuenow="${nextBadge.pct}" aria-valuemin="0" aria-valuemax="100">
+                <i style="width:${nextBadge.pct}%;background:${this._tierColor(nextBadge.badge.tier)}"></i>
+              </div>
+            </div>
           </div>` : ""}
         ${sectionLine}
         ${this._renderRoulette(child, childChores, pointsIcon)}

--- a/tests/test_sensor_attributes.py
+++ b/tests/test_sensor_attributes.py
@@ -388,6 +388,70 @@ class TestChildBadgesSensor:
         assert attrs["available"][0]["badge_id"] == "locked"
         # Progress 5/10 = 50%
         assert attrs["available"][0]["progress_pct"] == 50
+        assert attrs["available"][0]["closest_criterion"] == {
+            "metric": "total_chores",
+            "current": 5,
+            "target": 10,
+        }
+
+    def test_and_badge_reports_weakest_criterion(self, hass):
+        """AND badges are gated by their worst criterion — report that one."""
+        child = Child(name="Mia", total_chores_completed=8, total_points_earned=10)
+        child.id = "c1"
+        locked = Badge(
+            name="Both",
+            criteria=[
+                BadgeCriterion("total_chores", ">=", 10),
+                BadgeCriterion("total_points", ">=", 100),
+            ],
+            combinator="AND",
+        )
+        locked.id = "locked"
+        coord = self._coordinator_for(child, [locked], [])
+        sensor = ChildBadgesSensor(coord, _MockEntry(), child)
+        avail = sensor.extra_state_attributes["available"][0]
+        # points is 10/100 = 10%, chores is 8/10 = 80% — AND takes the worse.
+        assert avail["progress_pct"] == 10
+        assert avail["closest_criterion"] == {
+            "metric": "total_points",
+            "current": 10,
+            "target": 100,
+        }
+
+    def test_or_badge_reports_strongest_criterion(self, hass):
+        """OR badges fire on any criterion, so progress is the best one (#780)."""
+        child = Child(name="Mia", total_chores_completed=8, total_points_earned=10)
+        child.id = "c1"
+        locked = Badge(
+            name="Either",
+            criteria=[
+                BadgeCriterion("total_chores", ">=", 10),
+                BadgeCriterion("total_points", ">=", 100),
+            ],
+            combinator="OR",
+        )
+        locked.id = "locked"
+        coord = self._coordinator_for(child, [locked], [])
+        sensor = ChildBadgesSensor(coord, _MockEntry(), child)
+        avail = sensor.extra_state_attributes["available"][0]
+        assert avail["progress_pct"] == 80
+        assert avail["closest_criterion"] == {
+            "metric": "total_chores",
+            "current": 8,
+            "target": 10,
+        }
+
+    def test_criteria_free_badge_has_no_closest_criterion(self, hass):
+        """Manual-award-only badges never auto-fire — no progress to show."""
+        child = Child(name="Mia")
+        child.id = "c1"
+        manual = Badge(name="Manual", criteria=[])
+        manual.id = "manual"
+        coord = self._coordinator_for(child, [manual], [])
+        sensor = ChildBadgesSensor(coord, _MockEntry(), child)
+        avail = sensor.extra_state_attributes["available"][0]
+        assert avail["progress_pct"] == 0
+        assert avail["closest_criterion"] is None
 
     def test_excludes_disabled_badges(self, hass):
         child = Child(name="Mia")


### PR DESCRIPTION
Closes #780.

The kid-facing child card only ever showed *already-earned* badges, so a child working toward "10 Perfect Weeks" got no feedback until it popped. Badge progress lived exclusively in `taskmate-badges-card`, which kids rarely open.

### Child card — "Next up"

A compact line under the earned strip: tier-coloured icon, badge name, a thin progress bar and an `840 / 1000` count for the closest unearned badge.

- Picks the highest `progress_pct` from `available[]`.
- Hidden when there are no unearned badges, or every remaining one sits at 0% (a bar stuck at zero is noise, not motivation).
- Tap (or Enter/Space — it is a focusable `role="button"`) opens the panel's badges section, same as the earned strip.
- Turn it off with `show_next_badge: false`, matching the existing `show_badges: false`. YAML-only, like `show_badges`.
- Built-in badge names are localised via `badge.name_<suffix>` (same scheme as the panel) rather than shown in raw English.

### Backend: the count needed a new field after all

The issue assumed no backend change was needed, but `available[]` carried only `progress_pct` — no current/target, so `840 / 1000` could not be built client-side. The sensor now also emits `closest_criterion: {metric, current, target}`.

That field is exactly what `taskmate-badges-card` has always read for its locked-tile progress bars. Because nothing emitted it, **those bars never drew on real data** — only in the editor preview, whose stub sets `progress_label`. They work now. Verified on ha-dev: `.badge-progress` elements 0 before the change, 9 after. The README claim about locked tiles having progress bars is finally true.

### Bug: OR-combinator badges reported the wrong progress

`sensor.py` took `min()` across criteria unconditionally, but `BadgeEvaluator` awards on `any()` when `combinator == "OR"`. An OR badge therefore reported its *worst* criterion — understated, and it could show below 100% while already earned. Now `min()` for AND, `max()` for OR, and `closest_criterion` names whichever criterion actually gates the award.

### Verification

- 1561 tests pass (up from 1557); 4 new cases cover `closest_criterion`, AND-weakest, OR-strongest, and criteria-free manual badges.
- ESLint clean, ruff clean, translation parity and data-file checks pass.
- Rendered on ha-dev in **all five designs** — classic, playroom, console, cleanpro, accessible — against Malia's live badges sensor (1000 Points, 84%, `840 / 1000`), zero console errors.
- Negative cases confirmed in the same run: `show_next_badge: false` hides it on both render paths, all-zero progress hides it, empty `available[]` hides it, default-on shows it.

Screenshots of all five designs were captured in-session; the line reads **Next up — 1000 Points — 840 / 1000** with an 84% bar on every one.

### i18n

`badges.next_up` added to all 8 locale files (de/en/en-GB/fr/nb/nn/pt/pt-BR) in this PR.