### PR TITLE
docs: v5.3.0 release prep

### DIFF
--- a/README.md
+++ b/README.md
@@ -768,6 +768,30 @@ Leave all targets empty to use persistent (in-app) notifications only.
 
 > **Tip:** Use `binary_sensor.taskmate_has_pending_approvals` in your own automations for more customised notification logic.
 
+### Grouping Notifications on Your Phone
+
+TaskMate stamps every push with a **group key** so the companion app stacks its
+alerts into one bundle instead of scattering them through everything else Home
+Assistant sends you. This is on by default with the key `taskmate` — no setup
+needed.
+
+To change it, use **Group key** on the Notifications tab. Set it globally, or
+override it per notification type to split TaskMate's alerts into separate
+stacks (say, approvals in one bundle and badges in another). **Leave it blank
+to turn grouping off.**
+
+Keys must be 64 characters or fewer with no spaces or control characters —
+use `family-chores`, not `family chores`.
+
+| Platform | Key sent | Effect |
+|---|---|---|
+| Android | `data.group` | Notifications collapse into one group |
+| iOS | `push.thread-id` | Notifications thread together |
+
+Both are sent with the same value and each platform ignores the other's, so one
+setting covers both. The keys are only added for `mobile_app.*` notify services —
+other targets (email, Telegram, persistent notifications) are unaffected.
+
 ---
 
 ## Quiet Hours
@@ -1837,6 +1861,22 @@ Beyond the sensors above, TaskMate also exposes:
 ---
 
 ## Changelog
+
+### v5.3.0
+
+Phone notifications now stack into a single bundle instead of scattering through the rest of Home Assistant's alerts, and two sensors stop flooding the log with recorder warnings. Both changes are drop-in — grouping is on by default and needs no configuration, and nothing about the data your cards read has changed.
+
+**New**
+- **TaskMate notifications group on your phone** — every push now carries a group key, so the companion app collapses them into one stack rather than interleaving them with everything else HA sends you. Android reads `data.group`, iOS threads on `push.thread-id`; both are sent with the same value and each platform ignores the other's key. The keys only go to `mobile_app.*` services, matching how `clickAction` is already gated, and custom reminders stamp the group themselves so no alert is left outside the bundle. Applied by default as `taskmate` with no setup at all. To change it, use **Group key** in the notifications panel — global, or per notification type, exactly like the existing tap-target (`nav_url`) setting. A blank value turns grouping off. ([#812](https://github.com/tempus2016/taskmate/pull/812), closes [#811](https://github.com/tempus2016/taskmate/issues/811))
+
+**Fixes**
+- **Recorder warnings on `sensor.taskmate_activity`** — its four lists (`recent_completions`, `recent_transactions`, `career_score_history`, `photo_gallery`) measured 14,425 bytes on a *two-child* test instance, 88% of Home Assistant's 16,384-byte attribute limit. Batch approving tipped it over, at which point the recorder logged *"State attributes … exceed maximum size"* and threw away the entity's **entire** attribute set for that state. Auditing every TaskMate entity turned up a quieter, worse case: `sensor.taskmate_pending_approvals` measured 62,506 bytes and had never recorded a single attribute in its history. The growth-prone lists across all the sensors are now declared unrecorded, so the recorder skips them and the size check only ever sees the compact scalars. They are untouched on the live state — cards, `state_attr()`, templates and automations read them exactly as before — and the scalar counters stay recorded, so history and statistics keep working. ([#818](https://github.com/tempus2016/taskmate/pull/818), closes [#817](https://github.com/tempus2016/taskmate/issues/817))
+- **A rejected group key or tap target looked like it had saved** — the notifications panel discarded the validation error and left the invalid value sitting in the field, so an entry like `family chores` (with a space) appeared accepted but was never stored. The panel now surfaces the rejection and restores the last good value. ([#816](https://github.com/tempus2016/taskmate/pull/816))
+- **A non-string `group` or `nav_url` in stored config raised on load** — `NotificationConfig` assumed both fields were strings, so a value of the wrong type (from a hand-edited store or a partial write) broke loading rather than degrading. Both now coerce to empty. ([#815](https://github.com/tempus2016/taskmate/pull/815))
+
+**Internal**
+- The sensor size tests measured hand-assembled attribute dicts rather than what the sensors actually publish, which is how `career_score_history`, `photo_gallery` and `mandatory_misses` went unmeasured. They now drive the real entities and assert on the recorder-visible payload, with a guard that every declared unrecorded attribute is genuinely published. ([#818](https://github.com/tempus2016/taskmate/pull/818))
+- A sponsor button on the repository. ([#814](https://github.com/tempus2016/taskmate/pull/814))
 
 ### v5.2.0
 

--- a/custom_components/taskmate/manifest.json
+++ b/custom_components/taskmate/manifest.json
@@ -17,5 +17,5 @@
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/tempus2016/taskmate/issues",
   "requirements": [],
-  "version": "5.2.0"
+  "version": "5.3.0"
 }


### PR DESCRIPTION
Release prep for **v5.3.0**.

- Bumps `manifest.json` to `5.3.0` so it matches the tag — `release-guard.yml` enforces this, and HACS reads the manifest rather than the tag.
- Adds the v5.3.0 changelog entry: notification grouping ([#812](https://github.com/tempus2016/taskmate/pull/812)), the recorder attribute fix ([#818](https://github.com/tempus2016/taskmate/pull/818)), and the two notification config fixes ([#815](https://github.com/tempus2016/taskmate/pull/815), [#816](https://github.com/tempus2016/taskmate/pull/816)).
- Documents notification grouping under **Configuring Push Notifications**. The feature shipped in #812 with no user-facing docs outside the panel itself — the new section covers the default key, the global and per-type overrides, blank-to-disable, the key validation rules, and which key each platform reads.

### Release gate

Notification grouping was exercised against the live ha-dev instance by driving the real dispatcher over the WebSocket API and capturing the actual `call_service` event, so these are the bytes that would reach a phone:

| Scenario | `data.group` | `push.thread-id` |
|---|---|---|
| Default, no configuration | `taskmate` | `taskmate` |
| Global override | `family-chores` | `family-chores` |
| Per-type override | `badges-only` | `badges-only` |
| Per-type blank → falls back to global | `family-chores` | `family-chores` |
| Global blank → grouping off | *(absent)* | *(absent)* |

Key validation rejected `has spaces` with `group must not contain spaces (try family-chores)` — the path #816 now surfaces in the panel.

The recorder fix (#818) was verified live earlier the same way: the reported batch-approve scenario produced **0** `exceed maximum size` warnings, with the heavy lists absent from recorded history and the scalars stored for the first time.

The temporary `command_line` notify service used for the capture has been reverted and ha-dev restarted, so the instance is back to pristine.

Full suite: **1652 passed**. Ruff, ruff format and ESLint clean.