### PR TITLE
chore(deps): stop Dependabot bumping httpx in the floor constraints

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -47,3 +47,8 @@ updates:
       - "ci"
     cooldown:
       default-days: 14
+    ignore:
+      # ci/constraints-floor.txt is a snapshot of a green floor-leg run, not a
+      # dependency list to keep current: HA 2024.7.0 pins httpx==0.27.0 exactly,
+      # so any bump makes the floor leg unresolvable (see closed PR #844).
+      - dependency-name: "httpx"


### PR DESCRIPTION
## What

Adds an `ignore` rule for `httpx` to the `pip` Dependabot ecosystem.

## Why

`ci/constraints-floor.txt` is a **captured snapshot of a green floor-leg run**, not a dependency list to keep current. Home Assistant 2024.7.0 (our supported floor) depends on `httpx==0.27.0` *exactly*, so Dependabot bumping that pin makes the install unresolvable before the harness is even installed:

```
homeassistant 2024.7.0 depends on httpx==0.27.0
The user requested (constraint) httpx==0.28.1
→ ResolutionImpossible
```

That is what red-flagged the required `Run tests` check on #844 (`tests (py3.12, HA 2024.7.0)`). The bump is unmergeable by construction — it cannot be fixed by rebasing — and Dependabot would re-raise it on every httpx release.

Closing #844 in favour of this.

## Note

Every other pin in `ci/constraints-floor.txt` is exposed to the same failure mode, since the whole file mirrors what HA 2024.7.0 resolved. A broader rule (ignoring the floor constraints file wholesale) would be the more durable fix if this recurs with another package.