### PR TITLE
fix(panel): make the icon field match the panel's own inputs

### DIFF
--- a/custom_components/taskmate/www/taskmate-panel.js
+++ b/custom_components/taskmate/www/taskmate-panel.js
@@ -6248,11 +6248,21 @@ class TaskMatePanel extends HTMLElement {
     if (engine) engine.play(value, this._customSounds());
   }
 
+  /**
+   * Icon field. `ha-icon-picker` is HA's own component — we keep it for the
+   * searchable MDI list, but its Material shell (grey fill, underline, 56px
+   * box) reads as a foreign control beside the panel's own inputs. The
+   * `.tm-icon-well` wrapper supplies the tm-input frame and the picker inside
+   * it is made transparent; see the CSS for why the wrapper, not the picker,
+   * carries the border.
+   */
   _iconPickerField(label, name, value) {
     return `
       <div class="tm-field">
         <span class="tm-field-label">${this._esc(label)}</span>
-        <ha-icon-picker data-field="${name}" data-current="${this._esc(value || "")}"></ha-icon-picker>
+        <div class="tm-icon-well">
+          <ha-icon-picker data-field="${name}" data-current="${this._esc(value || "")}"></ha-icon-picker>
+        </div>
       </div>`;
   }
 
@@ -7616,6 +7626,42 @@ class TaskMatePanel extends HTMLElement {
       .tm-field ha-icon-picker,
       .tm-section-body ha-icon-picker {
         display: block; width: 100%;
+      }
+
+      /* Icon field well: make ha-icon-picker sit in the dialogs like a
+         tm-input. The picker's inner shell can't be reached from here (shadow
+         DOM), so the wrapper carries the frame and the picker is stripped back:
+           - the fill and the 1px "active indicator" are var() usages inside
+             ha-picker-field, so overriding the vars here does reach them;
+           - ha-combo-box-item hard-sets its own 56px row height and square
+             bottom corners, which no variable overrides — so the well is
+             tm-input height with overflow:hidden, and the picker is pulled up
+             by half the difference to keep its content optically centred.
+         The --mdc-* vars cover older HA, which still renders an mwc textfield. */
+      .tm-icon-well {
+        box-sizing: border-box;
+        height: 37px;
+        background: var(--tm-surface-0);
+        border: 1px solid var(--tm-border);
+        border-radius: var(--tm-radius-sm);
+        box-shadow: var(--tm-shadow-xs);
+        overflow: hidden;
+        transition: all 0.1s var(--tm-easing);
+      }
+      .tm-icon-well:hover { border-color: var(--tm-border-strong); }
+      .tm-icon-well:focus-within { border-color: var(--tm-accent); box-shadow: var(--tm-shadow-focus); }
+      .tm-icon-well ha-icon-picker {
+        display: block; width: 100%;
+        margin-top: calc((37px - 56px) / 2);
+        --ha-color-form-background: transparent;
+        --ha-color-border-neutral-loud: transparent;
+        --md-list-item-leading-space: 11px;
+        --md-list-item-trailing-space: 4px;
+        --md-list-item-label-text-size: 13px;
+        --mdc-text-field-fill-color: transparent;
+        --mdc-text-field-idle-line-color: transparent;
+        --mdc-text-field-hover-line-color: transparent;
+        --mdc-text-field-focused-line-color: transparent;
       }
 
       /* Chip multi-select */


### PR DESCRIPTION
`ha-icon-picker` is Home Assistant's own component, so in the panel's dialogs it rendered with a Material shell — grey fill, dark active-indicator line, square bottom corners and a 56px box — sitting beside 37px `tm-input`s styled by the panel. It read as a borrowed control rather than part of the form.

It is kept (the searchable MDI list is worth it) but wrapped in a `.tm-icon-well` that carries the `tm-input` frame, with the picker itself stripped back to transparent.

## Before / after

| | |
|---|---|
| Before | grey filled box, underline, 56px tall next to a 37px Cost field |
| After | same height, border, radius and background as the field beside it |

## How

- The fill and the indicator line are `var()` usages inside `ha-picker-field`, so overriding `--ha-color-form-background` and `--ha-color-border-neutral-loud` from the light DOM does reach them.
- The 56px row height and the square bottom corners are hard-set on `ha-combo-box-item` inside the shadow root, and no variable overrides them. So the well is a fixed `tm-input`-height box with `overflow:hidden`, and the picker is pulled up by half the difference to keep its contents optically centred. That offset is the fragile bit — if HA changes the 56px row height the icon drifts — and it is commented in the CSS.
- The `--mdc-text-field-*` overrides are kept alongside for older HA, which still renders an mwc textfield here.

## Scope

This changes the shared `_iconPickerField` helper, so every dialog using it is covered: reward, chore, badge, quest, challenge and child avatar. The settings page's `points_icon` picker and the notification period rows build their own markup and are left alone.

## Testing

Verified on the live ha-dev instance, not just locally:

- Reward and chore dialogs render the field matching its neighbours (well 37px, same frame).
- The picker still works: click opens the list anchored under the field, typing `star` filters it, `✕` clears.
- An empty picker (no icon set) renders as an empty well with just the chevron — nothing is clipped by the fixed height.
- ESLint clean, 1792 tests pass.

Not verified: dark theme has no screenshot — the browser profile's own theme setting overrides `frontend.set_theme` on ha-dev. The well is built from the same tokens as `.tm-input` (`--tm-surface-0`, `--tm-border`, `--tm-accent`), so it tracks the theme the way the other inputs do by construction.