### PR TITLE
Internal hardening and input-validation pass

### DIFF
--- a/custom_components/taskmate/__init__.py
+++ b/custom_components/taskmate/__init__.py
@@ -650,6 +650,7 @@ async def _async_register_services(hass: HomeAssistant) -> None:
         if not coordinator:
             _LOGGER.error("No TaskMate coordinator available")
             return
+        await _async_require_linked_child(hass, call, coordinator, call.data[ATTR_CHILD_ID])
         try:
             await coordinator.async_read_aloud(
                 child_id=call.data[ATTR_CHILD_ID],

--- a/custom_components/taskmate/authz.py
+++ b/custom_components/taskmate/authz.py
@@ -51,9 +51,7 @@ async def async_context_is_parent(hass: HomeAssistant, coordinator: Any, context
     return user_id in parent_ids
 
 
-async def async_context_allows_child(
-    hass: HomeAssistant, coordinator: Any, context: Any, child_id: str
-) -> bool:
+async def async_context_allows_child(hass: HomeAssistant, coordinator: Any, context: Any, child_id: str) -> bool:
     """True if the context user may act *as* ``child_id`` (linked-child rule).
 
     Mirrors the service-layer ``_async_require_linked_child`` gate: a child that

--- a/custom_components/taskmate/authz.py
+++ b/custom_components/taskmate/authz.py
@@ -1,0 +1,79 @@
+"""Shared authorization checks for TaskMate.
+
+The panel's WebSocket commands are admin-gated and the ``taskmate.*`` services
+carry admin / parent / linked-child checks. The auto-generated entity platforms
+(number/select/button/todo) and the mobile-action event handler reach the same
+coordinator mutations through a different door, so they must apply the *same*
+checks. These helpers work off a plain Home Assistant ``Context`` (its
+``user_id``) so every caller — service, entity, or event — shares one
+implementation and the rules can't drift between doors.
+
+Context-less callers (automations, scripts, schedules, internal refreshes) are
+trusted and pass every check, matching the long-standing service behaviour.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.core import HomeAssistant
+
+
+def _context_user_id(context: Any) -> str:
+    """Return the acting user id, or "" for a trusted/context-less caller."""
+    return getattr(context, "user_id", "") or "" if context is not None else ""
+
+
+async def async_user_is_admin(hass: HomeAssistant, user_id: str) -> bool:
+    """True if ``user_id`` resolves to an admin HA user."""
+    if not user_id:
+        return False
+    user = await hass.auth.async_get_user(user_id)
+    return bool(user and user.is_admin)
+
+
+async def async_context_is_admin(hass: HomeAssistant, context: Any) -> bool:
+    """True if the context is trusted (no user) or belongs to an admin."""
+    user_id = _context_user_id(context)
+    if not user_id:
+        return True
+    return await async_user_is_admin(hass, user_id)
+
+
+async def async_context_is_parent(hass: HomeAssistant, coordinator: Any, context: Any) -> bool:
+    """True if the context is trusted, an admin, or a configured TaskMate parent."""
+    user_id = _context_user_id(context)
+    if not user_id:
+        return True
+    if await async_user_is_admin(hass, user_id):
+        return True
+    parent_ids = coordinator.storage.get_parent_user_ids() if coordinator else []
+    return user_id in parent_ids
+
+
+async def async_context_allows_child(
+    hass: HomeAssistant, coordinator: Any, context: Any, child_id: str
+) -> bool:
+    """True if the context user may act *as* ``child_id`` (linked-child rule).
+
+    Mirrors the service-layer ``_async_require_linked_child`` gate: a child that
+    has ``linked_user_id`` set may only be driven by that HA user (or an admin);
+    an unlinked child keeps the open/kiosk behaviour, except a user who is
+    themselves linked to a *different* child may never act through an unlinked
+    child.
+    """
+    user_id = _context_user_id(context)
+    if not user_id:
+        return True
+    child = coordinator.get_child(child_id) if coordinator else None
+    linked = getattr(child, "linked_user_id", "") if child else ""
+    if linked == user_id:
+        return True
+    if await async_user_is_admin(hass, user_id):
+        return True
+    if linked:
+        return False
+    others = coordinator.storage.get_children() or []
+    if any(getattr(c, "linked_user_id", "") == user_id for c in others):
+        return False
+    return True

--- a/custom_components/taskmate/button.py
+++ b/custom_components/taskmate/button.py
@@ -7,10 +7,12 @@ import logging
 from homeassistant.components.button import ButtonEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import Unauthorized
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
+from . import authz
 from .const import DOMAIN
 from .coordinator import TaskMateCoordinator
 from .entity import taskmate_device_info
@@ -152,6 +154,9 @@ class CompleteChoreButton(TaskMateBaseButton):
 
     async def async_press(self) -> None:
         """Handle the button press."""
+        ctx = getattr(self, "_context", None)
+        if not await authz.async_context_allows_child(getattr(self, "hass", None), self.coordinator, ctx, self.child_id):
+            raise Unauthorized(context=ctx)
         try:
             await self.coordinator.async_complete_chore(self.chore_id, self.child_id)
         except ValueError as err:
@@ -236,6 +241,9 @@ class ClaimRewardButton(TaskMateBaseButton):
 
     async def async_press(self) -> None:
         """Handle the button press."""
+        ctx = getattr(self, "_context", None)
+        if not await authz.async_context_allows_child(getattr(self, "hass", None), self.coordinator, ctx, self.child_id):
+            raise Unauthorized(context=ctx)
         try:
             await self.coordinator.async_claim_reward(self.reward_id, self.child_id)
         except ValueError as err:

--- a/custom_components/taskmate/button.py
+++ b/custom_components/taskmate/button.py
@@ -155,7 +155,9 @@ class CompleteChoreButton(TaskMateBaseButton):
     async def async_press(self) -> None:
         """Handle the button press."""
         ctx = getattr(self, "_context", None)
-        if not await authz.async_context_allows_child(getattr(self, "hass", None), self.coordinator, ctx, self.child_id):
+        if not await authz.async_context_allows_child(
+            getattr(self, "hass", None), self.coordinator, ctx, self.child_id
+        ):
             raise Unauthorized(context=ctx)
         try:
             await self.coordinator.async_complete_chore(self.chore_id, self.child_id)
@@ -242,7 +244,9 @@ class ClaimRewardButton(TaskMateBaseButton):
     async def async_press(self) -> None:
         """Handle the button press."""
         ctx = getattr(self, "_context", None)
-        if not await authz.async_context_allows_child(getattr(self, "hass", None), self.coordinator, ctx, self.child_id):
+        if not await authz.async_context_allows_child(
+            getattr(self, "hass", None), self.coordinator, ctx, self.child_id
+        ):
             raise Unauthorized(context=ctx)
         try:
             await self.coordinator.async_claim_reward(self.reward_id, self.child_id)

--- a/custom_components/taskmate/coord_chores.py
+++ b/custom_components/taskmate/coord_chores.py
@@ -17,6 +17,10 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
+# Cap on simultaneously-pending swap requests, so a scripted caller can't grow
+# storage / the approval queue without bound.
+_MAX_PENDING_SWAP_REQUESTS = 50
+
 
 def _add_months(d: date, months: int) -> date:
     """Step a date forward by calendar months, clamping to the month's last day."""
@@ -158,6 +162,14 @@ class ChoresMixin:
         current = getattr(chore, "assignment_current_child_id", "") or ""
         if current == requester_id:
             raise ValueError("Chore is already assigned to that child today")
+        # Reject a duplicate pending request for the same chore+requester, and
+        # cap the pending queue, so a scripted caller can't flood storage or the
+        # parent's approval list with identical swap requests.
+        pending = [r for r in self.storage.get_swap_requests() if r.get("status") == "pending"]
+        if any(r.get("chore_id") == chore_id and r.get("requester_id") == requester_id for r in pending):
+            raise ValueError("A swap request for this chore is already pending")
+        if len(pending) >= _MAX_PENDING_SWAP_REQUESTS:
+            raise ValueError("Too many pending swap requests")
         req = {
             "id": generate_id(),
             "chore_id": chore_id,
@@ -738,6 +750,24 @@ class ChoresMixin:
                     child.name,
                 )
                 return None
+
+        # specific_days chores were historically only filtered by the child card
+        # (see get_due_chores_for_child), so a crafted service / entity / Dev
+        # Tools call could complete one that is disabled, not scheduled today, or
+        # assigned to a different child. Enforce the same eligibility the card
+        # uses, server-side. Parents completing on behalf are the authority and
+        # stay exempt.
+        if (
+            not as_parent
+            and getattr(chore, "schedule_mode", "specific_days") == "specific_days"
+            and not self._is_chore_completable_by_child(chore, child_id)
+        ):
+            _LOGGER.debug(
+                "complete_chore no-op: '%s' not eligible for %s today (assignment/schedule/availability)",
+                chore.name,
+                child.name,
+            )
+            return None
 
         # Check recurrence window for Mode B chores
         if getattr(chore, "schedule_mode", "specific_days") == "recurring" and not self.is_chore_available_for_child(
@@ -1473,6 +1503,30 @@ class ChoresMixin:
         days_since = (today - last_dt).days
         return days_since >= window_days
 
+    def _is_chore_completable_by_child(self, chore, child_id: str) -> bool:
+        """Whether ``child_id`` may complete ``chore`` right now (card parity).
+
+        Combines ``is_chore_available_for_child``
+        (enabled/vacation/disabled_for/rotation/visibility/weather/deadline/
+        recurrence) with everyone-mode ``assigned_to`` membership and the
+        ``specific_days`` ``due_days`` day-of-week filter. Does NOT apply the
+        daily-limit cap — callers handle that. This is the single source of
+        truth the child card, the todo platform and the completion path share.
+        """
+        if not self.is_chore_available_for_child(chore, child_id):
+            return False
+        assigned = getattr(chore, "assigned_to", []) or []
+        if assigned and child_id not in assigned:
+            return False
+        if getattr(chore, "schedule_mode", "specific_days") == "specific_days":
+            due_days = getattr(chore, "due_days", []) or []
+            if due_days:
+                today = dt_util.as_local(dt_util.now()).date()
+                dow = ("monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday")[today.weekday()]
+                if dow not in due_days:
+                    return False
+        return True
+
     def get_due_chores_for_child(self, child_id: str) -> list:
         """Chores this child should still act on today (their outstanding to-dos).
 
@@ -1485,20 +1539,12 @@ class ChoresMixin:
         Used by the todo platform (and reusable by cards/automations).
         """
         today = dt_util.as_local(dt_util.now()).date()
-        dow = ("monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday")[today.weekday()]
         out = []
         with self.availability_build_scope():
             completions = self._cached_completions()
             for chore in self.storage.get_chores():
-                if not self.is_chore_available_for_child(chore, child_id):
+                if not self._is_chore_completable_by_child(chore, child_id):
                     continue
-                assigned = getattr(chore, "assigned_to", []) or []
-                if assigned and child_id not in assigned:
-                    continue
-                if getattr(chore, "schedule_mode", "specific_days") == "specific_days":
-                    due_days = getattr(chore, "due_days", []) or []
-                    if due_days and dow not in due_days:
-                        continue
                 limit = getattr(chore, "daily_limit", 1) or 1
                 done = 0
                 for c in completions:

--- a/custom_components/taskmate/coord_notifications.py
+++ b/custom_components/taskmate/coord_notifications.py
@@ -20,6 +20,7 @@ from typing import Any
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.event import async_track_time_change
 
+from . import authz
 from .const import (
     DEFAULT_NOTIFICATION_GROUP,
     DEFAULT_NOTIFICATION_NAV_URL,
@@ -553,6 +554,13 @@ class NotificationCoordinator:
             return
         coordinator = getattr(self, "coordinator", None)
         if coordinator is None:
+            return
+        # Approving/rejecting is a parent action. The event bus is a second door
+        # into it, so enforce the same admin/parent identity check the service
+        # and WebSocket approval paths use — otherwise anyone who can fire this
+        # event (e.g. a child's Companion-app registration) could self-approve.
+        if not await authz.async_context_is_parent(self.hass, coordinator, getattr(event, "context", None)):
+            _LOGGER.warning("Ignoring TaskMate mobile action from a non-parent user")
             return
 
         if action.startswith("TASKMATE_APPROVE_"):

--- a/custom_components/taskmate/coord_timed.py
+++ b/custom_components/taskmate/coord_timed.py
@@ -33,24 +33,31 @@ class TimedMixin:
 
         now = dt_util.now()
         today = dt_util.as_local(now).date().isoformat()
+        cap_seconds = chore.timed_max_daily_minutes * 60 if chore.timed_max_daily_minutes > 0 else 0
 
         existing = self.storage.get_active_timed_session(chore_id, child_id)
         if existing and existing.state == "running":
             raise ValueError("Timer is already running")
 
+        # Seconds already credited today survive a stop (which removes the live
+        # session); count them so the cap is a true daily budget rather than a
+        # per-session one that resets on every stop.
+        credited_today = self._timed_seconds_credited_today(chore_id, child_id)
+
         if existing and existing.state == "paused":
-            # Check daily cap before resuming
-            if chore.timed_max_daily_minutes > 0 and existing.total_seconds_today >= chore.timed_max_daily_minutes * 60:
+            if cap_seconds and (credited_today + existing.total_seconds_today) >= cap_seconds:
                 raise ValueError(f"Daily cap reached ({chore.timed_max_daily_minutes} min)")
             existing.state = "running"
             existing.segments.append({"start": now.isoformat(), "end": None})
             self.storage.save_timed_session(existing)
         else:
-            # Check daily cap before starting fresh
-            if chore.timed_max_daily_minutes > 0:
-                old_session = self.storage.get_timed_session(chore_id, child_id, today)
-                if old_session and old_session.total_seconds_today >= chore.timed_max_daily_minutes * 60:
-                    raise ValueError(f"Daily cap reached ({chore.timed_max_daily_minutes} min)")
+            # Fresh start: enforce the same assignment/enabled/schedule
+            # eligibility the child card uses, so a disabled, off-day, or
+            # not-yours timed chore can't be farmed via a crafted start call.
+            if not self._timed_start_allowed(chore, child_id):
+                raise ValueError(f"'{chore.name}' is not available for {child.name} right now")
+            if cap_seconds and credited_today >= cap_seconds:
+                raise ValueError(f"Daily cap reached ({chore.timed_max_daily_minutes} min)")
             session = TimedSession(
                 chore_id=chore_id,
                 child_id=child_id,
@@ -102,10 +109,11 @@ class TimedMixin:
 
         total_seconds = self._calc_session_seconds(session)
 
-        # Clamp to daily cap
+        # Clamp to the remaining daily budget (cap minus what was already
+        # credited today), so repeated start/stop cycles can't exceed the cap.
         if chore.timed_max_daily_minutes > 0:
-            max_seconds = chore.timed_max_daily_minutes * 60
-            total_seconds = min(total_seconds, max_seconds)
+            remaining = max(0, chore.timed_max_daily_minutes * 60 - self._timed_seconds_credited_today(chore_id, child_id))
+            total_seconds = min(total_seconds, remaining)
 
         # Calculate points. Guard against a mis-configured zero rate, which
         # would otherwise raise ZeroDivisionError and wedge the session.
@@ -142,6 +150,53 @@ class TimedMixin:
             )
 
         await self.async_refresh()
+
+    def _timed_start_allowed(self, chore, child_id: str) -> bool:
+        """Assignment/enabled/schedule eligibility for starting a timed task.
+
+        A lightweight, self-contained gate (no live-state lookups): the chore
+        must be enabled, not per-child disabled, assigned to this child if it
+        has an assignee list, and — for a specific_days schedule — due today.
+        """
+        if not getattr(chore, "enabled", True):
+            return False
+        if child_id in (getattr(chore, "disabled_for", []) or []):
+            return False
+        assigned = getattr(chore, "assigned_to", []) or []
+        if assigned and child_id not in assigned:
+            return False
+        if getattr(chore, "schedule_mode", "specific_days") == "specific_days":
+            due_days = getattr(chore, "due_days", []) or []
+            if due_days:
+                today = dt_util.as_local(dt_util.now()).date()
+                dow = ("monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday")[today.weekday()]
+                if dow not in due_days:
+                    return False
+        return True
+
+    def _timed_seconds_credited_today(self, chore_id: str, child_id: str) -> int:
+        """Seconds already credited today for this timed chore + child.
+
+        Sums ``timed_duration_seconds`` across today's completions (approved or
+        pending). Stop removes the live session, so the daily cap is enforced
+        against these persisted completions instead of a session that vanishes.
+        """
+        today = dt_util.as_local(dt_util.now()).date()
+        total = 0
+        for c in self.storage.get_completions():
+            if c.chore_id != chore_id or c.child_id != child_id:
+                continue
+            if getattr(c, "bonus_subtask_id", ""):
+                continue
+            secs = getattr(c, "timed_duration_seconds", 0) or 0
+            if secs <= 0:
+                continue
+            try:
+                if dt_util.as_local(c.completed_at).date() == today:
+                    total += int(secs)
+            except (AttributeError, TypeError, ValueError):
+                continue
+        return total
 
     def _calc_session_seconds(self, session: TimedSession) -> int:
         """Calculate total elapsed seconds from session segments."""

--- a/custom_components/taskmate/coord_timed.py
+++ b/custom_components/taskmate/coord_timed.py
@@ -112,7 +112,9 @@ class TimedMixin:
         # Clamp to the remaining daily budget (cap minus what was already
         # credited today), so repeated start/stop cycles can't exceed the cap.
         if chore.timed_max_daily_minutes > 0:
-            remaining = max(0, chore.timed_max_daily_minutes * 60 - self._timed_seconds_credited_today(chore_id, child_id))
+            remaining = max(
+                0, chore.timed_max_daily_minutes * 60 - self._timed_seconds_credited_today(chore_id, child_id)
+            )
             total_seconds = min(total_seconds, remaining)
 
         # Calculate points. Guard against a mis-configured zero rate, which

--- a/custom_components/taskmate/http_calendar.py
+++ b/custom_components/taskmate/http_calendar.py
@@ -53,7 +53,14 @@ class TaskMateCalendarFeedView(HomeAssistantView):
 
         expected = coordinator.storage.get_setting("ics_token", "")
         supplied = request.query.get("token", "")
-        if not expected or not supplied or not hmac.compare_digest(str(expected), supplied):
+        # Compare as bytes: hmac.compare_digest raises on non-ASCII str inputs,
+        # which on this pre-auth endpoint would turn a crafted ?token= into an
+        # unhandled 500 + traceback rather than a clean 401.
+        if (
+            not expected
+            or not supplied
+            or not hmac.compare_digest(str(expected).encode("utf-8"), supplied.encode("utf-8"))
+        ):
             return web.Response(status=HTTPStatus.UNAUTHORIZED)
 
         days = coordinator._calendar_projection_days()

--- a/custom_components/taskmate/http_photos.py
+++ b/custom_components/taskmate/http_photos.py
@@ -20,10 +20,49 @@ from homeassistant.components.http import HomeAssistantView
 from homeassistant.core import HomeAssistant
 
 from . import photos
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
 HTTP_VIEWS_REGISTERED = "photo_http_registered"
+
+
+def _get_coordinator(hass: HomeAssistant):
+    from .coordinator import TaskMateCoordinator
+
+    for value in hass.data.get(DOMAIN, {}).values():
+        if isinstance(value, TaskMateCoordinator):
+            return value
+    return None
+
+
+async def _may_view_photo(hass: HomeAssistant, request: web.Request, filename: str) -> bool:
+    """Whether the requesting user may read this evidence photo.
+
+    Evidence photos can contain images of children, so being merely logged in is
+    not enough: allow an admin, a configured TaskMate parent, or the child whose
+    own completion references the file (via their linked HA user). Signed
+    ``<img>`` requests resolve to the signing user, so per-user client-side
+    signing keeps this bound to the actual viewer.
+    """
+    user = request.get("hass_user")
+    if user is None:
+        return False
+    if getattr(user, "is_admin", False):
+        return True
+    coordinator = _get_coordinator(hass)
+    if coordinator is None:
+        return False
+    if user.id in (coordinator.storage.get_parent_user_ids() or []):
+        return True
+    photo_url = f"{photos.URL_PREFIX}/{filename}"
+    for comp in coordinator.storage.get_completions():
+        if getattr(comp, "photo_url", "") != photo_url:
+            continue
+        child = coordinator.get_child(comp.child_id)
+        if child and getattr(child, "linked_user_id", "") == user.id:
+            return True
+    return False
 
 
 class TaskMatePhotoUploadView(HomeAssistantView):
@@ -45,9 +84,14 @@ class TaskMatePhotoUploadView(HomeAssistantView):
         except (ValueError, AssertionError):
             return self.json_message("Expected multipart form", HTTPStatus.BAD_REQUEST)
 
-        # Find the "file" part.
+        # Find the "file" part. Bound the scan so a stream of endlessly-named
+        # non-"file" parts can't hold a handler open indefinitely.
         field = await reader.next()
+        parts_scanned = 0
         while field is not None and field.name != "file":
+            parts_scanned += 1
+            if parts_scanned > 16:
+                return self.json_message("Too many form parts", HTTPStatus.BAD_REQUEST)
             field = await reader.next()
         if field is None:
             return self.json_message("No file provided", HTTPStatus.BAD_REQUEST)
@@ -101,6 +145,11 @@ class TaskMatePhotoServeView(HomeAssistantView):
         if not photos.FILENAME_RE.match(filename):
             return web.Response(status=HTTPStatus.NOT_FOUND)
 
+        # Return 404 (not 403) when unauthorized so the endpoint doesn't confirm
+        # a file exists to a caller who may not read it.
+        if not await _may_view_photo(self.hass, request, filename):
+            return web.Response(status=HTTPStatus.NOT_FOUND)
+
         path = photos.photos_path(self.hass) / filename
 
         def _read() -> bytes | None:
@@ -116,7 +165,11 @@ class TaskMatePhotoServeView(HomeAssistantView):
         return web.Response(
             body=data,
             content_type=photos.content_type_for(filename),
-            headers={"Cache-Control": "private, max-age=31536000"},
+            headers={
+                "Cache-Control": "private, max-age=31536000",
+                "X-Content-Type-Options": "nosniff",
+                "Content-Disposition": "inline",
+            },
         )
 
 

--- a/custom_components/taskmate/ics.py
+++ b/custom_components/taskmate/ics.py
@@ -14,8 +14,21 @@ PRODID = "-//TaskMate//Chores//EN"
 
 
 def _escape(text: str) -> str:
-    """Escape a value per RFC 5545 (backslash, comma, semicolon, newline)."""
-    return str(text).replace("\\", "\\\\").replace("\n", "\\n").replace(",", "\\,").replace(";", "\\;")
+    """Escape a value per RFC 5545 (backslash, comma, semicolon, newline).
+
+    Carriage returns are normalised to the escaped ``\\n`` too: content lines
+    terminate on CRLF, so a bare ``\\r`` left in a SUMMARY/DESCRIPTION could be
+    read by a lenient parser as a line break and let a value inject a property.
+    """
+    return (
+        str(text)
+        .replace("\\", "\\\\")
+        .replace("\r\n", "\\n")
+        .replace("\r", "\\n")
+        .replace("\n", "\\n")
+        .replace(",", "\\,")
+        .replace(";", "\\;")
+    )
 
 
 def _fold(line: str) -> str:

--- a/custom_components/taskmate/number.py
+++ b/custom_components/taskmate/number.py
@@ -10,10 +10,12 @@ from __future__ import annotations
 from homeassistant.components.number import NumberEntity, NumberMode
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import Unauthorized
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
+from . import authz
 from .const import DOMAIN
 from .coordinator import TaskMateCoordinator
 from .entity import taskmate_device_info
@@ -62,6 +64,12 @@ class TaskMateSettingNumber(CoordinatorEntity, NumberEntity):
             return float(self._default)
 
     async def async_set_native_value(self, value: float) -> None:
+        # These entities write panel settings that are admin-only over the
+        # WebSocket; enforce the same gate here so a non-admin call_service
+        # can't retune the point economy.
+        ctx = getattr(self, "_context", None)
+        if not await authz.async_context_is_admin(getattr(self, "hass", None), ctx):
+            raise Unauthorized(context=ctx)
         stored = int(value) if float(value).is_integer() else value
         self.coordinator.storage.set_setting(self._key, stored)
         await self.coordinator.storage.async_save()

--- a/custom_components/taskmate/select.py
+++ b/custom_components/taskmate/select.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 from homeassistant.components.select import SelectEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import Unauthorized
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
+from . import authz
 from .const import DOMAIN
 from .coordinator import TaskMateCoordinator
 from .entity import taskmate_device_info
@@ -57,6 +59,10 @@ class TaskMateSettingSelect(CoordinatorEntity, SelectEntity):
         return val if val in self._attr_options else self._default
 
     async def async_select_option(self, option: str) -> None:
+        # Panel setting write — admin-only, matching the WebSocket gate.
+        ctx = getattr(self, "_context", None)
+        if not await authz.async_context_is_admin(getattr(self, "hass", None), ctx):
+            raise Unauthorized(context=ctx)
         if option not in self._attr_options:
             return
         self.coordinator.storage.set_setting(self._key, option)

--- a/custom_components/taskmate/sensor.py
+++ b/custom_components/taskmate/sensor.py
@@ -16,7 +16,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import dt as dt_util
 
-from . import images, photos
+from . import images
 from .const import DOMAIN
 from .coordinator import TaskMateCoordinator
 from .entity import taskmate_device_info
@@ -389,11 +389,14 @@ def _build_todays_completions(common: dict) -> list[dict]:
         }
         if timed_secs > 0:
             rec["timed_duration_seconds"] = timed_secs
-        # Sign the evidence photo so a card's <img> (which carries no bearer
-        # token) can load it from the auth-gated serve view.
+        # Emit the bare (unsigned) photo path. A card's <img> carries no bearer
+        # token, so the card signs each path per-viewer via auth/sign_path before
+        # rendering — this keeps a self-authenticating URL out of this
+        # world-readable attribute (a signed URL here would be redeemable by
+        # anyone who could read the state).
         photo = getattr(comp, "photo_url", "") or ""
         if photo:
-            rec["photo_url"] = photos.sign_photo_url(common["hass"], photo)
+            rec["photo_url"] = photo
         out.append(rec)
     return out
 
@@ -1344,9 +1347,12 @@ class PendingApprovalsSensor(TaskMateBaseSensor):
                 }
                 if timed_secs > 0:
                     detail["timed_duration_seconds"] = timed_secs
+                # Bare (unsigned) path; the card signs per-viewer via
+                # auth/sign_path so no self-authenticating URL lands in this
+                # world-readable attribute.
                 photo = getattr(comp, "photo_url", "") or ""
                 if photo:
-                    detail["photo_url"] = photos.sign_photo_url(self.coordinator.hass, photo)
+                    detail["photo_url"] = photo
                 completion_details.append(detail)
 
         reward_details = []

--- a/custom_components/taskmate/storage.py
+++ b/custom_components/taskmate/storage.py
@@ -1172,12 +1172,37 @@ class TaskMateStorage:
         """Re-validate untrusted inner records after a full-replace import (SEC-5).
 
         ``import_data`` deep-copies the payload in with only top-level coercion,
-        so a crafted backup could smuggle a ``photo_url`` that bypasses the
-        ``is_taskmate_photo_url`` gate enforced at the ``complete_chore``
-        boundary. Strip any completion ``photo_url`` that isn't one of our own
-        well-formed photo URLs so the panel never renders a foreign/dangerous one.
+        so a crafted backup could smuggle values that never passed the WebSocket
+        schemas: a foreign ``photo_url``/``image_url`` (bypassing the gates at the
+        service/WS boundary), or an enum field the panel renders into markup.
+        Normalise every field that reaches a template — unknown enum values fall
+        back to their safe default and foreign URLs are dropped — so a restored
+        backup can never carry stored content into the admin panel.
         """
+        from .const import ASSIGNMENT_MODES, BADGE_TIERS, SCHEDULE_MODES, TASK_GROUP_POLICIES
+        from .images import is_taskmate_image_url
         from .photos import is_taskmate_photo_url
+
+        _STREAK_MODES = ("reset", "pause")
+        _CARD_DESIGNS = ("classic", "playroom", "console", "cleanpro", "accessible")
+        _NUMERIC_SETTINGS = (
+            "history_days",
+            "weekend_multiplier",
+            "difficulty_multiplier_easy",
+            "difficulty_multiplier_medium",
+            "difficulty_multiplier_hard",
+            "calendar_projection_days",
+            "surprise_bonus_chance",
+            "surprise_bonus_min",
+            "surprise_bonus_max",
+            "roulette_multiplier",
+            "roulette_daily_spins",
+            "points_decay_percent",
+            "level_xp_step",
+            "spend_cap_amount",
+            "interest_percent",
+            "perfect_week_bonus",
+        )
 
         for comp in self._data.get("completions", []):
             if not isinstance(comp, dict):
@@ -1189,6 +1214,50 @@ class TaskMateStorage:
                     comp.get("id", "?"),
                 )
                 comp["photo_url"] = ""
+
+        for chore in self._data.get("chores", []):
+            if not isinstance(chore, dict):
+                continue
+            if chore.get("assignment_mode") not in ASSIGNMENT_MODES:
+                chore["assignment_mode"] = "everyone"
+            if chore.get("schedule_mode") not in SCHEDULE_MODES:
+                chore["schedule_mode"] = "specific_days"
+            img = chore.get("image_url")
+            if img and not is_taskmate_image_url(img):
+                _LOGGER.warning(
+                    "Import: dropped non-TaskMate image_url on chore %s",
+                    chore.get("id", "?"),
+                )
+                chore["image_url"] = ""
+
+        for grp in self._data.get("task_groups", []):
+            if isinstance(grp, dict) and grp.get("policy") not in TASK_GROUP_POLICIES:
+                grp["policy"] = "sticky"
+
+        for badge in self._data.get("badges", []):
+            if isinstance(badge, dict) and badge.get("tier") not in BADGE_TIERS:
+                badge["tier"] = "bronze"
+
+        settings = self._data.get("settings")
+        if isinstance(settings, dict):
+            if settings.get("streak_reset_mode") not in _STREAK_MODES:
+                settings.pop("streak_reset_mode", None)
+            if settings.get("card_design") not in _CARD_DESIGNS:
+                settings.pop("card_design", None)
+            # Numeric settings are rendered into the panel's number inputs; the
+            # WebSocket update path coerces them, but import does not, so coerce
+            # here too. A value that isn't a number (e.g. a crafted string) is
+            # coerced if it parses, else dropped so its default applies — it can
+            # never reach the panel as raw markup.
+            for key in _NUMERIC_SETTINGS:
+                if key not in settings:
+                    continue
+                val = settings[key]
+                if isinstance(val, bool) or not isinstance(val, (int, float)):
+                    try:
+                        settings[key] = float(val)
+                    except (TypeError, ValueError):
+                        settings.pop(key, None)
 
     def replace_completions(self, completions: list[ChoreCompletion]) -> None:
         """Replace all completions with the given list."""

--- a/custom_components/taskmate/todo.py
+++ b/custom_components/taskmate/todo.py
@@ -74,7 +74,9 @@ class TaskMateChildTodoList(CoordinatorEntity, TodoListEntity):
     async def async_update_todo_item(self, item: TodoItem) -> None:
         """Checking an item off completes the chore for this child."""
         ctx = getattr(self, "_context", None)
-        if not await authz.async_context_allows_child(getattr(self, "hass", None), self.coordinator, ctx, self._child_id):
+        if not await authz.async_context_allows_child(
+            getattr(self, "hass", None), self.coordinator, ctx, self._child_id
+        ):
             raise Unauthorized(context=ctx)
         if item.status == TodoItemStatus.COMPLETED and item.uid:
             await self.coordinator.async_complete_chore(item.uid, self._child_id)

--- a/custom_components/taskmate/todo.py
+++ b/custom_components/taskmate/todo.py
@@ -16,10 +16,12 @@ from homeassistant.components.todo import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import Unauthorized
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
+from . import authz
 from .const import DOMAIN
 from .coordinator import TaskMateCoordinator
 from .entity import taskmate_device_info
@@ -71,5 +73,8 @@ class TaskMateChildTodoList(CoordinatorEntity, TodoListEntity):
 
     async def async_update_todo_item(self, item: TodoItem) -> None:
         """Checking an item off completes the chore for this child."""
+        ctx = getattr(self, "_context", None)
+        if not await authz.async_context_allows_child(getattr(self, "hass", None), self.coordinator, ctx, self._child_id):
+            raise Unauthorized(context=ctx)
         if item.status == TodoItemStatus.COMPLETED and item.uid:
             await self.coordinator.async_complete_chore(item.uid, self._child_id)

--- a/custom_components/taskmate/www/taskmate-approvals-card.js
+++ b/custom_components/taskmate/www/taskmate-approvals-card.js
@@ -32,6 +32,7 @@ class TaskMateApprovalsCard extends LitElement {
       hass: { type: Object },
       config: { type: Object },
       _loading: { type: Object },
+      _signed: { state: true },
     };
   }
 
@@ -47,11 +48,63 @@ class TaskMateApprovalsCard extends LitElement {
   constructor() {
     super();
     this._loading = {};
+    this._signed = {};        // safe photo path -> per-viewer signed path
+    this._inflight = new Set();
   }
 
   _t(key, params) {
     const fn = window.__taskmate_localize;
     return fn ? fn(this.hass, key, params) : key;
+  }
+
+  // Evidence photos are served from an auth-gated view; an <img> carries no
+  // bearer token, so each path is signed per-viewer via auth/sign_path. The
+  // sensor now publishes bare paths (no self-authenticating URL in shared
+  // state), so this binds photo access to the actual viewer.
+  _photoHref(raw) {
+    const safe = tmSafePhotoUrl(raw);
+    return (safe && this._signed[safe]) || "";
+  }
+
+  _collectPhotoUrls() {
+    const out = [];
+    const st = this.hass && this.hass.states;
+    if (!st) return out;
+    for (const eid in st) {
+      if (eid.indexOf("sensor.taskmate") !== 0) continue;
+      const attrs = (st[eid] && st[eid].attributes) || {};
+      for (const k in attrs) {
+        const v = attrs[k];
+        if (!Array.isArray(v)) continue;
+        for (const item of v) {
+          if (item && typeof item === "object" && typeof item.photo_url === "string" && item.photo_url) {
+            out.push(item.photo_url);
+          }
+        }
+      }
+    }
+    return out;
+  }
+
+  async _ensureSignedPhotos(rawUrls) {
+    for (const raw of rawUrls) {
+      const url = tmSafePhotoUrl(raw);
+      if (!url || this._signed[url] || this._inflight.has(url)) continue;
+      this._inflight.add(url);
+      try {
+        const res = await this.hass.callWS({ type: "auth/sign_path", path: url, expires: 3600 });
+        if (res && res.path) this._signed = { ...this._signed, [url]: res.path };
+      } catch (e) {
+        console.warn("taskmate: sign_path failed", e);
+      } finally {
+        this._inflight.delete(url);
+      }
+    }
+  }
+
+  updated() {
+    const urls = this._collectPhotoUrls();
+    if (urls.length) this._ensureSignedPhotos(urls);
   }
 
   static get styles() {
@@ -811,7 +864,7 @@ class TaskMateApprovalsCard extends LitElement {
   }
 
   _apPhotoDesigned(it, cls) {
-    const photoUrl = tmSafePhotoUrl(it.photo);
+    const photoUrl = this._photoHref(it.photo);
     if (it.kind !== "completion" || !photoUrl) {
       return it.kind === "claim" && it.icon
         ? html`<div class="${cls}"><ha-icon icon="${it.icon}"></ha-icon></div>`
@@ -1338,11 +1391,11 @@ class TaskMateApprovalsCard extends LitElement {
               ${completion.points}
             </span>
           </div>
-          ${tmSafePhotoUrl(completion.photo_url) ? html`
-            <a class="approval-photo" href="${tmSafePhotoUrl(completion.photo_url)}" target="_blank" rel="noopener"
-               @click="${(e) => this._openPhoto(e, tmSafePhotoUrl(completion.photo_url), this._photoCaption(completion.chore_name, completion.child_name, completion.completed_at))}"
+          ${this._photoHref(completion.photo_url) ? html`
+            <a class="approval-photo" href="${this._photoHref(completion.photo_url)}" target="_blank" rel="noopener"
+               @click="${(e) => this._openPhoto(e, this._photoHref(completion.photo_url), this._photoCaption(completion.chore_name, completion.child_name, completion.completed_at))}"
                title="${this._t('approvals.view_photo') || 'View photo'}">
-              <img src="${tmSafePhotoUrl(completion.photo_url)}" alt="" loading="lazy">
+              <img src="${this._photoHref(completion.photo_url)}" alt="" loading="lazy">
             </a>
           ` : ''}
         </div>

--- a/custom_components/taskmate/www/taskmate-localize.js
+++ b/custom_components/taskmate/www/taskmate-localize.js
@@ -84,7 +84,11 @@ function localize(hass, key, params) {
     str = _cache[_FALLBACK][key];
   }
   if (str === undefined) {
-    str = key;
+    // Missing translation: only echo the key back when it's a plain identifier.
+    // A key carrying HTML-significant characters is not a real key — it's caller
+    // data concatenated into the lookup (e.g. `panel.assign_${value}_short`) —
+    // so refuse to reflect it, since some call sites render _t() output as HTML.
+    str = /^[\w.-]+$/.test(key) ? key : "";
   }
 
   // Trigger background loads for any language not yet in cache
@@ -93,10 +97,12 @@ function localize(hass, key, params) {
   }
   if (!(_FALLBACK in _cache)) _loadLocale(_FALLBACK);
 
-  // Replace {placeholder} tokens
+  // Replace {placeholder} tokens. Use a replacer function so a value containing
+  // "$&", "$1" etc. is inserted literally rather than interpreted as a
+  // replacement pattern.
   if (params && typeof str === 'string') {
     for (const [k, v] of Object.entries(params)) {
-      str = str.replace(new RegExp(`\\{${k}\\}`, 'g'), String(v));
+      str = str.replace(new RegExp(`\\{${k}\\}`, 'g'), () => String(v));
     }
   }
 

--- a/custom_components/taskmate/www/taskmate-panel.js
+++ b/custom_components/taskmate/www/taskmate-panel.js
@@ -3349,7 +3349,7 @@ class TaskMatePanel extends HTMLElement {
       : ((c.due_days || []).length === 0 ? this._t("panel.common_daily") : (c.due_days || []).map(d => this._labelOf(DAYS, d)).join(" · "));
     const schedClass = c.schedule_mode === "recurring" ? "tm-pill-accent" : c.schedule_mode === "one_shot" ? "tm-pill-warn" : "tm-pill-success";
     const modeBadge = c.assignment_mode && c.assignment_mode !== "everyone"
-      ? `<span class="tm-pill tm-pill-${c.assignment_mode}">${this._t(`panel.assign_${c.assignment_mode}_short`)}</span>` : "";
+      ? `<span class="tm-pill tm-pill-${this._esc(c.assignment_mode)}">${this._t(`panel.assign_${c.assignment_mode}_short`)}</span>` : "";
     const nameCell = renaming
       ? `<input class="tm-inline-input" type="text" data-field="_inlineRename" value="${this._esc(this._inlineRename.value)}" autofocus>
          <button type="button" class="tm-icon-btn" data-act="rename-chore-commit" title="${this._t("panel.tooltip_save")}">✓</button>
@@ -3571,7 +3571,7 @@ class TaskMatePanel extends HTMLElement {
   }
 
   _tierClass(tier) {
-    return `tm-badge-tier-${(tier || "bronze").toLowerCase()}`;
+    return `tm-badge-tier-${this._esc((tier || "bronze").toLowerCase())}`;
   }
 
   _criteriaLabel(criteria, combinator = "AND") {
@@ -3973,7 +3973,7 @@ class TaskMatePanel extends HTMLElement {
                 <div class="tm-child-name">
                   <h3>${this._esc(g.name)}</h3>
                   ${this._idBadge(g.id)}
-                  <div class="tm-meta"><span class="tm-pill tm-pill-${g.policy}">${this._t(`panel.group_policy_${g.policy}_short`)}</span> · ${this._t("panel.group_chore_count", {count: (g.chore_ids || []).length})}</div>
+                  <div class="tm-meta"><span class="tm-pill tm-pill-${this._esc(g.policy)}">${this._t(`panel.group_policy_${g.policy}_short`)}</span> · ${this._t("panel.group_chore_count", {count: (g.chore_ids || []).length})}</div>
                 </div>
               </div>
               <ul class="tm-group-list">
@@ -4103,7 +4103,7 @@ class TaskMatePanel extends HTMLElement {
 
   _renderTemplateChoreCard(chore, idx) {
     const expanded = chore._expanded;
-    const schedLabel = (chore.due_days || []).length === 0 ? this._t("panel.common_daily") : (chore.due_days || []).map(d => this._labelOf(DAYS, d)).join(", ");
+    const schedLabel = (chore.due_days || []).length === 0 ? this._t("panel.common_daily") : (chore.due_days || []).map(d => this._esc(this._labelOf(DAYS, d))).join(", ");
     return `
       <div class="tm-tpl-preview-card">
         <div class="tm-tpl-preview-header" data-act="tpl-toggle-expand" data-idx="${idx}">
@@ -5387,7 +5387,7 @@ class TaskMatePanel extends HTMLElement {
         const value = f === "assigned_to"
           ? (v || []).map(id => this._esc((children.find(c => c.id === id) || {}).name || id)).join(", ")
               || this._t("panel.sched_value_nobody")
-          : Array.isArray(v) ? v.join(", ")
+          : Array.isArray(v) ? this._esc(v.join(", "))
           : typeof v === "boolean" ? this._t(v ? "panel.sched_value_yes" : "panel.sched_value_no")
           : this._esc(String(v));
         return `${label}: <strong>${value}</strong>`;

--- a/custom_components/taskmate/www/taskmate-parent-dashboard-card.js
+++ b/custom_components/taskmate/www/taskmate-parent-dashboard-card.js
@@ -36,6 +36,7 @@ class TaskMateParentDashboardCard extends LitElement {
       _loading: { type: Object },
       _activeSection: { type: String },
       _expanded: { type: Object },
+      _signed: { state: true },
     };
   }
 
@@ -76,6 +77,58 @@ class TaskMateParentDashboardCard extends LitElement {
     this._loading = {};
     this._activeSection = "overview";
     this._expanded = {};
+    this._signed = {};        // safe photo path -> per-viewer signed path
+    this._inflight = new Set();
+  }
+
+  // Evidence photos come from an auth-gated view; an <img> sends no bearer
+  // token, so sign each path per-viewer via auth/sign_path. The sensor now
+  // publishes bare paths, keeping any self-authenticating URL out of shared
+  // state and binding photo access to the actual viewer.
+  _photoHref(raw) {
+    const safe = tmSafePhotoUrl(raw);
+    return (safe && this._signed[safe]) || "";
+  }
+
+  _collectPhotoUrls() {
+    const out = [];
+    const st = this.hass && this.hass.states;
+    if (!st) return out;
+    for (const eid in st) {
+      if (eid.indexOf("sensor.taskmate") !== 0) continue;
+      const attrs = (st[eid] && st[eid].attributes) || {};
+      for (const k in attrs) {
+        const v = attrs[k];
+        if (!Array.isArray(v)) continue;
+        for (const item of v) {
+          if (item && typeof item === "object" && typeof item.photo_url === "string" && item.photo_url) {
+            out.push(item.photo_url);
+          }
+        }
+      }
+    }
+    return out;
+  }
+
+  async _ensureSignedPhotos(rawUrls) {
+    for (const raw of rawUrls) {
+      const url = tmSafePhotoUrl(raw);
+      if (!url || this._signed[url] || this._inflight.has(url)) continue;
+      this._inflight.add(url);
+      try {
+        const res = await this.hass.callWS({ type: "auth/sign_path", path: url, expires: 3600 });
+        if (res && res.path) this._signed = { ...this._signed, [url]: res.path };
+      } catch (e) {
+        console.warn("taskmate: sign_path failed", e);
+      } finally {
+        this._inflight.delete(url);
+      }
+    }
+  }
+
+  updated() {
+    const urls = this._collectPhotoUrls();
+    if (urls.length) this._ensureSignedPhotos(urls);
   }
 
   static get styles() {
@@ -823,7 +876,7 @@ class TaskMateParentDashboardCard extends LitElement {
       const time = comp.completed_at
         ? new Date(comp.completed_at).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" }) : "";
       const pts = comp.points || choreMap[comp.chore_id]?.points || 0;
-      const photoUrl = tmSafePhotoUrl(comp.photo_url);
+      const photoUrl = this._photoHref(comp.photo_url);
       const photoCap = this._photoCaption(comp.chore_name, child && child.name, comp.completed_at);
       const photo = photoUrl
         ? html`<a class="pd-photo-link" href="${photoUrl}" target="_blank" rel="noopener"
@@ -1156,11 +1209,11 @@ class TaskMateParentDashboardCard extends LitElement {
                   +${comp.points || chore?.points || 0}
                 </span>
               </div>
-              ${tmSafePhotoUrl(comp.photo_url) ? html`
-                <a class="approval-photo" href="${tmSafePhotoUrl(comp.photo_url)}" target="_blank" rel="noopener"
-                   @click="${(e) => this._openPhoto(e, tmSafePhotoUrl(comp.photo_url), this._photoCaption(comp.chore_name || chore?.name, child && child.name, comp.completed_at))}"
+              ${this._photoHref(comp.photo_url) ? html`
+                <a class="approval-photo" href="${this._photoHref(comp.photo_url)}" target="_blank" rel="noopener"
+                   @click="${(e) => this._openPhoto(e, this._photoHref(comp.photo_url), this._photoCaption(comp.chore_name || chore?.name, child && child.name, comp.completed_at))}"
                    title="${this._t('approvals.view_photo') || 'View photo'}">
-                  <img src="${tmSafePhotoUrl(comp.photo_url)}" alt="" loading="lazy">
+                  <img src="${this._photoHref(comp.photo_url)}" alt="" loading="lazy">
                 </a>
               ` : ''}
             </div>

--- a/custom_components/taskmate/www/taskmate-photo-gallery-card.js
+++ b/custom_components/taskmate/www/taskmate-photo-gallery-card.js
@@ -87,7 +87,10 @@ class TaskMatePhotoGalleryCard extends LitElement {
   async _ensureSigned(items) {
     for (const it of items) {
       const url = it.photo_url;
-      if (!url || this._signed[url] || this._inflight.has(url)) continue;
+      // Only sign our own photo paths; never hand auth/sign_path a foreign or
+      // javascript:/data: value that could round-trip into a clickable href.
+      if (!url || typeof url !== "string" || !url.startsWith("/api/taskmate/photo/")) continue;
+      if (this._signed[url] || this._inflight.has(url)) continue;
       this._inflight.add(url);
       try {
         const res = await this.hass.callWS({ type: "auth/sign_path", path: url, expires: 3600 });

--- a/tests/test_security_hardening.py
+++ b/tests/test_security_hardening.py
@@ -1,0 +1,266 @@
+"""Regression tests for the authorization / input-hardening pass.
+
+These lock in that the "second doors" into privileged operations — the entity
+platforms, the mobile-action event bus, and backup import — enforce the same
+checks as the WebSocket/service layer, and that a few input-validation gaps
+stay closed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from homeassistant.exceptions import Unauthorized
+
+from custom_components.taskmate import authz
+from custom_components.taskmate.button import ClaimRewardButton, CompleteChoreButton
+from custom_components.taskmate.coord_notifications import NotificationCoordinator
+from custom_components.taskmate.models import Child, Chore, Reward
+from custom_components.taskmate.number import TaskMateSettingNumber
+from custom_components.taskmate.select import TaskMateSettingSelect
+from custom_components.taskmate.storage import TaskMateStorage
+from custom_components.taskmate.todo import TaskMateChildTodoList
+
+
+def run(coro):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+def _ctx(user_id):
+    c = MagicMock()
+    c.user_id = user_id
+    return c
+
+
+def _hass(user):
+    hass = MagicMock()
+    hass.auth.async_get_user = AsyncMock(return_value=user)
+    return hass
+
+
+def _entry():
+    e = MagicMock()
+    e.entry_id = "e1"
+    return e
+
+
+# ── authz helpers (parity with the service-layer gate) ──────────────────────
+
+
+def test_context_is_admin_trusts_contextless():
+    assert run(authz.async_context_is_admin(_hass(None), None)) is True
+    assert run(authz.async_context_is_admin(_hass(None), _ctx(""))) is True
+
+
+def test_context_is_admin_rejects_non_admin():
+    hass = _hass(MagicMock(is_admin=False))
+    assert run(authz.async_context_is_admin(hass, _ctx("u1"))) is False
+
+
+def test_context_is_parent_accepts_configured_parent():
+    coord = MagicMock()
+    coord.storage.get_parent_user_ids.return_value = ["parent-1"]
+    hass = _hass(MagicMock(is_admin=False))
+    assert run(authz.async_context_is_parent(hass, coord, _ctx("parent-1"))) is True
+    assert run(authz.async_context_is_parent(hass, coord, _ctx("stranger"))) is False
+
+
+def test_allows_child_blocks_cross_child():
+    coord = MagicMock()
+    coord.get_child.return_value = MagicMock(linked_user_id="uid-malia")
+    coord.storage.get_children.return_value = []
+    hass = _hass(MagicMock(is_admin=False))
+    # Ella's HA user acting as Malia (who is linked to someone else) → denied.
+    assert run(authz.async_context_allows_child(hass, coord, _ctx("uid-ella"), "malia")) is False
+    # Malia's own linked user → allowed.
+    assert run(authz.async_context_allows_child(hass, coord, _ctx("uid-malia"), "malia")) is True
+
+
+# ── entity platforms enforce the gate ───────────────────────────────────────
+
+
+def test_number_rejects_non_admin():
+    coord = MagicMock()
+    store = {}
+    coord.storage.set_setting = MagicMock(side_effect=store.__setitem__)
+    coord.storage.async_save = AsyncMock()
+    coord.async_refresh = AsyncMock()
+    num = TaskMateSettingNumber(coord, _entry(), "weekend_multiplier", "weekend_multiplier", 1.0, 5.0, 0.5, 1.0, "mdi:x")
+    num.hass = _hass(MagicMock(is_admin=False))
+    num._context = _ctx("child-user")
+    with pytest.raises(Unauthorized):
+        run(num.async_set_native_value(5.0))
+    assert store == {}  # nothing persisted
+
+
+def test_select_rejects_non_admin():
+    coord = MagicMock()
+    store = {}
+    coord.storage.set_setting = MagicMock(side_effect=store.__setitem__)
+    coord.storage.async_save = AsyncMock()
+    coord.async_refresh = AsyncMock()
+    sel = TaskMateSettingSelect(coord, _entry(), "streak_reset_mode", "streak_reset_mode", ["reset", "pause"], "reset", "mdi:x")
+    sel.hass = _hass(MagicMock(is_admin=False))
+    sel._context = _ctx("child-user")
+    with pytest.raises(Unauthorized):
+        run(sel.async_select_option("pause"))
+    assert store == {}
+
+
+def test_claim_reward_button_rejects_cross_child():
+    child = Child(name="Malia", id="malia", linked_user_id="uid-malia")
+    reward = Reward(name="Cinema", cost=100, id="rw1")
+    coord = MagicMock()
+    coord.get_child.return_value = child
+    coord.get_reward.return_value = reward
+    coord.storage.get_children.return_value = [child]
+    coord.async_claim_reward = AsyncMock()
+    btn = ClaimRewardButton(coord, _entry(), child, reward)
+    btn.hass = _hass(MagicMock(is_admin=False))
+    btn._context = _ctx("uid-ella")  # a different child's HA user
+    with pytest.raises(Unauthorized):
+        run(btn.async_press())
+    coord.async_claim_reward.assert_not_called()
+
+
+def test_complete_chore_button_rejects_cross_child():
+    child = Child(name="Malia", id="malia", linked_user_id="uid-malia")
+    chore = Chore(name="Dishes", id="cho1")
+    coord = MagicMock()
+    coord.get_child.return_value = child
+    coord.get_chore.return_value = chore
+    coord.storage.get_children.return_value = [child]
+    coord.async_complete_chore = AsyncMock()
+    btn = CompleteChoreButton(coord, _entry(), child, chore)
+    btn.hass = _hass(MagicMock(is_admin=False))
+    btn._context = _ctx("uid-ella")
+    with pytest.raises(Unauthorized):
+        run(btn.async_press())
+    coord.async_complete_chore.assert_not_called()
+
+
+def test_todo_rejects_cross_child():
+    child = Child(name="Malia", id="malia", linked_user_id="uid-malia")
+    coord = MagicMock()
+    coord.get_child.return_value = child
+    coord.storage.get_children.return_value = [child]
+    coord.async_complete_chore = AsyncMock()
+    lst = TaskMateChildTodoList(coord, _entry(), child)
+    lst.hass = _hass(MagicMock(is_admin=False))
+    lst._context = _ctx("uid-ella")
+    item = MagicMock()
+    item.status = "completed"
+    item.uid = "cho1"
+    with pytest.raises(Unauthorized):
+        run(lst.async_update_todo_item(item))
+    coord.async_complete_chore.assert_not_called()
+
+
+# ── mobile-action event handler is parent-gated ─────────────────────────────
+
+
+def _notif_with_coordinator(parent_ids, user):
+    nc = NotificationCoordinator(_hass(user), MagicMock())
+    nc.coordinator = MagicMock()
+    # authz reads coordinator.storage.get_parent_user_ids(), so wire it there.
+    nc.coordinator.storage.get_parent_user_ids.return_value = parent_ids
+    nc.coordinator.async_approve_chore = AsyncMock()
+    nc.coordinator.async_approve_reward = AsyncMock()
+    return nc
+
+
+def _event(action, user_id):
+    ev = MagicMock()
+    ev.data = {"action": action}
+    ev.context.user_id = user_id
+    return ev
+
+
+def test_mobile_action_ignored_from_non_parent():
+    nc = _notif_with_coordinator(parent_ids=["parent-1"], user=MagicMock(is_admin=False))
+    run(nc.handle_mobile_action(_event("TASKMATE_APPROVE_abc", "child-user")))
+    nc.coordinator.async_approve_chore.assert_not_called()
+    nc.coordinator.async_approve_reward.assert_not_called()
+
+
+def test_mobile_action_allowed_from_parent():
+    nc = _notif_with_coordinator(parent_ids=["parent-1"], user=MagicMock(is_admin=False))
+    run(nc.handle_mobile_action(_event("TASKMATE_APPROVE_abc", "parent-1")))
+    nc.coordinator.async_approve_chore.assert_called_once_with("abc")
+
+
+# ── backup import re-validates untrusted records ────────────────────────────
+
+
+def _storage():
+    return TaskMateStorage.__new__(TaskMateStorage)
+
+
+def test_import_normalises_crafted_enum_and_urls():
+    st = _storage()
+    st.import_data(
+        {
+            "chores": [
+                {
+                    "id": "c1",
+                    "name": "Tidy",
+                    "assignment_mode": 'a"><img src=x onerror=alert(1)>',
+                    "schedule_mode": "bogus",
+                    "image_url": "https://evil.example/track.png",
+                }
+            ],
+            "task_groups": [{"id": "g1", "policy": '"><script>'}],
+            "badges": [{"id": "b1", "tier": '"><script>'}],
+            "settings": {
+                "history_days": '1" onfocus=alert(1) autofocus x="',
+                "streak_reset_mode": '"><img>',
+            },
+        }
+    )
+    chore = st._data["chores"][0]
+    assert chore["assignment_mode"] == "everyone"
+    assert chore["schedule_mode"] == "specific_days"
+    assert chore["image_url"] == ""
+    assert st._data["task_groups"][0]["policy"] == "sticky"
+    assert st._data["badges"][0]["tier"] == "bronze"
+    # A non-numeric numeric-setting is dropped (default applies), never rendered raw.
+    assert "history_days" not in st._data["settings"]
+    assert "streak_reset_mode" not in st._data["settings"]
+
+
+def test_import_coerces_numeric_string():
+    st = _storage()
+    st.import_data({"settings": {"weekend_multiplier": "2.5"}})
+    assert st._data["settings"]["weekend_multiplier"] == 2.5
+
+
+# ── smaller input-hardening gaps ────────────────────────────────────────────
+
+
+def test_ics_escape_neutralises_carriage_return():
+    from custom_components.taskmate.ics import _escape
+
+    assert _escape("a\rb") == "a\\nb"
+    assert _escape("a\r\nb") == "a\\nb"
+    assert _escape("a\nb") == "a\\nb"
+
+
+def test_timed_start_eligibility():
+    from custom_components.taskmate.coordinator import TaskMateCoordinator
+
+    coord = object.__new__(TaskMateCoordinator)
+    everyone = Chore(name="Piano", task_type="timed", id="t1")
+    assert coord._timed_start_allowed(everyone, "malia") is True
+
+    disabled = Chore(name="Piano", task_type="timed", id="t2", enabled=False)
+    assert coord._timed_start_allowed(disabled, "malia") is False
+
+    assigned_other = Chore(name="Piano", task_type="timed", id="t3", assigned_to=["ella"])
+    assert coord._timed_start_allowed(assigned_other, "malia") is False
+    assert coord._timed_start_allowed(assigned_other, "ella") is True

--- a/tests/test_security_hardening.py
+++ b/tests/test_security_hardening.py
@@ -91,7 +91,9 @@ def test_number_rejects_non_admin():
     coord.storage.set_setting = MagicMock(side_effect=store.__setitem__)
     coord.storage.async_save = AsyncMock()
     coord.async_refresh = AsyncMock()
-    num = TaskMateSettingNumber(coord, _entry(), "weekend_multiplier", "weekend_multiplier", 1.0, 5.0, 0.5, 1.0, "mdi:x")
+    num = TaskMateSettingNumber(
+        coord, _entry(), "weekend_multiplier", "weekend_multiplier", 1.0, 5.0, 0.5, 1.0, "mdi:x"
+    )
     num.hass = _hass(MagicMock(is_admin=False))
     num._context = _ctx("child-user")
     with pytest.raises(Unauthorized):
@@ -105,7 +107,9 @@ def test_select_rejects_non_admin():
     coord.storage.set_setting = MagicMock(side_effect=store.__setitem__)
     coord.storage.async_save = AsyncMock()
     coord.async_refresh = AsyncMock()
-    sel = TaskMateSettingSelect(coord, _entry(), "streak_reset_mode", "streak_reset_mode", ["reset", "pause"], "reset", "mdi:x")
+    sel = TaskMateSettingSelect(
+        coord, _entry(), "streak_reset_mode", "streak_reset_mode", ["reset", "pause"], "reset", "mdi:x"
+    )
     sel.hass = _hass(MagicMock(is_admin=False))
     sel._context = _ctx("child-user")
     with pytest.raises(Unauthorized):

--- a/tests/test_timed_task.py
+++ b/tests/test_timed_task.py
@@ -36,6 +36,7 @@ def _coord(chore=None, child=None, active=None, dated=None):
     storage.get_child = MagicMock(return_value=child)
     storage.get_active_timed_session = MagicMock(return_value=active)
     storage.get_timed_session = MagicMock(return_value=dated)
+    storage.get_completions = MagicMock(return_value=[])
     storage.save_timed_session = MagicMock()
     storage.async_save = AsyncMock()
     coord.storage = storage


### PR DESCRIPTION
Routine internal hardening pass across the integration.

- Makes authorization consistent across the entity platforms, event handlers and service entry points so every path applies the same admin/parent/linked-user checks as the panel.
- Adds validation/normalisation on imported backup data and tightens a couple of public HTTP endpoints.
- Scopes evidence-photo access to the requesting user (cards sign per-viewer).

Introduces a small shared `authz` helper plus regression tests. No user-facing feature or UI changes.

Verified on the dev HA instance and with the full test suite (ruff, ESLint, translation parity, data-file checks all green).