### PR TITLE
fix: surface rejected notification group/nav_url in the panel

### DIFF
--- a/custom_components/taskmate/coord_notifications.py
+++ b/custom_components/taskmate/coord_notifications.py
@@ -117,6 +117,8 @@ def _validate_group(value: str) -> str:
     value = (value or "").strip()
     if not value:
         return ""
+    if " " in value:
+        raise ValueError("group must not contain spaces (try family-chores)")
     if any(ord(c) <= 32 or ord(c) == 127 for c in value):
         raise ValueError("group must not contain control characters")
     if len(value) > 64:

--- a/custom_components/taskmate/www/taskmate-panel.js
+++ b/custom_components/taskmate/www/taskmate-panel.js
@@ -2246,14 +2246,16 @@ class TaskMatePanel extends HTMLElement {
   async _notifSetNavUrl(typeId, navUrl) {
     const payload = { type: "taskmate/notifications/set_nav_url", nav_url: navUrl || "" };
     if (typeId) payload.type_id = typeId;
-    await this._callWS(payload);
+    const { ok, err } = await this._callWS(payload);
+    if (!ok) this._showToast("err", this._t("panel.toast_save_failed", { error: err }));
     await this._fetchState();
   }
 
   async _notifSetGroup(typeId, group) {
     const payload = { type: "taskmate/notifications/set_group", group: group || "" };
     if (typeId) payload.type_id = typeId;
-    await this._callWS(payload);
+    const { ok, err } = await this._callWS(payload);
+    if (!ok) this._showToast("err", this._t("panel.toast_save_failed", { error: err }));
     await this._fetchState();
   }
 
@@ -4842,12 +4844,12 @@ class TaskMatePanel extends HTMLElement {
                 <input type="text" class="tm-notif-time-input" style="width:150px"
                        value="${this._esc(c.nav_url || "")}"
                        data-act="notif-set-nav-url-type" data-type-id="${this._esc(t.id)}"
-                       placeholder="${this._t("panel.notif_nav_url_row_placeholder")}">
+                       placeholder="${this._esc(this._t("panel.notif_nav_url_row_placeholder"))}">
                 <input type="text" class="tm-notif-time-input" style="width:150px" maxlength="64"
                        value="${this._esc(c.group || "")}"
                        data-act="notif-set-group-type" data-type-id="${this._esc(t.id)}"
-                       title="${this._t("panel.notif_group_global_label")}"
-                       placeholder="${this._t("panel.notif_group_row_placeholder")}">
+                       title="${this._esc(this._t("panel.notif_group_global_label"))}"
+                       placeholder="${this._esc(this._t("panel.notif_group_row_placeholder"))}">
               </div>
             </div>
           </div>

--- a/tests/test_notifications_dispatch.py
+++ b/tests/test_notifications_dispatch.py
@@ -440,3 +440,12 @@ async def test_custom_notification_group_skipped_for_non_mobile(coord, hass):
     coord.storage.upsert_custom_notification(n)
     await coord._make_custom_callback(n.id)(None)
     assert "data" not in _notify_data(hass)
+
+
+def test_validate_group_rejects_spaces_with_distinct_message():
+    from custom_components.taskmate.coord_notifications import _validate_group
+
+    with pytest.raises(ValueError, match="spaces"):
+        _validate_group("family chores")
+    with pytest.raises(ValueError, match="control characters"):
+        _validate_group("bad\x01group")


### PR DESCRIPTION
Addresses the two INFO notes from the security review of #812 (follow-up to #815).

**Silent revert → visible error.** `_notifSetGroup` and `_notifSetNavUrl` discarded the `{ok, err}` result from `_callWS`, so a value the backend rejected just snapped back to the stored value on the next refresh with no explanation. Both now show the standard `panel.toast_save_failed` toast (existing key, `{error}` placeholder — no new locale strings) with the backend message, then refresh as before.

**Clearer message for the common case.** A space in the group key (e.g. `family chores`) tripped the `ord(c) <= 32` control-character branch and was reported as "control characters". Spaces now get their own message: `group must not contain spaces (try family-chores)`. The no-whitespace rule itself is unchanged — the group stays an opaque key.

**Attribute escaping.** The localised `title`/`placeholder` strings interpolated into the per-type nav_url/group inputs are now wrapped in `_esc(...)`, so a future translation containing a quote can't break out of the attribute. (Shipped locales are quote-free today — this is hardening, not a live vulnerability.)

Tests: new unit test pinning both validator messages; full suite 1649 passed; `node --check` clean.