### PR TITLE
chore: bump manifest to 5.2.0-beta.1

### DIFF
--- a/custom_components/taskmate/manifest.json
+++ b/custom_components/taskmate/manifest.json
@@ -17,5 +17,5 @@
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/tempus2016/taskmate/issues",
   "requirements": [],
-  "version": "5.1.1"
+  "version": "5.2.0-beta.1"
 }


### PR DESCRIPTION
Version bump for the v5.2.0-beta.1 pre-release. release-guard.yml requires the manifest version to match the tag exactly, so the beta carries the full tag string.