### PR TITLE
fix: coerce non-string group/nav_url to empty on NotificationConfig load

### DIFF
--- a/custom_components/taskmate/models.py
+++ b/custom_components/taskmate/models.py
@@ -1224,12 +1224,16 @@ class NotificationConfig:
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> NotificationConfig:
         raw_routes = data.get("routes", {}) or {}
+        # Imported backups aren't field-validated, so non-string values must
+        # fall back to "" here or dispatch crashes on .strip() later.
+        raw_nav_url = data.get("nav_url")
+        raw_group = data.get("group")
         return cls(
             type_id=data.get("type_id", ""),
             master_enabled=bool(data.get("master_enabled", False)),
             routes={rid: NotificationRoute.from_dict(rdata) for rid, rdata in raw_routes.items()},
-            nav_url=data.get("nav_url", "") or "",
-            group=data.get("group", "") or "",
+            nav_url=raw_nav_url if isinstance(raw_nav_url, str) else "",
+            group=raw_group if isinstance(raw_group, str) else "",
         )
 
     def to_dict(self) -> dict[str, Any]:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -695,3 +695,14 @@ def test_notification_config_group_omitted_when_empty():
     cfg = NotificationConfig(type_id="badge_earned")
     assert "group" not in cfg.to_dict()
     assert NotificationConfig.from_dict({"type_id": "x"}).group == ""
+
+
+def test_notification_config_from_dict_drops_non_string_group_and_nav_url():
+    # Imported backups aren't field-validated, so a truthy non-string must
+    # fall back to "" instead of crashing .strip() in dispatch later.
+    from custom_components.taskmate.models import NotificationConfig
+
+    for bad in ({"x": 1}, ["a"], 7, True):
+        cfg = NotificationConfig.from_dict({"type_id": "badge_earned", "group": bad, "nav_url": bad})
+        assert cfg.group == ""
+        assert cfg.nav_url == ""


### PR DESCRIPTION
Fixes a LOW finding from the security review of #812.

`NotificationConfig.from_dict` passed `group` and `nav_url` through with only an `or ""` guard, so a truthy non-string (dict, list, int) from a restored backup survived into the model — `taskmate/config/import` deep-copies backup data with no per-field validation. Every subsequent dispatch of that notification type then raised `AttributeError` on `.strip()` in `_resolve_group`/`_resolve_nav_url`, and since `fire()` is awaited un-guarded at its call sites this was a persistent, storage-backed DoS that could also break the calling command (e.g. chore completion).

Non-string values now fall back to `""` (inherit the global default) at the single load point, which covers both storage load and config import. Regression test included: `test_notification_config_from_dict_drops_non_string_group_and_nav_url`.

Full suite: 1648 passed.