### PR TITLE
fix: keep heavy sensor attributes out of the recorder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1757,13 +1757,25 @@ the overview sensor and its companion sensors at render time.
 | `sensor.taskmate_chores` | total chores | `chores` list (definitions), `todays_completions` |
 | `sensor.taskmate_chore_availability` | total chores available today | `chore_availability`: `{chore_id: {child_id: bool}}` |
 | `sensor.taskmate_rewards` | total rewards | `rewards`, `pending_reward_claims`, `pool_allocations` |
-| `sensor.taskmate_activity` | total completions all-time | `recent_completions` (last 35), `recent_transactions` (last 20), `photo_gallery` |
+| `sensor.taskmate_activity` | total completions all-time | `recent_completions` (last 35), `recent_transactions` (last 20), `career_score_history`, `photo_gallery` |
 | `sensor.taskmate_incentives` | penalties + bonuses count | `penalties`, `bonuses` |
-| `sensor.taskmate_pending_approvals` | pending approvals count | `chore_completions`, `reward_claims` (detailed lists) |
+| `sensor.taskmate_pending_approvals` | pending approvals count | `chore_completions`, `reward_claims`, `mandatory_misses` (detailed lists) |
 | `sensor.taskmate_<child>_points` | points for that child | `child_id`, `current_streak`, `best_streak`, `total_*` |
 | `sensor.taskmate_<child>_stats` | chores completed by that child | `assigned_chores`, streak / totals |
 
 Automations that read the old overview attributes (e.g. `sensor.taskmate_overview.attributes.chores`) should instead read from the matching companion sensor listed above.
+
+### Attributes and the recorder
+
+The large list attributes above (`chores`, `recent_completions`, `mandatory_misses`,
+`children`, `earned` / `available` badges, and so on) are declared **unrecorded**.
+They are still published on the live state — cards, templates, `state_attr()` and
+automation conditions all read them exactly as before — but Home Assistant's
+recorder does not write them to the database. That keeps the database small and
+stops the `State attributes for sensor.taskmate_… exceed maximum size of 16384
+bytes` warning that a large family could otherwise trigger. The scalar attributes
+(counts, totals, settings) stay recorded, so history and statistics on them keep
+working.
 
 ### Other Platforms
 

--- a/custom_components/taskmate/sensor.py
+++ b/custom_components/taskmate/sensor.py
@@ -773,6 +773,10 @@ class TaskMateOverallStatsSensor(_CachedAttrsSensor):
     sensors so this entity stays well under the 16KB recorder limit.
     """
 
+    # The per-child summary grows with the family; the scalars stay recorded
+    # so history/statistics on them keep working (#817).
+    _unrecorded_attributes = frozenset({"children", "vacation_periods", "season_champions"})
+
     def __init__(
         self,
         coordinator: TaskMateCoordinator,
@@ -869,6 +873,8 @@ class TaskMateOverallStatsSensor(_CachedAttrsSensor):
 class TaskMateChoresSensor(_CachedAttrsSensor):
     """Chores catalog + today's completions."""
 
+    _unrecorded_attributes = frozenset({"chores", "todays_completions", "task_groups", "active_timed_sessions"})
+
     def __init__(
         self,
         coordinator: TaskMateCoordinator,
@@ -917,6 +923,8 @@ class TaskMateChoreAvailabilitySensor(_CachedAttrsSensor):
     The map is `{chore_id: {child_id: bool}}`.
     """
 
+    _unrecorded_attributes = frozenset({"chore_availability"})
+
     def __init__(
         self,
         coordinator: TaskMateCoordinator,
@@ -949,6 +957,8 @@ class TaskMateChoreAvailabilitySensor(_CachedAttrsSensor):
 class TaskMateRewardsSensor(_CachedAttrsSensor):
     """Rewards catalog + pending claims + pool allocations."""
 
+    _unrecorded_attributes = frozenset({"rewards", "pending_reward_claims", "pool_allocations"})
+
     def __init__(
         self,
         coordinator: TaskMateCoordinator,
@@ -977,6 +987,10 @@ class TaskMateRewardsSensor(_CachedAttrsSensor):
 
 class TaskMateActivitySensor(_CachedAttrsSensor):
     """Recent completions + recent points/reward transactions."""
+
+    _unrecorded_attributes = frozenset(
+        {"recent_completions", "recent_transactions", "career_score_history", "photo_gallery"}
+    )
 
     def __init__(
         self,
@@ -1011,6 +1025,8 @@ class TaskMateActivitySensor(_CachedAttrsSensor):
 
 class TaskMateIncentivesSensor(_CachedAttrsSensor):
     """Penalties + bonuses catalogue."""
+
+    _unrecorded_attributes = frozenset({"penalties", "bonuses"})
 
     def __init__(
         self,
@@ -1094,6 +1110,7 @@ class ChildStatsSensor(TaskMateBaseSensor):
     """Sensor for a child's statistics."""
 
     _attr_translation_key = "child_stats"
+    _unrecorded_attributes = frozenset({"assigned_chores", "chore_order"})
 
     def __init__(
         self,
@@ -1171,6 +1188,7 @@ class ChildBadgesSensor(TaskMateBaseSensor):
 
     _attr_icon = "mdi:trophy-award"
     _attr_translation_key = "child_badges"
+    _unrecorded_attributes = frozenset({"earned", "available"})
 
     def __init__(
         self,
@@ -1260,6 +1278,8 @@ class ChildBadgesSensor(TaskMateBaseSensor):
 
 class PendingApprovalsSensor(TaskMateBaseSensor):
     """Sensor for pending approvals."""
+
+    _unrecorded_attributes = frozenset({"chore_completions", "reward_claims", "mandatory_misses"})
 
     def __init__(
         self,

--- a/tests/test_sensor_attributes.py
+++ b/tests/test_sensor_attributes.py
@@ -593,3 +593,99 @@ class TestPendingApprovalsSensor:
         assert detail["chore_name"] == "Make bed › Tidy toys"
         assert detail["points"] == 3
         assert detail["bonus_subtask_id"] == "sub1"
+
+
+def _wired_stress_coordinator():
+    """Stress coordinator with the extras the whole-entity sensors reach for."""
+    coord = _stress_coordinator()
+    coord.external_state_version = 0
+    coord.hass = MagicMock()
+    coord.storage.get_career_score_history = MagicMock(
+        return_value=[{"date": f"2026-01-{(d % 28) + 1:02d}", "score": 100 + d} for d in range(90)]
+    )
+    coord.mandatory_misses_state = MagicMock(
+        return_value=[
+            {
+                "id": f"miss-{i:03d}",
+                "chore_id": f"chore-{i % 30:02d}",
+                "child_id": f"child-{i % 4}",
+                "date": "2026-04-20",
+                "chore_name": f"Chore {i % 30:02d}",
+                "child_name": f"Child {i % 4}",
+                "resolved": False,
+            }
+            for i in range(120)
+        ]
+    )
+    return coord
+
+
+def _stress_sensors(coord, entry):
+    """The six global sensors plus the pending-approvals sensor."""
+    return [
+        sensor_module.TaskMateOverallStatsSensor(coord, entry),
+        sensor_module.TaskMateChoresSensor(coord, entry),
+        sensor_module.TaskMateChoreAvailabilitySensor(coord, entry),
+        sensor_module.TaskMateRewardsSensor(coord, entry),
+        sensor_module.TaskMateActivitySensor(coord, entry),
+        sensor_module.TaskMateIncentivesSensor(coord, entry),
+        PendingApprovalsSensor(coord, entry),
+    ]
+
+
+def _recorder_payload(sensor_cls, attrs: dict) -> dict:
+    """Mirror HA's recorder filter: drop `_unrecorded_attributes` first.
+
+    ``StateAttributes.shared_attrs_bytes_from_event`` excludes an entity's
+    unrecorded attributes *before* measuring against MAX_STATE_ATTRS_BYTES,
+    so it is that subset which has to fit.
+    """
+    excluded = getattr(sensor_cls, "_unrecorded_attributes", frozenset())
+    return {k: v for k, v in attrs.items() if k not in excluded}
+
+
+def test_unrecorded_attribute_names_are_actually_published():
+    """A typo'd name in `_unrecorded_attributes` silently excludes nothing (#817)."""
+    coord = _wired_stress_coordinator()
+    entry = _MockEntry()
+    for sensor in _stress_sensors(coord, entry):
+        published = set(sensor.extra_state_attributes)
+        declared = set(getattr(type(sensor), "_unrecorded_attributes", frozenset()))
+        assert declared <= published, (
+            f"{type(sensor).__name__} declares unrecorded attributes it never publishes: {sorted(declared - published)}"
+        )
+
+
+def test_global_sensor_recorder_payloads_under_limit():
+    """Every sensor's recorder-visible payload must fit in 16 KB (#817).
+
+    The per-slice tests above assemble the attribute dicts by hand, so they
+    miss whatever a sensor actually publishes (that is how `career_score_history`,
+    `photo_gallery` and `mandatory_misses` slipped past). This one drives the
+    real entities end to end.
+    """
+    coord = _wired_stress_coordinator()
+    entry = _MockEntry()
+    oversized = []
+    for sensor in _stress_sensors(coord, entry):
+        size = _bytes(_recorder_payload(type(sensor), sensor.extra_state_attributes))
+        if size >= MAX_ATTR_BYTES:
+            oversized.append(f"{sensor._attr_name}: {size} bytes")
+    assert not oversized, "recorder payload over the 16384-byte limit: " + "; ".join(oversized)
+
+
+def test_heavy_lists_are_still_published_to_the_frontend():
+    """Excluding from the recorder must not remove data the cards read (#817)."""
+    coord = _wired_stress_coordinator()
+    entry = _MockEntry()
+    activity = sensor_module.TaskMateActivitySensor(coord, entry).extra_state_attributes
+    assert activity["recent_completions"]
+    assert activity["recent_transactions"]
+    assert activity["career_score_history"]
+    approvals = PendingApprovalsSensor(coord, entry).extra_state_attributes
+    assert approvals["chore_completions"]
+    assert approvals["mandatory_misses"]
+    # The scalar counters stay recorded so history/statistics keep working.
+    recorded = _recorder_payload(PendingApprovalsSensor, approvals)
+    assert recorded["pending_chore_completions"] == len(approvals["chore_completions"])
+    assert recorded["pending_mandatory_misses"] == 120


### PR DESCRIPTION
## Problem

`sensor.taskmate_activity` packs four lists into its state attributes — `recent_completions` (35), `recent_transactions` (20), `career_score_history` (up to 90 days × N children) and `photo_gallery` (40). Measured on the ha-dev instance with only **2 children and 6 chores**, that payload is already **14,425 bytes** — 88% of the recorder's 16,384-byte `MAX_STATE_ATTRS_BYTES`. Batch approving adds completions and transactions and tips it over, so the recorder logs:

```
WARNING (Recorder) [homeassistant.components.recorder.db_schema] State attributes for
sensor.taskmate_activity exceed maximum size of 16384 bytes. This can cause database
performance issues; Attributes will not be stored
```

…and discards the entity's **entire** attribute set for that state.

Measuring every TaskMate entity on ha-dev turned up a worse one: `sensor.taskmate_pending_approvals` was **62,506 bytes** (`mandatory_misses` is unbounded). It had never recorded a single attribute — its history showed `recorded_attrs=[]`.

## Fix

Declare the growth-prone lists in `_unrecorded_attributes`. HA's `StateAttributes.shared_attrs_bytes_from_event` excludes those keys **before** it measures against the limit, so the check now only ever sees the compact scalar payload.

The lists are untouched on the live state — cards, `state_attr()`, templates and automation conditions read them exactly as before. Only the recorder skips them. Scalar attributes (counts, totals, settings) stay recorded so history and statistics keep working.

| Entity | Now unrecorded |
|---|---|
| `taskmate_activity` | `recent_completions`, `recent_transactions`, `career_score_history`, `photo_gallery` |
| `taskmate_pending_approvals` | `chore_completions`, `reward_claims`, `mandatory_misses` |
| `taskmate_overview` | `children`, `vacation_periods`, `season_champions` |
| `taskmate_chores` | `chores`, `todays_completions`, `task_groups`, `active_timed_sessions` |
| `taskmate_chore_availability` | `chore_availability` |
| `taskmate_rewards` | `rewards`, `pending_reward_claims`, `pool_allocations` |
| `taskmate_incentives` | `penalties`, `bonuses` |
| `taskmate_<child>_stats` | `assigned_chores`, `chore_order` |
| `taskmate_<child>_badges` | `earned`, `available` |

`_unrecorded_attributes` has existed since well before our HA floor (verified present in 2024.7.0).

## Why the existing tests missed it

`tests/test_sensor_attributes.py` asserted size against **hand-assembled** attribute dicts rather than what the sensors actually publish, so `career_score_history`, `photo_gallery` and `mandatory_misses` were never measured. Added tests that instantiate the real entities and measure the recorder-visible payload; on the stress fixture they fail without this change:

```
AssertionError: recorder payload over the 16384-byte limit:
  TaskMate Activity: 25879 bytes; Pending Approvals: 38979 bytes
```

Plus a guard that every name in `_unrecorded_attributes` is actually published (a typo would silently exclude nothing), and one asserting the lists are still on the live state.

## Verification on ha-dev

Reproduced and fixed against the live dev instance.

**Before** — warning present, `pending_approvals` recording nothing:
```
13:36:20 WARNING (Recorder) ... sensor.taskmate_pending_approvals exceed maximum size of 16384 bytes
sensor.taskmate_pending_approvals 12:29:00 recorded_attr_keys= []
sensor.taskmate_activity          12:29:00 recorded_attr_keys= [career_score_history, friendly_name,
                                             icon, photo_gallery, recent_completions, recent_transactions]
```

**After** — heavy lists gone from the DB, scalars now stored:
```
sensor.taskmate_pending_approvals 12:36:45 recorded_attr_keys= [friendly_name, icon,
                                             pending_chore_completions, pending_mandatory_misses,
                                             pending_reward_claims, state_class]
sensor.taskmate_activity          12:36:45 recorded_attr_keys= [friendly_name, icon]
```

Then ran the reported scenario (4 completions + `taskmate.approve_all_chores`) — **0** "exceed maximum size" warnings. Live attributes byte-identical to before (activity still 14,425 bytes on the state machine), so no card can regress.

Full suite: **1652 passed**. Ruff clean.

Fixes #817