### PR TITLE
fix(cards): stop recurrence show leaving a dead-tappable chore

### DIFF
--- a/custom_components/taskmate/www/locales/de.json
+++ b/custom_components/taskmate/www/locales/de.json
@@ -248,7 +248,7 @@
   "child.editor.recurrence_dim": "Gedimmt – ausgegraut anzeigen, nicht interaktiv",
   "child.editor.recurrence_helper": "Was angezeigt werden soll, wenn eine wiederkehrende Aufgabe abgeschlossen wurde und das Fenster noch nicht zurückgesetzt wurde",
   "child.editor.recurrence_hide": "Ausblenden – erst wieder anzeigen, wenn es wieder verfügbar ist",
-  "child.editor.recurrence_show": "Anzeigen – trotzdem normal anzeigen",
+  "child.editor.recurrence_show": "Anzeigen – normal zeigen (weiterhin nicht antippbar)",
   "child.editor.recurring_when_completed": "Wiederkehrende Aufgaben – nach Abschluss",
   "child.editor.select_child": "Wählen Sie ein Kind aus...",
   "child.editor.show_countdown": "Countdown zum Zurücksetzen neben „Heutige Aufgaben“ anzeigen",

--- a/custom_components/taskmate/www/locales/en-GB.json
+++ b/custom_components/taskmate/www/locales/en-GB.json
@@ -250,7 +250,7 @@
   "child.editor.recurrence_dim": "Dim — show greyed out, non-interactive",
   "child.editor.recurrence_helper": "What to show when a recurring chore has been completed and the window hasn't reset yet",
   "child.editor.recurrence_hide": "Hide — don't show until available again",
-  "child.editor.recurrence_show": "Show — show normally regardless",
+  "child.editor.recurrence_show": "Show — show normally (still not tappable)",
   "child.editor.recurring_when_completed": "Recurring Chores — When Completed",
   "child.editor.select_child": "Select a child...",
   "child.editor.show_countdown": "Show reset countdown beside \"Today's Chores\"",

--- a/custom_components/taskmate/www/locales/en.json
+++ b/custom_components/taskmate/www/locales/en.json
@@ -250,7 +250,7 @@
   "child.editor.recurrence_dim": "Dim — show greyed out, non-interactive",
   "child.editor.recurrence_helper": "What to show when a recurring chore has been completed and the window hasn't reset yet",
   "child.editor.recurrence_hide": "Hide — don't show until available again",
-  "child.editor.recurrence_show": "Show — show normally regardless",
+  "child.editor.recurrence_show": "Show — show normally (still not tappable)",
   "child.editor.recurring_when_completed": "Recurring Chores — When Completed",
   "child.editor.select_child": "Select a child...",
   "child.editor.show_countdown": "Show reset countdown beside \"Today's Chores\"",

--- a/custom_components/taskmate/www/locales/fr.json
+++ b/custom_components/taskmate/www/locales/fr.json
@@ -248,7 +248,7 @@
   "child.editor.recurrence_dim": "Estomper — afficher en gris, non interactif",
   "child.editor.recurrence_helper": "Que montrer lorsqu'une tâche récurrente a été accomplie et que la fenêtre n'a pas encore été réinitialisée",
   "child.editor.recurrence_hide": "Masquer — ne pas afficher avant d'être à nouveau disponible",
-  "child.editor.recurrence_show": "Afficher — afficher normalement malgré tout",
+  "child.editor.recurrence_show": "Afficher — affichage normal (toujours non cliquable)",
   "child.editor.recurring_when_completed": "Tâches récurrentes — une fois terminées",
   "child.editor.select_child": "Sélectionner un enfant...",
   "child.editor.show_countdown": "Afficher le compte à rebours de réinitialisation à côté de \"Tâches d'aujourd'hui\"",

--- a/custom_components/taskmate/www/locales/nb.json
+++ b/custom_components/taskmate/www/locales/nb.json
@@ -248,7 +248,7 @@
   "child.editor.recurrence_dim": "Dim — vis gråtonet, ikke-interaktiv",
   "child.editor.recurrence_helper": "Hva som vises når en gjentagende oppgave er fullført og vinduet ikke har nullstilt seg ennå",
   "child.editor.recurrence_hide": "Skjul — ikke vis før tilgjengelig igjen",
-  "child.editor.recurrence_show": "Vis — vis normalt uansett",
+  "child.editor.recurrence_show": "Vis — vis normalt (fortsatt ikke trykkbar)",
   "child.editor.recurring_when_completed": "Gjentagende oppgaver — når fullført",
   "child.editor.select_child": "Velg et barn...",
   "child.editor.show_countdown": "Vis nedtelling ved siden av «Dagens oppgaver»",

--- a/custom_components/taskmate/www/locales/nn.json
+++ b/custom_components/taskmate/www/locales/nn.json
@@ -248,7 +248,7 @@
   "child.editor.recurrence_dim": "Dim — vis gråtona, ikkje-interaktiv",
   "child.editor.recurrence_helper": "Kva som visast når ei gjentakande oppgåve er fullført og vindauget ikkje har nullstilt seg enno",
   "child.editor.recurrence_hide": "Gøym — ikkje vis før tilgjengeleg att",
-  "child.editor.recurrence_show": "Vis — vis normalt uansett",
+  "child.editor.recurrence_show": "Vis — vis normalt (framleis ikkje trykkbar)",
   "child.editor.recurring_when_completed": "Gjentakande oppgåver — når fullført",
   "child.editor.select_child": "Vel eit born...",
   "child.editor.show_countdown": "Vis nedteljing ved sida av «Dagens oppgåver»",

--- a/custom_components/taskmate/www/locales/pt-BR.json
+++ b/custom_components/taskmate/www/locales/pt-BR.json
@@ -248,7 +248,7 @@
   "child.editor.recurrence_dim": "Atenuar — mostrar em cinzento, sem interação",
   "child.editor.recurrence_helper": "O que mostrar quando uma tarefa recorrente foi concluída e a janela ainda não reiniciou",
   "child.editor.recurrence_hide": "Ocultar — não mostrar até estar disponível novamente",
-  "child.editor.recurrence_show": "Mostrar — mostrar normalmente",
+  "child.editor.recurrence_show": "Mostrar — mostrar normalmente (continua sem toque)",
   "child.editor.recurring_when_completed": "Tarefas Recorrentes — Quando Concluídas",
   "child.editor.select_child": "Selecionar uma criança...",
   "child.editor.show_countdown": "Mostrar contagem regressiva de reinício junto a \"Tarefas de Hoje\"",

--- a/custom_components/taskmate/www/locales/pt.json
+++ b/custom_components/taskmate/www/locales/pt.json
@@ -248,7 +248,7 @@
   "child.editor.recurrence_dim": "Atenuar — mostrar em cinzento, sem interação",
   "child.editor.recurrence_helper": "O que mostrar quando uma tarefa recorrente foi concluída e a janela ainda não reiniciou",
   "child.editor.recurrence_hide": "Ocultar — não mostrar até estar disponível novamente",
-  "child.editor.recurrence_show": "Mostrar — mostrar normalmente",
+  "child.editor.recurrence_show": "Mostrar — mostrar normalmente (continua sem toque)",
   "child.editor.recurring_when_completed": "Tarefas Recorrentes — Quando Concluídas",
   "child.editor.select_child": "Selecionar uma criança...",
   "child.editor.show_countdown": "Mostrar contagem regressiva de reinício junto a \"Tarefas de Hoje\"",

--- a/custom_components/taskmate/www/taskmate-child-card.js
+++ b/custom_components/taskmate/www/taskmate-child-card.js
@@ -3724,8 +3724,12 @@ class TaskMateChildCard extends LitElement {
     // Click handler for the entire row
     const notDueToday = chore._hasDueDays && !chore._isDueToday && this.config.due_days_mode === 'dim';
     const recurrenceDoneMode = this.config.recurrence_done_mode || 'dim';
-    const notAvailableRecurrence = !!chore._isRecurrenceLocked
-      && !isCompletedForToday && recurrenceDoneMode === 'dim';
+    // The tap is refused whenever the chore is locked: async_complete_chore
+    // no-ops a recurring chore inside its window, so a clickable row under
+    // `show` would just swallow the tap (#805). Only the dim STYLING is
+    // mode-gated. Same split dependency_mode uses.
+    const recurrenceLocked = !!chore._isRecurrenceLocked && !isCompletedForToday;
+    const notAvailableRecurrence = recurrenceLocked && recurrenceDoneMode === 'dim';
     // Elapsed: only dim incomplete chores — completed ones keep their green "done" style
     const elapsedTimeMode = this.config.elapsed_time_mode || 'dim';
     const timeElapsed = chore._isTimeElapsed && !isCompletedForToday && elapsedTimeMode === 'dim';
@@ -3744,7 +3748,7 @@ class TaskMateChildCard extends LitElement {
     const handleRowClick = () => {
       if (isLoading) return;
       if (notDueToday) return;  // Dim mode — not interactive
-      if (notAvailableRecurrence) return;  // Recurrence window not open — not interactive
+      if (recurrenceLocked) return;  // Recurrence window not open — not interactive
       if (isLockedPreview) return;  // Next-period preview — not yet claimable
       if (depBlocked) return;  // Prerequisite chore not approved yet
       if (timeElapsed) return;  // Time period passed — not interactive
@@ -3754,7 +3758,7 @@ class TaskMateChildCard extends LitElement {
         this._handleComplete(chore, child);
       }
     };
-    const isInteractive = !(isLoading || notDueToday || notAvailableRecurrence || isLockedPreview || depBlocked || timeElapsed);
+    const isInteractive = !(isLoading || notDueToday || recurrenceLocked || isLockedPreview || depBlocked || timeElapsed);
     const handleRowKeyDown = (e) => {
       if (e.key === 'Enter' || e.key === ' ') {
         e.preventDefault();

--- a/tests/test_recurrence_availability.py
+++ b/tests/test_recurrence_availability.py
@@ -125,9 +125,7 @@ class TestShowModeIsNotTappable:
         # The dim-styling flag stays mode-gated...
         assert "'dim'" in stmt
         # ...but a separate flag must gate the click, without the mode.
-        assert "const recurrenceLocked" in row, (
-            "show still shares the dim flag, so the row stays clickable"
-        )
+        assert "const recurrenceLocked" in row, "show still shares the dim flag, so the row stays clickable"
 
     def test_click_handler_refuses_under_show_too(self):
         row = _row_source()

--- a/tests/test_recurrence_availability.py
+++ b/tests/test_recurrence_availability.py
@@ -81,13 +81,12 @@ class TestHideMode:
 
 class TestDimMode:
     def test_dim_still_allows_undo(self):
-        """notAvailableRecurrence short-circuits the click handler before the
-        undo branch, so it must not fire for a chore completed today."""
+        """recurrenceLocked short-circuits the click handler before the undo
+        branch, so it must not fire for a chore completed today."""
         row = _row_source()
-        idx = row.index("const notAvailableRecurrence =")
-        # The assignment may wrap over several lines; read to its semicolon.
+        idx = row.index("const recurrenceLocked =")
         stmt = row[idx : row.index(";", idx)]
-        assert "isCompletedForToday" in stmt, f"dimming a chore completed today would block its undo, got: {stmt!r}"
+        assert "isCompletedForToday" in stmt, f"a chore completed today must stay undoable, got: {stmt!r}"
 
     def test_designed_styles_dim_too(self):
         """The designed row builder computes its own `dimmed` flag."""
@@ -107,3 +106,50 @@ class TestLabelComesAlive:
         """The sensor omits `recurrence` when it is the default weekly, so the
         label has to cope with it being absent."""
         assert "child.recurring" in CARD
+
+
+class TestShowModeIsNotTappable:
+    """`show` must not leave a dead-tappable chore (#805).
+
+    `async_complete_chore` returns None for a recurring chore still inside its
+    window, so a tap does nothing. Leaving the row interactive reproduces the
+    "nothing happens" papercut of #794/#799. `dependency_mode` already refuses
+    the tap under both dim and show; recurrence conflated styling with
+    interactivity and only refused it under dim.
+    """
+
+    def test_interactivity_is_separate_from_the_dim_styling(self):
+        row = _row_source()
+        idx = row.index("const notAvailableRecurrence =")
+        stmt = row[idx : row.index(";", idx)]
+        # The dim-styling flag stays mode-gated...
+        assert "'dim'" in stmt
+        # ...but a separate flag must gate the click, without the mode.
+        assert "const recurrenceLocked" in row, (
+            "show still shares the dim flag, so the row stays clickable"
+        )
+
+    def test_click_handler_refuses_under_show_too(self):
+        row = _row_source()
+        handler = row[row.index("const handleRowClick") : row.index("const isInteractive")]
+        assert "recurrenceLocked" in handler
+
+    def test_row_is_marked_non_interactive(self):
+        row = _row_source()
+        idx = row.index("const isInteractive =")
+        assert "recurrenceLocked" in row[idx : row.index(";", idx)]
+
+    def test_designed_styles_already_agreed(self):
+        """They gate the button on the lock itself, not on the mode."""
+        assert "r.loading || r.blocked || r.recLocked" in CARD
+
+    def test_label_no_longer_promises_normal_behaviour(self):
+        import json
+        import pathlib
+
+        www = pathlib.Path(__file__).resolve().parent.parent / "custom_components" / "taskmate" / "www"
+        for path in sorted((www / "locales").glob("*.json")):
+            data = json.loads(path.read_text(encoding="utf-8"))
+            value = data["child.editor.recurrence_show"]
+            assert "regardless" not in value.lower(), f"{path.name} still promises 'regardless'"
+            assert value != "Show — show normally regardless"


### PR DESCRIPTION
## Problem

`recurrence_done_mode` conflated the dim *styling* with *interactivity* — both hung off `notAvailableRecurrence`, which is only true under `dim`. So under `show` the row stayed clickable, and `async_complete_chore` no-ops a recurring chore still inside its window:

```python
if getattr(chore, "schedule_mode", "specific_days") == "recurring" and not self.is_chore_available_for_child(chore, child_id):
    _LOGGER.debug("complete_chore no-op: %s not available yet (recurrence window)", chore.name)
    return None
```

The row invited a tap and silently swallowed it — the same papercut as #794 and #799.

It was inconsistent two ways as well: `dependency_mode` (#793) already refuses the tap under both `dim` and `show`, and the designed row builder gates its DONE button on the lock itself rather than the mode. Only the classic card was affected.

## Fix

Split the two, mirroring `dependency_mode`:

- `recurrenceLocked` — refuses the tap whenever the chore is locked, regardless of mode.
- `notAvailableRecurrence` — keeps its mode gate, now only drives the greying.

The completed-today exclusion moves to `recurrenceLocked`, so a recurring chore ticked today stays undoable.

The shipped label promised the old behaviour, so it changes in all 8 locales: *"show normally regardless"* -> *"show normally (still not tappable)"*. **No behaviour is lost** — the tap already did nothing. The wiki already described `show` as *"child can see it's done but can't complete again"*, so the code now matches the docs rather than the other way round; no doc change needed.

## Verification

Ran the same probe against **main** as a baseline and against this branch on the live dev instance. The only difference:

| | main | this branch |
| --- | --- | --- |
| cooldown chore, `show` | `tappable: true` | **`tappable: false`** |
| cooldown chore, `dim` | dimmed, not tappable | unchanged |
| cooldown chore, `hide` | not rendered | unchanged |
| chore completed today | undoable in every mode | unchanged |
| unrelated chore | unchanged | unchanged |

(The unrelated chore reads as non-tappable in both runs — that is the pre-existing `elapsed_time_mode` dim, time-of-day dependent, present on main too.)

- `pytest tests/` -> **1629 passed**, 0 failures (5 new tests). Ruff, ESLint and `node --check` clean.

Closes #805