### PR TITLE
chore: bump manifest to 5.4.2

### DIFF
--- a/custom_components/taskmate/manifest.json
+++ b/custom_components/taskmate/manifest.json
@@ -17,5 +17,5 @@
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/tempus2016/taskmate/issues",
   "requirements": [],
-  "version": "5.4.1"
+  "version": "5.4.2"
 }


### PR DESCRIPTION
Version bump for the v5.4.2 patch release. `manifest.json` must equal the tag exactly — HACS reads the manifest, not the tag, and `release-guard.yml` fails the release otherwise.

Shipping in 5.4.2: #835, #836, #838.