### PR TITLE
chore: bump manifest to 5.4.3

### DIFF
--- a/custom_components/taskmate/manifest.json
+++ b/custom_components/taskmate/manifest.json
@@ -17,5 +17,5 @@
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/tempus2016/taskmate/issues",
   "requirements": [],
-  "version": "5.4.2"
+  "version": "5.4.3"
 }


### PR DESCRIPTION
Bump manifest to 5.4.3 for the 5.4.3 release (hardening/maintenance pass merged in #841).