### PR TITLE
fix(approvals): refresh once per Approve All, not once per chore

### DIFF
--- a/custom_components/taskmate/coord_chores.py
+++ b/custom_components/taskmate/coord_chores.py
@@ -389,6 +389,15 @@ class ChoresMixin:
         approved. If None/empty, every currently-unapproved completion is approved.
         Reuses async_approve_chore so all award/badge/quest/celebration side-effects
         match single approval exactly.
+
+        Each approval is told not to refresh (#794). ``async_approve_chore``
+        normally ends in a full coordinator rebuild plus a state write for every
+        TaskMate entity, which at ~0.13s a time made a 60-chore Approve All block
+        the websocket call for ~8s with nothing pushed to the frontend meanwhile —
+        the panel and the approvals card sit unchanged for that whole window, so
+        the button reads as broken. The batch refreshes once at the end instead.
+        Safe because the per-approval side-effects (badges, quests, challenges,
+        the all-done check) all read `storage` directly, never `self.data`.
         """
         pending = {c.id for c in self.storage.get_completions() if not c.approved}
         if completion_ids:
@@ -398,8 +407,10 @@ class ChoresMixin:
             targets = [c.id for c in self.storage.get_completions() if not c.approved]
         count = 0
         for cid in targets:
-            await self.async_approve_chore(cid)
+            await self.async_approve_chore(cid, refresh=False)
             count += 1
+        if count:
+            await self.async_refresh()
         return count
 
     async def async_add_chores_bulk(
@@ -991,8 +1002,13 @@ class ChoresMixin:
         await self.async_refresh()
         return completion
 
-    async def async_approve_chore(self, completion_id: str) -> None:
-        """Approve a chore completion."""
+    async def async_approve_chore(self, completion_id: str, refresh: bool = True) -> None:
+        """Approve a chore completion.
+
+        ``refresh=False`` is used by ``async_approve_chores_bulk`` so a batch
+        pays for one coordinator rebuild rather than one per completion (#794).
+        The caller must refresh once it is done.
+        """
         completions = self.storage.get_completions()
         for completion in completions:
             if completion.id == completion_id:
@@ -1058,7 +1074,8 @@ class ChoresMixin:
                         self.storage.update_chore(chore)
 
                     await self.storage.async_save()
-                    await self.async_refresh()
+                    if refresh:
+                        await self.async_refresh()
 
                     # Trigger badge evaluation after approval awards points/chore count/streak
                     if getattr(self, "badges", None):

--- a/tests/test_approve_all_chores.py
+++ b/tests/test_approve_all_chores.py
@@ -35,14 +35,17 @@ def _coord(completions):
     coord.storage = storage
     approved = []
 
-    async def _approve(cid):
+    async def _approve(cid, refresh=True):
         for c in completions:
             if c.id == cid and not c.approved:
                 c.approved = True
                 approved.append(cid)
+        coord._refresh_flags.append(refresh)
 
     coord.async_approve_chore = AsyncMock(side_effect=_approve)
+    coord.async_refresh = AsyncMock()
     coord._approved = approved
+    coord._refresh_flags = []
     return coord
 
 
@@ -75,3 +78,49 @@ def test_empty_pending_returns_zero():
     n = run(coord.async_approve_chores_bulk())
     assert n == 0
     coord.async_approve_chore.assert_not_awaited()
+
+
+class TestBulkApprovalRefreshesOnce:
+    """Approve All rebuilt the whole coordinator once per completion (#794).
+
+    ``async_approve_chore`` ends in ``await self.async_refresh()`` — a full
+    rebuild plus a state write for every TaskMate entity. Reusing it per
+    completion made "Approve All" cost O(N) refreshes: measured at ~0.13 s
+    each on the dev instance, so 60 pending approvals blocked the websocket
+    call for ~8 s with no intermediate state pushed to the frontend. The panel
+    and the approvals card both look frozen for that whole window, which is
+    indistinguishable from the button doing nothing.
+    """
+
+    def test_refresh_happens_once_not_per_completion(self):
+        cs = [_completion(c) for c in "abcdefgh"]
+        coord = _coord(cs)
+        n = run(coord.async_approve_chores_bulk())
+        assert n == 8
+        assert coord.async_refresh.await_count == 1, (
+            f"expected a single refresh for the whole batch, got "
+            f"{coord.async_refresh.await_count} — one per completion is the #794 stall"
+        )
+
+    def test_per_completion_refresh_is_suppressed(self):
+        cs = [_completion(c) for c in "abc"]
+        coord = _coord(cs)
+        run(coord.async_approve_chores_bulk())
+        assert coord._refresh_flags == [False, False, False], (
+            "each approval must be told not to refresh; the batch refreshes at the end"
+        )
+
+    def test_nothing_to_approve_skips_the_refresh_entirely(self):
+        coord = _coord([_completion("a", approved=True)])
+        assert run(coord.async_approve_chores_bulk()) == 0
+        coord.async_refresh.assert_not_awaited()
+
+    def test_single_approval_still_refreshes_by_default(self):
+        """The default must stay refresh-on-approve — a lone approval from the
+        card or a service call has nothing else to trigger the update."""
+        import inspect
+
+        from custom_components.taskmate.coord_chores import ChoresMixin
+
+        sig = inspect.signature(ChoresMixin.async_approve_chore)
+        assert sig.parameters["refresh"].default is True


### PR DESCRIPTION
## Root cause

`async_approve_chores_bulk` reuses `async_approve_chore` per completion so that every side-effect (points, badges, quests, challenges, celebrations) matches a single approval exactly. But that method ends in:

```python
await self.storage.async_save()
await self.async_refresh()          # full coordinator rebuild + a state write for EVERY entity
```

so **Approve All paid for one full coordinator refresh per chore**. The save is already debounced; the refresh is not.

Measured on the dev instance with 60 pending approvals:

| | elapsed | per completion |
|---|---|---|
| before | **7.40s** | 123 ms |
| after | **0.21s** | 4 ms |

Nothing is pushed to the frontend during that window (I instrumented the live `hass` object — exactly **one** state push, at the very end). Meanwhile neither UI renders an in-flight state: the panel button keeps its normal label, the full pending list stays on screen, no spinner. So for ~12 seconds the panel is pixel-identical to "the button did nothing" — people reload, and find the approvals went through after all. That is precisely the report in #794.

## Fix

The batch suppresses the per-completion refresh and refreshes once at the end:

```python
for cid in targets:
    await self.async_approve_chore(cid, refresh=False)
    count += 1
if count:
    await self.async_refresh()
```

`refresh: bool = True` keeps single approvals (card, service call, WS) behaving exactly as before. This mirrors the `refresh=False` convention already used by `_async_expire_deadline_chores`.

**Why deferring is safe:** every side-effect that runs after the refresh inside `async_approve_chore` — badge evaluation, quest advance, challenge evaluation, the all-done celebration check — reads `storage` directly and never touches `self.data`, so none of them can observe a stale coordinator snapshot.

## Verification

Reproduced and confirmed against the live ha-dev instance through browserless, driving the real UI:

- **Panel, before:** 60 rows and the Approve All button still on screen at +8000ms, cleared only at ~+12000ms.
- **Panel, after:** cleared by +1000ms, "Approved 60 chores" toast.
- **Approvals card, before:** 60 rows still rendered at +8000ms. **After:** 0 rows by +1000ms.
- Backend timing measured over the websocket: 7.40s → 0.21s for the same 60 approvals.
- `pytest tests/` → **1580 passed**, 0 failures (4 new tests in `tests/test_approve_all_chores.py` pinning one-refresh-per-batch and the `refresh=True` default). Ruff clean.

Closes #794