### PR TITLE
fix(cards): stop the pending-approvals count clobbering the claims list

### DIFF
--- a/custom_components/taskmate/www/taskmate-approvals-card.js
+++ b/custom_components/taskmate/www/taskmate-approvals-card.js
@@ -17,6 +17,13 @@ const css = LitElement.prototype.css;
 const tmSafePhotoUrl = (u) =>
   typeof u === "string" && u.startsWith("/api/taskmate/photo/") ? u : "";
 
+// A pending-claims attribute is only ever usable as a list. The resolver used
+// to hand back the pending-approvals sensor's scalar COUNT under this name,
+// which turned .filter()/.some() into a TypeError and blanked the whole card
+// (#834). The name collision is fixed in the resolver; this keeps a stray
+// value from taking the card down again.
+const tmClaimList = (v) => (Array.isArray(v) ? v : []);
+
 const _safeColor = (c, d) => (typeof c === "string" && /^#[0-9a-fA-F]{3,8}$/.test(c) ? c : d);
 
 class TaskMateApprovalsCard extends LitElement {
@@ -530,10 +537,9 @@ class TaskMateApprovalsCard extends LitElement {
 
     // Pending reward claims: supported via either the pending_approvals sensor
     // (reward_claims attribute) or the rewards sensor (pending_reward_claims).
-    let rewardClaims =
-      entity.attributes.reward_claims ||
-      attrs.pending_reward_claims ||
-      [];
+    let rewardClaims = tmClaimList(
+      entity.attributes.reward_claims || attrs.pending_reward_claims,
+    );
     const filteredClaims = this._filterClaimsByChild(rewardClaims);
 
     // Missed mandatory chores awaiting parent review (#532)
@@ -611,7 +617,7 @@ class TaskMateApprovalsCard extends LitElement {
     if (!completions) completions = (attrs.todays_completions || []).filter(c => !c.approved);
     const filteredCompletions = this._filterByChild(completions);
 
-    const rewardClaims = entity.attributes.reward_claims || attrs.pending_reward_claims || [];
+    const rewardClaims = tmClaimList(entity.attributes.reward_claims || attrs.pending_reward_claims);
     const filteredClaims = this._filterClaimsByChild(rewardClaims);
 
     const misses = this._filterMissesByChild(attrs.mandatory_misses || []);

--- a/custom_components/taskmate/www/taskmate-attr-resolver.js
+++ b/custom_components/taskmate/www/taskmate-attr-resolver.js
@@ -37,6 +37,30 @@
     "sensor.taskmate_pending_approvals",
   ];
 
+  // Attributes a companion must NOT contribute to the merge, because another
+  // sensor already owns that name for different data (#834).
+  //
+  // sensor.taskmate_pending_approvals publishes both the full lists and a
+  // scalar count of each. Its `pending_reward_claims` count collides with
+  // sensor.taskmate_rewards' `pending_reward_claims` LIST, and the approvals
+  // sensor merges last, so the number won — every card that did
+  // `claims.filter(...)` / `claims.some(...)` threw as soon as a claim was
+  // pending, blanking the card. Zero pending claims hid it: the cards' own
+  // `|| []` fallback catches a count of 0 because it is falsy, so the crash
+  // only appeared once a child actually claimed something.
+  //
+  // Nothing reads these counts through the resolver — the admin panel takes
+  // its badge counts from the taskmate/get_state WebSocket call and the cards
+  // derive theirs from the lists' length. They stay readable directly off
+  // sensor.taskmate_pending_approvals for templates and automations.
+  const COMPANION_SKIP_KEYS = {
+    "sensor.taskmate_pending_approvals": [
+      "pending_chore_completions",
+      "pending_reward_claims",
+      "pending_mandatory_misses",
+    ],
+  };
+
   function mergedAttributes(hass, primaryEntityId) {
     if (!hass || !hass.states) return {};
     const merged = {};
@@ -46,8 +70,14 @@
     }
     for (const id of COMPANIONS) {
       const s = hass.states[id];
-      if (s && s.attributes) {
+      if (!s || !s.attributes) continue;
+      const skip = COMPANION_SKIP_KEYS[id];
+      if (!skip) {
         Object.assign(merged, s.attributes);
+        continue;
+      }
+      for (const [key, value] of Object.entries(s.attributes)) {
+        if (!skip.includes(key)) merged[key] = value;
       }
     }
     return merged;

--- a/custom_components/taskmate/www/taskmate-parent-dashboard-card.js
+++ b/custom_components/taskmate/www/taskmate-parent-dashboard-card.js
@@ -19,6 +19,13 @@ const css = LitElement.prototype.css;
 const tmSafePhotoUrl = (u) =>
   typeof u === "string" && u.startsWith("/api/taskmate/photo/") ? u : "";
 
+// A pending-claims attribute is only ever usable as a list. The resolver used
+// to hand back the pending-approvals sensor's scalar COUNT under this name,
+// which turned .filter()/.some() into a TypeError and blanked the whole card
+// (#834). The name collision is fixed in the resolver; this keeps a stray
+// value from taking the card down again.
+const tmClaimList = (v) => (Array.isArray(v) ? v : []);
+
 const _safeColor = (c, d) => (typeof c === "string" && /^#[0-9a-fA-F]{3,8}$/.test(c) ? c : d);
 
 class TaskMateParentDashboardCard extends LitElement {
@@ -527,7 +534,7 @@ class TaskMateParentDashboardCard extends LitElement {
     // approve button after a recurring chore resets. `completions` stays
     // today-only for the overview tab's activity display.
     const pendingCompletions = attrs.chore_completions || completions.filter(c => !c.approved);
-    const pendingRewardClaims = attrs.pending_reward_claims || [];
+    const pendingRewardClaims = tmClaimList(attrs.pending_reward_claims);
     const pointsIcon = attrs.points_icon || "mdi:star";
     const pointsName = attrs.points_name || this._t('common.points');
     const totalPending = pendingCompletions.length + pendingRewardClaims.length;
@@ -662,7 +669,7 @@ class TaskMateParentDashboardCard extends LitElement {
     const chores = attrs.chores || [];
     const completions = attrs.todays_completions || [];
     const pendingCompletions = attrs.chore_completions || completions.filter(c => !c.approved);
-    const pendingRewardClaims = attrs.pending_reward_claims || [];
+    const pendingRewardClaims = tmClaimList(attrs.pending_reward_claims);
     const pointsIcon = attrs.points_icon || "mdi:star";
     const pointsName = attrs.points_name || this._t('common.points');
     const totalPending = pendingCompletions.length + pendingRewardClaims.length;

--- a/custom_components/taskmate/www/taskmate-rewards-card.js
+++ b/custom_components/taskmate/www/taskmate-rewards-card.js
@@ -15,6 +15,13 @@ const LitElement = customElements.get("hui-masonry-view")
 const html = LitElement.prototype.html;
 const css = LitElement.prototype.css;
 
+// A pending-claims attribute is only ever usable as a list. The resolver used
+// to hand back the pending-approvals sensor's scalar COUNT under this name,
+// which turned .filter()/.some() into a TypeError and blanked the whole card
+// (#834). The name collision is fixed in the resolver; this keeps a stray
+// value from taking the card down again.
+const tmClaimList = (v) => (Array.isArray(v) ? v : []);
+
 const _safeColor = (c, d) => (typeof c === "string" && /^#[0-9a-fA-F]{3,8}$/.test(c) ? c : d);
 
 class TaskMateRewardsCard extends LitElement {
@@ -1363,7 +1370,8 @@ class TaskMateRewardsCard extends LitElement {
 
     // Pending claim check
     const pcAttrs = (window.__taskmate_attrs && window.__taskmate_attrs(this.hass, this.config?.entity)) || this.hass?.states?.[this.config?.entity]?.attributes || {};
-    const pendingClaims = pcAttrs.pending_reward_claims || [];
+    // Always a list, even if the attribute arrives as something else (#834).
+    const pendingClaims = tmClaimList(pcAttrs.pending_reward_claims);
     const hasPendingClaim = pendingClaims.some(c =>
       c.reward_id === reward.id && (!childId || c.child_id === childId)
     );
@@ -1842,7 +1850,8 @@ class TaskMateRewardsCard extends LitElement {
 
     const pcAttrs = (window.__taskmate_attrs && window.__taskmate_attrs(this.hass, this.config?.entity))
       || this.hass?.states?.[this.config?.entity]?.attributes || {};
-    const pendingClaims = pcAttrs.pending_reward_claims || [];
+    // Always a list, even if the attribute arrives as something else (#834).
+    const pendingClaims = tmClaimList(pcAttrs.pending_reward_claims);
     const hasPendingClaim = pendingClaims.some(c =>
       c.reward_id === reward.id && (!childId || c.child_id === childId)
     );

--- a/tests/test_attr_resolver_companions.py
+++ b/tests/test_attr_resolver_companions.py
@@ -99,9 +99,7 @@ def _pending_approvals_count_keys() -> list[str]:
     Derived from sensor.py so adding a fourth count is caught here rather than
     by a user whose card goes blank.
     """
-    block = re.search(
-        r"class PendingApprovalsSensor.*?(?=\nclass |\Z)", SENSOR_SRC, re.S
-    )
+    block = re.search(r"class PendingApprovalsSensor.*?(?=\nclass |\Z)", SENSOR_SRC, re.S)
     assert block, "PendingApprovalsSensor not found in sensor.py"
     return re.findall(r'"([a-z_]+)":\s*len\(', block.group(0))
 

--- a/tests/test_attr_resolver_companions.py
+++ b/tests/test_attr_resolver_companions.py
@@ -80,3 +80,59 @@ class TestCompanionIdsAreReal:
         """Cheap structural guard — every TaskMate entity id starts this way."""
         bad = [c for c in _companions() if not c.startswith("sensor.taskmate_")]
         assert bad == [], f"companion ids missing the taskmate_ prefix: {bad}"
+
+
+def _skip_keys() -> dict[str, list[str]]:
+    """COMPANION_SKIP_KEYS as the browser sees it (#834)."""
+    block = re.search(r"const COMPANION_SKIP_KEYS = \{(.*?)\};", RESOLVER, re.S)
+    assert block, "COMPANION_SKIP_KEYS object not found in the resolver"
+    code = re.sub(r"//[^\n]*", "", block.group(1))
+    out: dict[str, list[str]] = {}
+    for entity, body in re.findall(r'"(sensor\.[a-z_]+)"\s*:\s*\[(.*?)\]', code, re.S):
+        out[entity] = re.findall(r'"([^"]+)"', body)
+    return out
+
+
+def _pending_approvals_count_keys() -> list[str]:
+    """Keys PendingApprovalsSensor publishes as a scalar count, not a list.
+
+    Derived from sensor.py so adding a fourth count is caught here rather than
+    by a user whose card goes blank.
+    """
+    block = re.search(
+        r"class PendingApprovalsSensor.*?(?=\nclass |\Z)", SENSOR_SRC, re.S
+    )
+    assert block, "PendingApprovalsSensor not found in sensor.py"
+    return re.findall(r'"([a-z_]+)":\s*len\(', block.group(0))
+
+
+class TestCollidingAttributesAreNotMerged:
+    """#834: two sensors used one name for two different shapes.
+
+    sensor.taskmate_rewards owns `pending_reward_claims` as the LIST of claims;
+    sensor.taskmate_pending_approvals published the same name as an integer
+    count. The approvals sensor merges last, so the number won, and every card
+    calling .filter()/.some() on it threw — the rewards card and the
+    child-filtered approvals card both rendered as an empty box the moment a
+    child claimed a reward.
+    """
+
+    def test_pending_approvals_counts_are_skipped_in_the_merge(self):
+        counts = _pending_approvals_count_keys()
+        assert counts, "expected PendingApprovalsSensor to publish count attributes"
+        skipped = _skip_keys().get("sensor.taskmate_pending_approvals", [])
+        missing = [k for k in counts if k not in skipped]
+        assert missing == [], (
+            f"PendingApprovalsSensor publishes {missing} as a scalar count, but the "
+            "resolver still merges them. Any card reading one of these names as a "
+            "list will throw and render blank."
+        )
+
+    def test_the_colliding_key_is_covered(self):
+        """Pin the exact key from the bug report so this can't silently narrow."""
+        skipped = _skip_keys().get("sensor.taskmate_pending_approvals", [])
+        assert "pending_reward_claims" in skipped
+
+    def test_skip_lists_only_name_real_companions(self):
+        unknown = [e for e in _skip_keys() if e not in _companions()]
+        assert unknown == [], f"skip list names non-companion sensors: {unknown}"


### PR DESCRIPTION
Fixes #834.

## Root cause

Two sensors publish different data under the same attribute name, and the resolver merges companions in order:

| Sensor | `pending_reward_claims` |
|---|---|
| `sensor.taskmate_rewards` | the **list** of pending claims |
| `sensor.taskmate_pending_approvals` | an **integer count** (`sensor.py:1373`) |

`taskmate_pending_approvals` is last in `COMPANIONS`, so the number always won. Cards then called `.some()` / `.filter()` on it, the render threw, and a thrown render leaves a Lit card as an empty box.

The reporter could not pin down when it happened because the cards `|| []` fallback masks it — a count of **0** is falsy, so with nothing pending everything works. The card only dies once a child actually claims something, and returns the instant a parent approves. That is precisely what they described.

## Blast radius (measured on the dev HA with one claim pending)

| Card | Before | After |
|---|---|---|
| `taskmate-rewards-card` | **0px, empty** — `pendingClaims.some is not a function` | 684px, renders |
| `taskmate-approvals-card` with `child_id` | **0px, empty** — `claims.filter is not a function` | renders |
| `taskmate-approvals-card` without `child_id` | claims section wrong | correct |
| `taskmate-parent-dashboard-card` | pending total `NaN` | shows `Claims 1` |

Console errors went from 3 to 0, and the merged attribute now resolves to `list[1]` instead of `number:1`.

## Regression point

`9380107` (2026-08-18, shipped in **v5.2.0**) — the fix that corrected the companion sensor id so `taskmate_pending_approvals` actually got merged. Before that the id never matched, so the collision was never triggered. Affects v5.2.0 through v5.4.1.

## The fix

- The resolver skips the three scalar counts the approvals sensor publishes. Nothing reads them through the merge — the admin panel takes its badge counts from `taskmate/get_state` and the cards derive theirs from the lists length — and they stay readable directly off `sensor.taskmate_pending_approvals` for templates and automations, so this is not a breaking attribute change.
- The six card call sites coerce through `tmClaimList()`, so a stray value degrades to an empty list rather than taking the card down.

## Tests

Three new cases in `tests/test_attr_resolver_companions.py`, deriving the count keys from `PendingApprovalsSensor` itself so a fourth count added later fails here rather than in someone dashboard. Verified they fail when the skip entry is removed.

Full suite 1669 passed, ruff clean, eslint clean.

## Not the cause

The points rename (`canes` -> `ananas`) is a red herring — I reproduced it under both names. Worth saying so in the issue reply so the reporter does not rename anything back.