### PR TITLE
chore(ci): put the floor constraints out of Dependabot's reach

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -47,8 +47,3 @@ updates:
       - "ci"
     cooldown:
       default-days: 14
-    ignore:
-      # ci/constraints-floor.txt is a snapshot of a green floor-leg run, not a
-      # dependency list to keep current: HA 2024.7.0 pins httpx==0.27.0 exactly,
-      # so any bump makes the floor leg unresolvable (see closed PR #844).
-      - dependency-name: "httpx"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,7 +57,7 @@ jobs:
             # Rather than chase each break with another one-off pin, this file
             # holds the complete set a known-good run resolved. See the header
             # in it for why, and for how to regenerate.
-            constraints: "ci/constraints-floor.txt"
+            constraints: "ci/constraints-floor.pins"
 
     steps:
       - name: Check out repository
@@ -76,7 +76,7 @@ jobs:
           cache: "pip"
           cache-dependency-path: |
             requirements_test.txt
-            ci/constraints-floor.txt
+            ci/constraints-floor.pins
 
       - name: Install dependencies
         env:

--- a/ci/constraints-floor.pins
+++ b/ci/constraints-floor.pins
@@ -16,6 +16,19 @@
 # These are constraints, not requirements: pip applies them to whatever the
 # harness pulls in, and unlisted packages still resolve normally.
 #
+# Why the .pins extension
+# -----------------------
+# Not cosmetic, and please don't rename it back to .txt. Dependabot's pip
+# fetcher walks one level into every subdirectory and picks up anything ending
+# .txt or .in whose contents parse as requirements (dependabot-core,
+# SharedFileFetcher#req_txt_and_in_files). This file qualified, so Dependabot
+# kept raising PRs against it -- but every pin here mirrors what HA 2024.7.0
+# itself resolved, and HA pins several of them exactly. Bumping one makes the
+# floor leg unresolvable before pytest can install, which is what happened to
+# httpx (#844) and fnv-hash-fast (#851). An extension outside .txt/.in is not
+# collected at all, so the whole file is invisible to Dependabot. pip does not
+# care about the extension for -c.
+#
 # Regenerating
 # ------------
 # Take the "Successfully installed" line from a green floor-leg job log and


### PR DESCRIPTION
## Problem

Dependabot keeps raising unmergeable PRs against `ci/constraints-floor.txt`: #844 (httpx), then #851 (fnv-hash-fast) within hours of the first being closed.

That file is a **captured snapshot of a green floor-leg run**, not a dependency list to keep current. Every pin in it mirrors what Home Assistant 2024.7.0 resolved, and HA pins several of them exactly, so raising one makes the floor leg unresolvable before pytest can even install:

```
homeassistant 2024.7.0 depends on httpx==0.27.0
The user requested (constraint) httpx==0.28.1
→ ResolutionImpossible
```

The per-package `ignore` rule added in #849 fixed httpx and nothing else — #851 proved the problem is the file, not the package.

## Why Dependabot sees it at all

From `dependabot-core`, `SharedFileFetcher#req_txt_and_in_files`:

```ruby
repo_contents
  .select { |f| f.type == "file" }
  .select { |f| f.name.end_with?(".txt", ".in") }
  ...
  .select { |f| requirements_file?(f) }

repo_contents
  .select { |f| f.type == "dir" }
  .each { |f| files.concat(req_files_for_dir(f)) }
```

It walks one level into every subdirectory and collects anything ending `.txt`/`.in` whose contents parse as requirements. `ci/constraints-floor.txt` qualifies on both counts. Dependabot has no `exclude-paths` option, and `directory: "/"` does not stop the subdirectory walk.

## Fix

Rename `ci/constraints-floor.txt` → `ci/constraints-floor.pins`. An extension outside `.txt`/`.in` is never collected, so the file is invisible to Dependabot; `pip` does not care about the extension for `-c`. The reasoning is recorded in the file header so it does not get renamed back.

Also drops the now-redundant `ignore: httpx` rule from #849.

## Scope

- `requirements_test.txt` is untouched — it is in the repo root and still matches, so the deliberate one-PR-a-month harness-pin trickle still arrives.
- `tests.yml` updated in both places (the matrix `constraints:` value and the `cache-dependency-path`).
- CI-only. Nothing here ships in the integration.

Supersedes #851, which should be closed.