### PR TITLE
fix: accept the signed image URL the panel is handed back on save (#827)

### DIFF
--- a/custom_components/taskmate/images.py
+++ b/custom_components/taskmate/images.py
@@ -59,6 +59,7 @@ __all__ = [
     "image_file_for_url",
     "images_path",
     "is_taskmate_image_url",
+    "normalize_taskmate_image_url",
     "sign_image_url",
     "total_images_bytes",
 ]
@@ -88,6 +89,23 @@ def is_taskmate_image_url(image_url: str) -> bool:
     if not image_url.startswith(prefix):
         return False
     return bool(FILENAME_RE.match(image_url[len(prefix) :]))
+
+
+def normalize_taskmate_image_url(image_url: str) -> str | None:
+    """Return the canonical bare form of one of our image URLs, else None.
+
+    State delivery hands the panel a *signed* URL (``?authSig=<jwt>``) so a
+    plain ``<img>`` loads without a bearer token, and the chore editor seeds
+    its dialog from that state and posts the same value straight back on save.
+    Dropping the query (and any fragment) lets that round-trip validate while
+    still storing only the bare URL — a signature expires in 24h, is per-user,
+    and would rot the stored chore and break the delete-by-equality check in
+    ``coord_chores._async_release_image`` (#827).
+    """
+    if not image_url:
+        return None
+    base = str(image_url).split("#", 1)[0].split("?", 1)[0]
+    return base if is_taskmate_image_url(base) else None
 
 
 def image_file_for_url(hass, image_url: str) -> Path | None:

--- a/custom_components/taskmate/websocket.py
+++ b/custom_components/taskmate/websocket.py
@@ -524,13 +524,20 @@ async def _ws_list_ha_users(hass, connection, msg, coordinator):
 def _image_url_or_blank(value):
     """Accept a blank string (clears the picture) or one of our image URLs.
 
+    Returns the *canonical* URL: the panel is handed a signed one for its
+    <img> and posts it back verbatim, so the signature is stripped here rather
+    than persisted (#827).
+
     A bare predicate can't be used as a voluptuous validator: voluptuous treats
     a callable as a coercer, so returning False would be a *value*, not a
     rejection. This raises instead.
     """
     text = str(value or "")
-    if not text or images.is_taskmate_image_url(text):
+    if not text:
         return text
+    canonical = images.normalize_taskmate_image_url(text)
+    if canonical:
+        return canonical
     raise vol.Invalid("image_url must be a TaskMate image URL")
 
 

--- a/tests/test_chore_image_field.py
+++ b/tests/test_chore_image_field.py
@@ -53,7 +53,7 @@ def test_image_url_is_an_editable_field():
 
 
 def test_websocket_validates_the_url():
-    assert "is_taskmate_image_url" in WS, "an unvalidated image_url would let a chore point at any URL"
+    assert "normalize_taskmate_image_url" in WS, "an unvalidated image_url would let a chore point at any URL"
 
 
 def test_state_snapshot_signs_the_image_url():
@@ -100,3 +100,38 @@ def test_validator_accepts_blank_and_our_urls(ok):
     from custom_components.taskmate.websocket import _image_url_or_blank
 
     assert _image_url_or_blank(ok) == (ok or "")
+
+
+# --- #827: the panel round-trips the *signed* URL it was given ---------------
+#
+# _build_state_snapshot hands the panel a signed URL so its <img> loads without
+# a bearer token. The chore editor seeds its dialog straight from that state
+# and posts the same value back on save, so the validator saw
+# `<our url>?authSig=<jwt>` and rejected every edit of a chore with an image.
+
+SIGNED = GOOD + (
+    "?authSig=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
+    ".eyJpc3MiOiIxNzJlZDRjYTNmNTA0OGQ4YmNiNGFiNzcyMTE4NTIyNSJ9"
+    ".Sd5AmNlzLX_46dqdzfv2iCIdCUnA-srciXw71yUtU0E"
+)
+
+
+def test_validator_accepts_the_signed_url_the_panel_was_handed():
+    from custom_components.taskmate.websocket import _image_url_or_blank
+
+    assert _image_url_or_blank(SIGNED) == GOOD
+
+
+def test_validator_strips_the_signature_before_storing():
+    # A signature expires in 24h and is per-user; persisting one would rot the
+    # stored chore and break image deletion, which compares URLs by equality.
+    from custom_components.taskmate.websocket import _image_url_or_blank
+
+    assert "authSig" not in _image_url_or_blank(SIGNED)
+
+
+def test_validator_still_rejects_a_foreign_url_with_a_query():
+    from custom_components.taskmate.websocket import _image_url_or_blank
+
+    with pytest.raises(vol.Invalid):
+        _image_url_or_blank("https://evil.example/x.jpg?authSig=abc")

--- a/tests/test_image_storage.py
+++ b/tests/test_image_storage.py
@@ -119,3 +119,22 @@ def test_sign_image_url_passes_through_foreign_urls(tmp_path):
     hass = _hass(tmp_path)
     assert images.sign_image_url(hass, "") == ""
     assert images.sign_image_url(hass, "https://x/y.jpg") == "https://x/y.jpg"
+
+
+def test_normalize_strips_a_signature_query(tmp_path):
+    good = "/api/taskmate/image/" + "a" * 32 + ".jpg"
+    assert images.normalize_taskmate_image_url(good + "?authSig=abc.def.ghi") == good
+    assert images.normalize_taskmate_image_url(good + "?authSig=abc#frag") == good
+    assert images.normalize_taskmate_image_url(good) == good
+
+
+def test_normalize_rejects_what_is_taskmate_image_url_rejects():
+    for bad in (
+        "",
+        None,
+        "/api/taskmate/photo/" + "a" * 32 + ".jpg?authSig=abc",
+        "/api/taskmate/image/../../secret.txt?authSig=abc",
+        "https://evil.example/x.jpg?authSig=abc",
+        "javascript:alert(1)",
+    ):
+        assert images.normalize_taskmate_image_url(bad) is None, bad


### PR DESCRIPTION
## Problem

Editing any chore that has an image failed with:

```
image_url must be a TaskMate image URL for dictionary value @ data['image_url'].
Got '/api/taskmate/image/<name>.jpg?authSig=eyJhbGciOiJIUzI1NiIs...'
```

## Root cause

`_build_state_snapshot` (and `_build_chores_list`) **sign** chore image URLs — browsers do not send the HA bearer token on a plain `<img>` request, so a bare URL 401s. The panel's chore editor seeds its dialog straight from that state, and `_doSaveChore` posts `d.image_url` back verbatim.

So the value arriving at `_image_url_or_blank` was `/api/taskmate/image/<32hex>.jpg?authSig=<jwt>`, while `is_taskmate_image_url` requires a bare `<32hex>.<ext>` path — every save of a chore with an image was rejected. Uploading a *new* image worked (the POST response is unsigned); only re-saving an existing one failed, which matches the reporter's "error every time I try and edit the chore".

## Fix

Normalise at the websocket boundary rather than loosening the guard:

- `images.normalize_taskmate_image_url()` — drops any query/fragment, validates the bare path with the existing strict `is_taskmate_image_url`, returns the canonical URL or `None`.
- `_image_url_or_blank` returns that canonical URL, so only the **bare** URL is ever persisted.

Storing the signed form would have been wrong regardless: a signature expires in 24h and is per-user, so it would rot the stored chore and break the delete-by-equality check in `coord_chores._async_release_image`. `is_taskmate_image_url` itself stays strict — it still guards `image_file_for_url`, so no traversal or foreign-URL surface is widened.

The panel is unchanged and keeps rendering the signed URL, so the editor preview still loads.

## Verified on ha-dev (HA 2026.8.x)

Reproduced against unpatched code, then re-ran with the fix:

| | before | after |
|---|---|---|
| re-save chore with image | `invalid_format` — same message as the issue | OK |
| signature accumulation over repeated saves | n/a | exactly one `authSig`, path intact |
| `GET` signed URL without bearer | 200 | 200 |

Also `1664 passed` locally, ruff clean.

## Tests

- `normalize_taskmate_image_url` strips `?authSig=` / `#frag`, and still rejects the photo store, traversal, foreign URLs and `javascript:`.
- Validator accepts the signed URL the panel is handed and returns it stripped.
- Validator still rejects a foreign URL carrying a query.

Fixes #827