### PR TITLE
feat(child-card): add current-time-period filter and anytime opt-out

### DIFF
--- a/custom_components/taskmate/www/locales/de.json
+++ b/custom_components/taskmate/www/locales/de.json
@@ -265,6 +265,7 @@
   "child.editor.time_category": "Zeitkategorie",
   "child.editor.time_category_afternoon": "Nachmittagsaufgaben",
   "child.editor.time_category_all": "Heutige Aufgaben (Alle)",
+  "child.editor.time_category_current": "Aktueller Zeitabschnitt (live)",
   "child.editor.time_category_anytime": "Heutige Aufgaben (jederzeit)",
   "child.editor.time_category_evening": "Abendliche Aufgaben",
   "child.editor.time_category_helper": "Zu welcher Tageszeit Aufgaben angezeigt werden sollen – legt auch den Kartentitel fest",
@@ -1758,5 +1759,7 @@
   "child.editor.pre_reader": "Nur-Bilder-Modus (für kleine Kinder)",
   "child.editor.pre_reader_labels": "Namen im Bildmodus anzeigen",
   "child.editor.pre_reader_points": "Punktzahl statt Sterne im Bildmodus anzeigen",
-  "common.design.accessible": "Barrierefrei"
+  "common.design.accessible": "Barrierefrei",
+  "child.editor.include_anytime_chores": "Jederzeit-Aufgaben einbeziehen",
+  "child.editor.include_anytime_chores_helper": "Jederzeit-Aufgaben erscheinen normalerweise in jeder Zeitkategorie – deaktivieren, um sie auszublenden"
 }

--- a/custom_components/taskmate/www/locales/en-GB.json
+++ b/custom_components/taskmate/www/locales/en-GB.json
@@ -267,6 +267,7 @@
   "child.editor.time_category": "Time Category",
   "child.editor.time_category_afternoon": "Afternoon Chores",
   "child.editor.time_category_all": "Today's Chores (All)",
+  "child.editor.time_category_current": "Current Time Period (Live)",
   "child.editor.time_category_anytime": "Today's Chores (Anytime)",
   "child.editor.time_category_evening": "Evening Chores",
   "child.editor.time_category_helper": "Which time of day to show chores for — also sets the card title",
@@ -1758,5 +1759,7 @@
   "child.editor.pre_reader": "Picture-only mode (for young children)",
   "child.editor.pre_reader_labels": "Show names in picture mode",
   "child.editor.pre_reader_points": "Show point values instead of stars in picture mode",
-  "common.design.accessible": "Accessible"
+  "common.design.accessible": "Accessible",
+  "child.editor.include_anytime_chores": "Include anytime chores",
+  "child.editor.include_anytime_chores_helper": "Anytime chores normally appear under every time category — turn this off to hide them"
 }

--- a/custom_components/taskmate/www/locales/en.json
+++ b/custom_components/taskmate/www/locales/en.json
@@ -267,6 +267,7 @@
   "child.editor.time_category": "Time Category",
   "child.editor.time_category_afternoon": "Afternoon Chores",
   "child.editor.time_category_all": "Today's Chores (All)",
+  "child.editor.time_category_current": "Current Time Period (Live)",
   "child.editor.time_category_anytime": "Today's Chores (Anytime)",
   "child.editor.time_category_evening": "Evening Chores",
   "child.editor.time_category_helper": "Which time of day to show chores for — also sets the card title",
@@ -1758,5 +1759,7 @@
   "child.editor.pre_reader": "Picture-only mode (for young children)",
   "child.editor.pre_reader_labels": "Show names in picture mode",
   "child.editor.pre_reader_points": "Show point values instead of stars in picture mode",
-  "common.design.accessible": "Accessible"
+  "common.design.accessible": "Accessible",
+  "child.editor.include_anytime_chores": "Include anytime chores",
+  "child.editor.include_anytime_chores_helper": "Anytime chores normally appear under every time category — turn this off to hide them"
 }

--- a/custom_components/taskmate/www/locales/fr.json
+++ b/custom_components/taskmate/www/locales/fr.json
@@ -265,6 +265,7 @@
   "child.editor.time_category": "Catégorie de temps",
   "child.editor.time_category_afternoon": "Tâches de l'après-midi",
   "child.editor.time_category_all": "Tâches d'aujourd'hui (toutes)",
+  "child.editor.time_category_current": "Période actuelle (en direct)",
   "child.editor.time_category_anytime": "Tâches d'aujourd'hui (n'importe quand)",
   "child.editor.time_category_evening": "Tâches du soir",
   "child.editor.time_category_helper": "Pour quel moment de la journée afficher les tâches — définit également le titre de la carte",
@@ -1758,5 +1759,7 @@
   "child.editor.pre_reader": "Mode images seules (jeunes enfants)",
   "child.editor.pre_reader_labels": "Afficher les noms en mode images",
   "child.editor.pre_reader_points": "Afficher les points au lieu des étoiles en mode images",
-  "common.design.accessible": "Accessible"
+  "common.design.accessible": "Accessible",
+  "child.editor.include_anytime_chores": "Inclure les tâches « n'importe quand »",
+  "child.editor.include_anytime_chores_helper": "Les tâches « n'importe quand » apparaissent normalement dans toutes les catégories de temps — désactivez pour les masquer"
 }

--- a/custom_components/taskmate/www/locales/nb.json
+++ b/custom_components/taskmate/www/locales/nb.json
@@ -265,6 +265,7 @@
   "child.editor.time_category": "Tidskategori",
   "child.editor.time_category_afternoon": "Ettermiddagsoppgaver",
   "child.editor.time_category_all": "Dagens oppgaver (alle)",
+  "child.editor.time_category_current": "Gjeldende tidsperiode (live)",
   "child.editor.time_category_anytime": "Dagens oppgaver (når som helst)",
   "child.editor.time_category_evening": "Kveldsoppgaver",
   "child.editor.time_category_helper": "Hvilken tid på dagen skal oppgaver vises — setter også korttittelen",
@@ -1758,5 +1759,7 @@
   "child.editor.pre_reader": "Kun bilder (for små barn)",
   "child.editor.pre_reader_labels": "Vis navn i bildemodus",
   "child.editor.pre_reader_points": "Vis poengverdier i stedet for stjerner i bildemodus",
-  "common.design.accessible": "Tilgjengelig"
+  "common.design.accessible": "Tilgjengelig",
+  "child.editor.include_anytime_chores": "Ta med «når som helst»-oppgaver",
+  "child.editor.include_anytime_chores_helper": "«Når som helst»-oppgaver vises normalt i alle tidskategorier — slå av for å skjule dem"
 }

--- a/custom_components/taskmate/www/locales/nn.json
+++ b/custom_components/taskmate/www/locales/nn.json
@@ -265,6 +265,7 @@
   "child.editor.time_category": "Tidskategori",
   "child.editor.time_category_afternoon": "Ettermiddagsoppgåver",
   "child.editor.time_category_all": "Dagens oppgåver (alle)",
+  "child.editor.time_category_current": "Gjeldande tidsperiode (live)",
   "child.editor.time_category_anytime": "Dagens oppgåver (kva tid som helst)",
   "child.editor.time_category_evening": "Kveldsoppgåver",
   "child.editor.time_category_helper": "Kva tid på dagen oppgåver skal visast — set òg korttittelen",
@@ -1758,5 +1759,7 @@
   "child.editor.pre_reader": "Berre bilete (for små born)",
   "child.editor.pre_reader_labels": "Vis namn i biletemodus",
   "child.editor.pre_reader_points": "Vis poengverdiar i staden for stjerner i biletemodus",
-  "common.design.accessible": "Tilgjengeleg"
+  "common.design.accessible": "Tilgjengeleg",
+  "child.editor.include_anytime_chores": "Ta med «kva tid som helst»-oppgåver",
+  "child.editor.include_anytime_chores_helper": "«Kva tid som helst»-oppgåver vert normalt viste i alle tidskategoriar — slå av for å skjule dei"
 }

--- a/custom_components/taskmate/www/locales/pt-BR.json
+++ b/custom_components/taskmate/www/locales/pt-BR.json
@@ -265,6 +265,7 @@
   "child.editor.time_category": "Categoria de Hora",
   "child.editor.time_category_afternoon": "Tarefas da Tarde",
   "child.editor.time_category_all": "Tarefas de Hoje (Todas)",
+  "child.editor.time_category_current": "Período Atual (Ao Vivo)",
   "child.editor.time_category_anytime": "Tarefas de Hoje (Qualquer Hora)",
   "child.editor.time_category_evening": "Tarefas da Noite",
   "child.editor.time_category_helper": "Qual período do dia mostrar tarefas — também define o título do cartão",
@@ -1758,5 +1759,7 @@
   "child.editor.pre_reader": "Modo só imagens (crianças pequenas)",
   "child.editor.pre_reader_labels": "Mostrar nomes no modo imagens",
   "child.editor.pre_reader_points": "Mostrar pontos em vez de estrelas no modo imagens",
-  "common.design.accessible": "Acessível"
+  "common.design.accessible": "Acessível",
+  "child.editor.include_anytime_chores": "Incluir tarefas de qualquer hora",
+  "child.editor.include_anytime_chores_helper": "As tarefas de qualquer hora aparecem normalmente em todas as categorias de hora — desative para ocultá-las"
 }

--- a/custom_components/taskmate/www/locales/pt.json
+++ b/custom_components/taskmate/www/locales/pt.json
@@ -265,6 +265,7 @@
   "child.editor.time_category": "Categoria de Hora",
   "child.editor.time_category_afternoon": "Tarefas da Tarde",
   "child.editor.time_category_all": "Tarefas de Hoje (Todas)",
+  "child.editor.time_category_current": "Período Atual (Ao Vivo)",
   "child.editor.time_category_anytime": "Tarefas de Hoje (Qualquer Hora)",
   "child.editor.time_category_evening": "Tarefas da Noite",
   "child.editor.time_category_helper": "Qual período do dia mostrar tarefas — também define o título do cartão",
@@ -1758,5 +1759,7 @@
   "child.editor.pre_reader": "Modo só imagens (crianças pequenas)",
   "child.editor.pre_reader_labels": "Mostrar nomes no modo imagens",
   "child.editor.pre_reader_points": "Mostrar pontos em vez de estrelas no modo imagens",
-  "common.design.accessible": "Acessível"
+  "common.design.accessible": "Acessível",
+  "child.editor.include_anytime_chores": "Incluir tarefas de qualquer hora",
+  "child.editor.include_anytime_chores_helper": "As tarefas de qualquer hora aparecem normalmente em todas as categorias de hora — desative para as ocultar"
 }

--- a/custom_components/taskmate/www/taskmate-child-card.js
+++ b/custom_components/taskmate/www/taskmate-child-card.js
@@ -2228,6 +2228,7 @@ class TaskMateChildCard extends LitElement {
     }
     this.config = {
       time_category: "anytime",
+      include_anytime_chores: true,  // false hides the Anytime bucket from every filter
       debug: false,
       default_sound: "coin",
       undo_sound: "undo",
@@ -2449,7 +2450,7 @@ class TaskMateChildCard extends LitElement {
             ? this._renderEmptyState()
             : html`
                 <div class="section-title">
-                  <ha-icon icon="${this._getTimeCategoryIcon(this.config.time_category)}"></ha-icon>
+                  <ha-icon icon="${this._getTimeCategoryIcon(this._effectiveTimeCategory())}"></ha-icon>
                   <span class="section-title-text">${this._getDynamicTitle()}</span>
                   ${this.config.show_countdown !== false ? (() => {
                     const countdown = this._getMidnightCountdown();
@@ -3068,6 +3069,10 @@ class TaskMateChildCard extends LitElement {
     // or a sensor that hasn't published yet) has to read as available, or the
     // card would blank itself.
     const availability = attrs.chore_availability || {};
+    // "current" resolves to the live period; anytime chores are opt-out (#847).
+    const isCurrentMode = this.config.time_category === 'current';
+    const effectiveCategory = this._effectiveTimeCategory();
+    const includeAnytime = this.config.include_anytime_chores !== false;
 
     // First, filter chores for this child and time category
     const filteredChores = chores.filter(chore => {
@@ -3076,18 +3081,30 @@ class TaskMateChildCard extends LitElement {
       const disabledFor = chore.disabled_for || [];
       if (disabledFor.includes(childId)) return false;
 
+      // Anytime chores match every filter, so opting out has to be an early
+      // return: _isChoreInClaimWindow() reports "anytime" as always in-window,
+      // and a clause inside matchesCardFilter would be bypassed below.
+      if (!includeAnytime && chore.time_category === "anytime") return false;
+
       // Check time category. The card's configured filter matches as before;
       // on top of that, chores currently in their claim window (including the
       // post-period grace) and any future-period chores are let through so
       // they can render as locked previews or keep claimable during grace.
       const isLockedPreview = this._isChorePreviewLocked(chore);
       const inClaimWindow = this._isChoreInClaimWindow(chore);
-      chore._isLockedPreview = isLockedPreview;
+      // In "current" mode a future chore must not survive as a dimmed preview
+      // either, so the flag is cleared rather than just filtered around.
+      chore._isLockedPreview = isCurrentMode ? false : isLockedPreview;
       const matchesCardFilter =
-        this.config.time_category === "all" ||
-        chore.time_category === this.config.time_category ||
+        effectiveCategory === "all" ||
+        chore.time_category === effectiveCategory ||
         chore.time_category === "anytime";
-      const matchesTime = matchesCardFilter || isLockedPreview || inClaimWindow;
+      // "current" drops the future-preview pass-through; the claim window stays
+      // so a chore inside its post-period grace is still tappable, and past
+      // periods keep being governed by elapsed_time_mode.
+      const matchesTime = isCurrentMode
+        ? matchesCardFilter || inClaimWindow
+        : matchesCardFilter || isLockedPreview || inClaimWindow;
 
       // Check assignment
       let assignedTo = chore.assigned_to;
@@ -3320,6 +3337,16 @@ class TaskMateChildCard extends LitElement {
     });
   }
 
+  // Resolves the configured time_category. "current" is dynamic: it tracks
+  // whichever period is active right now, so a wall dashboard shows only the
+  // chores that are actually due (#847). Everything else passes through.
+  // _getCurrentTimePeriod() reads the user's own time_periods, so custom
+  // periods work here without any extra mapping.
+  _effectiveTimeCategory() {
+    const configured = this.config?.time_category;
+    return configured === 'current' ? this._getCurrentTimePeriod() : configured;
+  }
+
   _getTimeCategoryIcon(category) {
     const period = this._getTimePeriods().find(p => p.id === category);
     if (period) return period.icon;
@@ -3349,7 +3376,7 @@ class TaskMateChildCard extends LitElement {
   }
 
   _getDynamicTitle() {
-    const category = this.config.time_category;
+    const category = this._effectiveTimeCategory();
     const period = this._getTimePeriods().find(p => p.id === category);
     if (period && period.label) return period.label;
     const keyMap = {
@@ -4866,6 +4893,7 @@ class TaskMateChildCardEditor extends LitElement {
         }))
       : Object.entries(builtinLabels).map(([value, label]) => ({ value, label }));
     return [
+      { value: 'current', label: this._t('child.editor.time_category_current') },
       ...periodOptions,
       { value: 'anytime', label: this._t('child.editor.time_category_anytime') },
       { value: 'all', label: this._t('child.editor.time_category_all') },
@@ -4977,6 +5005,7 @@ class TaskMateChildCardEditor extends LitElement {
           },
         },
       },
+      { name: 'include_anytime_chores', selector: { boolean: {} } },
       { name: 'show_countdown', selector: { boolean: {} } },
       { name: 'show_description', selector: { boolean: {} } },
       { name: 'pre_reader', selector: { boolean: {} } },
@@ -4997,6 +5026,7 @@ class TaskMateChildCardEditor extends LitElement {
       first_come_claimed_mode: this._t('child.editor.first_come_when_completed'),
       dependency_mode: this._t('child.editor.dependency_mode'),
       elapsed_time_mode: this._t('child.editor.missed_time_chores'),
+      include_anytime_chores: this._t('child.editor.include_anytime_chores'),
       show_countdown: this._t('child.editor.show_countdown'),
       show_description: this._t('child.editor.show_description'),
       pre_reader: this._t('child.editor.pre_reader'),
@@ -5017,6 +5047,7 @@ class TaskMateChildCardEditor extends LitElement {
       first_come_claimed_mode: this._t('child.editor.first_come_helper'),
       dependency_mode: this._t('child.editor.dependency_helper'),
       elapsed_time_mode: this._t('child.editor.elapsed_helper'),
+      include_anytime_chores: this._t('child.editor.include_anytime_chores_helper'),
     };
     return helpers[entry.name] ?? '';
   };
@@ -5034,6 +5065,7 @@ class TaskMateChildCardEditor extends LitElement {
       first_come_claimed_mode: this.config.first_come_claimed_mode || 'hide',
       dependency_mode: this.config.dependency_mode || 'hide',
       elapsed_time_mode: this.config.elapsed_time_mode || 'dim',
+      include_anytime_chores: this.config.include_anytime_chores !== false,
       show_countdown: this.config.show_countdown !== false,
       show_description: this.config.show_description === true,
       pre_reader: this.config.pre_reader === true,

--- a/tests/test_child_card_current_period.py
+++ b/tests/test_child_card_current_period.py
@@ -1,0 +1,173 @@
+"""Current-time-period filtering on the child card (#847).
+
+A wall dashboard wants "chores due right now" without losing the child card's
+layout. Two card options cover it:
+
+* ``time_category: current`` resolves to whatever period is active at render
+  time, so future-period chores stop leaking in as dimmed locked previews;
+* ``include_anytime_chores: false`` suppresses the Anytime bucket, which
+  otherwise matches every filter (including ``all``).
+
+Both live entirely in the card. ``_filterAndSortChores`` is the single filter
+used by the classic and the designed render paths, so one change covers all
+five design styles.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent / "custom_components" / "taskmate"
+WWW = ROOT / "www"
+CARD = (WWW / "taskmate-child-card.js").read_text(encoding="utf-8")
+
+
+def _section(start_marker: str, end_marker: str) -> str:
+    start = CARD.index(start_marker)
+    return CARD[start : CARD.index(end_marker, start)]
+
+
+def _filter_source() -> str:
+    return _section("  _filterAndSortChores(chores, child) {", "\n  _getTimeCategoryIcon(")
+
+
+def _editor_options_source() -> str:
+    return _section("  _timeCategoryEditorOptions(overviewEntity) {", "\n  _buildSchema(")
+
+
+class TestEffectiveCategoryHelper:
+    """`current` is resolved through one helper so every consumer agrees."""
+
+    def test_helper_exists(self):
+        assert "_effectiveTimeCategory(" in CARD
+
+    def test_helper_resolves_current_to_the_live_period(self):
+        src = _section("  _effectiveTimeCategory(", "\n  _getTimeCategoryIcon(")
+        assert "'current'" in src or '"current"' in src
+        # Must go through _getCurrentTimePeriod so user-defined periods work.
+        assert "_getCurrentTimePeriod()" in src
+
+    def test_helper_passes_other_categories_through(self):
+        src = _section("  _effectiveTimeCategory(", "\n  _getTimeCategoryIcon(")
+        assert "time_category" in src
+
+
+class TestFilterUsesEffectiveCategory:
+    """The filter must compare against the resolved period, not the raw config."""
+
+    def test_filter_resolves_the_configured_category(self):
+        assert "_effectiveTimeCategory()" in _filter_source()
+
+    def test_filter_no_longer_compares_chores_to_raw_config(self):
+        # Reading config.time_category to detect current mode is fine; matching a
+        # chore against it directly is what broke `current`.
+        assert "chore.time_category === this.config.time_category" not in _filter_source()
+
+
+class TestFuturePreviewsSuppressed:
+    """`current` mode is the whole point: no future-period chores."""
+
+    def test_locked_preview_passthrough_is_conditional(self):
+        src = _filter_source()
+        # The preview pass-through leaked future chores in. It must survive only
+        # on the non-current branch of an isCurrentMode ternary.
+        assert "isCurrentMode" in src
+        assert "? matchesCardFilter || inClaimWindow" in src
+        assert ": matchesCardFilter || isLockedPreview || inClaimWindow" in src
+
+    def test_preview_flag_cleared_in_current_mode(self):
+        # Nothing should render as a dimmed preview when the card is "right now".
+        assert "isCurrentMode ? false : isLockedPreview" in _filter_source()
+
+    def test_claim_window_still_honoured_in_current_mode(self):
+        # A chore inside its post-period grace stays actionable (elapsed_time_mode
+        # keeps owning past periods).
+        src = _filter_source()
+        assert "inClaimWindow" in src
+
+
+class TestAnytimeToggle:
+    def test_filter_reads_include_anytime_chores(self):
+        assert "include_anytime_chores" in _filter_source()
+
+    def test_defaults_to_true_so_existing_cards_are_unchanged(self):
+        # `!== false` is the house idiom for a default-on boolean.
+        assert "include_anytime_chores !== false" in CARD
+
+    def test_anytime_match_is_gated_on_the_toggle(self):
+        src = _filter_source()
+        assert 'chore.time_category === "anytime"' in src or "chore.time_category === 'anytime'" in src
+        assert "includeAnytime" in src
+
+    def test_opting_out_is_a_hard_gate_not_a_filter_clause(self):
+        # Caught on ha-dev: _isChoreInClaimWindow() returns true for "anytime",
+        # so gating only the matchesCardFilter clause let every anytime chore
+        # back in through the claim-window branch. It has to be an early return.
+        src = _filter_source()
+        assert 'if (!includeAnytime && chore.time_category === "anytime") return false;' in src
+
+    def test_claim_window_still_short_circuits_anytime(self):
+        # Guards the trap above from regressing at its source.
+        src = _section("  _isChoreInClaimWindow(chore) {", "\n  // Returns true when")
+        assert "if (cat === 'anytime') return true;" in src
+
+    def test_setconfig_declares_the_default(self):
+        src = _section("  setConfig(config) {", "\n  getCardSize()")
+        assert "include_anytime_chores: true" in src
+
+
+class TestTitleAndIcon:
+    """The header must follow the live period, not print 'current'."""
+
+    def test_dynamic_title_resolves_current(self):
+        src = _section("  _getDynamicTitle() {", "\n  _getTimezone()")
+        assert "_effectiveTimeCategory()" in src
+
+    def test_header_icon_resolves_current(self):
+        # The render path must not pass the raw config value to the icon map.
+        assert "_getTimeCategoryIcon(this.config.time_category)" not in CARD
+        assert "_getTimeCategoryIcon(this._effectiveTimeCategory())" in CARD
+
+
+class TestEditor:
+    def test_current_is_offered_in_the_dropdown(self):
+        src = _editor_options_source()
+        assert "'current'" in src or '"current"' in src
+        assert "child.editor.time_category_current" in src
+
+    def test_include_anytime_chores_has_a_schema_entry(self):
+        schema = _section("  _buildSchema() {", "\n  _computeLabel")
+        assert "include_anytime_chores" in schema
+
+    def test_editor_renders_the_toggle_state(self):
+        src = _section("  render() {\n    if (!this.hass || !this.config) return html``;", "\n    return html`")
+        assert "include_anytime_chores" in src
+
+
+class TestTranslations:
+    """New user-facing strings ship translated in every locale, same PR."""
+
+    KEYS = (
+        "child.editor.time_category_current",
+        "child.editor.include_anytime_chores",
+        "child.editor.include_anytime_chores_helper",
+    )
+
+    def test_every_locale_has_the_new_keys(self):
+        locales = sorted(p for p in (WWW / "locales").glob("*.json"))
+        assert locales, "no locale files found"
+        for path in locales:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            for key in self.KEYS:
+                assert key in data, f"{path.name} missing {key}"
+                assert data[key].strip(), f"{path.name} has an empty {key}"
+
+    def test_non_english_locales_are_actually_translated(self):
+        en = json.loads((WWW / "locales" / "en.json").read_text(encoding="utf-8"))
+        for path in sorted((WWW / "locales").glob("*.json")):
+            if path.stem in ("en", "en-GB"):
+                continue
+            data = json.loads(path.read_text(encoding="utf-8"))
+            untranslated = [k for k in self.KEYS if data[k] == en[k]]
+            assert not untranslated, f"{path.name} left English: {untranslated}"


### PR DESCRIPTION
## What

Adds two card-level options to `custom:taskmate-child-card` so a family dashboard or wall kiosk can show only the chores that are actually due right now — while keeping the normal child-card layout.

### `time_category: current`

A new value in the Time Category dropdown that resolves to whichever TaskMate period is active at render time.

```yaml
type: custom:taskmate-child-card
entity: sensor.taskmate_overview
child_id: b281c62ec9604084
time_category: current
```

During Afternoon the card shows Afternoon chores and titles itself "Afternoon Chores"; when Evening starts it switches over on its own. It resolves through `_getCurrentTimePeriod()`, so **custom time periods work too** — not just the built-in four.

Future-period chores no longer come through as dimmed locked previews in this mode, which is what was putting tomorrow evening's work on the kiosk. Chores still inside their post-period claim grace stay tappable, and past periods keep being governed by `elapsed_time_mode` exactly as before.

### `include_anytime_chores`

```yaml
include_anytime_chores: false
```

Anytime chores match every time category, so they showed up alongside whatever period was selected. This turns them off. **Defaults to `true`, so every existing card renders exactly as it does today.**

Both options are in the visual editor with translated labels and helper text.

## Notes

Only the `time_category: current` shape from the issue was implemented — not the separate `show_only_current_time_category` boolean. They express the same thing, and having both would let a card be configured two contradictory ways in the visual editor.

One trap worth recording: `_isChoreInClaimWindow()` reports `anytime` as always in-window, so gating the anytime match inside `matchesCardFilter` was not enough — every anytime chore came straight back in through the claim-window branch. It has to be an early return. Caught on the dev instance, not by the unit tests.

## Testing

Everything lands in `_filterAndSortChores`, the single filter shared by the classic and designed render paths, so all five design styles are covered by one change.

Verified on the dev HA instance with real chores across all five time categories:

| Config | Result |
|---|---|
| `current` + afternoon | Afternoon + anytime only; evening/night gone; title "Afternoon Chores" |
| `current` + morning / evening | Correct period only, title follows |
| `current` + `include_anytime_chores: false` | Afternoon chore alone |
| `time_category: morning` (existing) | Unchanged — future chores still render as dimmed previews |
| `time_category: all` (existing) | Unchanged |

Checked in all five design styles (classic, playroom, console, cleanpro, accessible) and in the visual editor.

- 1709 tests pass (21 new in `tests/test_child_card_current_period.py`)
- ESLint, Ruff and translation parity clean
- New strings translated into de, fr, nb, nn, pt, pt-BR in this PR

Closes #847