### PR TITLE
fix(cards): make recurrence_done_mode actually work

### DIFF
--- a/custom_components/taskmate/www/taskmate-child-card.js
+++ b/custom_components/taskmate/www/taskmate-child-card.js
@@ -2650,6 +2650,7 @@ class TaskMateChildCard extends LitElement {
     const dueDaysMode = this.config.due_days_mode || "hide";
     const elapsedTimeMode = this.config.elapsed_time_mode || "dim";
     const dependencyMode = this.config.dependency_mode || "hide";
+    const recurrenceDoneMode = this.config.recurrence_done_mode || "dim";
 
     // Annotate each chore with done-state + handlers, preserving the classic path's logic.
     const rows = childChores.map((chore, i) => {
@@ -2658,8 +2659,11 @@ class TaskMateChildCard extends LitElement {
       // Blocked chores only reach here under dim/show — hide is filtered
       // upstream. Either way the tap must be refused (#793).
       const blocked = !!chore._isDependencyBlocked && !done;
+      // Recurring chore still inside its cooldown. Excluded when done so the
+      // undo chip stays live, exactly as on the classic row.
+      const recLocked = !!chore._isRecurrenceLocked && !done;
       const onAct = () => {
-        if (loading || blocked) return;
+        if (loading || blocked || recLocked) return;
         if (done) this._handleUndo(chore, child, completions);
         else this._handleComplete(chore, child);
       };
@@ -2670,10 +2674,11 @@ class TaskMateChildCard extends LitElement {
         (notDueToday && dueDaysMode === "dim") ||
         (chore._isTimeElapsed && elapsedTimeMode === "dim") ||
         (blocked && dependencyMode === "dim") ||
+        (chore._isRecurrenceLocked && recurrenceDoneMode === "dim") ||
         chore._isLockedPreview === true
       );
       return {
-        chore, child, done, loading, onAct, index: i, dimmed, blocked,
+        chore, child, done, loading, onAct, index: i, dimmed, blocked, recLocked,
         tone: this._designTone(i),
         glyph: this._choreGlyph(chore),
         points: chore.effective_points ?? chore.points,
@@ -2806,12 +2811,18 @@ class TaskMateChildCard extends LitElement {
     // A blocked chore says what unlocks it here too — the classic row carries
     // the same label, and a dimmed row with no reason is just confusing (#793).
     const depNames = r.blocked ? (r.chore._dependencyNames || []) : [];
+    // Same reason label the classic row carries, so a dimmed designed row is
+    // not just mysteriously grey (#803).
+    const recLabel = r.recLocked
+      ? (r.chore.recurrence ? r.chore.recurrence.replace(/_/g, " ") : this._t("child.recurring"))
+      : "";
     return html`
-      ${r.mandatory || r.photo || depNames.length ? html`
+      ${r.mandatory || r.photo || depNames.length || recLabel ? html`
         <div class="tmd-meta">
           ${r.mandatory ? html`<span class="tmd-tag mandatory">⚠ ${this._t("child.mandatory")}</span>` : ""}
           ${r.photo ? html`<span class="tmd-tag photo">📷 ${this._t("child.photo_needed")}</span>` : ""}
           ${depNames.length ? html`<span class="tmd-tag">🔒 ${this._t("child.blocked_by_dependency", { chores: depNames.join(", ") })}</span>` : ""}
+          ${recLabel ? html`<span class="tmd-tag">🕒 ${recLabel}</span>` : ""}
         </div>` : ""}
       ${showDesc ? html`<div class="tmd-desc">${r.chore.description}</div>` : ""}`;
   }
@@ -2827,7 +2838,7 @@ class TaskMateChildCard extends LitElement {
 
   _designDoneBtn(r, label, cls) {
     return html`<button class="btn ${cls || ""}"
-      ?disabled=${r.loading || r.blocked}
+      ?disabled=${r.loading || r.blocked || r.recLocked}
       @click=${(e) => { e.stopPropagation(); r.onAct(); }}>${label}</button>`;
   }
 
@@ -2997,7 +3008,15 @@ class TaskMateChildCard extends LitElement {
     // Hide by default: the backend simply reports a dependency-blocked chore
     // as unavailable, so hiding is what matches it (#793).
     const dependencyMode = this.config.dependency_mode || 'hide';
+    const recurrenceDoneMode = this.config.recurrence_done_mode || 'dim';
     const allCompletionsToday = attrs.todays_completions || [];
+    // Availability comes from the backend's own matrix (#803). The card cannot
+    // work a recurrence window out for itself: last_completed is not exposed,
+    // `recurrence` is omitted from the payload when it is the default weekly,
+    // and the maths is calendar-month aware. A missing matrix (older backend,
+    // or a sensor that hasn't published yet) has to read as available, or the
+    // card would blank itself.
+    const availability = attrs.chore_availability || {};
 
     // First, filter chores for this child and time category
     const filteredChores = chores.filter(chore => {
@@ -3165,6 +3184,21 @@ class TaskMateChildCard extends LitElement {
             .filter(Boolean)
         : [];
       if (chore._isDependencyBlocked && dependencyMode === 'hide') return false;
+
+      // Recurring chores in their cooldown window (#803). Both of these are
+      // read by the render path, which until now found them undefined.
+      chore._isRecurring = (chore.schedule_mode || 'specific_days') === 'recurring';
+      const availableNow = (availability[chore.id] || {})[childId] !== false;
+      // Completing a recurring chore makes it unavailable at once, so hiding on
+      // availability alone would vanish it the instant it is ticked — no done
+      // state, no way to undo. The mode is about the days *after* that.
+      const completedToday = allCompletionsToday.some(
+        (comp) => comp.chore_id === chore.id
+          && (String(comp.child_id) === childId || comp.child_id === '__parent__')
+          && !comp.bonus_subtask_id
+      );
+      chore._isRecurrenceLocked = chore._isRecurring && !availableNow && !completedToday;
+      if (chore._isRecurrenceLocked && recurrenceDoneMode === 'hide') return false;
 
       // Mark whether this chore's time period has elapsed (grace-aware).
       chore._isTimeElapsed = this._isTimePeriodElapsed(chore);
@@ -3690,7 +3724,8 @@ class TaskMateChildCard extends LitElement {
     // Click handler for the entire row
     const notDueToday = chore._hasDueDays && !chore._isDueToday && this.config.due_days_mode === 'dim';
     const recurrenceDoneMode = this.config.recurrence_done_mode || 'dim';
-    const notAvailableRecurrence = chore._isRecurring && !chore._isAvailableForChild && recurrenceDoneMode === 'dim';
+    const notAvailableRecurrence = !!chore._isRecurrenceLocked
+      && !isCompletedForToday && recurrenceDoneMode === 'dim';
     // Elapsed: only dim incomplete chores — completed ones keep their green "done" style
     const elapsedTimeMode = this.config.elapsed_time_mode || 'dim';
     const timeElapsed = chore._isTimeElapsed && !isCompletedForToday && elapsedTimeMode === 'dim';
@@ -3767,7 +3802,7 @@ class TaskMateChildCard extends LitElement {
                 ${this._t('child.blocked_by_dependency', { chores: chore._dependencyNames.join(', ') })}
               </div>
             ` : ''}
-            ${chore._isRecurring && !chore._isAvailableForChild ? html`
+            ${chore._isRecurrenceLocked ? html`
               <div class="recurrence-label">
                 <ha-icon icon="mdi:clock-outline"></ha-icon>
                 ${chore.recurrence ? chore.recurrence.replace(/_/g, ' ') : this._t('child.recurring')}

--- a/tests/test_recurrence_availability.py
+++ b/tests/test_recurrence_availability.py
@@ -1,0 +1,115 @@
+"""recurrence_done_mode was dead code (#803).
+
+The child card reads `chore._isRecurring` and `chore._isAvailableForChild` in
+its render path, but nothing ever assigned either field — a repo-wide search
+found no assignment anywhere. `undefined && …` is always falsy, so:
+
+* `recurrence_done_mode: dim` never dimmed anything and never made the row
+  non-interactive;
+* the `.recurrence-label` block was unreachable;
+* and `hide` was dead too, because the filter never looked at recurrence at all.
+
+The card cannot compute the window itself: `last_completed` is not exposed to
+the frontend and `recurrence` is omitted from the sensor payload when it is the
+default weekly. So availability is taken from the authoritative
+`chore_availability` matrix, the same one the backend publishes.
+
+Reproduced on the dev instance with a recurring chore anchored in the future:
+the matrix reported it unavailable while the card rendered it as tappable under
+all three modes.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent / "custom_components" / "taskmate"
+CARD = (ROOT / "www" / "taskmate-child-card.js").read_text(encoding="utf-8")
+
+
+def _filter_source() -> str:
+    start = CARD.index("  _filterAndSortChores(chores, child) {")
+    return CARD[start : CARD.index("\n  _getTimeCategoryIcon(", start)]
+
+
+def _row_source() -> str:
+    start = CARD.index("  _renderChoreCard(chore, child, pointsIcon")
+    return CARD[start : CARD.index("\n  _renderTimedChoreCard(", start)]
+
+
+class TestFieldsAreActuallyAssigned:
+    def test_is_recurring_is_assigned(self):
+        assert "_isRecurring =" in _filter_source(), (
+            "the card reads chore._isRecurring but never assigns it"
+        )
+
+    def test_lock_uses_a_dedicated_field(self):
+        """Deliberately NOT chore._isAvailableForChild. That field is also read
+        by the picture-mode tile, where a matrix-unavailable chore would become
+        an undisablable tile — including losing undo. Reviving it globally is a
+        separate question from this fix."""
+        src = _filter_source()
+        assert "_isRecurrenceLocked =" in src
+        assert "_isAvailableForChild =" not in src
+
+    def test_availability_comes_from_the_backend_matrix(self):
+        """Not recomputed client-side: last_completed isn't exposed and the
+        recurrence maths is calendar-month aware."""
+        assert "chore_availability" in _filter_source()
+
+    def test_missing_matrix_defaults_to_available(self):
+        """An older backend, or a cold sensor, must not blank the card."""
+        assert "!== false" in _filter_source()
+
+    def test_recurring_is_keyed_on_schedule_mode(self):
+        assert "'recurring'" in _filter_source() or '"recurring"' in _filter_source()
+
+
+class TestHideMode:
+    def test_filter_honours_hide(self):
+        src = _filter_source()
+        assert "recurrence_done_mode" in src, "hide was never applied at filter stage"
+
+    def test_hide_does_not_swallow_a_chore_completed_today(self):
+        """Ticking a recurring chore makes it unavailable immediately; hiding it
+        on the spot would remove the done state and any way to undo."""
+        src = _filter_source()
+        # The lock is what hide keys on, so the exclusion has to live in it.
+        idx = src.index("_isRecurrenceLocked =")
+        lock = src[idx : src.index(";", idx)]
+        assert "completedToday" in lock, (
+            f"the lock must exclude chores completed today, got: {lock!r}"
+        )
+        assert "_isRecurrenceLocked" in src[src.index("recurrenceDoneMode === 'hide'") - 60 :]
+
+
+class TestDimMode:
+    def test_dim_still_allows_undo(self):
+        """notAvailableRecurrence short-circuits the click handler before the
+        undo branch, so it must not fire for a chore completed today."""
+        row = _row_source()
+        idx = row.index("const notAvailableRecurrence =")
+        # The assignment may wrap over several lines; read to its semicolon.
+        stmt = row[idx : row.index(";", idx)]
+        assert "isCompletedForToday" in stmt, (
+            f"dimming a chore completed today would block its undo, got: {stmt!r}"
+        )
+
+    def test_designed_styles_dim_too(self):
+        """The designed row builder computes its own `dimmed` flag."""
+        start = CARD.index("    const rows = childChores.map((chore, i) => {")
+        rows = CARD[start : CARD.index("_designChoreMeta(r) {", start)]
+        assert "_isRecurrenceLocked" in rows, "designed styles never dim an unavailable recurring chore"
+
+    def test_designed_done_button_is_disabled_when_locked(self):
+        assert "r.loading || r.blocked || r.recLocked" in CARD
+
+
+class TestLabelComesAlive:
+    def test_label_block_still_present(self):
+        assert "recurrence-label" in CARD
+
+    def test_label_falls_back_when_recurrence_is_omitted(self):
+        """The sensor omits `recurrence` when it is the default weekly, so the
+        label has to cope with it being absent."""
+        assert "child.recurring" in CARD

--- a/tests/test_recurrence_availability.py
+++ b/tests/test_recurrence_availability.py
@@ -39,9 +39,7 @@ def _row_source() -> str:
 
 class TestFieldsAreActuallyAssigned:
     def test_is_recurring_is_assigned(self):
-        assert "_isRecurring =" in _filter_source(), (
-            "the card reads chore._isRecurring but never assigns it"
-        )
+        assert "_isRecurring =" in _filter_source(), "the card reads chore._isRecurring but never assigns it"
 
     def test_lock_uses_a_dedicated_field(self):
         """Deliberately NOT chore._isAvailableForChild. That field is also read
@@ -77,9 +75,7 @@ class TestHideMode:
         # The lock is what hide keys on, so the exclusion has to live in it.
         idx = src.index("_isRecurrenceLocked =")
         lock = src[idx : src.index(";", idx)]
-        assert "completedToday" in lock, (
-            f"the lock must exclude chores completed today, got: {lock!r}"
-        )
+        assert "completedToday" in lock, f"the lock must exclude chores completed today, got: {lock!r}"
         assert "_isRecurrenceLocked" in src[src.index("recurrenceDoneMode === 'hide'") - 60 :]
 
 
@@ -91,9 +87,7 @@ class TestDimMode:
         idx = row.index("const notAvailableRecurrence =")
         # The assignment may wrap over several lines; read to its semicolon.
         stmt = row[idx : row.index(";", idx)]
-        assert "isCompletedForToday" in stmt, (
-            f"dimming a chore completed today would block its undo, got: {stmt!r}"
-        )
+        assert "isCompletedForToday" in stmt, f"dimming a chore completed today would block its undo, got: {stmt!r}"
 
     def test_designed_styles_dim_too(self):
         """The designed row builder computes its own `dimmed` flag."""


### PR DESCRIPTION
## Root cause

The child card reads `chore._isRecurring` and `chore._isAvailableForChild` in its render path, but **nothing ever assigned either field** — a repo-wide search finds no assignment anywhere. `undefined && …` is always falsy, so:

- **`dim` never dimmed** a recurring chore waiting to reset, and never made the row non-interactive;
- the `.recurrence-label` block was unreachable, so its CSS was dead too;
- **`hide` was dead as well** — the filter never looked at recurrence at all, the mode was only ever consulted in the render path.

So the whole option was inert: `show` was the only behaviour, whatever you set. README has documented the intended behaviour all along.

Reproduced on the dev instance with a recurring chore anchored three weeks out — the backend reported it unavailable while the card rendered it tappable under **all three** modes.

## Why the matrix

The card cannot work the window out for itself: `last_completed` is not exposed to the frontend, `recurrence` is omitted from the sensor payload when it is the default weekly, and the maths is calendar-month aware (`_MONTH_STEPS`, anchors, `first_occurrence_mode`, DOW targets). Duplicating ~80 lines of date logic client-side would drift. Availability comes from the backend's own `chore_availability` matrix instead. A missing matrix reads as **available**, so an older backend, or a sensor that has not published yet, cannot blank the card.

## Two deliberate choices

**A dedicated `_isRecurrenceLocked`, not a revived `_isAvailableForChild`.** That field is also read by the picture-mode tile:

```js
const available = chore._isAvailableForChild !== false && !chore._isLockedPreview && …
```

Assigning it from the matrix disabled ordinary tiles — including their undo — for any child the matrix reports unavailable. I hit exactly that mid-verification. Whether picture mode should honour availability is a separate question, so this leaves it alone.

**The lock excludes chores completed today.** Completing a recurring chore makes it unavailable immediately. Without the exclusion, ticking one would vanish it on the spot under `hide`, and under `dim` put it out of reach of undo — `notAvailableRecurrence` short-circuits the click handler *before* the undo branch. The mode is about the days after, which is what the helper text says: *"when a recurring chore has been completed and the window hasn't reset yet"*.

## Verification

Against the live dev instance:

| | cooldown chore | completed today | unrelated chore |
|---|---|---|---|
| `hide` | not rendered | still rendered, still undoable | untouched |
| `dim` | dimmed, not tappable, label shown | not dimmed, undoable | untouched |
| `show` | rendered normally | not dimmed, undoable | untouched |

- All four designed styles dim it, disable the DONE button, and show the reason tag.
- Picture mode re-checked: an ordinary tile is still enabled (`normalEnabled: true`).
- `pytest tests/` -> **1624 passed**, 0 failures (12 new tests). Ruff, ESLint and `node --check` clean.

`show` leaves the row tappable, matching its shipped description (*"show normally regardless"*); the backend no-ops the completion. Happy to make it non-tappable like the dependency modes if you would rather — it would mean changing that string.

Closes #803