### PR TITLE
fix(coordinator): repoint rotation chores when their assignee is deleted (#787)

### DIFF
--- a/custom_components/taskmate/coordinator.py
+++ b/custom_components/taskmate/coordinator.py
@@ -847,11 +847,7 @@ class TaskMateCoordinator(
         # when assignment_current_child_id matches, and a deleted id matches
         # nobody. Repoint at today's live pool rather than just blanking it, so
         # the chore reappears for the survivors now instead of at midnight.
-        stale = [
-            c
-            for c in self.storage.get_chores()
-            if getattr(c, "assignment_current_child_id", "") == child_id
-        ]
+        stale = [c for c in self.storage.get_chores() if getattr(c, "assignment_current_child_id", "") == child_id]
         if stale:
             daily = self._compute_daily_assignments()
             for chore in stale:

--- a/custom_components/taskmate/coordinator.py
+++ b/custom_components/taskmate/coordinator.py
@@ -842,6 +842,21 @@ class TaskMateCoordinator(
                 dirty = True
             if dirty:
                 self.storage.update_chore(chore)
+        # A rotation pointer left on the deleted child hides the chore from
+        # everyone (#787): the child sensor includes a non-everyone chore only
+        # when assignment_current_child_id matches, and a deleted id matches
+        # nobody. Repoint at today's live pool rather than just blanking it, so
+        # the chore reappears for the survivors now instead of at midnight.
+        stale = [
+            c
+            for c in self.storage.get_chores()
+            if getattr(c, "assignment_current_child_id", "") == child_id
+        ]
+        if stale:
+            daily = self._compute_daily_assignments()
+            for chore in stale:
+                chore.assignment_current_child_id = daily.get(chore.id, "")
+                self.storage.update_chore(chore)
         await self.storage.async_save()
         await self.async_refresh()
 

--- a/tests/test_rotation_quota.py
+++ b/tests/test_rotation_quota.py
@@ -186,3 +186,69 @@ class TestSwappedRotation:
         with patch.object(_mod.dt_util, "now", return_value=now):
             assert coord.is_chore_available_for_child(stored, inactive) is True
             assert coord.is_chore_available_for_child(stored, active) is False
+
+
+class _MockEntry:
+    entry_id = "test_entry"
+
+
+class TestRemovedChildLeavesRotationPointer:
+    """#787 — deleting the child holding today's rotation slot left
+    `assignment_current_child_id` pointing at them, and the child sensor
+    filters on exactly that field, so the chore vanished for everyone left
+    until the midnight pass recomputed it."""
+
+    def test_pointer_is_repointed_at_a_surviving_child(self):
+        coord, storage, _mod = _make_system()
+        now = _now()
+        chore, active, survivor = _alternating_chore(coord, _mod, now)
+        assert storage.get_chore(chore.id).assignment_current_child_id == active
+
+        with patch.object(_mod.dt_util, "now", return_value=now):
+            run(coord.async_remove_child(active))
+
+        stored = storage.get_chore(chore.id)
+        assert stored.assignment_current_child_id == survivor
+        assert stored.assigned_to == [survivor]
+
+    def test_child_sensor_still_lists_the_chore_for_the_survivor(self):
+        """Where the bug actually bit: the child sensor filters on the pointer,
+        so a stale one hid the chore from the card even though the completion
+        service, button entity and to-do list all still accepted it."""
+        from custom_components.taskmate.sensor import ChildStatsSensor
+
+        coord, storage, _mod = _make_system()
+        now = _now()
+        chore, active, survivor = _alternating_chore(coord, _mod, now)
+
+        with patch.object(_mod.dt_util, "now", return_value=now):
+            run(coord.async_remove_child(active))
+            stored = storage.get_chore(chore.id)
+            coord.data = {"chores": [stored]}
+            coord.get_child = storage.get_child
+            coord._is_rotation_done_today = lambda c: False
+            sensor = ChildStatsSensor(coord, _MockEntry(), storage.get_child(survivor))
+            listed = [c["id"] for c in sensor.extra_state_attributes["assigned_chores"]]
+
+        assert listed == [chore.id]
+
+    def test_pointer_is_cleared_when_nobody_is_left_in_the_pool(self):
+        coord, storage, _mod = _make_system()
+        now = _now()
+        chore, active, survivor = _alternating_chore(coord, _mod, now)
+
+        with patch.object(_mod.dt_util, "now", return_value=now):
+            run(coord.async_remove_child(active))
+            run(coord.async_remove_child(survivor))
+
+        assert storage.get_chore(chore.id).assignment_current_child_id == ""
+
+    def test_removing_an_off_rotation_child_leaves_the_pointer_alone(self):
+        coord, storage, _mod = _make_system()
+        now = _now()
+        chore, active, inactive = _alternating_chore(coord, _mod, now)
+
+        with patch.object(_mod.dt_util, "now", return_value=now):
+            run(coord.async_remove_child(inactive))
+
+        assert storage.get_chore(chore.id).assignment_current_child_id == active


### PR DESCRIPTION
Closes #787.

`async_remove_child` stripped the child from `assigned_to` and (since #786) cleared the swap override, but never touched `assignment_current_child_id`. `ChildStatsSensor` includes a non-`everyone` chore only when that field matches the child — and a deleted id matches nobody, so the chore went invisible to **every surviving child** until the midnight pass recomputed it.

The completion service, the per-chore button entity and the to-do list all gate on `_compute_active_children`, which recomputes from the live pool, so they carried on accepting the survivor. Only the card disagreed — the mirror image of #781, where the card showed a chore the backend refused.

### Fix

Chores whose pointer names the removed child are repointed at today's live pool via `_compute_daily_assignments()`, in `async_remove_child` after the child is out of storage. Recomputed rather than just blanked, per the issue's open question: blanking would leave the chore hidden until midnight anyway, and the daily map is exactly what the midnight pass would have produced. When the pool empties, the pointer clears.

### Verification

Reproduced on the live **ha-dev** instance first — two children, an alternating chore, delete today's assignee:

```
active   = zz787 Ana
survivor = zz787 Ben
after deleting the assignee:
  assignment_current_child_id = 7fe753256dba4bdf (zz787 Ana)
  points at a deleted child   = True
  assigned_to                 = [743d7f16c9764b9c]      <- correctly stripped
  survivor stats sensor lists it = False                <- the bug
RESULT: FAIL — chore hidden from the survivor
```

The same probe is re-run against the merged fix on ha-dev.

4 new tests in `tests/test_rotation_quota.py`, 3 of which fail on `main`:
- pointer is repointed at a surviving child
- **the child sensor still lists the chore for the survivor** — the user-visible symptom, via a real `ChildStatsSensor`
- pointer clears when the pool empties
- removing an off-rotation child leaves the pointer alone (control; passed before the fix too)

1565 tests pass, ruff clean.