### PR TITLE
chore: bump manifest to 5.5.0

### DIFF
--- a/custom_components/taskmate/manifest.json
+++ b/custom_components/taskmate/manifest.json
@@ -17,5 +17,5 @@
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/tempus2016/taskmate/issues",
   "requirements": [],
-  "version": "5.4.3"
+  "version": "5.5.0"
 }


### PR DESCRIPTION
Bumps `custom_components/taskmate/manifest.json` to `5.5.0` ahead of the v5.5.0 release.

HACS reads the version from the manifest rather than the git tag, and `release-guard.yml` fails the release if the two disagree, so this has to land before the tag is cut.

Release contents (`v5.4.3...main`):

- #848 — child card `time_category: current` and `include_anytime_chores` (closes #847). The only user-facing change.
- #849 — Dependabot ignore rule for `httpx` in the CI floor constraints.
- #846 — Home Assistant community forum badge in the README.

No code changes here beyond the version string.