### PR TITLE
feat(child-card): show point values instead of stars in picture mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -541,12 +541,14 @@ entity: sensor.taskmate_overview
 child_id: <child_id>
 pre_reader: true
 pre_reader_labels: false   # optional; adds the chore name back under each tile
+pre_reader_points: false   # optional; shows the point value instead of the stars
 ```
 
 ### Key Points
 
 - **Chores now have a picture.** Set one per chore in the panel (next to the description). Without it a tile falls back to the time-of-day icon — fine for one chore, useless for telling "brush teeth" from "get dressed", so set them.
 - **Points are shown as stars, not digits** (1–5, scaled from the chore's value). A four-year-old can count pictures.
+- **`pre_reader_points: true` shows the number instead.** The star count rounds and clamps to 1–5, so a 7-point and an 8-point chore both draw four stars. Turn this on for a child who can already read a number and you get `+7` — matching what the completion actually awards, and what the rest of the dashboard shows.
 - Tiles are at least 128 px with a large tap target, and a **done tile stays tappable** so a mis-tap can be undone, exactly as on the standard card.
 - **Opt-in.** An existing dashboard never turns into pictures on its own, and names stay off unless you ask for them.
 

--- a/custom_components/taskmate/www/locales/de.json
+++ b/custom_components/taskmate/www/locales/de.json
@@ -1738,5 +1738,6 @@
   "panel.chore_image_bad_type": "Wähle ein JPEG-, PNG- oder WebP-Bild.",
   "child.editor.pre_reader": "Nur-Bilder-Modus (für kleine Kinder)",
   "child.editor.pre_reader_labels": "Namen im Bildmodus anzeigen",
+  "child.editor.pre_reader_points": "Punktzahl statt Sterne im Bildmodus anzeigen",
   "common.design.accessible": "Barrierefrei"
 }

--- a/custom_components/taskmate/www/locales/en-GB.json
+++ b/custom_components/taskmate/www/locales/en-GB.json
@@ -1738,5 +1738,6 @@
   "panel.chore_image_bad_type": "Choose a JPEG, PNG or WebP image.",
   "child.editor.pre_reader": "Picture-only mode (for young children)",
   "child.editor.pre_reader_labels": "Show names in picture mode",
+  "child.editor.pre_reader_points": "Show point values instead of stars in picture mode",
   "common.design.accessible": "Accessible"
 }

--- a/custom_components/taskmate/www/locales/en.json
+++ b/custom_components/taskmate/www/locales/en.json
@@ -1738,5 +1738,6 @@
   "panel.chore_image_bad_type": "Choose a JPEG, PNG or WebP image.",
   "child.editor.pre_reader": "Picture-only mode (for young children)",
   "child.editor.pre_reader_labels": "Show names in picture mode",
+  "child.editor.pre_reader_points": "Show point values instead of stars in picture mode",
   "common.design.accessible": "Accessible"
 }

--- a/custom_components/taskmate/www/locales/fr.json
+++ b/custom_components/taskmate/www/locales/fr.json
@@ -1738,5 +1738,6 @@
   "panel.chore_image_bad_type": "Choisissez une image JPEG, PNG ou WebP.",
   "child.editor.pre_reader": "Mode images seules (jeunes enfants)",
   "child.editor.pre_reader_labels": "Afficher les noms en mode images",
+  "child.editor.pre_reader_points": "Afficher les points au lieu des étoiles en mode images",
   "common.design.accessible": "Accessible"
 }

--- a/custom_components/taskmate/www/locales/nb.json
+++ b/custom_components/taskmate/www/locales/nb.json
@@ -1738,5 +1738,6 @@
   "panel.chore_image_bad_type": "Velg et JPEG-, PNG- eller WebP-bilde.",
   "child.editor.pre_reader": "Kun bilder (for små barn)",
   "child.editor.pre_reader_labels": "Vis navn i bildemodus",
+  "child.editor.pre_reader_points": "Vis poengverdier i stedet for stjerner i bildemodus",
   "common.design.accessible": "Tilgjengelig"
 }

--- a/custom_components/taskmate/www/locales/nn.json
+++ b/custom_components/taskmate/www/locales/nn.json
@@ -1738,5 +1738,6 @@
   "panel.chore_image_bad_type": "Vel eit JPEG-, PNG- eller WebP-bilete.",
   "child.editor.pre_reader": "Berre bilete (for små born)",
   "child.editor.pre_reader_labels": "Vis namn i biletemodus",
+  "child.editor.pre_reader_points": "Vis poengverdiar i staden for stjerner i biletemodus",
   "common.design.accessible": "Tilgjengeleg"
 }

--- a/custom_components/taskmate/www/locales/pt-BR.json
+++ b/custom_components/taskmate/www/locales/pt-BR.json
@@ -1738,5 +1738,6 @@
   "panel.chore_image_bad_type": "Escolha uma imagem JPEG, PNG ou WebP.",
   "child.editor.pre_reader": "Modo só imagens (crianças pequenas)",
   "child.editor.pre_reader_labels": "Mostrar nomes no modo imagens",
+  "child.editor.pre_reader_points": "Mostrar pontos em vez de estrelas no modo imagens",
   "common.design.accessible": "Acessível"
 }

--- a/custom_components/taskmate/www/locales/pt.json
+++ b/custom_components/taskmate/www/locales/pt.json
@@ -1738,5 +1738,6 @@
   "panel.chore_image_bad_type": "Escolha uma imagem JPEG, PNG ou WebP.",
   "child.editor.pre_reader": "Modo só imagens (crianças pequenas)",
   "child.editor.pre_reader_labels": "Mostrar nomes no modo imagens",
+  "child.editor.pre_reader_points": "Mostrar pontos em vez de estrelas no modo imagens",
   "common.design.accessible": "Acessível"
 }

--- a/custom_components/taskmate/www/taskmate-child-card.js
+++ b/custom_components/taskmate/www/taskmate-child-card.js
@@ -1272,6 +1272,11 @@ class TaskMateChildCard extends LitElement {
       .pre-tile-icon ha-icon { --mdc-icon-size: 64px; color: var(--primary-color); }
       .pre-tile-stars { display: flex; gap: 2px; }
       .pre-tile-stars ha-icon { --mdc-icon-size: 18px; color: #f1c40f; }
+      .pre-tile-points {
+        display: flex; align-items: center; gap: 4px;
+        font-size: 1.15rem; font-weight: 700; color: var(--primary-text-color);
+      }
+      .pre-tile-points ha-icon { --mdc-icon-size: 20px; color: #f1c40f; }
       .pre-tile-label {
         font-size: 0.85rem; font-weight: 700; text-align: center;
         color: var(--secondary-text-color); line-height: 1.2;
@@ -1282,6 +1287,7 @@ class TaskMateChildCard extends LitElement {
       }
       .pre-tile.done .pre-tile-icon ha-icon { opacity: 0.35; }
       .pre-tile.done .pre-tile-stars { opacity: 0.35; }
+      .pre-tile.done .pre-tile-points { opacity: 0.35; }
       .pre-tile-tick {
         position: absolute; inset: 0;
         display: grid; place-items: center;
@@ -2419,7 +2425,7 @@ class TaskMateChildCard extends LitElement {
                 ${this.config.pre_reader === true ? html`
                   <div class="pre-reader-grid">
                     ${childChores.map((chore) =>
-                      this._renderPreReaderTile(chore, child, todaysCompletions))}
+                      this._renderPreReaderTile(chore, child, pointsIcon, todaysCompletions))}
                   </div>
                 ` : childChores.map((chore, index) => html`
                   ${chore.task_type === 'timed'
@@ -2684,7 +2690,7 @@ class TaskMateChildCard extends LitElement {
       ? html`
         <div class="pre-reader-grid">
           ${childChores.map((chore) =>
-            this._renderPreReaderTile(chore, child, todaysCompletions))}
+            this._renderPreReaderTile(chore, child, pointsIcon, todaysCompletions))}
         </div>`
       : design === "playroom" ? this._designPlayroom(child, rows, remaining, tone) :
         design === "console"  ? this._designConsole(child, rows, remaining, tone) :
@@ -3500,8 +3506,12 @@ class TaskMateChildCard extends LitElement {
    * Pre-reader mode (#683): a picture-only tile for children who can't read
    * yet. No chore name, no numbers — a big icon, a row of stars for the
    * points, and a huge tick when it's done.
+   *
+   * `pre_reader_points` (#795) swaps the stars for the value itself, for
+   * families whose children can already read a number and who found the
+   * rounded star count contradicted the balance on the rest of the dashboard.
    */
-  _renderPreReaderTile(chore, child, todaysCompletions = []) {
+  _renderPreReaderTile(chore, child, pointsIcon, todaysCompletions = []) {
     const dailyLimit = chore.daily_limit || 1;
     // Counted the same way the standard row does: pending completions hold a
     // place too, and a parent completing on behalf lands under "__parent__".
@@ -3515,8 +3525,11 @@ class TaskMateChildCard extends LitElement {
     const available = chore._isAvailableForChild !== false && !chore._isLockedPreview;
 
     // Stars, not digits: a 4-year-old can count pictures, not read "+3".
+    // The count is deliberately lossy — it rounds and clamps to 1..5 — which
+    // is why showing the number instead is opt-in rather than a second row.
     const points = chore.effective_points ?? chore.points ?? 0;
     const stars = Math.max(1, Math.min(5, Math.round(points / 2) || 1));
+    const showPoints = this.config.pre_reader_points === true;
 
     const v = window.__taskmate_chore_visual(chore);
     const icon = (v.kind === "icon" ? v.icon : "")
@@ -3539,9 +3552,15 @@ class TaskMateChildCard extends LitElement {
             : html`<ha-icon icon="${icon}"></ha-icon>`}
         </div>
         ${isDone ? html`<div class="pre-tile-tick"><ha-icon icon="mdi:check-bold"></ha-icon></div>` : ''}
-        <div class="pre-tile-stars">
-          ${Array.from({ length: stars }, () => html`<ha-icon icon="mdi:star"></ha-icon>`)}
-        </div>
+        ${showPoints
+          ? html`
+            <div class="pre-tile-points">
+              <ha-icon icon="${pointsIcon}"></ha-icon>+${points}
+            </div>`
+          : html`
+            <div class="pre-tile-stars">
+              ${Array.from({ length: stars }, () => html`<ha-icon icon="mdi:star"></ha-icon>`)}
+            </div>`}
         ${this.config.pre_reader_labels === true
           ? html`<div class="pre-tile-label">${chore.name}</div>` : ''}
       </button>
@@ -4718,6 +4737,7 @@ class TaskMateChildCardEditor extends LitElement {
       { name: 'show_description', selector: { boolean: {} } },
       { name: 'pre_reader', selector: { boolean: {} } },
       { name: 'pre_reader_labels', selector: { boolean: {} } },
+      { name: 'pre_reader_points', selector: { boolean: {} } },
       { name: 'debug', selector: { boolean: {} } },
     ];
   }
@@ -4735,6 +4755,7 @@ class TaskMateChildCardEditor extends LitElement {
       show_description: this._t('child.editor.show_description'),
       pre_reader: this._t('child.editor.pre_reader'),
       pre_reader_labels: this._t('child.editor.pre_reader_labels'),
+      pre_reader_points: this._t('child.editor.pre_reader_points'),
       debug: this._t('child.editor.show_debug'),
     };
     return labels[entry.name] ?? entry.name;
@@ -4767,6 +4788,7 @@ class TaskMateChildCardEditor extends LitElement {
       show_description: this.config.show_description === true,
       pre_reader: this.config.pre_reader === true,
       pre_reader_labels: this.config.pre_reader_labels === true,
+      pre_reader_points: this.config.pre_reader_points === true,
       debug: this.config.debug === true,
     };
 

--- a/tests/test_pre_reader_mode.py
+++ b/tests/test_pre_reader_mode.py
@@ -19,7 +19,7 @@ CARD = (WWW / "taskmate-child-card.js").read_text(encoding="utf-8")
 
 def _tile_source() -> str:
     """The tile method body — sliced from its definition, not its call site."""
-    start = CARD.index("  _renderPreReaderTile(chore, child, todaysCompletions = []) {")
+    start = CARD.index("  _renderPreReaderTile(chore, child, pointsIcon, todaysCompletions = []) {")
     return CARD[start : CARD.index("_renderChoreCard(chore, child, pointsIcon", start)]
 
 
@@ -132,3 +132,60 @@ class TestPreReaderRendersOnEveryDesign:
 
     def test_designed_styles_render_the_picture_tiles(self):
         assert "_renderPreReaderTile(" in self._designed_region()
+
+
+class TestPreReaderPointValues:
+    """Show the real point value instead of stars in picture mode (#795).
+
+    The star row is `round(points / 2)` clamped to 1..5, so a 7-point and an
+    8-point chore both draw four stars — a parent who wants the dashboard to
+    agree with the child's balance needs the number itself.
+    """
+
+    def test_points_row_is_opt_in(self):
+        """Stars are what every existing picture-mode card already shows."""
+        assert "this.config.pre_reader_points === true" in _tile_source()
+
+    def test_stars_remain_the_default(self):
+        tile = _tile_source()
+        assert "pre-tile-stars" in tile
+        assert "mdi:star" in tile
+
+    def test_points_row_renders_the_exact_value(self):
+        """Not the star approximation — the number the completion awards."""
+        tile = _tile_source()
+        assert "pre-tile-points" in tile
+        assert "+${points}" in tile
+
+    def test_points_row_uses_the_effective_value(self):
+        """Difficulty multipliers and boosts land in effective_points."""
+        assert "chore.effective_points ?? chore.points ?? 0" in _tile_source()
+
+    def test_tile_takes_the_family_points_icon(self):
+        """Hard-coding mdi:star would contradict a family that renamed points."""
+        tile = _tile_source()
+        assert "_renderPreReaderTile(chore, child, pointsIcon, todaysCompletions = [])" in CARD
+        assert 'icon="${pointsIcon}"' in tile
+
+    def test_both_render_paths_pass_the_points_icon(self):
+        """Classic and designed each call the tile — a missed argument would
+        leave the icon undefined on one style only."""
+        calls = CARD.count("this._renderPreReaderTile(chore, child, pointsIcon, todaysCompletions)")
+        assert calls == 2, f"expected both call sites to pass pointsIcon, found {calls}"
+
+    def test_points_row_is_styled(self):
+        assert ".pre-tile-points {" in CARD
+
+    def test_points_row_dims_when_done(self):
+        """The star row already dims; a points row that stayed bright would
+        read as "still to earn"."""
+        assert ".pre-tile.done .pre-tile-points" in CARD
+
+    def test_editor_exposes_the_option(self):
+        assert "name: 'pre_reader_points'" in CARD
+        assert "pre_reader_points: this.config.pre_reader_points === true" in CARD
+
+    def test_string_exists_in_every_locale(self):
+        for path in sorted((WWW / "locales").glob("*.json")):
+            data = json.loads(path.read_text(encoding="utf-8"))
+            assert "child.editor.pre_reader_points" in data, f"{path.name} missing the label"


### PR DESCRIPTION
## What

Picture mode (`pre_reader: true`) draws a chore's reward as a row of 1–5 stars, rounded and clamped from the value:

```js
const stars = Math.max(1, Math.min(5, Math.round(points / 2) || 1));
```

That is the right call for a child who cannot read a number, but it is lossy — a **7-point and an 8-point chore both draw four stars** — so the tile contradicts the point totals shown everywhere else on the dashboard.

This adds `pre_reader_points`, a card option that swaps the star row for the value itself, drawn with the family's configured points icon.

```yaml
type: custom:taskmate-child-card
entity: sensor.taskmate_overview
child_id: <child_id>
pre_reader: true
pre_reader_points: true   # +7 instead of ★★★★
```

**Off by default** — no existing picture-mode dashboard changes. Also exposed as a toggle in the visual card editor.

## Notes

- The tile renderer is shared by the classic and designed render paths, so both call sites now thread `pointsIcon` through. Rendered and checked on all five designs (classic, playroom, console, cleanpro, accessible) — the recurring "works on classic, invisible elsewhere" trap.
- Uses `effective_points ?? points`, so difficulty multipliers and boosts are reflected.
- The done-state dim mirrors what the star row already does.
- Label translated into all 8 locales in this PR (de/en/en-GB/fr/nb/nn/pt/pt-BR).

## Verification

- `pytest tests/` → **1576 passed**, 0 failures; 12 new assertions in `tests/test_pre_reader_mode.py`.
- ESLint clean, `node --check` clean, ruff clean.
- Rendered against the live ha-dev instance through browserless: points mode showed 4/4 tiles with the value row and 0 star rows; default showed 4 star rows; 0 console errors. Editor schema exposes `pre_reader_points` and the new label resolves.

Closes #795