### PR TITLE
Internal hardening and validation pass

### DIFF
--- a/.github/workflows/release-guard.yml
+++ b/.github/workflows/release-guard.yml
@@ -64,3 +64,42 @@ jobs:
           echo "::error::taskmate.zip is missing from release $TAG — HACS installs will fail."
           echo "Re-run the 'Attach HACS zip to release' workflow, then re-run this check."
           exit 1
+
+      - name: Check out the released tag
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.tag || github.event.release.tag_name }}
+          persist-credentials: false
+          path: src
+
+      - name: Verify the attached zip matches the tag
+        # Checking only that an asset *named* taskmate.zip exists says nothing
+        # about what is inside it — and the upload uses --clobber, so an asset
+        # can be replaced on an already-green release without leaving a commit
+        # behind. Compare the contents against the tag instead. Zip bytes are
+        # not reproducible (timestamps), so compare a per-file digest listing.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          TAG: ${{ inputs.tag || github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          gh release download "$TAG" --repo "$REPO" --pattern taskmate.zip --dir .
+          mkdir -p from_asset
+          unzip -q taskmate.zip -d from_asset
+
+          digest() {
+            ( cd "$1" && find . -type f \
+                ! -path '*/__pycache__/*' ! -name '*.pyc' \
+                -print0 | sort -z | xargs -0 sha256sum )
+          }
+          digest from_asset > asset.txt
+          digest src/custom_components/taskmate > tag.txt
+
+          if diff -u tag.txt asset.txt; then
+            echo "taskmate.zip matches the source at $TAG ($(wc -l < tag.txt) files)."
+          else
+            echo "::error::taskmate.zip does not match custom_components/taskmate at $TAG."
+            echo "Rebuild it with the 'Attach HACS zip to release' workflow before announcing this release."
+            exit 1
+          fi

--- a/.github/workflows/release-zip.yml
+++ b/.github/workflows/release-zip.yml
@@ -12,12 +12,19 @@ on:
   release:
     types: [published]
 
+# Default to read; the one job that needs to write to the release asks for it.
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   attach-zip:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      # Signed build provenance for the asset HACS actually installs, so a
+      # swapped-in zip can be detected with `gh attestation verify`.
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -25,6 +32,7 @@ jobs:
           persist-credentials: false
 
       - name: Build taskmate.zip
+        id: build
         run: |
           cd custom_components/taskmate
           zip -r -X "$GITHUB_WORKSPACE/taskmate.zip" . \
@@ -32,6 +40,12 @@ jobs:
           cd "$GITHUB_WORKSPACE"
           echo "--- zip contents (top level) ---"
           unzip -l taskmate.zip | grep -E 'manifest.json' || (echo "manifest.json missing from zip root" && exit 1)
+          echo "sha256=$(sha256sum taskmate.zip | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+
+      - name: Attest build provenance for taskmate.zip
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-path: taskmate.zip
 
       - name: Upload taskmate.zip to release
         env:
@@ -40,4 +54,10 @@ jobs:
           # and inline expansion would splice it straight into the shell.
           TAG: ${{ github.event.release.tag_name }}
           REPO: ${{ github.repository }}
-        run: gh release upload "$TAG" taskmate.zip --clobber --repo "$REPO"
+        run: |
+          gh release upload "$TAG" taskmate.zip --clobber --repo "$REPO"
+          {
+            echo "### HACS asset"
+            echo ""
+            echo "\`taskmate.zip\` SHA-256: \`${{ steps.build.outputs.sha256 }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -39,8 +39,18 @@ jobs:
           persist-credentials: false
 
       - name: Run actionlint
+        env:
+          # Pinned release + checksum rather than piping an installer from a
+          # mutable branch into bash: that was the one unpinned third-party
+          # thing in CI, and it runs on every push and fork PR.
+          ACTIONLINT_VERSION: 1.7.12
+          ACTIONLINT_SHA256: 8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8
         run: |
-          bash <(curl -sSL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+          set -euo pipefail
+          url="https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          curl -sSLf -o actionlint.tar.gz "$url"
+          echo "${ACTIONLINT_SHA256}  actionlint.tar.gz" | sha256sum -c -
+          tar -xzf actionlint.tar.gz actionlint
           ./actionlint -color
 
   zizmor:

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,20 @@ dev-config/
 .coverage
 coverage.xml
 htmlcov/
+
+# Internal review artefacts — never belong in the public repo
+AUDIT_PROMPT.md
+AUDIT_REPORT.md
+.claude/
+
+# Secrets and tokens. These should never be in the working tree at all, but a
+# stray `git add -A` must not be the thing that decides that.
+.env
+.env.*
+secrets.yaml
+.ha_token
+.ha_token*
+.ha_test_user
+*.token
+*.pem
+*.key

--- a/custom_components/taskmate/__init__.py
+++ b/custom_components/taskmate/__init__.py
@@ -472,6 +472,23 @@ async def _async_register_services(hass: HomeAssistant) -> None:
         # Unauthorized (not ValueError), so it is unaffected and still 401s.
         return _safe(wrapped)
 
+    def _audited(handler):
+        """Wrap a child-facing handler so its mutation is recorded too.
+
+        Only the admin and parent wrappers used to audit. Everything a child
+        can drive — completing a chore, claiming a reward, allocating points —
+        therefore left no trail at all, which is exactly the set of actions
+        worth being able to review. The guards stay inside each handler; this
+        only adds the record.
+        """
+
+        @wraps(handler)
+        async def wrapped(call: ServiceCall) -> None:
+            await handler(call)
+            await _async_record_service_audit(hass, call)
+
+        return _safe(wrapped)
+
     def _parent(handler):
         """Like _admin, but also allows non-admin users in parent_user_ids (#661).
 
@@ -1103,7 +1120,7 @@ async def _async_register_services(hass: HomeAssistant) -> None:
     hass.services.async_register(
         DOMAIN,
         SERVICE_COMPLETE_CHORE,
-        handle_complete_chore,
+        _audited(handle_complete_chore),
         schema=vol.Schema(
             {
                 vol.Required(ATTR_CHORE_ID): cv.string,
@@ -1117,7 +1134,7 @@ async def _async_register_services(hass: HomeAssistant) -> None:
     hass.services.async_register(
         DOMAIN,
         SERVICE_COMPLETE_BONUS_SUBTASK,
-        _safe(handle_complete_bonus_subtask),
+        _audited(handle_complete_bonus_subtask),
         schema=vol.Schema(
             {
                 vol.Required(ATTR_CHORE_ID): cv.string,
@@ -1130,7 +1147,7 @@ async def _async_register_services(hass: HomeAssistant) -> None:
     hass.services.async_register(
         DOMAIN,
         SERVICE_START_TIMED_TASK,
-        _safe(handle_start_timed_task),
+        _audited(handle_start_timed_task),
         schema=vol.Schema(
             {
                 vol.Required(ATTR_CHORE_ID): cv.string,
@@ -1142,7 +1159,7 @@ async def _async_register_services(hass: HomeAssistant) -> None:
     hass.services.async_register(
         DOMAIN,
         SERVICE_PAUSE_TIMED_TASK,
-        _safe(handle_pause_timed_task),
+        _audited(handle_pause_timed_task),
         schema=vol.Schema(
             {
                 vol.Required(ATTR_CHORE_ID): cv.string,
@@ -1154,7 +1171,7 @@ async def _async_register_services(hass: HomeAssistant) -> None:
     hass.services.async_register(
         DOMAIN,
         SERVICE_STOP_TIMED_TASK,
-        _safe(handle_stop_timed_task),
+        _audited(handle_stop_timed_task),
         schema=vol.Schema(
             {
                 vol.Required(ATTR_CHORE_ID): cv.string,
@@ -1277,7 +1294,7 @@ async def _async_register_services(hass: HomeAssistant) -> None:
     hass.services.async_register(
         DOMAIN,
         SERVICE_REQUEST_SWAP,
-        _safe(handle_request_swap),
+        _audited(handle_request_swap),
         schema=vol.Schema(
             {
                 vol.Required("chore_id"): cv.string,
@@ -1305,14 +1322,14 @@ async def _async_register_services(hass: HomeAssistant) -> None:
     hass.services.async_register(
         DOMAIN,
         SERVICE_SPIN_ROULETTE,
-        _safe(handle_spin_roulette),
+        _audited(handle_spin_roulette),
         schema=vol.Schema({vol.Required(ATTR_CHILD_ID): cv.string}),
     )
 
     hass.services.async_register(
         DOMAIN,
         SERVICE_CHOOSE_AVATAR,
-        _safe(handle_choose_avatar),
+        _audited(handle_choose_avatar),
         schema=vol.Schema(
             {
                 vol.Required(ATTR_CHILD_ID): cv.string,
@@ -1324,7 +1341,7 @@ async def _async_register_services(hass: HomeAssistant) -> None:
     hass.services.async_register(
         DOMAIN,
         SERVICE_CLAIM_REWARD,
-        _safe(handle_claim_reward),
+        _audited(handle_claim_reward),
         schema=vol.Schema(
             {
                 vol.Required(ATTR_REWARD_ID): cv.string,
@@ -1354,7 +1371,7 @@ async def _async_register_services(hass: HomeAssistant) -> None:
     hass.services.async_register(
         DOMAIN,
         SERVICE_ALLOCATE_POINTS_TO_POOL,
-        _safe(handle_allocate_points_to_pool),
+        _audited(handle_allocate_points_to_pool),
         schema=vol.Schema(
             {
                 vol.Required(ATTR_CHILD_ID): cv.string,

--- a/custom_components/taskmate/__init__.py
+++ b/custom_components/taskmate/__init__.py
@@ -445,6 +445,13 @@ async def _async_require_linked_child(hass: HomeAssistant, call: ServiceCall, co
     others = coordinator.storage.get_children() or []
     if any(getattr(c, "linked_user_id", "") == user_id for c in others):
         raise Unauthorized(context=call.context)
+    # Strict mode: households where every child has their own HA login can
+    # require a link, so an unlinked child profile is no longer an open door
+    # for any authenticated user. Parents keep acting on any child's behalf.
+    if coordinator.storage.get_require_linked_child():
+        if user_id in (coordinator.storage.get_parent_user_ids() or []):
+            return
+        raise Unauthorized(context=call.context)
 
 
 async def _async_register_services(hass: HomeAssistant) -> None:

--- a/custom_components/taskmate/__init__.py
+++ b/custom_components/taskmate/__init__.py
@@ -18,6 +18,7 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.service import async_set_service_schema
 from homeassistant.util import dt as dt_util
 
+from . import authz
 from .const import (
     ATTR_AS_PARENT,
     ATTR_AWARDED_BADGE_ID,
@@ -670,12 +671,20 @@ async def _async_register_services(hass: HomeAssistant) -> None:
             _LOGGER.error("No TaskMate coordinator available")
             return
         await _async_require_linked_child(hass, call, coordinator, call.data[ATTR_CHILD_ID])
+        # A child may have their own chore list read out; choosing the words is
+        # a parent action. Otherwise any account that can act as a child could
+        # make a speaker in the house say anything, at any hour.
+        message = call.data.get("message", "")
+        if message and not await authz.async_context_is_parent(hass, coordinator, call.context):
+            _LOGGER.warning("Ignoring caller-supplied read_aloud message from a non-parent user")
+            message = ""
         try:
             await coordinator.async_read_aloud(
                 child_id=call.data[ATTR_CHILD_ID],
                 media_player=call.data.get("media_player", ""),
                 tts_entity=call.data.get("tts_entity", ""),
-                message=call.data.get("message", ""),
+                message=message,
+                context=call.context,
             )
         except ValueError as err:
             raise ServiceValidationError(str(err)) from err
@@ -1284,9 +1293,11 @@ async def _async_register_services(hass: HomeAssistant) -> None:
         schema=vol.Schema(
             {
                 vol.Required(ATTR_CHILD_ID): cv.string,
-                vol.Optional("media_player", default=""): cv.string,
-                vol.Optional("tts_entity", default=""): cv.string,
-                vol.Optional("message", default=""): cv.string,
+                # Blank means "use the configured default"; anything else has to
+                # be an entity in the right domain, not an arbitrary string.
+                vol.Optional("media_player", default=""): vol.Any("", cv.entity_domain("media_player")),
+                vol.Optional("tts_entity", default=""): vol.Any("", cv.entity_domain("tts")),
+                vol.Optional("message", default=""): vol.All(cv.string, vol.Length(max=500)),
             }
         ),
     )

--- a/custom_components/taskmate/authz.py
+++ b/custom_components/taskmate/authz.py
@@ -74,4 +74,8 @@ async def async_context_allows_child(hass: HomeAssistant, coordinator: Any, cont
     others = coordinator.storage.get_children() or []
     if any(getattr(c, "linked_user_id", "") == user_id for c in others):
         return False
+    # Strict mode (opt-in): an unlinked child is not an open door. Mirrors the
+    # service-layer gate — parents may still act on any child's behalf.
+    if coordinator is not None and coordinator.storage.get_require_linked_child():
+        return user_id in (coordinator.storage.get_parent_user_ids() or [])
     return True

--- a/custom_components/taskmate/coord_chores.py
+++ b/custom_components/taskmate/coord_chores.py
@@ -844,13 +844,19 @@ class ChoresMixin:
             photo_url=photo_url or "",
         )
 
+        # Record the completion before awarding anything. Awarding can suspend
+        # (a level-up or streak milestone sends a notification), and the
+        # daily-limit check above counts stored completions — so with the write
+        # last, two calls that arrive together could both pass the check and
+        # both be paid. Writing the marker first closes that window.
+        self.storage.add_completion(completion)
+
         if auto_approve:
             total_awarded = await self._award_points(child, effective_points, chore_id=chore_id)
             completion.approved = True
             completion.approved_at = dt_util.now()
             completion.points_awarded = total_awarded
-
-        self.storage.add_completion(completion)
+            self.storage.update_completion(completion)
 
         self.hass.bus.async_fire(
             "taskmate_chore_completed",
@@ -1022,13 +1028,17 @@ class ChoresMixin:
             bonus_subtask_id=bonus_subtask_id,
         )
 
+        # Written before the award for the same reason as the main completion
+        # path: the duplicate check above reads stored completions, and
+        # awarding can suspend.
+        self.storage.add_completion(completion)
+
         if not chore.requires_approval:
             total_awarded = await self._award_points(child, subtask.points, skip_streak=True)
             completion.approved = True
             completion.approved_at = dt_util.now()
             completion.points_awarded = total_awarded
-
-        self.storage.add_completion(completion)
+            self.storage.update_completion(completion)
         await self.storage.async_save()
 
         if chore.requires_approval:
@@ -1075,6 +1085,16 @@ class ChoresMixin:
                         pts = self._apply_time_adjustment(
                             chore, self.effective_chore_points(chore), completion.completed_at
                         )
+                    # Claim the completion before awarding. The "already
+                    # approved" check above and the award are separated by an
+                    # await that can suspend, so two approvals landing together
+                    # (a double-tap, or Approve All overlapping a single
+                    # approve) could otherwise both get through and pay twice.
+                    completion.approved = True
+                    completion.approved_at = dt_util.now()
+                    completion.points_awarded = 0
+                    self.storage.update_completion(completion)
+
                     total_awarded = await self._award_points(
                         child,
                         pts,
@@ -1082,8 +1102,6 @@ class ChoresMixin:
                         skip_streak=is_bonus,
                         chore_id=completion.chore_id,
                     )
-                    completion.approved = True
-                    completion.approved_at = dt_util.now()
                     completion.points_awarded = total_awarded
                     self.storage.update_completion(completion)
 

--- a/custom_components/taskmate/coord_chores.py
+++ b/custom_components/taskmate/coord_chores.py
@@ -1290,6 +1290,11 @@ class ChoresMixin:
                 self.storage.remove_completion(bc.id)
 
         self.storage.remove_completion(completion_id)
+        if target_completion and target_completion.approved and not target_completion.bonus_subtask_id:
+            # Same as undo: a rejected completion must not leave the quest
+            # chain standing on the step it unlocked.
+            if hasattr(self, "_async_rewind_quests"):
+                await self._async_rewind_quests(target_completion.child_id, target_completion.chore_id)
         # The completion record is gone, so its evidence photo is now orphaned —
         # delete it (best-effort; foreign/blank URLs are ignored).
         if target_completion and getattr(target_completion, "photo_url", ""):
@@ -1354,6 +1359,12 @@ class ChoresMixin:
         target.approved_at = None
         target.points_awarded = 0
         self.storage.update_completion(target)
+
+        # Quest progress advanced on approval, so it has to come back too —
+        # otherwise re-approving the same completion advances the chain a
+        # second time and pays a repeatable quest's bonus twice.
+        if not target.bonus_subtask_id and hasattr(self, "_async_rewind_quests"):
+            await self._async_rewind_quests(target.child_id, target.chore_id)
 
         await self.storage.async_save()
         await self.async_refresh()

--- a/custom_components/taskmate/coord_chores.py
+++ b/custom_components/taskmate/coord_chores.py
@@ -1299,6 +1299,15 @@ class ChoresMixin:
             if getattr(self, "notifications", None):
                 await self.notifications.clear_approval("pending_chore_approval", completion_id)
 
+            # A rejected submission no longer counts as "done", so a mandatory
+            # chore whose period has already closed may now owe a miss that
+            # end-of-period detection skipped.
+            await self.async_recheck_mandatory_miss(
+                target_completion.chore_id,
+                target_completion.child_id,
+                dt_util.as_local(target_completion.completed_at).date(),
+            )
+
     async def async_undo_chore_approval(self, completion_id: str) -> None:
         """Undo an accidental approval: reverse the awards and return the
         completion to *pending* so it re-enters the approval queue.

--- a/custom_components/taskmate/coord_chores.py
+++ b/custom_components/taskmate/coord_chores.py
@@ -751,17 +751,16 @@ class ChoresMixin:
                 )
                 return None
 
-        # specific_days chores were historically only filtered by the child card
-        # (see get_due_chores_for_child), so a crafted service / entity / Dev
-        # Tools call could complete one that is disabled, not scheduled today, or
+        # Chores were historically only filtered by the child card (see
+        # get_due_chores_for_child), so a crafted service / entity / Dev Tools
+        # call could complete one that is disabled, not scheduled today, or
         # assigned to a different child. Enforce the same eligibility the card
-        # uses, server-side. Parents completing on behalf are the authority and
-        # stay exempt.
-        if (
-            not as_parent
-            and getattr(chore, "schedule_mode", "specific_days") == "specific_days"
-            and not self._is_chore_completable_by_child(chore, child_id)
-        ):
+        # uses, server-side, for EVERY schedule mode — the `assigned_to`
+        # membership test lives in _is_chore_completable_by_child, so gating
+        # this on specific_days left recurring/one_shot chores unchecked.
+        # Parents completing on behalf are the authority and stay exempt (the
+        # recurrence/one-shot window below still applies to them).
+        if not as_parent and not self._is_chore_completable_by_child(chore, child_id):
             _LOGGER.debug(
                 "complete_chore no-op: '%s' not eligible for %s today (assignment/schedule/availability)",
                 chore.name,
@@ -979,6 +978,14 @@ class ChoresMixin:
 
         now = dt_util.now()
         today = dt_util.as_local(now).date()
+
+        # A bonus sub-task belongs to its parent chore's assignment. Availability
+        # is deliberately NOT re-checked here — the parent chore being done today
+        # is what makes the bonus available, and for one_shot/recurring chores
+        # that same completion closes the availability window.
+        assigned = getattr(chore, "assigned_to", []) or []
+        if assigned and child_id not in assigned:
+            raise ValueError(f"Bonus sub-task '{subtask.name}' is not assigned to {child.name}.")
 
         # Gate check: parent chore must be completed today
         all_completions = self.storage.get_completions()

--- a/custom_components/taskmate/coord_mandatory.py
+++ b/custom_components/taskmate/coord_mandatory.py
@@ -63,6 +63,44 @@ class MandatoryMixin:
                 return True
         return False
 
+    def _period_has_ended(self, period_id: str, day: date, now: datetime | None = None) -> bool:
+        """True once ``period_id`` on ``day`` is over and a miss could be owed."""
+        now = now or dt_util.now()
+        today = dt_util.as_local(now).date()
+        if day < today:
+            return True
+        if day > today:
+            return False
+        for p in self.get_time_periods():
+            if p.get("id") != period_id:
+                continue
+            try:
+                eh, em = [int(x) for x in p["end"].split(":")]
+            except (ValueError, KeyError, TypeError):
+                return False
+            return dt_util.as_local(now).time() >= dt_time(eh, em)
+        # "anytime" and unknown periods only close at midnight, which the
+        # midnight sweep already handles.
+        return False
+
+    async def async_recheck_mandatory_miss(self, chore_id: str, child_id: str, day: date) -> int:
+        """Re-run miss detection after a completion stops counting.
+
+        Detection accepts a *pending* completion as "done" on purpose — a child
+        who did the chore shouldn't be penalised because a parent hasn't got to
+        the approval yet. The gap is that detection only ran once, at the end of
+        the period: submitting just before the deadline and having it rejected
+        afterwards left no miss behind. Rejection re-opens the question, so ask
+        it again (detection is idempotent and dedupes existing misses).
+        """
+        chore = self.get_chore(chore_id)
+        if not chore or not getattr(chore, "mandatory", False):
+            return 0
+        period_id = self._effective_period_for(chore, child_id, day)
+        if not self._period_has_ended(period_id, day):
+            return 0
+        return await self.async_detect_mandatory_misses(period_id, day)
+
     async def async_detect_mandatory_misses(self, period_id: str, day: date) -> int:
         """Create misses for due+incomplete mandatory chores in `period_id`."""
         existing = {(m.chore_id, m.child_id, m.due_date) for m in self.storage.get_mandatory_misses()}

--- a/custom_components/taskmate/coord_quests.py
+++ b/custom_components/taskmate/coord_quests.py
@@ -122,6 +122,70 @@ class QuestsMixin:
             await self.storage.async_save()
             await self.async_refresh()
 
+    async def _async_rewind_quests(self, child_id: str, chore_id: str) -> None:
+        """Undo a quest step that a now-reversed completion had advanced.
+
+        Progress used to be one-way: rejecting or un-approving a completion left
+        the quest sitting on the step it unlocked, so re-approving the same
+        completion advanced it again — and on a repeatable quest that meant
+        paying the completion bonus a second time for one piece of work.
+        """
+        child = self.get_child(child_id)
+        if not child:
+            return
+        changed = False
+        for quest in self.storage.get_quests():
+            if not quest.active or not quest.steps:
+                continue
+            if not self._quest_applies_to(quest, child_id):
+                continue
+            prog = dict(self.storage.get_quest_child_progress(quest.id, child_id))
+            step = int(prog.get("step", 0))
+            completed = int(prog.get("completed_count", 0))
+            was_finished = False
+
+            if step > 0 and quest.steps[step - 1] == chore_id:
+                # Ordinary mid-quest step, or the final step of a one-shot
+                # quest (whose step stays at len(steps) once finished).
+                was_finished = step >= len(quest.steps)
+                prog["step"] = step - 1
+            elif step == 0 and completed > 0 and quest.steps[-1] == chore_id:
+                # A repeatable quest wrapped back to the start on this very
+                # completion: step back into its final step.
+                was_finished = True
+                prog["step"] = len(quest.steps) - 1
+            else:
+                continue
+
+            if was_finished:
+                prog["completed_count"] = max(0, completed - 1)
+                self._refund_quest_bonus(quest, child)
+
+            self.storage.set_quest_child_progress(quest.id, child_id, prog)
+            changed = True
+
+        if changed:
+            self.storage.update_child(child)
+            await self.storage.async_save()
+            await self.async_refresh()
+
+    def _refund_quest_bonus(self, quest: Quest, child) -> None:
+        """Take back a quest completion bonus, logging the reversal."""
+        bonus = int(quest.bonus_points or 0)
+        if bonus <= 0:
+            return
+        child.points = max(0, child.points - bonus)
+        child.total_points_earned = max(0, child.total_points_earned - bonus)
+        child.career_score = child.total_points_earned - child.total_penalties_received
+        self.storage.add_points_transaction(
+            PointsTransaction(
+                child_id=child.id,
+                points=-bonus,
+                reason=f"Quest reversed: {quest.name}",
+                created_at=dt_util.now(),
+            )
+        )
+
     async def _complete_quest(self, quest: Quest, child, prog: dict) -> None:
         """Award the quest bonus and reset/finalise progress."""
         prog["completed_count"] = int(prog.get("completed_count", 0)) + 1

--- a/custom_components/taskmate/coord_rewards.py
+++ b/custom_components/taskmate/coord_rewards.py
@@ -404,6 +404,18 @@ class RewardsMixin:
                 if not reward or not child:
                     raise ValueError(f"Reward or child not found for claim {claim_id}")
 
+                # Stock and expiry are checked when the claim is made, but a
+                # claim can sit in the queue for days and several can stack up
+                # against the same item. Re-check here or approving them in
+                # turn hands out more units than exist (the counter floors at
+                # zero, so it doesn't even show). The time lock is deliberately
+                # not re-checked: approval is the parent's call, not the
+                # child's, so an out-of-hours approval is legitimate.
+                if self._reward_is_sold_out(reward):
+                    raise ValueError(f"Reward '{reward.name}' is sold out")
+                if self._reward_is_expired(reward):
+                    raise ValueError(f"Reward '{reward.name}' has expired")
+
                 # Cost is always static
                 effective_cost = reward.cost
 

--- a/custom_components/taskmate/coord_rewards.py
+++ b/custom_components/taskmate/coord_rewards.py
@@ -16,6 +16,12 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
+# Upper bound on a single child's pending reward claims. Each claim writes a
+# permanent record and pushes a notification to every routed parent, so an
+# unbounded queue is a way to bury the approvals list and spam phones. Mirrors
+# the pending-swap-request cap.
+_MAX_PENDING_CLAIMS_PER_CHILD = 20
+
 
 def reward_is_time_locked(reward: Reward, now: datetime | None = None) -> bool:
     """True if a time-locked reward is currently outside its allowed window (#857).
@@ -272,6 +278,16 @@ class RewardsMixin:
             raise ValueError(f"Reward '{reward.name}' has expired")
         if self._reward_is_time_locked(reward):
             raise ValueError(f"Reward '{reward.name}' is not available right now")
+
+        # A pool-filled claim skips the wallet check below, and a zero-cost
+        # reward can never fail it, so without these two guards a child can
+        # queue unlimited claims — each one a stored record plus a push to
+        # every parent.
+        own_pending = [c for c in self.storage.get_pending_reward_claims() if c.child_id == child_id]
+        if any(c.reward_id == reward_id for c in own_pending):
+            raise ValueError(f"A claim for '{reward.name}' is already waiting for approval")
+        if len(own_pending) >= _MAX_PENDING_CLAIMS_PER_CHILD:
+            raise ValueError("Too many reward claims are already waiting for approval")
 
         # Cost is always static
         effective_cost = reward.cost

--- a/custom_components/taskmate/coord_rewards.py
+++ b/custom_components/taskmate/coord_rewards.py
@@ -148,6 +148,18 @@ class RewardsMixin:
     # Module-level so sensor.py can reuse the same rule when building state.
     _reward_is_time_locked = staticmethod(reward_is_time_locked)
 
+    @staticmethod
+    def _reward_is_for_child(reward: Reward, child_id: str) -> bool:
+        """True if ``child_id`` is allowed this reward.
+
+        An empty ``assigned_to`` means "everyone", matching how the cards build
+        their reward list. The cards filter on this, so the coordinator has to
+        as well — otherwise a direct service call can claim or save towards a
+        reward meant for a sibling.
+        """
+        assigned = reward.assigned_to if isinstance(reward.assigned_to, list) else []
+        return not assigned or child_id in assigned
+
     @classmethod
     def _reward_is_unavailable(cls, reward: Reward) -> bool:
         """True if the reward is permanently out of reach — sold out or expired.
@@ -252,6 +264,8 @@ class RewardsMixin:
         if not child:
             raise ValueError(f"Child {child_id} not found")
 
+        if not self._reward_is_for_child(reward, child_id):
+            raise ValueError(f"Reward '{reward.name}' is not available to {child.name}")
         if self._reward_is_sold_out(reward):
             raise ValueError(f"Reward '{reward.name}' is sold out")
         if self._reward_is_expired(reward):
@@ -494,6 +508,8 @@ class RewardsMixin:
         if not reward:
             raise ValueError(f"Reward {reward_id} not found")
 
+        if not self._reward_is_for_child(reward, child_id):
+            raise ValueError(f"Reward '{reward.name}' is not available to {child.name}")
         if self._reward_is_sold_out(reward):
             raise ValueError(f"Reward '{reward.name}' is sold out")
         if self._reward_is_expired(reward):

--- a/custom_components/taskmate/coord_sounds.py
+++ b/custom_components/taskmate/coord_sounds.py
@@ -39,6 +39,13 @@ class SoundsMixin:
                 "value": f"{CUSTOM_PREFIX}{s.file}",
                 "file": s.file,
                 "name": s.name,
+                # Signed here rather than per-viewer (as evidence photos are):
+                # playback is synchronous at the moment a chore is ticked off,
+                # and a sound that arrives late or not at all is a worse bug
+                # than the exposure. The trade-off is that this signed URL sits
+                # in a world-readable attribute for its lifetime — acceptable
+                # only because the asset is a sound effect, with nothing
+                # personal in it. Do NOT copy this to anything sensitive.
                 "url": sign_sound_url(self.hass, sound_url_for_name(s.file)),
             }
             for s in self.storage.get_custom_sounds()

--- a/custom_components/taskmate/coord_templates.py
+++ b/custom_components/taskmate/coord_templates.py
@@ -13,6 +13,31 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
+# Numeric template-chore fields, with the default used when a pack supplies
+# something that isn't a usable number.
+_NUMERIC_TEMPLATE_FIELDS = {
+    "points": 10,
+    "daily_limit": 1,
+    "timed_rate_points": 10,
+    "timed_rate_minutes": 15,
+    "timed_max_daily_minutes": 0,
+}
+# These are "unset" when None, so they can't take a numeric default.
+_OPTIONAL_NUMERIC_TEMPLATE_FIELDS = ("weather_temp_min", "weather_temp_max", "weather_wind_max")
+
+
+def _pack_number(value, default):
+    """Coerce a pack-supplied value to a finite number, else ``default``."""
+    if isinstance(value, bool) or isinstance(value, (dict, list)):
+        return default
+    try:
+        num = float(value)
+    except (TypeError, ValueError):
+        return default
+    if num != num or num in (float("inf"), float("-inf")):
+        return default
+    return int(num) if float(num).is_integer() else num
+
 
 class TemplatesMixin:
     """Mixin providing template CRUD and application logic."""
@@ -224,6 +249,18 @@ class TemplatesMixin:
                 # Whitelist: unknown keys are dropped, never carried through.
                 cleaned = {k: v for k, v in raw.items() if k in TEMPLATE_CHORE_FIELDS}
                 cleaned["name"] = chore_name[:200]
+                # The whitelist controls which keys survive, not what they hold.
+                # A shared pack is arbitrary JSON, so a field the rest of the app
+                # treats as a number has to actually be one — otherwise it lands
+                # in a Chore and every later read of it (points arithmetic, the
+                # panel's number inputs, the sensor attribute build) inherits a
+                # string, inf or NaN.
+                for key, default in _NUMERIC_TEMPLATE_FIELDS.items():
+                    if key in cleaned:
+                        cleaned[key] = _pack_number(cleaned[key], default)
+                for key in _OPTIONAL_NUMERIC_TEMPLATE_FIELDS:
+                    if cleaned.get(key) is not None:
+                        cleaned[key] = _pack_number(cleaned[key], None)
                 chores.append(cleaned)
 
             clean.append(

--- a/custom_components/taskmate/coord_tts.py
+++ b/custom_components/taskmate/coord_tts.py
@@ -94,6 +94,7 @@ class ReadAloudMixin:
         media_player: str = "",
         tts_entity: str = "",
         message: str = "",
+        context: Any = None,
     ) -> str:
         """Speak a child's outstanding chores. Returns what was said."""
         target = media_player or self._tts_setting("read_aloud_media_player", "")
@@ -109,6 +110,9 @@ class ReadAloudMixin:
         # blocking=True so a bad media player or a broken TTS reaches the
         # caller. This is a service a parent invokes deliberately; "it silently
         # did nothing" is the worst possible answer.
+        # Forward the caller's context so Home Assistant applies that user's
+        # entity permissions to the speaker, instead of the call arriving
+        # unattributed and bypassing them.
         await self.hass.services.async_call(
             "tts",
             "speak",
@@ -118,6 +122,7 @@ class ReadAloudMixin:
                 "message": text,
             },
             blocking=True,
+            context=context,
         )
         _LOGGER.info("Read aloud to %s via %s: %s", target, speaker, text)
 

--- a/custom_components/taskmate/http_images.py
+++ b/custom_components/taskmate/http_images.py
@@ -48,8 +48,14 @@ class TaskMateImageUploadView(HomeAssistantView):
         except (ValueError, AssertionError):
             return self.json_message("Expected multipart form", HTTPStatus.BAD_REQUEST)
 
+        # Bound the scan so a stream of endlessly-named non-"file" parts can't
+        # hold the handler open indefinitely (mirrors the photo upload).
         field = await reader.next()
+        parts_scanned = 0
         while field is not None and field.name != "file":
+            parts_scanned += 1
+            if parts_scanned > 16:
+                return self.json_message("Too many form parts", HTTPStatus.BAD_REQUEST)
             field = await reader.next()
         if field is None:
             return self.json_message("No file provided", HTTPStatus.BAD_REQUEST)
@@ -117,7 +123,14 @@ class TaskMateImageServeView(HomeAssistantView):
         return web.Response(
             body=data,
             content_type=images.content_type_for(filename),
-            headers={"Cache-Control": "private, max-age=31536000"},
+            headers={
+                "Cache-Control": "private, max-age=31536000",
+                # Same as the photo view: these files are user-supplied, so
+                # don't let a browser content-sniff them into something
+                # executable on the Home Assistant origin.
+                "X-Content-Type-Options": "nosniff",
+                "Content-Disposition": "inline",
+            },
         )
 
 

--- a/custom_components/taskmate/http_photos.py
+++ b/custom_components/taskmate/http_photos.py
@@ -11,6 +11,7 @@ the thin aiohttp wrapper, verified on the dev HA instance.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import uuid
 from http import HTTPStatus
@@ -71,13 +72,40 @@ class TaskMatePhotoUploadView(HomeAssistantView):
     url = photos.URL_PREFIX
     name = "api:taskmate:photo:upload"
 
+    # Unlike the image/sound uploads this one is deliberately open to any
+    # authenticated user — a child has to be able to post their own evidence.
+    # That makes it the one upload path a non-admin can drive, so it carries
+    # its own limits: a per-user rate cap, and a bound on how many bodies are
+    # buffered at once (each one can be MAX_UPLOAD_BYTES).
+    MAX_UPLOADS_PER_WINDOW = 20
+    RATE_WINDOW_SECONDS = 60
+    MAX_CONCURRENT_UPLOADS = 4
+
     def __init__(self, hass: HomeAssistant) -> None:
         self.hass = hass
+        self._limiter = photos.UploadRateLimiter(self.MAX_UPLOADS_PER_WINDOW, self.RATE_WINDOW_SECONDS)
+        self._slots = asyncio.Semaphore(self.MAX_CONCURRENT_UPLOADS)
 
     async def post(self, request: web.Request) -> web.Response:
+        user = request.get("hass_user")
+        user_id = getattr(user, "id", "") or "anonymous"
+        if self._limiter.check(user_id):
+            _LOGGER.warning("Rejecting photo upload from %s: rate limit exceeded", user_id)
+            return self.json_message("Too many uploads, try again shortly", HTTPStatus.TOO_MANY_REQUESTS)
+
+        async with self._slots:
+            return await self._handle_upload(request)
+
+    async def _handle_upload(self, request: web.Request) -> web.Response:
         # Cheap pre-check on the declared length before reading the body.
         if request.content_length and request.content_length > photos.MAX_UPLOAD_BYTES:
             return self.json_message("File too large", HTTPStatus.REQUEST_ENTITY_TOO_LARGE)
+
+        # Check the disk budget before accepting a body, not only after: there
+        # is no point buffering megabytes we are about to refuse.
+        used = await self.hass.async_add_executor_job(photos.total_photos_bytes, self.hass)
+        if used >= photos.MAX_TOTAL_BYTES:
+            return self.json_message("Photo storage full", HTTPStatus.INSUFFICIENT_STORAGE)
 
         try:
             reader = await request.multipart()
@@ -110,7 +138,8 @@ class TaskMatePhotoUploadView(HomeAssistantView):
         if ext is None:
             return self.json_message("Not a valid image", HTTPStatus.BAD_REQUEST)
 
-        # DoS guard: reject if the photo store is already at its disk budget.
+        # Re-check with the real size now the body is in hand (the pre-check
+        # above only knows the budget was not already full).
         used = await self.hass.async_add_executor_job(photos.total_photos_bytes, self.hass)
         if used + len(data) > photos.MAX_TOTAL_BYTES:
             return self.json_message("Photo storage full", HTTPStatus.INSUFFICIENT_STORAGE)

--- a/custom_components/taskmate/http_sounds.py
+++ b/custom_components/taskmate/http_sounds.py
@@ -48,8 +48,14 @@ class TaskMateSoundUploadView(HomeAssistantView):
         except (ValueError, AssertionError):
             return self.json_message("Expected multipart form", HTTPStatus.BAD_REQUEST)
 
+        # Bound the scan so a stream of endlessly-named non-"file" parts can't
+        # hold the handler open indefinitely (mirrors the photo upload).
         field = await reader.next()
+        parts_scanned = 0
         while field is not None and field.name != "file":
+            parts_scanned += 1
+            if parts_scanned > 16:
+                return self.json_message("Too many form parts", HTTPStatus.BAD_REQUEST)
             field = await reader.next()
         if field is None:
             return self.json_message("No file provided", HTTPStatus.BAD_REQUEST)
@@ -117,7 +123,14 @@ class TaskMateSoundServeView(HomeAssistantView):
         return web.Response(
             body=data,
             content_type=sounds.content_type_for(filename),
-            headers={"Cache-Control": "private, max-age=31536000"},
+            headers={
+                "Cache-Control": "private, max-age=31536000",
+                # Same as the photo view: these files are user-supplied, so
+                # don't let a browser content-sniff them into something
+                # executable on the Home Assistant origin.
+                "X-Content-Type-Options": "nosniff",
+                "Content-Disposition": "inline",
+            },
         )
 
 

--- a/custom_components/taskmate/photos.py
+++ b/custom_components/taskmate/photos.py
@@ -45,6 +45,40 @@ CONTENT_TYPES = {
 }
 
 
+class UploadRateLimiter:
+    """Sliding-window upload cap, keyed by HA user id.
+
+    The evidence-photo upload is the one upload path open to any authenticated
+    user (a child has to be able to post their own proof), so it needs a brake
+    that the admin-only uploads don't. Kept here, free of aiohttp, so it can be
+    unit-tested directly.
+    """
+
+    def __init__(self, max_per_window: int = 20, window_seconds: float = 60.0) -> None:
+        self.max_per_window = max_per_window
+        self.window_seconds = window_seconds
+        self._seen: dict[str, list[float]] = {}
+
+    def check(self, user_id: str, now: float | None = None) -> bool:
+        """Record an attempt. True when the caller is over its cap."""
+        now = time.monotonic() if now is None else now
+        cutoff = now - self.window_seconds
+        for uid in [u for u, stamps in list(self._seen.items()) if not any(t > cutoff for t in stamps)]:
+            self._seen.pop(uid, None)
+        stamps = [t for t in self._seen.get(user_id, []) if t > cutoff]
+        if len(stamps) >= self.max_per_window:
+            self._seen[user_id] = stamps
+            return True
+        stamps.append(now)
+        self._seen[user_id] = stamps
+        return False
+
+    @property
+    def tracked_users(self) -> int:
+        """How many users currently hold state (for leak checks)."""
+        return len(self._seen)
+
+
 def detect_image_ext(data: bytes) -> str | None:
     """Return a file extension for known image magic bytes, else None.
 

--- a/custom_components/taskmate/sensor.py
+++ b/custom_components/taskmate/sensor.py
@@ -310,6 +310,12 @@ def _build_chores_list(coordinator: TaskMateCoordinator, common: dict) -> list[d
         # `icon` above, to keep records under the 16KB recorder limit.
         image_url = getattr(c, "image_url", "")
         if image_url:
+            # Same trade-off as custom sounds, and unlike evidence photos
+            # (which deliberately emit a bare path for the card to sign per
+            # viewer): a chore picture is decorative and renders on first
+            # paint, so signing it here keeps that render synchronous. It does
+            # mean the signed URL is readable in this attribute — fine for a
+            # chore picture, not fine for anything personal.
             record["image_url"] = images.sign_image_url(common["hass"], image_url)
         completion_sound = getattr(c, "completion_sound", "coin")
         if completion_sound and completion_sound != "coin":

--- a/custom_components/taskmate/sensor.py
+++ b/custom_components/taskmate/sensor.py
@@ -863,7 +863,15 @@ class TaskMateOverallStatsSensor(_CachedAttrsSensor):
             "points_icon": data.get("points_icon", "mdi:star"),
             # Global default card-design style; cards read this when no per-card override (#design).
             "card_design": settings.get("card_design", "classic"),
-            # Non-admin parent role (#661): cards unlock parent controls for these HA users.
+            # Non-admin parent role (#661): cards unlock parent controls for
+            # these HA users. Deliberately still published in the clear, and
+            # deliberately never trusted: every privileged path re-resolves the
+            # role server-side (`_async_require_parent` / `authz`), so this list
+            # only decides which buttons a card draws. Any authenticated user
+            # can read it, which tells them which accounts hold the role — worth
+            # knowing, but it grants nothing, and the alternatives (digests, or
+            # a per-connection lookup) make the check asynchronous and race the
+            # first paint in every card that gates controls on it.
             "parent_user_ids": self.coordinator.storage.get_parent_user_ids(),
             "children": _build_children_summary(self.coordinator, common),
             "time_boundaries": time_boundaries,

--- a/custom_components/taskmate/sounds.py
+++ b/custom_components/taskmate/sounds.py
@@ -93,9 +93,18 @@ def detect_allowed_ext(data: bytes) -> str | None:
     """
     if data[:3] == b"ID3":
         return "mp3"
-    # Bare MPEG audio with no ID3 tag: an 11-bit frame sync (0xFFE).
-    if len(data) >= 2 and data[0] == 0xFF and (data[1] & 0xE0) == 0xE0:
-        return "mp3"
+    # Bare MPEG audio with no ID3 tag. The 11-bit frame sync (0xFFE) alone is
+    # far too weak a test: 0xFF 0xFE is also a UTF-16LE byte-order mark, so any
+    # UTF-16 text file passed as audio and was then stored and served back from
+    # this origin as audio/mpeg. Validate the whole 4-byte frame header, whose
+    # reserved values a BOM does not satisfy.
+    if len(data) >= 4 and data[0] == 0xFF and (data[1] & 0xE0) == 0xE0:
+        version = (data[1] >> 3) & 0x03  # 01 is reserved
+        layer = (data[1] >> 1) & 0x03  # 00 is reserved
+        bitrate = (data[2] >> 4) & 0x0F  # 0000 is "free", 1111 is bad
+        sample_rate = (data[2] >> 2) & 0x03  # 11 is reserved
+        if version != 0x01 and layer != 0x00 and bitrate not in (0x00, 0x0F) and sample_rate != 0x03:
+            return "mp3"
     if data[:4] == b"OggS":
         return "ogg"
     if data[:4] == b"RIFF" and data[8:12] == b"WAVE":

--- a/custom_components/taskmate/storage.py
+++ b/custom_components/taskmate/storage.py
@@ -1033,15 +1033,30 @@ class TaskMateStorage:
         return list(reversed(self._data.get("audit_log", [])))
 
     def add_audit_entry(self, entry: dict) -> None:
-        """Append an admin audit entry, capping the log at 500 (oldest dropped)."""
+        """Append an audit entry, capping the log at 500 (oldest dropped).
+
+        Truncation is counted, not silent: without a marker, generating 500
+        routine entries quietly pushes an earlier one out of the log and the
+        reader has no way to tell that anything is missing.
+        """
         log = self._data.setdefault("audit_log", [])
         log.append(entry)
         if len(log) > 500:
+            dropped = len(log) - 500
             del log[:-500]
+            self._data["audit_log_dropped"] = int(self._data.get("audit_log_dropped", 0) or 0) + dropped
+
+    def get_audit_dropped_count(self) -> int:
+        """How many audit entries have aged out of the capped log."""
+        try:
+            return int(self._data.get("audit_log_dropped", 0) or 0)
+        except (TypeError, ValueError):
+            return 0
 
     def clear_audit_log(self) -> None:
         """Remove all audit entries."""
         self._data["audit_log"] = []
+        self._data["audit_log_dropped"] = 0
 
     # ── Chore swap requests ──────────────────────────────────────────────
     def get_swap_requests(self) -> list[dict]:

--- a/custom_components/taskmate/storage.py
+++ b/custom_components/taskmate/storage.py
@@ -821,6 +821,17 @@ class TaskMateStorage:
             return []
         return [x for x in raw if isinstance(x, str) and x]
 
+    def get_require_linked_child(self) -> bool:
+        """True when acting *as* a child requires that child to be linked.
+
+        Off by default: the shared-tablet/kiosk setup (nobody linked, one
+        household account drives every child) is the common deployment and
+        must keep working on upgrade. Households where each child has their
+        own Home Assistant login can switch this on to stop one child acting
+        through another's profile.
+        """
+        return bool((self._data.get("settings", {}) or {}).get("require_linked_child", False))
+
     def set_parent_user_ids(self, ids: list[str]) -> None:
         """Replace the parent role list (deduped, order-preserving, strings only)."""
         seen: list[str] = []

--- a/custom_components/taskmate/storage.py
+++ b/custom_components/taskmate/storage.py
@@ -1388,6 +1388,34 @@ class TaskMateStorage:
                 )
                 chore["image_url"] = ""
 
+        # Custom sounds: `file` is concatenated into a path and handed to HA's
+        # URL signer, and `name` is rendered in the panel and the chore
+        # dropdown. Neither goes through the upload validation on an import.
+        from .sounds import FILENAME_RE as _SOUND_FILENAME_RE
+        from .sounds import clean_sound_name
+
+        sounds = self._data.get("custom_sounds")
+        if isinstance(sounds, list):
+            kept = []
+            for snd in sounds:
+                if not isinstance(snd, dict):
+                    continue
+                if not _SOUND_FILENAME_RE.match(str(snd.get("file", "") or "")):
+                    _LOGGER.warning("Import: dropped custom sound with an invalid file name")
+                    continue
+                snd["name"] = clean_sound_name(snd.get("name"))
+                kept.append(snd)
+            self._data["custom_sounds"] = kept
+
+        # A chore's completion_sound is an enum or a reference to one of those
+        # sounds; anything else would be rendered into the panel as-is.
+        from .const import is_valid_completion_sound
+
+        for chore in self._data.get("chores", []) or []:
+            if isinstance(chore, dict) and "completion_sound" in chore:
+                if not is_valid_completion_sound(str(chore.get("completion_sound") or "")):
+                    chore["completion_sound"] = "coin"
+
         for grp in self._data.get("task_groups", []):
             if isinstance(grp, dict) and grp.get("policy") not in TASK_GROUP_POLICIES:
                 grp["policy"] = "sticky"

--- a/custom_components/taskmate/storage.py
+++ b/custom_components/taskmate/storage.py
@@ -56,6 +56,7 @@ def _finite_number(value: Any, default: int | float) -> int | float:
         return default
     return int(num) if float(num).is_integer() else num
 
+
 STORAGE_VERSION = 1
 STORAGE_KEY = f"{DOMAIN}.storage"
 
@@ -1284,11 +1285,26 @@ class TaskMateStorage:
         _NUMERIC_RECORD_FIELDS = {
             # NB: streak_milestones_achieved is a list[int], not a scalar — it
             # must not be coerced here.
-            "children": ("points", "total_points_earned", "total_chores_completed", "current_streak",
-                         "best_streak", "career_score", "total_penalties_received"),
-            "chores": ("points", "claim_allowance_minutes", "daily_limit", "mandatory_penalty_points",
-                       "speed_bonus_points", "skip_count", "timed_rate_points", "timed_rate_minutes",
-                       "timed_max_daily_minutes"),
+            "children": (
+                "points",
+                "total_points_earned",
+                "total_chores_completed",
+                "current_streak",
+                "best_streak",
+                "career_score",
+                "total_penalties_received",
+            ),
+            "chores": (
+                "points",
+                "claim_allowance_minutes",
+                "daily_limit",
+                "mandatory_penalty_points",
+                "speed_bonus_points",
+                "skip_count",
+                "timed_rate_points",
+                "timed_rate_minutes",
+                "timed_max_daily_minutes",
+            ),
             "rewards": ("cost", "restock_amount", "unlock_minutes"),
             "penalties": ("points",),
             "bonuses": ("points",),
@@ -1439,9 +1455,15 @@ class TaskMateStorage:
                 if key not in settings:
                     continue
                 val = settings[key]
-                if isinstance(val, bool) or not isinstance(val, (int, float)) or val != val or val in (
-                    float("inf"),
-                    float("-inf"),
+                if (
+                    isinstance(val, bool)
+                    or not isinstance(val, (int, float))
+                    or val != val
+                    or val
+                    in (
+                        float("inf"),
+                        float("-inf"),
+                    )
                 ):
                     # inf/NaN parse happily via float() but blow up later in
                     # arithmetic (e.g. a multiplier), so drop them to the default.

--- a/custom_components/taskmate/storage.py
+++ b/custom_components/taskmate/storage.py
@@ -33,9 +33,28 @@ from .models import (
     ScheduledChange,
     TaskGroup,
     TimedSession,
+    parse_datetime,
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _finite_number(value: Any, default: int | float) -> int | float:
+    """Coerce an imported value to a real, finite number.
+
+    Returns ``default`` for anything that isn't usable — a string that doesn't
+    parse, a bool, a dict, or inf/NaN. Booleans are excluded deliberately:
+    ``float(True)`` is 1.0, which would silently turn a flag into a score.
+    """
+    if isinstance(value, bool) or isinstance(value, (dict, list)):
+        return default
+    try:
+        num = float(value)
+    except (TypeError, ValueError):
+        return default
+    if num != num or num in (float("inf"), float("-inf")):
+        return default
+    return int(num) if float(num).is_integer() else num
 
 STORAGE_VERSION = 1
 STORAGE_KEY = f"{DOMAIN}.storage"
@@ -1243,6 +1262,33 @@ class TaskMateStorage:
 
         _STREAK_MODES = ("reset", "pause")
         _CARD_DESIGNS = ("classic", "playroom", "console", "cleanpro", "accessible")
+        # Per-record numeric fields. The WebSocket schemas coerce these on every
+        # normal write; import bypasses the schemas entirely, so a crafted
+        # backup could leave a string (or inf/NaN) where the rest of the code —
+        # and the panel's number inputs — expect a number.
+        _NUMERIC_RECORD_FIELDS = {
+            # NB: streak_milestones_achieved is a list[int], not a scalar — it
+            # must not be coerced here.
+            "children": ("points", "total_points_earned", "total_chores_completed", "current_streak",
+                         "best_streak", "career_score", "total_penalties_received"),
+            "chores": ("points", "claim_allowance_minutes", "daily_limit", "mandatory_penalty_points",
+                       "speed_bonus_points", "skip_count", "timed_rate_points", "timed_rate_minutes",
+                       "timed_max_daily_minutes"),
+            "rewards": ("cost", "restock_amount", "unlock_minutes"),
+            "penalties": ("points",),
+            "bonuses": ("points",),
+            "completions": ("points_awarded", "timed_duration_seconds"),
+            "points_transactions": ("points",),
+            "mandatory_misses": ("penalty_points", "postpone_count", "escalation_stage"),
+            "pool_allocations": ("allocated_points",),
+        }
+        _DATETIME_RECORD_FIELDS = {
+            "completions": ("completed_at", "approved_at"),
+            "reward_claims": ("claimed_at", "approved_at"),
+            "points_transactions": ("created_at",),
+            "mandatory_misses": ("created_at",),
+            "allowance_payouts": ("created_at",),
+        }
         _NUMERIC_SETTINGS = (
             "history_days",
             "weekend_multiplier",
@@ -1261,6 +1307,45 @@ class TaskMateStorage:
             "interest_percent",
             "perfect_week_bonus",
         )
+
+        for bucket, keys in _NUMERIC_RECORD_FIELDS.items():
+            for record in self._data.get(bucket, []) or []:
+                if not isinstance(record, dict):
+                    continue
+                for key in keys:
+                    if key in record:
+                        record[key] = _finite_number(record[key], 0)
+                for sub in record.get("bonus_subtasks", []) or []:
+                    if isinstance(sub, dict) and "points" in sub:
+                        sub["points"] = _finite_number(sub["points"], 0)
+
+        # quantity is "unlimited" when absent/None, so it can't share the loop
+        # above — but a string or NaN there breaks the sold-out comparison.
+        for reward in self._data.get("rewards", []) or []:
+            if isinstance(reward, dict) and reward.get("quantity") is not None:
+                reward["quantity"] = _finite_number(reward["quantity"], 0)
+
+        for badge in self._data.get("badges", []) or []:
+            if not isinstance(badge, dict):
+                continue
+            if "points" in badge:
+                badge["points"] = _finite_number(badge["points"], 0)
+            for crit in badge.get("criteria", []) or []:
+                if isinstance(crit, dict) and "value" in crit:
+                    crit["value"] = _finite_number(crit["value"], 0)
+
+        # A timestamp that doesn't parse is dropped: models already turn it into
+        # None on load, and the panel renders a blank as an em dash rather than
+        # echoing whatever the string happened to be.
+        for bucket, keys in _DATETIME_RECORD_FIELDS.items():
+            for record in self._data.get(bucket, []) or []:
+                if not isinstance(record, dict):
+                    continue
+                for key in keys:
+                    raw = record.get(key)
+                    if raw and parse_datetime(raw) is None:
+                        _LOGGER.warning("Import: dropped unparseable %s on a %s record", key, bucket)
+                        record[key] = ""
 
         for comp in self._data.get("completions", []):
             if not isinstance(comp, dict):
@@ -1311,11 +1396,17 @@ class TaskMateStorage:
                 if key not in settings:
                     continue
                 val = settings[key]
-                if isinstance(val, bool) or not isinstance(val, (int, float)):
-                    try:
-                        settings[key] = float(val)
-                    except (TypeError, ValueError):
+                if isinstance(val, bool) or not isinstance(val, (int, float)) or val != val or val in (
+                    float("inf"),
+                    float("-inf"),
+                ):
+                    # inf/NaN parse happily via float() but blow up later in
+                    # arithmetic (e.g. a multiplier), so drop them to the default.
+                    coerced = _finite_number(val, None)
+                    if coerced is None:
                         settings.pop(key, None)
+                    else:
+                        settings[key] = coerced
 
     def replace_completions(self, completions: list[ChoreCompletion]) -> None:
         """Replace all completions with the given list."""

--- a/custom_components/taskmate/websocket.py
+++ b/custom_components/taskmate/websocket.py
@@ -2606,7 +2606,14 @@ async def ws_cal_regen_token(hass, connection, msg, coordinator):
 @websocket_api.async_response
 @_admin_only
 async def _ws_audit_list(hass, connection, msg, coordinator):
-    connection.send_result(msg["id"], {"entries": coordinator.storage.get_audit_log()})
+    connection.send_result(
+        msg["id"],
+        {
+            "entries": coordinator.storage.get_audit_log(),
+            # Non-zero means older entries have aged out of the capped log.
+            "dropped": coordinator.storage.get_audit_dropped_count(),
+        },
+    )
 
 
 @websocket_api.websocket_command({vol.Required("type"): WS_AUDIT_CLEAR})

--- a/custom_components/taskmate/websocket.py
+++ b/custom_components/taskmate/websocket.py
@@ -1641,6 +1641,7 @@ _TOP_LEVEL_SETTINGS = {"points_name", "points_icon"}
 _ALLOWED_CARD_DESIGNS = {"classic", "playroom", "console", "cleanpro", "accessible"}
 # Settings stored under storage._data["settings"][key]
 _SUBKEY_SETTINGS = {
+    "require_linked_child",
     "history_days",
     "streak_reset_mode",
     "card_design",
@@ -1848,6 +1849,7 @@ _UPDATE_SETTINGS_SCHEMA = {
     vol.Optional("difficulty_multiplier_medium"): vol.All(vol.Coerce(float), vol.Range(min=0.0, max=10.0)),
     vol.Optional("difficulty_multiplier_hard"): vol.All(vol.Coerce(float), vol.Range(min=0.0, max=10.0)),
     vol.Optional("unlock_allowlist"): [str],
+    vol.Optional("require_linked_child"): bool,
     vol.Optional("parent_routing"): vol.In(["all", "home", "round_robin"]),
     vol.Optional("read_aloud_media_player"): str,
     vol.Optional("read_aloud_tts_entity"): str,

--- a/custom_components/taskmate/www/locales/de.json
+++ b/custom_components/taskmate/www/locales/de.json
@@ -808,6 +808,8 @@
   "panel.settings_parents_title": "Eltern (ohne Admin-Rechte)",
   "panel.settings_parents_hint": "Geben Sie einem Haushaltsmitglied ohne Admin-Rechte die tägliche Kontrolle — Aufgaben bestätigen, Punkte anpassen, Belohnungen freigeben — ohne Home-Assistant-Administratorrechte. Dieses Admin-Panel können sie weiterhin nicht öffnen und die Konfiguration nicht ändern.",
   "panel.settings_parents_empty": "Keine Home-Assistant-Benutzer ohne Admin-Rechte gefunden. Erstellen Sie zuerst einen normalen HA-Benutzer und wählen Sie ihn dann hier aus.",
+  "panel.settings_require_linked_child_label": "Verknüpftes Konto pro Kind verlangen",
+  "panel.settings_require_linked_child_hint": "Nur das eigene Home-Assistant-Konto eines Kindes darf für dieses Kind handeln. Für ein gemeinsames Familien-Tablet, auf dem ein Konto für alle genutzt wird, ausgeschaltet lassen. Eltern und Admins können immer für jedes Kind handeln.",
   "panel.settings_evening_hint": "Standard 17:00 – 21:00",
   "panel.settings_evening_label": "Abend",
   "panel.settings_history_title": "Verlauf & Serien",

--- a/custom_components/taskmate/www/locales/en-GB.json
+++ b/custom_components/taskmate/www/locales/en-GB.json
@@ -846,6 +846,8 @@
   "panel.settings_parents_title": "Parents (no admin rights)",
   "panel.settings_parents_hint": "Give a non-admin household member day-to-day control — approve chores, adjust points, confirm rewards — without Home Assistant admin rights. They still can't open this admin panel or change configuration.",
   "panel.settings_parents_empty": "No non-admin Home Assistant users found. Create a standard HA user first, then tick them here.",
+  "panel.settings_require_linked_child_label": "Require a linked account per child",
+  "panel.settings_require_linked_child_hint": "Only let a child's own Home Assistant account act as that child. Leave off for a shared family tablet where one account is used for everyone. Parents and admins can always act for any child.",
   "panel.settings_evening_hint": "Default 17:00 – 21:00",
   "panel.settings_evening_label": "Evening",
   "panel.settings_history_title": "History & streaks",

--- a/custom_components/taskmate/www/locales/en.json
+++ b/custom_components/taskmate/www/locales/en.json
@@ -846,6 +846,8 @@
   "panel.settings_parents_title": "Parents (no admin rights)",
   "panel.settings_parents_hint": "Give a non-admin household member day-to-day control — approve chores, adjust points, confirm rewards — without Home Assistant admin rights. They still can't open this admin panel or change configuration.",
   "panel.settings_parents_empty": "No non-admin Home Assistant users found. Create a standard HA user first, then tick them here.",
+  "panel.settings_require_linked_child_label": "Require a linked account per child",
+  "panel.settings_require_linked_child_hint": "Only let a child's own Home Assistant account act as that child. Leave off for a shared family tablet where one account is used for everyone. Parents and admins can always act for any child.",
   "panel.settings_evening_hint": "Default 17:00 – 21:00",
   "panel.settings_evening_label": "Evening",
   "panel.settings_history_title": "History & streaks",

--- a/custom_components/taskmate/www/locales/fr.json
+++ b/custom_components/taskmate/www/locales/fr.json
@@ -808,6 +808,8 @@
   "panel.settings_parents_title": "Parents (sans droits admin)",
   "panel.settings_parents_hint": "Donnez à un membre du foyer non-administrateur le contrôle quotidien — valider les tâches, ajuster les points, confirmer les récompenses — sans droits d’administrateur Home Assistant. Il ne pourra toujours pas ouvrir ce panneau d’administration ni modifier la configuration.",
   "panel.settings_parents_empty": "Aucun utilisateur Home Assistant non-administrateur trouvé. Créez d’abord un utilisateur HA standard, puis cochez-le ici.",
+  "panel.settings_require_linked_child_label": "Exiger un compte lié par enfant",
+  "panel.settings_require_linked_child_hint": "Seul le compte Home Assistant d'un enfant peut agir en son nom. Laissez désactivé pour une tablette familiale partagée où un seul compte sert à tous. Les parents et les administrateurs peuvent toujours agir pour n'importe quel enfant.",
   "panel.settings_evening_hint": "Par défaut 17:00 – 21:00",
   "panel.settings_evening_label": "Soir",
   "panel.settings_history_title": "Historique et séries",

--- a/custom_components/taskmate/www/locales/nb.json
+++ b/custom_components/taskmate/www/locales/nb.json
@@ -808,6 +808,8 @@
   "panel.settings_parents_title": "Foreldre (uten adminrettigheter)",
   "panel.settings_parents_hint": "Gi et husstandsmedlem uten adminrettigheter daglig kontroll — godkjenne oppgaver, justere poeng, bekrefte belønninger — uten Home Assistant-adminrettigheter. De kan fortsatt ikke åpne dette adminpanelet eller endre konfigurasjonen.",
   "panel.settings_parents_empty": "Fant ingen Home Assistant-brukere uten adminrettigheter. Opprett en vanlig HA-bruker først, og huk deretter av her.",
+  "panel.settings_require_linked_child_label": "Krev en koblet konto per barn",
+  "panel.settings_require_linked_child_hint": "La bare barnets egen Home Assistant-konto handle som det barnet. La stå av for et delt familienettbrett der én konto brukes av alle. Foreldre og administratorer kan alltid handle for alle barn.",
   "panel.settings_evening_hint": "Standard 17:00 – 21:00",
   "panel.settings_evening_label": "Kveld",
   "panel.settings_history_title": "Historikk og serier",

--- a/custom_components/taskmate/www/locales/nn.json
+++ b/custom_components/taskmate/www/locales/nn.json
@@ -808,6 +808,8 @@
   "panel.settings_parents_title": "Foreldre (utan adminrettar)",
   "panel.settings_parents_hint": "Gi eit husstandsmedlem utan adminrettar dagleg kontroll — godkjenne oppgåver, justere poeng, stadfeste løningar — utan Home Assistant-adminrettar. Dei kan framleis ikkje opne dette adminpanelet eller endre konfigurasjonen.",
   "panel.settings_parents_empty": "Fann ingen Home Assistant-brukarar utan adminrettar. Opprett ein vanleg HA-brukar først, og hak deretter av her.",
+  "panel.settings_require_linked_child_label": "Krev ein kopla konto per barn",
+  "panel.settings_require_linked_child_hint": "Lat berre barnet sin eigen Home Assistant-konto handle som det barnet. Lat stå av for eit delt familienettbrett der éin konto vert brukt av alle. Foreldre og administratorar kan alltid handle for alle barn.",
   "panel.settings_evening_hint": "Standard 17:00 – 21:00",
   "panel.settings_evening_label": "Kveld",
   "panel.settings_history_title": "Historikk og rekkjer",

--- a/custom_components/taskmate/www/locales/pt-BR.json
+++ b/custom_components/taskmate/www/locales/pt-BR.json
@@ -808,6 +808,8 @@
   "panel.settings_parents_title": "Pais (sem direitos de administrador)",
   "panel.settings_parents_hint": "Dê a um membro da família sem permissões de administrador o controle do dia a dia — aprovar tarefas, ajustar pontos, confirmar recompensas — sem direitos de administrador do Home Assistant. Ele ainda não poderá abrir este painel de administração nem alterar a configuração.",
   "panel.settings_parents_empty": "Nenhum usuário do Home Assistant sem permissões de administrador foi encontrado. Crie primeiro um usuário HA padrão e depois marque-o aqui.",
+  "panel.settings_require_linked_child_label": "Exigir uma conta vinculada por criança",
+  "panel.settings_require_linked_child_hint": "Só permite que a conta do Home Assistant da própria criança atue como essa criança. Deixe desligado em um tablet familiar compartilhado em que uma conta serve para todos. Pais e administradores sempre podem atuar por qualquer criança.",
   "panel.settings_evening_hint": "Padrão 17:00 – 21:00",
   "panel.settings_evening_label": "Noite",
   "panel.settings_history_title": "Histórico e sequências",

--- a/custom_components/taskmate/www/locales/pt.json
+++ b/custom_components/taskmate/www/locales/pt.json
@@ -813,6 +813,8 @@
   "panel.settings_parents_title": "Pais (sem direitos de administrador)",
   "panel.settings_parents_hint": "Dê a um membro do agregado sem permissões de administrador o controlo do dia a dia — aprovar tarefas, ajustar pontos, confirmar recompensas — sem direitos de administrador do Home Assistant. Continuará sem poder abrir este painel de administração nem alterar a configuração.",
   "panel.settings_parents_empty": "Não foram encontrados utilizadores do Home Assistant sem permissões de administrador. Crie primeiro um utilizador HA normal e depois selecione-o aqui.",
+  "panel.settings_require_linked_child_label": "Exigir uma conta associada por criança",
+  "panel.settings_require_linked_child_hint": "Só permite que a conta do Home Assistant da própria criança atue como essa criança. Deixe desligado num tablet familiar partilhado em que uma conta serve todos. Os pais e administradores podem sempre atuar por qualquer criança.",
   "panel.settings_evening_hint": "Predefinição 17:00 – 21:00",
   "panel.settings_evening_label": "Noite",
   "panel.settings_history_title": "Histórico e sequências",

--- a/custom_components/taskmate/www/taskmate-panel.js
+++ b/custom_components/taskmate/www/taskmate-panel.js
@@ -2480,7 +2480,9 @@ class TaskMatePanel extends HTMLElement {
   _timeAgo(iso) {
     if (!iso) return "—";
     const then = new Date(iso);
-    if (isNaN(then)) return iso;
+    // Echoing an unparseable value straight back would put stored text into
+    // markup, so escape it — the panel builds its HTML as strings.
+    if (isNaN(then)) return this._esc(iso);
     const diffSec = Math.floor((Date.now() - then.getTime()) / 1000);
     if (diffSec < 60)         return this._t("panel.time_ago_just_now");
     if (diffSec < 3600)       return this._t("panel.time_ago_minutes", {count: Math.floor(diffSec / 60)});
@@ -2944,7 +2946,7 @@ class TaskMatePanel extends HTMLElement {
                 <td><strong>${this._t("panel.day_" + d.weekday.slice(0, 3))}</strong> <span class="tm-proj-date">${d.date.slice(5)}</span></td>
                 ${kids.map(k => {
                   const cell = d.children.find(c => c.id === k.id) || { points: 0, chores: 0 };
-                  return `<td>${cell.chores ? `${cell.points} <span class="tm-proj-count">(${cell.chores})</span>` : "—"}</td>`;
+                  return `<td>${cell.chores ? `${this._num(cell.points)} <span class="tm-proj-count">(${this._num(cell.chores)})</span>` : "—"}</td>`;
                 }).join("")}
               </tr>
             `).join("")}
@@ -3088,7 +3090,7 @@ class TaskMatePanel extends HTMLElement {
                 </div>
                 <div class="tm-fair-figs">
                   <strong>${c.completions}</strong> ${this._t(c.completions === 1 ? "panel.insights_chore" : "panel.insights_chores")}
-                  · ${c.points} ${this._esc(this._state.settings?.points_name || this._t("common.points"))}
+                  · ${this._num(c.points)} ${this._esc(this._state.settings?.points_name || this._t("common.points"))}
                   · ${c.share_completions}%
                 </div>
                 <div class="tm-fair-status tm-fair-${c.status}">${this._t("panel.insights_status_" + c.status)}</div>
@@ -3303,7 +3305,7 @@ class TaskMatePanel extends HTMLElement {
                   <div class="tm-approval-icon"><ha-icon icon="mdi:gift-outline"></ha-icon></div>
                   <div class="tm-approval-body">
                     <div class="tm-approval-line">${this._t("panel.activity_claimed_text", {child: this._esc((child && child.name) || "?"), reward: this._esc((reward && reward.name) || this._t("panel.activity_deleted_reward"))})}</div>
-                    <div class="tm-meta">${this._timeAgo(c.claimed_at)}${reward ? ` · ${reward.cost} ${this._t("panel.activity_points")}` : ""}</div>
+                    <div class="tm-meta">${this._timeAgo(c.claimed_at)}${reward ? ` · ${this._num(reward.cost)} ${this._t("panel.activity_points")}` : ""}</div>
                   </div>
                   <div class="tm-approval-actions">
                     <button type="button" class="tm-btn tm-btn-sm" data-act="reject-reward" data-id="${this._esc(c.id)}">${this._t("panel.activity_reject")}</button>
@@ -3346,7 +3348,7 @@ class TaskMatePanel extends HTMLElement {
                 <div class="tm-timeline-body">
                   <div><strong>${this._esc(ev.child)}</strong> · ${this._esc(ev.label)}</div>
                 </div>
-                <div class="tm-timeline-points ${ev.points >= 0 ? 'tm-pos' : 'tm-neg'} tm-numeric">${ev.points >= 0 ? '+' : ''}${ev.points || 0}</div>
+                <div class="tm-timeline-points ${ev.points >= 0 ? 'tm-pos' : 'tm-neg'} tm-numeric">${ev.points >= 0 ? '+' : ''}${this._num(ev.points)}</div>
               </div>
             `).join("")}
           </div>
@@ -3370,7 +3372,7 @@ class TaskMatePanel extends HTMLElement {
                     <tr class="tm-row">
                       <td class="tm-meta">${this._esc(this._timeAgo(t.created_at))}</td>
                       <td>${this._esc((child && child.name) || "?")}</td>
-                      <td><strong class="tm-numeric ${t.points >= 0 ? 'tm-pos' : 'tm-neg'}">${t.points >= 0 ? '+' : ''}${t.points}</strong></td>
+                      <td><strong class="tm-numeric ${t.points >= 0 ? 'tm-pos' : 'tm-neg'}">${t.points >= 0 ? '+' : ''}${this._num(t.points)}</strong></td>
                       <td>${this._esc(this._translateReason(t.reason) || "—")}</td>
                       <td>${undoable ? `<button type="button" class="tm-icon-btn" data-act="undo-tx" data-id="${this._esc(t.id)}" title="${this._esc(this._t("panel.activity_undo"))}"><ha-icon icon="mdi:undo-variant"></ha-icon></button>` : ""}</td>
                     </tr>
@@ -3477,7 +3479,7 @@ class TaskMatePanel extends HTMLElement {
             <button type="button" class="tm-icon-btn" data-act="toggle-row-menu" data-id="${this._esc(c.id)}" title="${this._t("panel.row_menu_more")}" aria-haspopup="menu" aria-label="${this._t("panel.row_menu_more")}">⋮</button>
           </span>`}
         </div></td>
-        <td><strong class="tm-numeric">${c.task_type === "timed" ? `${c.timed_rate_points || 0}/${c.timed_rate_minutes || 1} min` : c.points}</strong></td>
+        <td><strong class="tm-numeric">${c.task_type === "timed" ? `${this._num(c.timed_rate_points)}/${this._num(c.timed_rate_minutes, 1)} min` : this._num(c.points)}</strong></td>
         <td><span class="tm-pill">${this._esc(this._timeCategoryLabel(c.time_category))}</span></td>
         <td>${assignedNames} ${modeBadge}</td>
         <td>${currentName}</td>
@@ -3536,7 +3538,7 @@ class TaskMatePanel extends HTMLElement {
         </div>
         <div class="tm-stats-row" style="grid-template-columns: 1fr 1fr ${r.expires_at ? "1fr" : ""};">
           <div class="tm-stat"><div class="tm-stat-value tm-numeric tm-cost">${this._fmtNum(r.cost)}</div><div class="tm-stat-label">${this._t("panel.reward_stat_cost", {points_name: pointsName})}</div></div>
-          ${r.quantity != null ? `<div class="tm-stat"><div class="tm-stat-value tm-numeric">${r.quantity}</div><div class="tm-stat-label">${this._t("panel.reward_stat_remaining")}</div></div>` : `<div class="tm-stat"><div class="tm-stat-value">∞</div><div class="tm-stat-label">${this._t("panel.reward_stat_unlimited")}</div></div>`}
+          ${r.quantity != null ? `<div class="tm-stat"><div class="tm-stat-value tm-numeric">${this._num(r.quantity)}</div><div class="tm-stat-label">${this._t("panel.reward_stat_remaining")}</div></div>` : `<div class="tm-stat"><div class="tm-stat-value">∞</div><div class="tm-stat-label">${this._t("panel.reward_stat_unlimited")}</div></div>`}
           ${r.expires_at ? `<div class="tm-stat"><div class="tm-stat-value" style="font-size: 14px;">${this._esc(r.expires_at)}</div><div class="tm-stat-label">${this._t("panel.reward_stat_expires")}</div></div>` : ""}
         </div>
         ${showProgress ? `
@@ -3657,7 +3659,7 @@ class TaskMatePanel extends HTMLElement {
           </div>
         </div>
         <div class="tm-stats-row" style="grid-template-columns: 1fr 1fr;">
-          <div class="tm-stat"><div class="tm-stat-value tm-numeric">${c.target}</div><div class="tm-stat-label">${this._esc(metricLabel)}</div></div>
+          <div class="tm-stat"><div class="tm-stat-value tm-numeric">${this._num(c.target)}</div><div class="tm-stat-label">${this._esc(metricLabel)}</div></div>
           <div class="tm-stat"><div class="tm-stat-value tm-numeric">${this._fmtNum(c.bonus_points || 0)}</div><div class="tm-stat-label">${this._t("panel.quest_stat_bonus", {points_name: pointsName})}</div></div>
         </div>
         <div class="tm-meta">${this._t("panel.quest_assigned_to")}: ${this._esc(assigned.join(", "))}</div>
@@ -3701,7 +3703,7 @@ class TaskMatePanel extends HTMLElement {
   _criteriaLabel(criteria, combinator = "AND") {
     if (!criteria || !criteria.length) return this._t("badge.manual_award_only");
     const joinKey = combinator === "OR" ? "badge.criteria_or" : "badge.criteria_and";
-    return criteria.map(c => `${this._t("badge.criteria_" + c.metric)} ${c.operator} ${c.value}`).join(` ${this._t(joinKey)} `);
+    return criteria.map(c => `${this._t("badge.criteria_" + c.metric)} ${this._esc(c.operator)} ${this._num(c.value)}`).join(` ${this._t(joinKey)} `);
   }
 
   _badgeName(b) {
@@ -3994,7 +3996,7 @@ class TaskMatePanel extends HTMLElement {
                     <select class="tm-select tm-badge-op-select" data-badge-criterion-field="operator" data-badge-criterion-idx="${idx}">
                       ${BADGE_OPERATORS.map(sym => { const v = BADGE_OP_VALUES[sym]; return `<option value="${v}"${(c.operator || ">=") === v ? " selected" : ""}>${sym}</option>`; }).join("")}
                     </select>`}
-                    ${isBool ? `<span class="tm-field-hint" style="flex:1">true</span>` : `<input class="tm-input" type="number" min="0" value="${c.value || 1}" data-badge-criterion-field="value" data-badge-criterion-idx="${idx}">`}
+                    ${isBool ? `<span class="tm-field-hint" style="flex:1">true</span>` : `<input class="tm-input" type="number" min="0" value="${this._num(c.value, 1)}" data-badge-criterion-field="value" data-badge-criterion-idx="${idx}">`}
                     <button type="button" class="tm-icon-btn" data-act="badge-remove-criterion" data-idx="${idx}" title="${this._t("panel.badge_remove_criterion_btn")}">✕</button>
                   </div>
                 `;
@@ -4059,7 +4061,7 @@ class TaskMatePanel extends HTMLElement {
                 return `
                   <tr class="tm-row">
                     <td><span class="tm-row-icon">${this._mdi(item.icon)}</span><strong>${this._esc(item.name)}</strong>${this._idBadge(item.id)}${item.description ? `<div class="tm-meta">${this._esc(item.description)}</div>` : ""}</td>
-                    <td><strong class="tm-numeric ${kind === "penalty" ? "tm-neg" : "tm-pos"}">${kind === "penalty" ? "−" : "+"}${item.points}</strong></td>
+                    <td><strong class="tm-numeric ${kind === "penalty" ? "tm-neg" : "tm-pos"}">${kind === "penalty" ? "−" : "+"}${this._num(item.points)}</strong></td>
                     <td>${assignedNames}</td>
                     <td class="tm-row-actions"><div>
                       <button type="button" class="tm-btn tm-btn-sm" data-act="apply-${kind}" data-id="${this._esc(item.id)}">${this._t("panel.btn_apply")}</button>
@@ -4244,7 +4246,7 @@ class TaskMatePanel extends HTMLElement {
           <div class="tm-tpl-preview-body">
             <div class="tm-field-row">
               <div class="tm-field"><span class="tm-field-label">${this._t("panel.common_name")}</span><input class="tm-input" type="text" data-tpl-field="name" data-tpl-idx="${idx}" value="${this._esc(chore.name)}"></div>
-              <div class="tm-field"><span class="tm-field-label">${this._t("panel.common_points")}</span><input class="tm-input" type="number" data-tpl-field="points" data-tpl-idx="${idx}" value="${chore.points || 0}" min="0"></div>
+              <div class="tm-field"><span class="tm-field-label">${this._t("panel.common_points")}</span><input class="tm-input" type="number" data-tpl-field="points" data-tpl-idx="${idx}" value="${this._num(chore.points)}" min="0"></div>
             </div>
             <div class="tm-field-row">
               <div class="tm-field"><span class="tm-field-label">${this._t("panel.chore_time_category_label")}</span>
@@ -4271,7 +4273,7 @@ class TaskMatePanel extends HTMLElement {
                 </select>
               </div>
               <div class="tm-field"><span class="tm-field-label">${this._t("panel.template_daily_limit_label")}</span>
-                <input class="tm-input" type="number" data-tpl-field="daily_limit" data-tpl-idx="${idx}" value="${chore.daily_limit || 1}" min="1">
+                <input class="tm-input" type="number" data-tpl-field="daily_limit" data-tpl-idx="${idx}" value="${this._num(chore.daily_limit, 1)}" min="1">
               </div>
             </div>
           </div>
@@ -4571,7 +4573,7 @@ class TaskMatePanel extends HTMLElement {
           <div class="tm-section-body">
             <div class="tm-setting-row">
               <div class="tm-setting-label">${this._t("panel.settings_retention_label")}<small>${this._t("panel.settings_retention_hint")}</small></div>
-              <input type="number" class="tm-input" min="30" max="365" data-setting="history_days" value="${s.history_days || 90}">
+              <input type="number" class="tm-input" min="30" max="365" data-setting="history_days" value="${this._num(s.history_days, 90)}">
             </div>
             <div class="tm-setting-row">
               <div class="tm-setting-label">${this._t("panel.settings_streak_reset_label")}<small>${this._t("panel.settings_streak_reset_hint")}</small></div>
@@ -4585,19 +4587,19 @@ class TaskMatePanel extends HTMLElement {
             </div>
             <div class="tm-setting-row">
               <div class="tm-setting-label">${this._t("panel.settings_weekend_multiplier_label")}<small>${this._t("panel.settings_weekend_multiplier_hint")}</small></div>
-              <input type="number" class="tm-input" step="0.1" min="1" max="5" data-setting="weekend_multiplier" value="${s.weekend_multiplier || 1.0}">
+              <input type="number" class="tm-input" step="0.1" min="1" max="5" data-setting="weekend_multiplier" value="${this._num(s.weekend_multiplier, 1.0)}">
             </div>
             <div class="tm-setting-row">
               <div class="tm-setting-label">${this._t("panel.settings_difficulty_multipliers_label")}<small>${this._t("panel.settings_difficulty_multipliers_hint")}</small></div>
               <div class="tm-difficulty-mults">
-                <label>${this._t("panel.difficulty_easy")}<input type="number" class="tm-input" step="0.1" min="0" max="10" data-setting="difficulty_multiplier_easy" value="${s.difficulty_multiplier_easy ?? 0.5}"></label>
-                <label>${this._t("panel.difficulty_medium")}<input type="number" class="tm-input" step="0.1" min="0" max="10" data-setting="difficulty_multiplier_medium" value="${s.difficulty_multiplier_medium ?? 1.0}"></label>
-                <label>${this._t("panel.difficulty_hard")}<input type="number" class="tm-input" step="0.1" min="0" max="10" data-setting="difficulty_multiplier_hard" value="${s.difficulty_multiplier_hard ?? 2.0}"></label>
+                <label>${this._t("panel.difficulty_easy")}<input type="number" class="tm-input" step="0.1" min="0" max="10" data-setting="difficulty_multiplier_easy" value="${this._num(s.difficulty_multiplier_easy, 0.5)}"></label>
+                <label>${this._t("panel.difficulty_medium")}<input type="number" class="tm-input" step="0.1" min="0" max="10" data-setting="difficulty_multiplier_medium" value="${this._num(s.difficulty_multiplier_medium, 1.0)}"></label>
+                <label>${this._t("panel.difficulty_hard")}<input type="number" class="tm-input" step="0.1" min="0" max="10" data-setting="difficulty_multiplier_hard" value="${this._num(s.difficulty_multiplier_hard, 2.0)}"></label>
               </div>
             </div>
             <div class="tm-setting-row">
               <div class="tm-setting-label">${this._t("panel.settings_calendar_projection_label")}<small>${this._t("panel.settings_calendar_projection_hint")}</small></div>
-              <input type="number" class="tm-input" min="1" max="90" data-setting="calendar_projection_days" value="${s.calendar_projection_days || 14}">
+              <input type="number" class="tm-input" min="1" max="90" data-setting="calendar_projection_days" value="${this._num(s.calendar_projection_days, 14)}">
             </div>
             <div class="tm-setting-row">
               <div class="tm-setting-label">${this._t("panel.settings_surprise_enabled_label")}<small>${this._t("panel.settings_surprise_enabled_hint")}</small></div>
@@ -4606,9 +4608,9 @@ class TaskMatePanel extends HTMLElement {
             <div class="tm-setting-row">
               <div class="tm-setting-label">${this._t("panel.settings_surprise_params_label")}<small>${this._t("panel.settings_surprise_params_hint")}</small></div>
               <div class="tm-difficulty-mults">
-                <label>${this._t("panel.settings_surprise_chance")}<input type="number" class="tm-input" step="1" min="0" max="100" data-setting="surprise_bonus_chance" value="${s.surprise_bonus_chance ?? 15}"></label>
-                <label>${this._t("panel.settings_surprise_min")}<input type="number" class="tm-input" step="1" min="0" data-setting="surprise_bonus_min" value="${s.surprise_bonus_min ?? 5}"></label>
-                <label>${this._t("panel.settings_surprise_max")}<input type="number" class="tm-input" step="1" min="0" data-setting="surprise_bonus_max" value="${s.surprise_bonus_max ?? 20}"></label>
+                <label>${this._t("panel.settings_surprise_chance")}<input type="number" class="tm-input" step="1" min="0" max="100" data-setting="surprise_bonus_chance" value="${this._num(s.surprise_bonus_chance, 15)}"></label>
+                <label>${this._t("panel.settings_surprise_min")}<input type="number" class="tm-input" step="1" min="0" data-setting="surprise_bonus_min" value="${this._num(s.surprise_bonus_min, 5)}"></label>
+                <label>${this._t("panel.settings_surprise_max")}<input type="number" class="tm-input" step="1" min="0" data-setting="surprise_bonus_max" value="${this._num(s.surprise_bonus_max, 20)}"></label>
               </div>
             </div>
             <div class="tm-setting-row tm-setting-stack">
@@ -4634,8 +4636,8 @@ class TaskMatePanel extends HTMLElement {
             <div class="tm-setting-row">
               <div class="tm-setting-label">${this._t("panel.settings_roulette_section")}</div>
               <div class="tm-difficulty-mults">
-                <label>${this._t("panel.settings_roulette_multiplier")}<input type="number" class="tm-input" step="0.5" min="1" max="5" data-setting="roulette_multiplier" value="${s.roulette_multiplier ?? 2}"></label>
-                <label>${this._t("panel.settings_roulette_spins")}<input type="number" class="tm-input" step="1" min="1" max="10" data-setting="roulette_daily_spins" value="${s.roulette_daily_spins ?? 1}"></label>
+                <label>${this._t("panel.settings_roulette_multiplier")}<input type="number" class="tm-input" step="0.5" min="1" max="5" data-setting="roulette_multiplier" value="${this._num(s.roulette_multiplier, 2)}"></label>
+                <label>${this._t("panel.settings_roulette_spins")}<input type="number" class="tm-input" step="1" min="1" max="10" data-setting="roulette_daily_spins" value="${this._num(s.roulette_daily_spins, 1)}"></label>
               </div>
             </div>
             <div class="tm-setting-row">
@@ -4645,7 +4647,7 @@ class TaskMatePanel extends HTMLElement {
             <div class="tm-setting-row">
               <div class="tm-setting-label">${this._t("panel.settings_decay_params_label")}<small>${this._t("panel.settings_decay_params_hint")}</small></div>
               <div class="tm-difficulty-mults">
-                <label>${this._t("panel.settings_decay_percent")}<input type="number" class="tm-input" step="1" min="0" max="100" data-setting="points_decay_percent" value="${s.points_decay_percent ?? 10}"></label>
+                <label>${this._t("panel.settings_decay_percent")}<input type="number" class="tm-input" step="1" min="0" max="100" data-setting="points_decay_percent" value="${this._num(s.points_decay_percent, 10)}"></label>
                 <label>${this._t("panel.settings_decay_period")}
                   <select class="tm-select" data-setting="points_decay_period">
                     <option value="weekly" ${s.points_decay_period === "weekly" ? "selected" : ""}>${this._t("panel.reward_restock_weekly")}</option>
@@ -4660,7 +4662,7 @@ class TaskMatePanel extends HTMLElement {
             </div>
             <div class="tm-setting-row">
               <div class="tm-setting-label">${this._t("panel.settings_level_step_label")}<small>${this._t("panel.settings_level_step_hint")}</small></div>
-              <input type="number" class="tm-input" min="1" data-setting="level_xp_step" value="${s.level_xp_step || 100}">
+              <input type="number" class="tm-input" min="1" data-setting="level_xp_step" value="${this._num(s.level_xp_step, 100)}">
             </div>
             <div class="tm-setting-row">
               <div class="tm-setting-label">${this._t("panel.settings_spendcap_enabled_label")}<small>${this._t("panel.settings_spendcap_enabled_hint")}</small></div>
@@ -4669,7 +4671,7 @@ class TaskMatePanel extends HTMLElement {
             <div class="tm-setting-row">
               <div class="tm-setting-label">${this._t("panel.settings_spendcap_params_label")}<small>${this._t("panel.settings_spendcap_params_hint")}</small></div>
               <div class="tm-difficulty-mults">
-                <label>${this._t("panel.settings_spendcap_amount")}<input type="number" class="tm-input" step="1" min="0" data-setting="spend_cap_amount" value="${s.spend_cap_amount ?? 0}"></label>
+                <label>${this._t("panel.settings_spendcap_amount")}<input type="number" class="tm-input" step="1" min="0" data-setting="spend_cap_amount" value="${this._num(s.spend_cap_amount, 0)}"></label>
                 <label>${this._t("panel.settings_decay_period")}
                   <select class="tm-select" data-setting="spend_cap_period">
                     <option value="weekly" ${s.spend_cap_period === "weekly" ? "selected" : ""}>${this._t("panel.reward_restock_weekly")}</option>
@@ -4685,7 +4687,7 @@ class TaskMatePanel extends HTMLElement {
             <div class="tm-setting-row">
               <div class="tm-setting-label">${this._t("panel.settings_interest_params_label")}<small>${this._t("panel.settings_interest_params_hint")}</small></div>
               <div class="tm-difficulty-mults">
-                <label>${this._t("panel.settings_interest_percent")}<input type="number" class="tm-input" step="1" min="0" max="100" data-setting="interest_percent" value="${s.interest_percent ?? 5}"></label>
+                <label>${this._t("panel.settings_interest_percent")}<input type="number" class="tm-input" step="1" min="0" max="100" data-setting="interest_percent" value="${this._num(s.interest_percent, 5)}"></label>
                 <label>${this._t("panel.settings_decay_period")}
                   <select class="tm-select" data-setting="interest_period">
                     <option value="weekly" ${(s.interest_period || "weekly") === "weekly" ? "selected" : ""}>${this._t("panel.reward_restock_weekly")}</option>
@@ -4718,7 +4720,7 @@ class TaskMatePanel extends HTMLElement {
             </div>
             <div class="tm-setting-row">
               <div class="tm-setting-label">${this._t("panel.settings_perfect_week_bonus_label")}<small>${this._t("panel.settings_perfect_week_bonus_hint")}</small></div>
-              <input type="number" class="tm-input" min="0" data-setting="perfect_week_bonus" value="${s.perfect_week_bonus || 50}">
+              <input type="number" class="tm-input" min="0" data-setting="perfect_week_bonus" value="${this._num(s.perfect_week_bonus, 50)}">
             </div>
             <div class="tm-setting-row">
               <div class="tm-setting-label">${this._t("panel.settings_celebration_notify_label")}<small>${this._t("panel.settings_celebration_notify_hint")}</small></div>
@@ -4832,7 +4834,7 @@ class TaskMatePanel extends HTMLElement {
                   <tr>
                     <td>${this._esc((p.date || "").slice(0, 10))}</td>
                     <td>${this._esc(p.child_name || "")}</td>
-                    <td style="text-align:right">${p.points} → ${this._esc(p.currency || "")}${this._esc(String(p.amount))}</td>
+                    <td style="text-align:right">${this._num(p.points)} → ${this._esc(p.currency || "")}${this._esc(String(p.amount))}</td>
                   </tr>
                 `).join("")}
               </tbody></table></div>
@@ -5289,7 +5291,7 @@ class TaskMatePanel extends HTMLElement {
                 <div style="padding:0 14px 12px;border-top:1px solid var(--tm-border-soft)">
                   <div class="tm-field-row" style="margin-top:10px">
                     <div class="tm-field"><span class="tm-field-label">${this._t("panel.common_name")}</span><input class="tm-input" type="text" data-tpl-dialog-field="name" data-tpl-dialog-idx="${i}" value="${this._esc(c.name)}"></div>
-                    <div class="tm-field"><span class="tm-field-label">${this._t("panel.common_points")}</span><input class="tm-input" type="number" data-tpl-dialog-field="points" data-tpl-dialog-idx="${i}" value="${c.points || 0}" min="0"></div>
+                    <div class="tm-field"><span class="tm-field-label">${this._t("panel.common_points")}</span><input class="tm-input" type="number" data-tpl-dialog-field="points" data-tpl-dialog-idx="${i}" value="${this._num(c.points)}" min="0"></div>
                   </div>
                   <div class="tm-field-row">
                     <div class="tm-field"><span class="tm-field-label">${this._t("panel.chore_time_category_label")}</span>
@@ -5473,7 +5475,7 @@ class TaskMatePanel extends HTMLElement {
             ${(d.bonus_subtasks || []).map((b, idx) => `
               <div class="tm-field-row" style="align-items:flex-end;gap:6px;margin-bottom:6px">
                 <div class="tm-field" style="flex:2;margin:0"><input class="tm-input" placeholder="${this._t("panel.chore_subtask_name_placeholder")}" value="${this._esc(b.name)}" data-field="bonus_subtasks[${idx}].name"></div>
-                <div class="tm-field" style="flex:0 0 70px;margin:0"><input class="tm-input" type="number" min="0" placeholder="${this._t("panel.chore_subtask_points_placeholder")}" value="${b.points}" data-field="bonus_subtasks[${idx}].points"></div>
+                <div class="tm-field" style="flex:0 0 70px;margin:0"><input class="tm-input" type="number" min="0" placeholder="${this._t("panel.chore_subtask_points_placeholder")}" value="${this._num(b.points)}" data-field="bonus_subtasks[${idx}].points"></div>
                 <button type="button" class="tm-btn tm-btn-icon" data-act="remove-bonus-subtask" data-idx="${idx}" title="${this._t("panel.tooltip_remove")}" style="padding:6px 10px">✕</button>
               </div>
             `).join("")}
@@ -6092,7 +6094,7 @@ class TaskMatePanel extends HTMLElement {
              <div class="tm-reorder-item" draggable="true" data-drag-id="${this._esc(id)}">
                <div class="tm-reorder-handle">⠿</div>
                <div class="tm-reorder-name">${this._esc(c.name)}</div>
-               <div class="tm-reorder-points tm-numeric">${c.points}</div>
+               <div class="tm-reorder-points tm-numeric">${this._num(c.points)}</div>
                <div class="tm-reorder-moves">
                  <button type="button" class="tm-reorder-move" data-act="reorder-move" data-dir="-1" data-drag-id="${this._esc(id)}" ${idx === 0 ? "disabled" : ""} title="${this._t("reorder.move_up")}" aria-label="${this._t("reorder.move_up")}">▲</button>
                  <button type="button" class="tm-reorder-move" data-act="reorder-move" data-dir="1" data-drag-id="${this._esc(id)}" ${idx === arr.length - 1 ? "disabled" : ""} title="${this._t("reorder.move_down")}" aria-label="${this._t("reorder.move_down")}">▼</button>
@@ -6483,6 +6485,15 @@ class TaskMatePanel extends HTMLElement {
   _fmtNum(n) {
     if (n == null) return "0";
     return new Intl.NumberFormat().format(n);
+  }
+
+  // A number bound for a markup or attribute slot. The panel assembles its
+  // HTML as strings, so anything stored in a field we *assume* is numeric has
+  // to be proven numeric before it is echoed back. Non-numbers, inf and NaN
+  // fall back rather than reaching the DOM.
+  _num(v, fallback = 0) {
+    const n = Number(v);
+    return Number.isFinite(n) ? n : fallback;
   }
 
   // Quick point-adjust amounts (#746). Stored as a comma-separated string like

--- a/custom_components/taskmate/www/taskmate-panel.js
+++ b/custom_components/taskmate/www/taskmate-panel.js
@@ -6123,7 +6123,7 @@ class TaskMatePanel extends HTMLElement {
       </div>`;
   }
 
-  _field(label, name, value, type = "text", hint = "") {
+  _field(label, name, value, type = "text", hintHtml = "") {
     return `
       <div class="tm-field">
         <span class="tm-field-label">${this._esc(label)}</span>
@@ -6133,11 +6133,11 @@ class TaskMatePanel extends HTMLElement {
           value="${this._esc(value == null ? "" : value)}"
           ${type === "number" ? 'type="number"' : 'type="text"'}
         >
-        ${hint ? `<span class="tm-field-hint">${hint}</span>` : ""}
+        ${hintHtml ? `<span class="tm-field-hint">${hintHtml}</span>` : ""}
       </div>`;
   }
 
-  _dateField(label, name, value, hint = "") {
+  _dateField(label, name, value, hintHtml = "") {
     return `
       <div class="tm-field">
         <span class="tm-field-label">${this._esc(label)}</span>
@@ -6147,11 +6147,11 @@ class TaskMatePanel extends HTMLElement {
           value="${this._esc(value || "")}"
           type="date"
         >
-        ${hint ? `<span class="tm-field-hint">${hint}</span>` : ""}
+        ${hintHtml ? `<span class="tm-field-hint">${hintHtml}</span>` : ""}
       </div>`;
   }
 
-  _timeField(label, name, value, hint = "") {
+  _timeField(label, name, value, hintHtml = "") {
     return `
       <div class="tm-field">
         <span class="tm-field-label">${this._esc(label)}</span>
@@ -6161,11 +6161,11 @@ class TaskMatePanel extends HTMLElement {
           value="${this._esc(value || "")}"
           type="time"
         >
-        ${hint ? `<span class="tm-field-hint">${hint}</span>` : ""}
+        ${hintHtml ? `<span class="tm-field-hint">${hintHtml}</span>` : ""}
       </div>`;
   }
 
-  _select(label, name, value, options, hint = "", rerender = false) {
+  _select(label, name, value, options, hintHtml = "", rerender = false) {
     return `
       <div class="tm-field">
         <span class="tm-field-label">${this._esc(label)}</span>
@@ -6176,17 +6176,17 @@ class TaskMatePanel extends HTMLElement {
         >
           ${options.map(o => `<option value="${this._esc(o.v)}" ${String(o.v) === String(value) ? "selected" : ""}>${this._esc(o.lk ? this._t(o.lk) : o.l)}</option>`).join("")}
         </select>
-        ${hint ? `<span class="tm-field-hint">${hint}</span>` : ""}
+        ${hintHtml ? `<span class="tm-field-hint">${hintHtml}</span>` : ""}
       </div>`;
   }
 
-  _switch(label, name, checked, hint = "", rerender = false) {
+  _switch(label, name, checked, hintHtml = "", rerender = false) {
     return `
       <div class="tm-check-row">
         <ha-switch data-field="${name}" ${checked ? "checked" : ""} ${rerender ? 'data-rerender="true"' : ""}></ha-switch>
         <div>
           <div class="tm-check-title">${this._esc(label)}</div>
-          ${hint ? `<span class="tm-field-hint">${hint}</span>` : ""}
+          ${hintHtml ? `<span class="tm-field-hint">${hintHtml}</span>` : ""}
         </div>
       </div>`;
   }
@@ -6293,7 +6293,7 @@ class TaskMatePanel extends HTMLElement {
     else { (this._settingsEntityDraft = this._settingsEntityDraft || {})[field] = value; }
   }
 
-  _entityPickerField(label, name, value, domains, hint = "") {
+  _entityPickerField(label, name, value, domains, hintHtml = "") {
     const friendly = value && this._hass?.states?.[value]?.attributes?.friendly_name || "";
     const icon = value ? (this._hass?.states?.[value]?.attributes?.icon || this._entityDomainIcon(value)) : "";
     return `
@@ -6312,7 +6312,7 @@ class TaskMatePanel extends HTMLElement {
               </div>`
           }
         </div>
-        ${hint ? `<span class="tm-field-hint">${hint}</span>` : ""}
+        ${hintHtml ? `<span class="tm-field-hint">${hintHtml}</span>` : ""}
       </div>`;
   }
 

--- a/custom_components/taskmate/www/taskmate-panel.js
+++ b/custom_components/taskmate/www/taskmate-panel.js
@@ -4559,6 +4559,10 @@ class TaskMatePanel extends HTMLElement {
                 <input type="checkbox" class="tm-role-check" data-parent-user="${this._esc(u.id)}" ${(s.parent_user_ids || []).includes(u.id) ? "checked" : ""}>
               </label>`).join("")
               || `<p class="tm-meta">${this._t("panel.settings_parents_empty")}</p>`}
+            <div class="tm-setting-row">
+              <div class="tm-setting-label">${this._t("panel.settings_require_linked_child_label")}<small>${this._t("panel.settings_require_linked_child_hint")}</small></div>
+              <ha-switch data-setting="require_linked_child" ${s.require_linked_child ? "checked" : ""}></ha-switch>
+            </div>
           </div>
         </div>
 

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -12,4 +12,7 @@
 pytest-homeassistant-custom-component==0.13.357
 
 # Coverage reporting for CI (Tests workflow renders a per-module summary).
-pytest-cov
+# Pinned like the harness above: an unpinned dev dependency resolves to
+# whatever PyPI serves at job time, which is one supply-chain hop into every
+# test run.
+pytest-cov==7.1.0

--- a/tests/test_audit_log.py
+++ b/tests/test_audit_log.py
@@ -160,9 +160,9 @@ def test_child_facing_services_are_audited():
     """The actions a child can drive are exactly the ones worth reviewing."""
     import pathlib
 
-    src = (
-        pathlib.Path(__file__).resolve().parent.parent / "custom_components" / "taskmate" / "__init__.py"
-    ).read_text(encoding="utf-8")
+    src = (pathlib.Path(__file__).resolve().parent.parent / "custom_components" / "taskmate" / "__init__.py").read_text(
+        encoding="utf-8"
+    )
 
     for handler in (
         "handle_complete_chore",

--- a/tests/test_audit_log.py
+++ b/tests/test_audit_log.py
@@ -149,3 +149,61 @@ async def test_wrapper_does_not_audit_on_handler_error():
 
     await handler(_hass_with(coord), _conn(), {"id": 1, "type": "taskmate/add_chore", "name": "x"})
     coord.async_record_audit.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# child-facing mutations are audited too, and truncation is visible
+# ---------------------------------------------------------------------------
+
+
+def test_child_facing_services_are_audited():
+    """The actions a child can drive are exactly the ones worth reviewing."""
+    import pathlib
+
+    src = (
+        pathlib.Path(__file__).resolve().parent.parent / "custom_components" / "taskmate" / "__init__.py"
+    ).read_text(encoding="utf-8")
+
+    for handler in (
+        "handle_complete_chore",
+        "handle_complete_bonus_subtask",
+        "handle_claim_reward",
+        "handle_allocate_points_to_pool",
+        "handle_spin_roulette",
+        "handle_choose_avatar",
+        "handle_request_swap",
+        "handle_start_timed_task",
+        "handle_stop_timed_task",
+    ):
+        assert f"_audited({handler})" in src, f"{handler} is not audited"
+
+    # …and the wrapper really does record.
+    block = src[src.index("def _audited(handler):") : src.index("def _parent(handler):")]
+    assert "_async_record_service_audit(hass, call)" in block
+
+
+def test_dropped_audit_entries_are_counted():
+    from custom_components.taskmate.storage import TaskMateStorage
+
+    storage = TaskMateStorage.__new__(TaskMateStorage)
+    storage._data = {}
+    for i in range(520):
+        storage.add_audit_entry({"id": str(i), "action": "service.test"})
+
+    assert len(storage._data["audit_log"]) == 500
+    assert storage.get_audit_dropped_count() == 20
+    # The oldest really are gone — the count is what makes that visible.
+    assert storage._data["audit_log"][0]["id"] == "20"
+
+
+def test_clearing_the_log_resets_the_dropped_counter():
+    from custom_components.taskmate.storage import TaskMateStorage
+
+    storage = TaskMateStorage.__new__(TaskMateStorage)
+    storage._data = {}
+    for i in range(505):
+        storage.add_audit_entry({"id": str(i), "action": "service.test"})
+    assert storage.get_audit_dropped_count() == 5
+
+    storage.clear_audit_log()
+    assert storage.get_audit_dropped_count() == 0

--- a/tests/test_completion_concurrency.py
+++ b/tests/test_completion_concurrency.py
@@ -1,0 +1,179 @@
+"""Two requests landing together must not both be paid.
+
+Awarding points can suspend (a level-up or streak milestone sends a
+notification), while the duplicate/daily-limit checks read stored completions.
+If the record is written *after* the award, both callers pass the same check
+and the chore pays twice. These drive that interleaving deterministically by
+making the award yield.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import datetime as dt
+from datetime import timezone
+from unittest.mock import AsyncMock, patch
+
+from custom_components.taskmate.coordinator import TaskMateCoordinator
+from custom_components.taskmate.storage import TaskMateStorage
+
+UTC = timezone.utc
+
+
+def _now():
+    return dt.datetime(2024, 3, 20, 12, 0, 0, tzinfo=UTC)
+
+
+async def _make_system():
+    from tests.conftest import FakeHass, FakeStore
+
+    hass = FakeHass()
+    hass.states = type("FakeStates", (), {"get": lambda self, entity_id: None})()
+
+    storage = TaskMateStorage.__new__(TaskMateStorage)
+    storage.entry_id = "test_entry"
+    storage._store = FakeStore(None, 1, "test")
+    storage._data = {}
+    await storage.async_load()
+
+    coord = object.__new__(TaskMateCoordinator)
+    coord.hass = hass
+    coord.data = {}
+    coord.storage = storage
+    coord._unsub_midnight = None
+    coord._unsub_prune = None
+    coord._unsub_availability = None
+    coord._dt_now = _now()
+    coord.async_refresh = AsyncMock()
+    coord._async_notify_pending_approval = AsyncMock()
+    notifications = AsyncMock()
+    notifications._has_outstanding_chores_today = lambda _cid: True
+    coord.notifications = notifications
+    return coord, storage
+
+
+def _run(coro_factory):
+    """Run a coroutine factory on a fresh loop, returning its result."""
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    try:
+        return loop.run_until_complete(coro_factory())
+    finally:
+        loop.close()
+        asyncio.set_event_loop(None)
+
+
+def test_two_concurrent_completions_pay_once():
+    async def scenario():
+        import custom_components.taskmate.coordinator as _mod
+
+        coord, storage = await _make_system()
+        now = _now()
+        with patch.object(_mod.dt_util, "now", return_value=now):
+            child = await coord.async_add_child("Alice")
+            chore = await coord.async_add_chore(
+                "Dishes",
+                points=10,
+                requires_approval=False,
+                schedule_mode="specific_days",
+                assigned_to=[child.id],
+                daily_limit=1,
+            )
+
+            real_award = coord._award_points
+
+            async def slow_award(*args, **kwargs):
+                # Stand in for the notification await inside a real level-up.
+                await asyncio.sleep(0)
+                return await real_award(*args, **kwargs)
+
+            coord._award_points = slow_award
+
+            await asyncio.gather(
+                coord.async_complete_chore(chore.id, child.id),
+                coord.async_complete_chore(chore.id, child.id),
+            )
+            return storage, child.id
+
+    storage, child_id = _run(scenario)
+
+    assert len(storage.get_completions()) == 1, "daily limit was exceeded by a concurrent call"
+    assert storage.get_child(child_id).points == 10, "the chore paid out twice"
+
+
+def test_two_concurrent_approvals_pay_once():
+    async def scenario():
+        import custom_components.taskmate.coordinator as _mod
+
+        coord, storage = await _make_system()
+        now = _now()
+        with patch.object(_mod.dt_util, "now", return_value=now):
+            child = await coord.async_add_child("Alice")
+            chore = await coord.async_add_chore(
+                "Dishes",
+                points=10,
+                requires_approval=True,
+                schedule_mode="specific_days",
+                assigned_to=[child.id],
+            )
+            comp = await coord.async_complete_chore(chore.id, child.id)
+
+            real_award = coord._award_points
+
+            async def slow_award(*args, **kwargs):
+                await asyncio.sleep(0)
+                return await real_award(*args, **kwargs)
+
+            coord._award_points = slow_award
+
+            await asyncio.gather(
+                coord.async_approve_chore(comp.id),
+                coord.async_approve_chore(comp.id),
+            )
+            return storage, child.id
+
+    storage, child_id = _run(scenario)
+
+    assert storage.get_child(child_id).points == 10, "a double approval paid twice"
+
+
+def test_two_concurrent_bonus_subtasks_pay_once():
+    async def scenario():
+        import custom_components.taskmate.coordinator as _mod
+        from custom_components.taskmate.models import BonusSubTask
+
+        coord, storage = await _make_system()
+        now = _now()
+        with patch.object(_mod.dt_util, "now", return_value=now):
+            child = await coord.async_add_child("Alice")
+            chore = await coord.async_add_chore(
+                "Tidy",
+                points=10,
+                requires_approval=False,
+                schedule_mode="specific_days",
+                assigned_to=[child.id],
+            )
+            chore.bonus_subtasks = [BonusSubTask(id="b1", name="Hoover", points=25)]
+            storage.update_chore(chore)
+            await coord.async_complete_chore(chore.id, child.id)
+
+            real_award = coord._award_points
+
+            async def slow_award(*args, **kwargs):
+                await asyncio.sleep(0)
+                return await real_award(*args, **kwargs)
+
+            coord._award_points = slow_award
+
+            results = await asyncio.gather(
+                coord.async_complete_bonus_subtask(chore.id, "b1", child.id),
+                coord.async_complete_bonus_subtask(chore.id, "b1", child.id),
+                return_exceptions=True,
+            )
+            return storage, child.id, results
+
+    storage, child_id, results = _run(scenario)
+
+    errors = [r for r in results if isinstance(r, Exception)]
+    assert len(errors) == 1, "the duplicate bonus sub-task was not rejected"
+    assert storage.get_child(child_id).points == 35, "the bonus paid twice"

--- a/tests/test_completion_eligibility.py
+++ b/tests/test_completion_eligibility.py
@@ -1,0 +1,247 @@
+"""Server-side completion eligibility must hold for every schedule mode.
+
+The child card filters chores it offers, but a direct service / entity / Dev
+Tools call bypasses the card entirely. The coordinator is the authority, so the
+same ``assigned_to`` / schedule / availability rules have to be enforced there
+for ``specific_days``, ``recurring`` AND ``one_shot`` chores alike.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import datetime as dt
+from datetime import timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from custom_components.taskmate.models import BonusSubTask
+from custom_components.taskmate.coordinator import TaskMateCoordinator
+from custom_components.taskmate.storage import TaskMateStorage
+
+UTC = timezone.utc
+
+
+def run(coro):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+def _now(year=2024, month=3, day=20, hour=12):
+    # 2024-03-20 is a Wednesday.
+    return dt.datetime(year, month, day, hour, 0, 0, tzinfo=UTC)
+
+
+def _make_system(now=None):
+    from tests.conftest import FakeHass, FakeStore
+
+    if now is None:
+        now = _now()
+
+    hass = FakeHass()
+    hass.states = type("FakeStates", (), {"get": lambda self, entity_id: None})()
+
+    storage = TaskMateStorage.__new__(TaskMateStorage)
+    storage.entry_id = "test_entry"
+    storage._store = FakeStore(None, 1, "test")
+    storage._data = {}
+    run(storage.async_load())
+
+    coord = object.__new__(TaskMateCoordinator)
+    coord.hass = hass
+    coord.data = {}
+    coord.storage = storage
+    coord._unsub_midnight = None
+    coord._unsub_prune = None
+    coord._unsub_availability = None
+
+    import custom_components.taskmate.coordinator as _mod
+
+    coord._dt_now = now
+    coord.async_refresh = AsyncMock()
+    coord._async_notify_pending_approval = AsyncMock()
+
+    return coord, storage, _mod
+
+
+def _two_children(coord):
+    alice = run(coord.async_add_child("Alice"))
+    bob = run(coord.async_add_child("Bob"))
+    return alice, bob
+
+
+class TestAssignedToEnforcedForEveryScheduleMode:
+    @pytest.mark.parametrize("schedule_mode", ["specific_days", "recurring", "one_shot"])
+    def test_unassigned_child_cannot_complete(self, schedule_mode):
+        coord, storage, _mod = _make_system()
+        now = _now()
+        with patch.object(_mod.dt_util, "now", return_value=now):
+            alice, bob = _two_children(coord)
+            chore = run(
+                coord.async_add_chore(
+                    "Mow the lawn",
+                    points=50,
+                    requires_approval=False,
+                    schedule_mode=schedule_mode,
+                    recurrence="weekly",
+                    assigned_to=[alice.id],
+                )
+            )
+            result = run(coord.async_complete_chore(chore.id, bob.id))
+
+        assert result is None, f"{schedule_mode}: unassigned child completed the chore"
+        assert storage.get_completions() == []
+        assert storage.get_child(bob.id).points == 0
+
+    @pytest.mark.parametrize("schedule_mode", ["specific_days", "recurring", "one_shot"])
+    def test_assigned_child_can_still_complete(self, schedule_mode):
+        coord, storage, _mod = _make_system()
+        now = _now()
+        with patch.object(_mod.dt_util, "now", return_value=now):
+            alice, _bob = _two_children(coord)
+            chore = run(
+                coord.async_add_chore(
+                    "Mow the lawn",
+                    points=50,
+                    requires_approval=False,
+                    schedule_mode=schedule_mode,
+                    recurrence="weekly",
+                    assigned_to=[alice.id],
+                )
+            )
+            result = run(coord.async_complete_chore(chore.id, alice.id))
+
+        assert result is not None, f"{schedule_mode}: assigned child was wrongly blocked"
+        assert storage.get_child(alice.id).points == 50
+
+    @pytest.mark.parametrize("schedule_mode", ["specific_days", "recurring", "one_shot"])
+    def test_empty_assigned_to_still_means_everyone(self, schedule_mode):
+        coord, storage, _mod = _make_system()
+        now = _now()
+        with patch.object(_mod.dt_util, "now", return_value=now):
+            _alice, bob = _two_children(coord)
+            chore = run(
+                coord.async_add_chore(
+                    "Family tidy-up",
+                    points=5,
+                    requires_approval=False,
+                    schedule_mode=schedule_mode,
+                    recurrence="weekly",
+                    assigned_to=[],
+                )
+            )
+            result = run(coord.async_complete_chore(chore.id, bob.id))
+
+        assert result is not None, f"{schedule_mode}: everyone-mode chore blocked the child"
+        assert storage.get_child(bob.id).points == 5
+
+    @pytest.mark.parametrize("schedule_mode", ["specific_days", "recurring", "one_shot"])
+    def test_parent_may_still_complete_on_behalf(self, schedule_mode):
+        """as_parent is the authority and stays exempt from the assignment filter."""
+        coord, storage, _mod = _make_system()
+        now = _now()
+        with patch.object(_mod.dt_util, "now", return_value=now):
+            alice, bob = _two_children(coord)
+            chore = run(
+                coord.async_add_chore(
+                    "Mow the lawn",
+                    points=50,
+                    requires_approval=True,
+                    schedule_mode=schedule_mode,
+                    recurrence="weekly",
+                    assigned_to=[alice.id],
+                )
+            )
+            result = run(coord.async_complete_chore(chore.id, bob.id, as_parent=True))
+
+        assert result is not None, f"{schedule_mode}: parent blocked from completing on behalf"
+        assert storage.get_child(bob.id).points == 50
+
+    def test_unassigned_child_cannot_disable_a_one_shot_chore(self):
+        """The one_shot path appends to disabled_for — that must not be reachable."""
+        coord, storage, _mod = _make_system()
+        now = _now()
+        with patch.object(_mod.dt_util, "now", return_value=now):
+            alice, bob = _two_children(coord)
+            chore = run(
+                coord.async_add_chore(
+                    "Paint the fence",
+                    points=20,
+                    requires_approval=False,
+                    schedule_mode="one_shot",
+                    assigned_to=[alice.id],
+                )
+            )
+            run(coord.async_complete_chore(chore.id, bob.id))
+
+        assert bob.id not in (storage.get_chore(chore.id).disabled_for or [])
+
+    def test_day_filter_still_applies_to_specific_days(self):
+        coord, storage, _mod = _make_system()
+        now = _now()  # Wednesday
+        with patch.object(_mod.dt_util, "now", return_value=now):
+            alice, _bob = _two_children(coord)
+            chore = run(
+                coord.async_add_chore(
+                    "Bins out",
+                    points=10,
+                    requires_approval=False,
+                    schedule_mode="specific_days",
+                    due_days=["monday"],
+                    assigned_to=[alice.id],
+                )
+            )
+            result = run(coord.async_complete_chore(chore.id, alice.id))
+
+        assert result is None
+        assert storage.get_child(alice.id).points == 0
+
+
+class TestBonusSubtaskAssignment:
+    def test_unassigned_child_cannot_complete_a_bonus_subtask(self):
+        coord, storage, _mod = _make_system()
+        now = _now()
+        with patch.object(_mod.dt_util, "now", return_value=now):
+            alice, bob = _two_children(coord)
+            chore = run(
+                coord.async_add_chore(
+                    "Tidy room",
+                    points=10,
+                    requires_approval=False,
+                    schedule_mode="specific_days",
+                    assigned_to=[alice.id],
+                )
+            )
+            chore.bonus_subtasks = [BonusSubTask(id="b1", name="Hoover too", points=25)]
+            storage.update_chore(chore)
+            # Parent completes the base chore for Bob, opening the bonus gate.
+            run(coord.async_complete_chore(chore.id, bob.id, as_parent=True))
+
+            with pytest.raises(ValueError, match="not assigned"):
+                run(coord.async_complete_bonus_subtask(chore.id, "b1", bob.id))
+
+        assert storage.get_child(bob.id).points == 10  # base only, no bonus
+
+    def test_assigned_child_completes_bonus_subtask_normally(self):
+        coord, storage, _mod = _make_system()
+        now = _now()
+        with patch.object(_mod.dt_util, "now", return_value=now):
+            alice, _bob = _two_children(coord)
+            chore = run(
+                coord.async_add_chore(
+                    "Tidy room",
+                    points=10,
+                    requires_approval=False,
+                    schedule_mode="specific_days",
+                    assigned_to=[alice.id],
+                )
+            )
+            chore.bonus_subtasks = [BonusSubTask(id="b1", name="Hoover too", points=25)]
+            storage.update_chore(chore)
+            run(coord.async_complete_chore(chore.id, alice.id))
+            run(coord.async_complete_bonus_subtask(chore.id, "b1", alice.id))
+
+        assert storage.get_child(alice.id).points == 35

--- a/tests/test_completion_eligibility.py
+++ b/tests/test_completion_eligibility.py
@@ -15,8 +15,8 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from custom_components.taskmate.models import BonusSubTask
 from custom_components.taskmate.coordinator import TaskMateCoordinator
+from custom_components.taskmate.models import BonusSubTask
 from custom_components.taskmate.storage import TaskMateStorage
 
 UTC = timezone.utc

--- a/tests/test_coordinator_rewards.py
+++ b/tests/test_coordinator_rewards.py
@@ -878,3 +878,50 @@ class TestClaimFloodControl:
 
         run(coord.async_claim_reward("reward1", "kid1"))
         coord.storage.add_reward_claim.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# availability is re-checked at approval, not just at claim time
+# ---------------------------------------------------------------------------
+
+
+class TestApprovalRechecksAvailability:
+    def test_stacked_claims_cannot_oversell_stock(self):
+        """Two claims, one unit: the second approval must fail, not float to -1."""
+        alice = Child(name="Alice", points=500, id="kid1")
+        bob = Child(name="Bob", points=500, id="kid2")
+        reward = Reward(name="Cinema ticket", cost=10, id="reward1", quantity=1)
+        c1 = RewardClaim(child_id="kid1", reward_id="reward1", claimed_at=_ts(), approved=False, id="c1")
+        c2 = RewardClaim(child_id="kid2", reward_id="reward1", claimed_at=_ts(), approved=False, id="c2")
+        coord = _make_coord(children=[alice, bob], rewards=[reward], claims=[c1, c2])
+
+        run(coord.async_approve_reward("c1"))
+        assert reward.quantity == 0
+
+        with pytest.raises(ValueError, match="sold out"):
+            run(coord.async_approve_reward("c2"))
+
+        assert reward.quantity == 0
+        assert bob.points == 500  # not charged for a unit that doesn't exist
+
+    def test_expired_reward_cannot_be_approved(self):
+        alice = Child(name="Alice", points=500, id="kid1")
+        reward = Reward(name="Summer treat", cost=10, id="reward1", expires_at="2000-01-01")
+        claim = RewardClaim(child_id="kid1", reward_id="reward1", claimed_at=_ts(), approved=False, id="c1")
+        coord = _make_coord(children=[alice], rewards=[reward], claims=[claim])
+
+        with pytest.raises(ValueError, match="expired"):
+            run(coord.async_approve_reward("c1"))
+
+        assert alice.points == 500
+
+    def test_normal_approval_still_works(self):
+        alice = Child(name="Alice", points=500, id="kid1")
+        reward = Reward(name="Movie night", cost=10, id="reward1", quantity=5)
+        claim = RewardClaim(child_id="kid1", reward_id="reward1", claimed_at=_ts(), approved=False, id="c1")
+        coord = _make_coord(children=[alice], rewards=[reward], claims=[claim])
+
+        run(coord.async_approve_reward("c1"))
+        assert claim.approved is True
+        assert alice.points == 490
+        assert reward.quantity == 4

--- a/tests/test_coordinator_rewards.py
+++ b/tests/test_coordinator_rewards.py
@@ -751,3 +751,63 @@ class TestRemoveRewardRefundsPool:
         run(coord.async_remove_reward("reward1"))
         coord.storage.remove_reward.assert_called_once_with("reward1")
         assert coord.storage.add_points_transaction.call_count == 0
+
+
+# ---------------------------------------------------------------------------
+# assigned_to is a real restriction, not just a card-side filter
+# ---------------------------------------------------------------------------
+
+
+class TestRewardAssignment:
+    def test_claim_rejects_a_child_the_reward_is_not_assigned_to(self):
+        child = _child(points=500)
+        reward = _reward(cost=50)
+        reward.assigned_to = ["someone-else"]
+        coord = _make_coord(children=[child], rewards=[reward])
+
+        with pytest.raises(ValueError, match="not available to"):
+            run(coord.async_claim_reward("reward1", "kid1"))
+
+        coord.storage.add_reward_claim.assert_not_called()
+
+    def test_claim_allows_an_assigned_child(self):
+        child = _child(points=500)
+        reward = _reward(cost=50)
+        reward.assigned_to = ["kid1"]
+        coord = _make_coord(children=[child], rewards=[reward])
+
+        run(coord.async_claim_reward("reward1", "kid1"))
+        coord.storage.add_reward_claim.assert_called_once()
+
+    def test_claim_allows_everyone_when_assigned_to_is_empty(self):
+        child = _child(points=500)
+        reward = _reward(cost=50)
+        reward.assigned_to = []
+        coord = _make_coord(children=[child], rewards=[reward])
+
+        run(coord.async_claim_reward("reward1", "kid1"))
+        coord.storage.add_reward_claim.assert_called_once()
+
+    def test_pool_allocation_rejects_an_unassigned_child(self):
+        """Allocation deducts immediately and cannot be withdrawn — gate it too."""
+        child = _child(points=500)
+        reward = _reward(cost=50)
+        reward.assigned_to = ["someone-else"]
+        reward.pool_enabled = True
+        coord = _make_coord(children=[child], rewards=[reward])
+
+        with pytest.raises(ValueError, match="not available to"):
+            run(coord.async_allocate_points_to_pool("kid1", "reward1", 10))
+
+        assert child.points == 500
+        coord.storage.upsert_pool_allocation.assert_not_called()
+
+    def test_pool_allocation_allows_an_assigned_child(self):
+        child = _child(points=500)
+        reward = _reward(cost=50)
+        reward.assigned_to = ["kid1"]
+        reward.pool_enabled = True
+        coord = _make_coord(children=[child], rewards=[reward])
+
+        run(coord.async_allocate_points_to_pool("kid1", "reward1", 10))
+        coord.storage.upsert_pool_allocation.assert_called_once()

--- a/tests/test_coordinator_rewards.py
+++ b/tests/test_coordinator_rewards.py
@@ -811,3 +811,70 @@ class TestRewardAssignment:
 
         run(coord.async_allocate_points_to_pool("kid1", "reward1", 10))
         coord.storage.upsert_pool_allocation.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# pending-claim flood control
+# ---------------------------------------------------------------------------
+
+
+def _ts():
+    import datetime as _dt
+
+    return _dt.datetime(2024, 3, 20, 12, 0, 0, tzinfo=_dt.timezone.utc)
+
+
+class TestClaimFloodControl:
+    def test_duplicate_pending_claim_is_rejected(self):
+        child = _child(points=500)
+        reward = _reward(cost=10)
+        existing = RewardClaim(child_id="kid1", reward_id="reward1", claimed_at=_ts(), approved=False)
+        coord = _make_coord(children=[child], rewards=[reward], claims=[existing])
+
+        with pytest.raises(ValueError, match="already waiting"):
+            run(coord.async_claim_reward("reward1", "kid1"))
+
+        coord.storage.add_reward_claim.assert_not_called()
+
+    def test_zero_cost_reward_cannot_be_claimed_repeatedly(self):
+        """A free reward passes every balance check, so the dedupe guard is the brake."""
+        child = _child(points=0)
+        reward = _reward(cost=0)
+        existing = RewardClaim(child_id="kid1", reward_id="reward1", claimed_at=_ts(), approved=False)
+        coord = _make_coord(children=[child], rewards=[reward], claims=[existing])
+
+        with pytest.raises(ValueError, match="already waiting"):
+            run(coord.async_claim_reward("reward1", "kid1"))
+
+    def test_another_child_may_still_claim_the_same_reward(self):
+        alice = _child(points=500)
+        bob = Child(name="Bob", points=500, id="kid2")
+        reward = _reward(cost=10)
+        existing = RewardClaim(child_id="kid1", reward_id="reward1", claimed_at=_ts(), approved=False)
+        coord = _make_coord(children=[alice, bob], rewards=[reward], claims=[existing])
+
+        run(coord.async_claim_reward("reward1", "kid2"))
+        coord.storage.add_reward_claim.assert_called_once()
+
+    def test_pending_queue_is_capped_per_child(self):
+        from custom_components.taskmate.coord_rewards import _MAX_PENDING_CLAIMS_PER_CHILD
+
+        child = _child(points=100000)
+        rewards = [Reward(name=f"R{i}", cost=1, id=f"reward{i}") for i in range(_MAX_PENDING_CLAIMS_PER_CHILD + 1)]
+        claims = [
+            RewardClaim(child_id="kid1", reward_id=f"reward{i}", claimed_at=_ts(), approved=False)
+            for i in range(_MAX_PENDING_CLAIMS_PER_CHILD)
+        ]
+        coord = _make_coord(children=[child], rewards=rewards, claims=claims)
+
+        with pytest.raises(ValueError, match="Too many"):
+            run(coord.async_claim_reward(f"reward{_MAX_PENDING_CLAIMS_PER_CHILD}", "kid1"))
+
+    def test_approved_claims_do_not_count_towards_the_cap(self):
+        child = _child(points=500)
+        reward = _reward(cost=10)
+        done = RewardClaim(child_id="kid1", reward_id="reward1", claimed_at=_ts(), approved=True)
+        coord = _make_coord(children=[child], rewards=[reward], claims=[done])
+
+        run(coord.async_claim_reward("reward1", "kid1"))
+        coord.storage.add_reward_claim.assert_called_once()

--- a/tests/test_image_views.py
+++ b/tests/test_image_views.py
@@ -75,3 +75,13 @@ def test_frontend_registers_the_image_views():
         pathlib.Path(__file__).resolve().parent.parent / "custom_components" / "taskmate" / "frontend.py"
     ).read_text(encoding="utf-8")
     assert "async_register_image_views" in frontend, "views that are never registered mean every image 404s"
+
+
+def test_serve_view_sets_sniffing_protections():
+    """User-supplied bytes served from the HA origin need nosniff, like photos."""
+    assert '"X-Content-Type-Options": "nosniff"' in SRC
+    assert '"Content-Disposition": "inline"' in SRC
+
+
+def test_upload_bounds_the_form_part_scan():
+    assert "parts_scanned > 16" in SRC

--- a/tests/test_import_value_types.py
+++ b/tests/test_import_value_types.py
@@ -91,11 +91,7 @@ async def test_import_drops_unparseable_timestamps(hass):
     storage = TaskMateStorage(hass, "imp4")
     await storage.async_load()
     storage.import_data(
-        {
-            "completions": [
-                {"id": "x1", "chore_id": "c1", "child_id": "k1", "completed_at": XSS, "approved_at": XSS}
-            ]
-        }
+        {"completions": [{"id": "x1", "chore_id": "c1", "child_id": "k1", "completed_at": XSS, "approved_at": XSS}]}
     )
     comp = storage._data["completions"][0]
     assert comp["completed_at"] == ""
@@ -107,9 +103,7 @@ async def test_import_keeps_valid_timestamps(hass):
     storage = TaskMateStorage(hass, "imp5")
     await storage.async_load()
     stamp = "2026-06-21T13:00:00+00:00"
-    storage.import_data(
-        {"completions": [{"id": "x1", "chore_id": "c1", "child_id": "k1", "completed_at": stamp}]}
-    )
+    storage.import_data({"completions": [{"id": "x1", "chore_id": "c1", "child_id": "k1", "completed_at": stamp}]})
     assert storage._data["completions"][0]["completed_at"] == stamp
 
 
@@ -192,9 +186,7 @@ def test_template_pack_coerces_optional_numbers():
 
 def test_template_pack_preserves_valid_values():
     coord = _templates_coord()
-    clean = coord._validate_pack(
-        _pack({"name": "Make bed", "points": 25, "daily_limit": 2, "weather_temp_min": 4.5})
-    )
+    clean = coord._validate_pack(_pack({"name": "Make bed", "points": 25, "daily_limit": 2, "weather_temp_min": 4.5}))
     chore = clean[0]["chores"][0]
     assert chore["points"] == 25
     assert chore["daily_limit"] == 2
@@ -226,9 +218,7 @@ async def test_import_drops_custom_sounds_with_a_bad_filename(hass):
 async def test_import_cleans_custom_sound_names(hass):
     storage = TaskMateStorage(hass, "snd2")
     await storage.async_load()
-    storage.import_data(
-        {"custom_sounds": [{"id": "s1", "name": "x" * 200, "file": "b" * 32 + ".ogg"}]}
-    )
+    storage.import_data({"custom_sounds": [{"id": "s1", "name": "x" * 200, "file": "b" * 32 + ".ogg"}]})
     assert len(storage._data["custom_sounds"][0]["name"]) <= 40
 
 

--- a/tests/test_import_value_types.py
+++ b/tests/test_import_value_types.py
@@ -199,3 +199,51 @@ def test_template_pack_preserves_valid_values():
     assert chore["points"] == 25
     assert chore["daily_limit"] == 2
     assert chore["weather_temp_min"] == 4.5
+
+
+# ── custom sounds on import ─────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_import_drops_custom_sounds_with_a_bad_filename(hass):
+    """`file` is concatenated into a path and handed to HA's URL signer."""
+    storage = TaskMateStorage(hass, "snd1")
+    await storage.async_load()
+    storage.import_data(
+        {
+            "custom_sounds": [
+                {"id": "s1", "name": "Good", "file": "a" * 32 + ".mp3"},
+                {"id": "s2", "name": "Bad", "file": "../../secrets.yaml"},
+                {"id": "s3", "name": "Worse", "file": XSS},
+            ]
+        }
+    )
+    files = [s["file"] for s in storage._data["custom_sounds"]]
+    assert files == ["a" * 32 + ".mp3"]
+
+
+@pytest.mark.asyncio
+async def test_import_cleans_custom_sound_names(hass):
+    storage = TaskMateStorage(hass, "snd2")
+    await storage.async_load()
+    storage.import_data(
+        {"custom_sounds": [{"id": "s1", "name": "x" * 200, "file": "b" * 32 + ".ogg"}]}
+    )
+    assert len(storage._data["custom_sounds"][0]["name"]) <= 40
+
+
+@pytest.mark.asyncio
+async def test_import_resets_an_unknown_completion_sound(hass):
+    storage = TaskMateStorage(hass, "snd3")
+    await storage.async_load()
+    storage.import_data(
+        {
+            "chores": [
+                {"id": "c1", "name": "A", "completion_sound": XSS},
+                {"id": "c2", "name": "B", "completion_sound": "coin"},
+                {"id": "c3", "name": "C", "completion_sound": "custom:" + "c" * 32 + ".mp3"},
+            ]
+        }
+    )
+    sounds = [c["completion_sound"] for c in storage._data["chores"]]
+    assert sounds == ["coin", "coin", "custom:" + "c" * 32 + ".mp3"]

--- a/tests/test_import_value_types.py
+++ b/tests/test_import_value_types.py
@@ -1,0 +1,201 @@
+"""A restored backup or shared pack must not smuggle wrong value *types*.
+
+The key whitelists on import and on template packs decide which fields survive,
+not what they hold. Anything the rest of the app treats as a number has to
+actually be a finite number by the time it lands in storage — otherwise it
+flows into points arithmetic, the sensor attribute build, and the admin panel's
+number inputs, none of which expect a string, a dict, inf or NaN.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.taskmate.coordinator import TaskMateCoordinator
+from custom_components.taskmate.storage import TaskMateStorage
+
+XSS = '<img src=x onerror="alert(1)">'
+
+
+def run(coro):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+# ── backup import ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_import_coerces_chore_numbers(hass):
+    storage = TaskMateStorage(hass, "imp1")
+    await storage.async_load()
+    storage.import_data(
+        {
+            "chores": [
+                {
+                    "id": "c1",
+                    "name": "Tidy room",
+                    "points": XSS,
+                    "daily_limit": {"nested": 1},
+                    "timed_rate_minutes": "5",
+                    "bonus_subtasks": [{"id": "b1", "name": "Hoover", "points": XSS}],
+                }
+            ]
+        }
+    )
+    chore = storage._data["chores"][0]
+    assert chore["points"] == 0
+    assert chore["daily_limit"] == 0
+    assert chore["timed_rate_minutes"] == 5  # a numeric string is fine, coerced
+    assert chore["bonus_subtasks"][0]["points"] == 0
+    # The escape hatch is gone: nothing numeric is a string any more.
+    assert not isinstance(chore["points"], str)
+
+
+@pytest.mark.asyncio
+async def test_import_coerces_child_reward_and_badge_numbers(hass):
+    storage = TaskMateStorage(hass, "imp2")
+    await storage.async_load()
+    storage.import_data(
+        {
+            "children": [{"id": "k1", "name": "Alice", "points": XSS, "current_streak": "abc"}],
+            "rewards": [{"id": "r1", "name": "Movie", "cost": XSS, "quantity": "many"}],
+            "badges": [{"id": "b1", "name": "Star", "criteria": [{"metric": "points", "value": XSS}]}],
+            "points_transactions": [{"id": "t1", "child_id": "k1", "points": XSS}],
+        }
+    )
+    assert storage._data["children"][0]["points"] == 0
+    assert storage._data["children"][0]["current_streak"] == 0
+    assert storage._data["rewards"][0]["cost"] == 0
+    assert storage._data["rewards"][0]["quantity"] == 0
+    assert storage._data["badges"][0]["criteria"][0]["value"] == 0
+    assert storage._data["points_transactions"][0]["points"] == 0
+
+
+@pytest.mark.asyncio
+async def test_import_keeps_unlimited_reward_quantity_as_none(hass):
+    storage = TaskMateStorage(hass, "imp3")
+    await storage.async_load()
+    storage.import_data({"rewards": [{"id": "r1", "name": "Movie", "cost": 5, "quantity": None}]})
+    assert storage._data["rewards"][0]["quantity"] is None
+
+
+@pytest.mark.asyncio
+async def test_import_drops_unparseable_timestamps(hass):
+    storage = TaskMateStorage(hass, "imp4")
+    await storage.async_load()
+    storage.import_data(
+        {
+            "completions": [
+                {"id": "x1", "chore_id": "c1", "child_id": "k1", "completed_at": XSS, "approved_at": XSS}
+            ]
+        }
+    )
+    comp = storage._data["completions"][0]
+    assert comp["completed_at"] == ""
+    assert comp["approved_at"] == ""
+
+
+@pytest.mark.asyncio
+async def test_import_keeps_valid_timestamps(hass):
+    storage = TaskMateStorage(hass, "imp5")
+    await storage.async_load()
+    stamp = "2026-06-21T13:00:00+00:00"
+    storage.import_data(
+        {"completions": [{"id": "x1", "chore_id": "c1", "child_id": "k1", "completed_at": stamp}]}
+    )
+    assert storage._data["completions"][0]["completed_at"] == stamp
+
+
+@pytest.mark.asyncio
+async def test_import_rejects_non_finite_settings(hass):
+    storage = TaskMateStorage(hass, "imp6")
+    await storage.async_load()
+    storage.import_data({"settings": {"weekend_multiplier": "inf", "level_xp_step": "nan"}})
+    settings = storage._data["settings"]
+    assert "weekend_multiplier" not in settings
+    assert "level_xp_step" not in settings
+
+
+@pytest.mark.asyncio
+async def test_import_leaves_good_data_alone(hass):
+    storage = TaskMateStorage(hass, "imp7")
+    await storage.async_load()
+    storage.import_data(
+        {
+            "children": [{"id": "k1", "name": "Alice", "points": 120}],
+            "chores": [{"id": "c1", "name": "Dishes", "points": 10, "daily_limit": 2}],
+            "settings": {"weekend_multiplier": 1.5},
+        }
+    )
+    assert storage._data["children"][0]["points"] == 120
+    assert storage._data["chores"][0]["points"] == 10
+    assert storage._data["chores"][0]["daily_limit"] == 2
+    assert storage._data["settings"]["weekend_multiplier"] == 1.5
+
+
+# ── template packs ──────────────────────────────────────────────────────────
+
+
+def _templates_coord():
+    coord = object.__new__(TaskMateCoordinator)
+    coord.storage = MagicMock()
+    coord.storage.async_save = AsyncMock()
+    coord.async_refresh = AsyncMock()
+    return coord
+
+
+def _pack(chore):
+    return {
+        "format": "taskmate.template-pack",
+        "version": 1,
+        "templates": [{"name": "Morning", "icon": "mdi:x", "chores": [chore]}],
+    }
+
+
+def test_template_pack_coerces_numeric_fields():
+    coord = _templates_coord()
+    clean = coord._validate_pack(
+        _pack({"name": "Make bed", "points": XSS, "daily_limit": "3", "timed_rate_minutes": {"a": 1}})
+    )
+    chore = clean[0]["chores"][0]
+    assert chore["points"] == 10  # falls back to the field default
+    assert chore["daily_limit"] == 3
+    assert chore["timed_rate_minutes"] == 15
+
+
+def test_template_pack_rejects_non_finite_numbers():
+    coord = _templates_coord()
+    clean = coord._validate_pack(_pack({"name": "Make bed", "points": "inf", "daily_limit": "nan"}))
+    chore = clean[0]["chores"][0]
+    assert chore["points"] == 10
+    assert chore["daily_limit"] == 1
+
+
+def test_template_pack_keeps_optional_numbers_unset():
+    coord = _templates_coord()
+    clean = coord._validate_pack(_pack({"name": "Wash car", "weather_temp_min": None}))
+    assert clean[0]["chores"][0]["weather_temp_min"] is None
+
+
+def test_template_pack_coerces_optional_numbers():
+    coord = _templates_coord()
+    clean = coord._validate_pack(_pack({"name": "Wash car", "weather_temp_min": XSS}))
+    assert clean[0]["chores"][0]["weather_temp_min"] is None
+
+
+def test_template_pack_preserves_valid_values():
+    coord = _templates_coord()
+    clean = coord._validate_pack(
+        _pack({"name": "Make bed", "points": 25, "daily_limit": 2, "weather_temp_min": 4.5})
+    )
+    chore = clean[0]["chores"][0]
+    assert chore["points"] == 25
+    assert chore["daily_limit"] == 2
+    assert chore["weather_temp_min"] == 4.5

--- a/tests/test_mandatory_detection.py
+++ b/tests/test_mandatory_detection.py
@@ -125,8 +125,9 @@ def _mandatory_chore(category="evening"):
 
 def test_recheck_creates_the_miss_once_the_period_has_closed():
     """Submit before the deadline, get rejected after it: the miss is now owed."""
-    import custom_components.taskmate.coord_mandatory as _mod
     from unittest.mock import patch
+
+    import custom_components.taskmate.coord_mandatory as _mod
 
     chore = _mandatory_chore("evening")
     now = dt.datetime(2026, 6, 21, 21, 30, tzinfo=dt.timezone.utc)
@@ -142,8 +143,9 @@ def test_recheck_creates_the_miss_once_the_period_has_closed():
 
 def test_recheck_is_a_no_op_while_the_period_is_still_open():
     """Rejecting early in the period must not penalise a child who can still act."""
-    import custom_components.taskmate.coord_mandatory as _mod
     from unittest.mock import patch
+
+    import custom_components.taskmate.coord_mandatory as _mod
 
     chore = _mandatory_chore("evening")
     now = dt.datetime(2026, 6, 21, 19, 0, tzinfo=dt.timezone.utc)
@@ -155,8 +157,9 @@ def test_recheck_is_a_no_op_while_the_period_is_still_open():
 
 
 def test_recheck_ignores_non_mandatory_chores():
-    import custom_components.taskmate.coord_mandatory as _mod
     from unittest.mock import patch
+
+    import custom_components.taskmate.coord_mandatory as _mod
 
     chore = Chore(name="Extra", mandatory=False, time_category="evening", assigned_to=["k1"], id="c1")
     now = dt.datetime(2026, 6, 21, 23, 0, tzinfo=dt.timezone.utc)
@@ -167,9 +170,10 @@ def test_recheck_ignores_non_mandatory_chores():
 
 
 def test_recheck_does_not_double_up_an_existing_miss():
+    from unittest.mock import patch
+
     import custom_components.taskmate.coord_mandatory as _mod
     from custom_components.taskmate.models import MandatoryMiss
-    from unittest.mock import patch
 
     chore = _mandatory_chore("evening")
     now = dt.datetime(2026, 6, 21, 22, 0, tzinfo=dt.timezone.utc)
@@ -183,8 +187,9 @@ def test_recheck_does_not_double_up_an_existing_miss():
 
 
 def test_recheck_on_a_past_day_always_counts_as_closed():
-    import custom_components.taskmate.coord_mandatory as _mod
     from unittest.mock import patch
+
+    import custom_components.taskmate.coord_mandatory as _mod
 
     chore = _mandatory_chore("evening")
     now = dt.datetime(2026, 6, 23, 9, 0, tzinfo=dt.timezone.utc)

--- a/tests/test_mandatory_detection.py
+++ b/tests/test_mandatory_detection.py
@@ -91,3 +91,104 @@ def test_disabled_for_child_skipped():
     )
     coord = _coord([chore], [Child(name="Kid", id="k1")], [])
     assert run(coord.async_detect_mandatory_misses("afternoon", DAY)) == 0
+
+
+# ---------------------------------------------------------------------------
+# rejection re-opens the miss question (#detection only ran at period end)
+# ---------------------------------------------------------------------------
+
+
+def _recheck_coord(chore, completions, now):
+    coord = _coord([chore], [Child(name="Kid", id="k1")], completions)
+    coord.get_chore = MagicMock(return_value=chore)
+    coord.get_time_periods = MagicMock(
+        return_value=[
+            {"id": "morning", "start": "06:00", "end": "12:00"},
+            {"id": "afternoon", "start": "12:00", "end": "18:00"},
+            {"id": "evening", "start": "18:00", "end": "21:00"},
+        ]
+    )
+    coord._dt_now = now
+    return coord
+
+
+def _mandatory_chore(category="evening"):
+    return Chore(
+        name="Bins out",
+        mandatory=True,
+        mandatory_penalty_points=20,
+        time_category=category,
+        assigned_to=["k1"],
+        id="c1",
+    )
+
+
+def test_recheck_creates_the_miss_once_the_period_has_closed():
+    """Submit before the deadline, get rejected after it: the miss is now owed."""
+    import custom_components.taskmate.coord_mandatory as _mod
+    from unittest.mock import patch
+
+    chore = _mandatory_chore("evening")
+    now = dt.datetime(2026, 6, 21, 21, 30, tzinfo=dt.timezone.utc)
+    coord = _recheck_coord(chore, [], now)
+
+    with patch.object(_mod.dt_util, "now", return_value=now):
+        created = run(coord.async_recheck_mandatory_miss("c1", "k1", DAY))
+
+    assert created == 1
+    assert coord.storage._added[0].chore_id == "c1"
+    assert coord.storage._added[0].penalty_points == 20
+
+
+def test_recheck_is_a_no_op_while_the_period_is_still_open():
+    """Rejecting early in the period must not penalise a child who can still act."""
+    import custom_components.taskmate.coord_mandatory as _mod
+    from unittest.mock import patch
+
+    chore = _mandatory_chore("evening")
+    now = dt.datetime(2026, 6, 21, 19, 0, tzinfo=dt.timezone.utc)
+    coord = _recheck_coord(chore, [], now)
+
+    with patch.object(_mod.dt_util, "now", return_value=now):
+        assert run(coord.async_recheck_mandatory_miss("c1", "k1", DAY)) == 0
+    assert coord.storage._added == []
+
+
+def test_recheck_ignores_non_mandatory_chores():
+    import custom_components.taskmate.coord_mandatory as _mod
+    from unittest.mock import patch
+
+    chore = Chore(name="Extra", mandatory=False, time_category="evening", assigned_to=["k1"], id="c1")
+    now = dt.datetime(2026, 6, 21, 23, 0, tzinfo=dt.timezone.utc)
+    coord = _recheck_coord(chore, [], now)
+
+    with patch.object(_mod.dt_util, "now", return_value=now):
+        assert run(coord.async_recheck_mandatory_miss("c1", "k1", DAY)) == 0
+
+
+def test_recheck_does_not_double_up_an_existing_miss():
+    import custom_components.taskmate.coord_mandatory as _mod
+    from custom_components.taskmate.models import MandatoryMiss
+    from unittest.mock import patch
+
+    chore = _mandatory_chore("evening")
+    now = dt.datetime(2026, 6, 21, 22, 0, tzinfo=dt.timezone.utc)
+    coord = _recheck_coord(chore, [], now)
+    coord.storage.get_mandatory_misses = MagicMock(
+        return_value=[MandatoryMiss(chore_id="c1", child_id="k1", due_date=DAY.isoformat(), period_id="evening")]
+    )
+
+    with patch.object(_mod.dt_util, "now", return_value=now):
+        assert run(coord.async_recheck_mandatory_miss("c1", "k1", DAY)) == 0
+
+
+def test_recheck_on_a_past_day_always_counts_as_closed():
+    import custom_components.taskmate.coord_mandatory as _mod
+    from unittest.mock import patch
+
+    chore = _mandatory_chore("evening")
+    now = dt.datetime(2026, 6, 23, 9, 0, tzinfo=dt.timezone.utc)
+    coord = _recheck_coord(chore, [], now)
+
+    with patch.object(_mod.dt_util, "now", return_value=now):
+        assert run(coord.async_recheck_mandatory_miss("c1", "k1", DAY)) == 1

--- a/tests/test_photo_storage.py
+++ b/tests/test_photo_storage.py
@@ -162,3 +162,38 @@ def test_sweep_removes_old_unreferenced_only(tmp_path):
 def test_sweep_missing_dir_is_noop(tmp_path):
     hass = _hass(tmp_path)
     assert run(photos.async_sweep_orphan_photos(hass, [])) == 0
+
+
+# ---------------------------------------------------------------------------
+# upload rate limiting (the one upload path open to non-admin users)
+# ---------------------------------------------------------------------------
+
+
+class TestUploadRateLimiter:
+    def test_allows_up_to_the_cap_then_refuses(self):
+        rl = photos.UploadRateLimiter(max_per_window=3, window_seconds=60)
+        assert [rl.check("u1", now=100 + i) for i in range(3)] == [False, False, False]
+        assert rl.check("u1", now=104) is True
+
+    def test_window_slides(self):
+        rl = photos.UploadRateLimiter(max_per_window=2, window_seconds=60)
+        rl.check("u1", now=100)
+        rl.check("u1", now=101)
+        assert rl.check("u1", now=102) is True
+        # Once the earlier attempts age out, the caller is allowed again.
+        assert rl.check("u1", now=200) is False
+
+    def test_users_are_independent(self):
+        rl = photos.UploadRateLimiter(max_per_window=1, window_seconds=60)
+        assert rl.check("u1", now=100) is False
+        assert rl.check("u1", now=101) is True
+        assert rl.check("u2", now=101) is False
+
+    def test_state_does_not_leak_for_idle_users(self):
+        rl = photos.UploadRateLimiter(max_per_window=5, window_seconds=60)
+        for i in range(50):
+            rl.check(f"user{i}", now=100 + i)
+        assert rl.tracked_users == 50
+        # Long after their windows closed, the map is swept.
+        rl.check("late", now=100_000)
+        assert rl.tracked_users == 1

--- a/tests/test_photo_views.py
+++ b/tests/test_photo_views.py
@@ -10,9 +10,9 @@ from __future__ import annotations
 
 import pathlib
 
-SRC = (
-    pathlib.Path(__file__).resolve().parent.parent / "custom_components" / "taskmate" / "http_photos.py"
-).read_text(encoding="utf-8")
+SRC = (pathlib.Path(__file__).resolve().parent.parent / "custom_components" / "taskmate" / "http_photos.py").read_text(
+    encoding="utf-8"
+)
 
 
 def test_upload_is_rate_limited_per_user():

--- a/tests/test_photo_views.py
+++ b/tests/test_photo_views.py
@@ -1,0 +1,39 @@
+"""The evidence-photo upload view's resource limits (source-level wiring).
+
+aiohttp is not installed in the test environment, so — as with
+``test_image_views.py`` — this asserts on the wiring in the source and leaves
+the behaviour to ``test_photo_storage.py`` (the limiter itself) and the live
+ha-dev run.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+SRC = (
+    pathlib.Path(__file__).resolve().parent.parent / "custom_components" / "taskmate" / "http_photos.py"
+).read_text(encoding="utf-8")
+
+
+def test_upload_is_rate_limited_per_user():
+    assert "photos.UploadRateLimiter" in SRC
+    assert "self._limiter.check(user_id)" in SRC
+    assert "TOO_MANY_REQUESTS" in SRC
+
+
+def test_upload_bounds_concurrent_bodies():
+    """Each in-flight upload can buffer MAX_UPLOAD_BYTES, so cap how many run."""
+    assert "asyncio.Semaphore(self.MAX_CONCURRENT_UPLOADS)" in SRC
+    assert "async with self._slots:" in SRC
+
+
+def test_disk_budget_is_checked_before_reading_a_body():
+    """The budget check must not sit only after megabytes are already buffered."""
+    pre = SRC.index("Check the disk budget before accepting a body")
+    multipart = SRC.index("await request.multipart()")
+    assert pre < multipart
+
+
+def test_rate_limit_is_keyed_on_the_requesting_user():
+    assert 'user = request.get("hass_user")' in SRC
+    assert 'user_id = getattr(user, "id", "") or "anonymous"' in SRC

--- a/tests/test_quests.py
+++ b/tests/test_quests.py
@@ -109,3 +109,72 @@ def test_create_quest_validates():
         run(coord.async_create_quest(name="No steps", steps=[]))
     with pytest.raises(ValueError):
         run(coord.async_create_quest(name="", steps=["a"]))
+
+
+# ---------------------------------------------------------------------------
+# reversing an approval must rewind the chain, not leave it advanced
+# ---------------------------------------------------------------------------
+
+
+class TestQuestRewind:
+    def test_mid_chain_step_is_rewound(self):
+        q = Quest(name="Morning", steps=["a", "b", "c"], bonus_points=30, id="q1")
+        child = Child(name="Mia", id="kid", points=0, total_points_earned=0)
+        coord = _coord([q], child)
+        run(coord._async_advance_quests("kid", "a"))
+        assert coord._progress["q1"]["kid"]["step"] == 1
+
+        run(coord._async_rewind_quests("kid", "a"))
+        assert coord._progress["q1"]["kid"]["step"] == 0
+
+    def test_rewind_ignores_a_chore_that_did_not_advance_it(self):
+        q = Quest(name="Morning", steps=["a", "b", "c"], bonus_points=30, id="q1")
+        child = Child(name="Mia", id="kid", points=0, total_points_earned=0)
+        coord = _coord([q], child)
+        run(coord._async_advance_quests("kid", "a"))
+
+        run(coord._async_rewind_quests("kid", "zzz"))
+        assert coord._progress["q1"]["kid"]["step"] == 1
+
+    def test_repeatable_quest_bonus_is_not_paid_twice(self):
+        """undo → re-approve on the final step used to pay the bonus again."""
+        q = Quest(name="Loop", steps=["a"], bonus_points=30, id="q1", repeatable=True)
+        child = Child(name="Mia", id="kid", points=0, total_points_earned=0)
+        coord = _coord([q], child)
+
+        run(coord._async_advance_quests("kid", "a"))
+        assert child.points == 30
+        assert coord._progress["q1"]["kid"]["completed_count"] == 1
+
+        run(coord._async_rewind_quests("kid", "a"))
+        assert child.points == 0, "the quest bonus was not taken back"
+        assert coord._progress["q1"]["kid"]["completed_count"] == 0
+
+        run(coord._async_advance_quests("kid", "a"))
+        assert child.points == 30, "re-approving paid the quest bonus twice"
+
+    def test_one_shot_quest_completion_is_reversible(self):
+        q = Quest(name="Once", steps=["a", "b"], bonus_points=50, id="q1", repeatable=False)
+        child = Child(name="Mia", id="kid", points=0, total_points_earned=0)
+        coord = _coord([q], child)
+        run(coord._async_advance_quests("kid", "a"))
+        run(coord._async_advance_quests("kid", "b"))
+        assert child.points == 50
+        assert coord._progress["q1"]["kid"]["step"] == 2
+
+        run(coord._async_rewind_quests("kid", "b"))
+        assert coord._progress["q1"]["kid"]["step"] == 1
+        assert child.points == 0
+        assert coord._progress["q1"]["kid"]["completed_count"] == 0
+
+    def test_rewind_logs_the_reversal(self):
+        q = Quest(name="Loop", steps=["a"], bonus_points=30, id="q1", repeatable=True)
+        child = Child(name="Mia", id="kid", points=0, total_points_earned=0)
+        coord = _coord([q], child)
+        run(coord._async_advance_quests("kid", "a"))
+        coord.storage.add_points_transaction.reset_mock()
+
+        run(coord._async_rewind_quests("kid", "a"))
+        tx = coord.storage.add_points_transaction.call_args[0][0]
+        assert tx.points == -30
+        assert "reversed" in tx.reason.lower()

--- a/tests/test_read_aloud.py
+++ b/tests/test_read_aloud.py
@@ -97,6 +97,7 @@ class TestSpeaking:
             "speak",
             {"entity_id": "tts.piper", "media_player_entity_id": "media_player.kitchen", "message": said},
             blocking=True,
+            context=None,
         )
 
     @pytest.mark.asyncio
@@ -164,3 +165,17 @@ class TestPreview:
         assert preview["message"] == DEFAULT_ONE_TEMPLATE.format(name="Ella", count=1, chores="a")
         assert preview["tts_entity"] == "tts.piper"
         coord.hass.services.async_call.assert_not_awaited()
+
+
+class TestReadAloudContext:
+    @pytest.mark.asyncio
+    async def test_caller_context_is_forwarded_to_tts(self):
+        """Without the context the speaker call is unattributed, so HA can't
+        apply the calling user's entity permissions to it."""
+        coord = _coord()
+        ctx = object()
+        await coord.async_read_aloud(
+            "kid1", media_player="media_player.kitchen", tts_entity="tts.piper", context=ctx
+        )
+        _, kwargs = coord.hass.services.async_call.call_args
+        assert kwargs["context"] is ctx

--- a/tests/test_read_aloud.py
+++ b/tests/test_read_aloud.py
@@ -174,8 +174,6 @@ class TestReadAloudContext:
         apply the calling user's entity permissions to it."""
         coord = _coord()
         ctx = object()
-        await coord.async_read_aloud(
-            "kid1", media_player="media_player.kitchen", tts_entity="tts.piper", context=ctx
-        )
+        await coord.async_read_aloud("kid1", media_player="media_player.kitchen", tts_entity="tts.piper", context=ctx)
         _, kwargs = coord.hass.services.async_call.call_args
         assert kwargs["context"] is ctx

--- a/tests/test_read_aloud_guardrails.py
+++ b/tests/test_read_aloud_guardrails.py
@@ -1,0 +1,56 @@
+"""read_aloud speaks through a household speaker, so its inputs are guarded.
+
+A child may have *their own chore list* read out. Choosing the words, and
+picking which speaker says them, is a parent action — otherwise any account
+that can act as a child can make a speaker in the house say anything.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+
+SRC = (pathlib.Path(__file__).resolve().parent.parent / "custom_components" / "taskmate" / "__init__.py").read_text(
+    encoding="utf-8"
+)
+
+
+def _read_aloud_schema_block() -> str:
+    # The constant also appears in the import block, so anchor on the
+    # registration call instead.
+    idx = SRC.index("hass.services.async_register(")
+    while "SERVICE_READ_ALOUD" not in SRC[idx : idx + 400]:
+        idx = SRC.index("hass.services.async_register(", idx + 1)
+    return SRC[idx : idx + 1400]
+
+
+def test_media_player_must_be_a_media_player_entity():
+    block = _read_aloud_schema_block()
+    assert 'cv.entity_domain("media_player")' in block
+
+
+def test_tts_entity_must_be_a_tts_entity():
+    block = _read_aloud_schema_block()
+    assert 'cv.entity_domain("tts")' in block
+
+
+def test_blank_target_is_still_allowed():
+    """Blank means "use the configured default" — that must keep working."""
+    block = _read_aloud_schema_block()
+    assert 'vol.Any("", cv.entity_domain("media_player"))' in block
+
+
+def test_message_length_is_bounded():
+    block = _read_aloud_schema_block()
+    assert "vol.Length(max=500)" in block
+
+
+def test_custom_message_requires_a_parent():
+    """The handler drops a caller-supplied message from a non-parent."""
+    idx = SRC.index("async def handle_read_aloud")
+    handler = SRC[idx : SRC.index("async def handle_spin_roulette")]
+    assert "authz.async_context_is_parent" in handler
+    # …and what it drops it to is the empty string, i.e. the generated text.
+    assert re.search(r"message = \"\"", handler)
+    # The context is forwarded so HA can apply the caller's entity policy.
+    assert "context=call.context" in handler

--- a/tests/test_security_hardening.py
+++ b/tests/test_security_hardening.py
@@ -75,11 +75,30 @@ def test_allows_child_blocks_cross_child():
     coord = MagicMock()
     coord.get_child.return_value = MagicMock(linked_user_id="uid-malia")
     coord.storage.get_children.return_value = []
+    coord.storage.get_require_linked_child.return_value = False
     hass = _hass(MagicMock(is_admin=False))
     # Ella's HA user acting as Malia (who is linked to someone else) → denied.
     assert run(authz.async_context_allows_child(hass, coord, _ctx("uid-ella"), "malia")) is False
     # Malia's own linked user → allowed.
     assert run(authz.async_context_allows_child(hass, coord, _ctx("uid-malia"), "malia")) is True
+
+
+def test_allows_child_strict_mode_mirrors_the_service_gate():
+    """authz and _async_require_linked_child must not drift on strict mode."""
+    coord = MagicMock()
+    coord.get_child.return_value = MagicMock(linked_user_id="")
+    coord.storage.get_children.return_value = []
+    coord.storage.get_parent_user_ids.return_value = ["uid-parent"]
+    hass = _hass(MagicMock(is_admin=False))
+
+    coord.storage.get_require_linked_child.return_value = False
+    assert run(authz.async_context_allows_child(hass, coord, _ctx("uid-anyone"), "malia")) is True
+
+    coord.storage.get_require_linked_child.return_value = True
+    assert run(authz.async_context_allows_child(hass, coord, _ctx("uid-anyone"), "malia")) is False
+    # Parents and trusted/context-less callers still pass.
+    assert run(authz.async_context_allows_child(hass, coord, _ctx("uid-parent"), "malia")) is True
+    assert run(authz.async_context_allows_child(hass, coord, _ctx(""), "malia")) is True
 
 
 # ── entity platforms enforce the gate ───────────────────────────────────────

--- a/tests/test_service_linked_child_gate.py
+++ b/tests/test_service_linked_child_gate.py
@@ -39,6 +39,10 @@ def _coordinator(linked_user_id, others=None):
     # mirror that exact path so a regression to a non-existent coordinator
     # method (issue #641) is caught here rather than only at runtime.
     coord.storage.get_children.return_value = others or []
+    # Strict mode is opt-in; default the flag off so the kiosk cases below
+    # exercise the shipped default rather than a truthy MagicMock.
+    coord.storage.get_require_linked_child.return_value = False
+    coord.storage.get_parent_user_ids.return_value = []
     return coord
 
 
@@ -105,3 +109,49 @@ async def test_unlinked_child_admin_still_allowed_with_other_links():
     """An admin is allowed through an unlinked child even when other links exist."""
     coord = _coordinator("", others=[MagicMock(linked_user_id="uid-sibling")])
     await tm._async_require_linked_child(_hass(MagicMock(is_admin=True)), _call("uid-parent"), coord, "child-1")
+
+
+@pytest.mark.asyncio
+async def test_strict_mode_blocks_unlinked_child():
+    """With require_linked_child on, an unlinked child is no longer an open door."""
+    coord = _coordinator("")
+    coord.storage.get_require_linked_child.return_value = True
+    with pytest.raises(tm.Unauthorized):
+        await tm._async_require_linked_child(
+            _hass(MagicMock(is_admin=False)), _call("uid-anyone"), coord, "child-1"
+        )
+
+
+@pytest.mark.asyncio
+async def test_strict_mode_allows_the_linked_user():
+    """Strict mode is about *unlinked* children — the linked user still passes."""
+    coord = _coordinator("uid-malia")
+    coord.storage.get_require_linked_child.return_value = True
+    await tm._async_require_linked_child(
+        _hass(MagicMock(is_admin=False)), _call("uid-malia"), coord, "child-1"
+    )
+
+
+@pytest.mark.asyncio
+async def test_strict_mode_allows_admins_and_parents():
+    """Admins and configured TaskMate parents keep acting for any child."""
+    coord = _coordinator("")
+    coord.storage.get_require_linked_child.return_value = True
+    await tm._async_require_linked_child(
+        _hass(MagicMock(is_admin=True)), _call("uid-admin"), coord, "child-1"
+    )
+
+    coord2 = _coordinator("")
+    coord2.storage.get_require_linked_child.return_value = True
+    coord2.storage.get_parent_user_ids.return_value = ["uid-parent"]
+    await tm._async_require_linked_child(
+        _hass(MagicMock(is_admin=False)), _call("uid-parent"), coord2, "child-1"
+    )
+
+
+@pytest.mark.asyncio
+async def test_strict_mode_still_passes_context_less_calls():
+    """Automations and scripts stay trusted in strict mode."""
+    coord = _coordinator("")
+    coord.storage.get_require_linked_child.return_value = True
+    await tm._async_require_linked_child(_hass(None), _call(None), coord, "child-1")

--- a/tests/test_service_linked_child_gate.py
+++ b/tests/test_service_linked_child_gate.py
@@ -117,9 +117,7 @@ async def test_strict_mode_blocks_unlinked_child():
     coord = _coordinator("")
     coord.storage.get_require_linked_child.return_value = True
     with pytest.raises(tm.Unauthorized):
-        await tm._async_require_linked_child(
-            _hass(MagicMock(is_admin=False)), _call("uid-anyone"), coord, "child-1"
-        )
+        await tm._async_require_linked_child(_hass(MagicMock(is_admin=False)), _call("uid-anyone"), coord, "child-1")
 
 
 @pytest.mark.asyncio
@@ -127,9 +125,7 @@ async def test_strict_mode_allows_the_linked_user():
     """Strict mode is about *unlinked* children — the linked user still passes."""
     coord = _coordinator("uid-malia")
     coord.storage.get_require_linked_child.return_value = True
-    await tm._async_require_linked_child(
-        _hass(MagicMock(is_admin=False)), _call("uid-malia"), coord, "child-1"
-    )
+    await tm._async_require_linked_child(_hass(MagicMock(is_admin=False)), _call("uid-malia"), coord, "child-1")
 
 
 @pytest.mark.asyncio
@@ -137,16 +133,12 @@ async def test_strict_mode_allows_admins_and_parents():
     """Admins and configured TaskMate parents keep acting for any child."""
     coord = _coordinator("")
     coord.storage.get_require_linked_child.return_value = True
-    await tm._async_require_linked_child(
-        _hass(MagicMock(is_admin=True)), _call("uid-admin"), coord, "child-1"
-    )
+    await tm._async_require_linked_child(_hass(MagicMock(is_admin=True)), _call("uid-admin"), coord, "child-1")
 
     coord2 = _coordinator("")
     coord2.storage.get_require_linked_child.return_value = True
     coord2.storage.get_parent_user_ids.return_value = ["uid-parent"]
-    await tm._async_require_linked_child(
-        _hass(MagicMock(is_admin=False)), _call("uid-parent"), coord2, "child-1"
-    )
+    await tm._async_require_linked_child(_hass(MagicMock(is_admin=False)), _call("uid-parent"), coord2, "child-1")
 
 
 @pytest.mark.asyncio

--- a/tests/test_sound_storage.py
+++ b/tests/test_sound_storage.py
@@ -211,3 +211,33 @@ def test_sign_sound_url_passes_through_foreign_urls(tmp_path):
     # is that a non-TaskMate URL is never handed to the signer at all.
     assert sounds.sign_sound_url(hass, "") == ""
     assert sounds.sign_sound_url(hass, "https://example.com/a.mp3") == "https://example.com/a.mp3"
+
+
+# ---------------------------------------------------------------------------
+# the bare-frame MP3 sniff must not accept text
+# ---------------------------------------------------------------------------
+
+
+class TestMp3SniffRejectsText:
+    def test_utf16_bom_is_not_audio(self):
+        """0xFF 0xFE is a UTF-16LE BOM; it passes a sync-bits-only check."""
+        html = '<html><script>alert(1)</script></html>'.encode("utf-16-le")
+        assert sounds.detect_allowed_ext(b"\xff\xfe" + html) is None
+
+    def test_utf16_be_bom_is_not_audio(self):
+        assert sounds.detect_allowed_ext(b"\xfe\xff" + "<html>".encode("utf-16-be")) is None
+
+    def test_reserved_mpeg_version_is_rejected(self):
+        # 0xFF 0xEB: sync ok, but version bits are the reserved 01.
+        assert sounds.detect_allowed_ext(b"\xff\xeb" + b"\x00" * 64) is None
+
+    def test_reserved_layer_is_rejected(self):
+        # 0xFF 0xF9: sync ok, version ok, but layer bits are the reserved 00.
+        assert sounds.detect_allowed_ext(b"\xff\xf9" + b"\x00" * 64) is None
+
+    def test_a_real_mpeg1_layer3_frame_is_still_accepted(self):
+        # 0xFF 0xFB = sync + MPEG-1 (11) + Layer III (01).
+        assert sounds.detect_allowed_ext(b"\xff\xfb\x90\x44" + b"\x00" * 64) == "mp3"
+
+    def test_id3_tagged_mp3_is_still_accepted(self):
+        assert sounds.detect_allowed_ext(b"ID3\x03\x00" + b"\x00" * 64) == "mp3"

--- a/tests/test_sound_storage.py
+++ b/tests/test_sound_storage.py
@@ -221,7 +221,7 @@ def test_sign_sound_url_passes_through_foreign_urls(tmp_path):
 class TestMp3SniffRejectsText:
     def test_utf16_bom_is_not_audio(self):
         """0xFF 0xFE is a UTF-16LE BOM; it passes a sync-bits-only check."""
-        html = '<html><script>alert(1)</script></html>'.encode("utf-16-le")
+        html = "<html><script>alert(1)</script></html>".encode("utf-16-le")
         assert sounds.detect_allowed_ext(b"\xff\xfe" + html) is None
 
     def test_utf16_be_bom_is_not_audio(self):

--- a/tests/test_sound_views.py
+++ b/tests/test_sound_views.py
@@ -135,3 +135,13 @@ def test_child_card_delegates_to_the_shared_engine():
 def test_child_card_reads_custom_sounds_from_the_sensor():
     assert "_customSounds()" in CHILD_CARD
     assert "custom_sounds" in CHILD_CARD
+
+
+def test_serve_view_sets_sniffing_protections():
+    """User-supplied bytes served from the HA origin need nosniff, like photos."""
+    assert '"X-Content-Type-Options": "nosniff"' in SRC
+    assert '"Content-Disposition": "inline"' in SRC
+
+
+def test_upload_bounds_the_form_part_scan():
+    assert "parts_scanned > 16" in SRC


### PR DESCRIPTION
Follow-up hardening pass across the integration, the admin panel and CI. No user-facing feature changes beyond one new optional setting.

**What changed**

- Completion eligibility (assignment, schedule and availability) is now enforced the same way for every schedule mode, and bonus sub-tasks inherit their parent chore's assignment.
- New opt-in setting **Require a linked account per child** (off by default, so existing shared-tablet setups are unchanged). Translated into all shipped locales.
- Rewards honour their assigned-children list on both claim and pool allocation, re-check stock and expiry at approval, and no longer accept an unlimited queue of pending claims.
- Mandatory chores re-check for a miss when a completion is rejected, and only once that period has closed.
- Backup restore and shared template packs validate value *types*, not just which keys are allowed; the panel coerces the same fields again on render.
- Evidence-photo uploads carry a per-user rate cap and a bound on concurrent bodies.
- `read_aloud` validates its media player and TTS targets, bounds the message, forwards the caller's context, and only lets a parent choose the words.
- Completions are recorded before they are awarded, so two requests arriving together cannot both be paid.
- Quest progress rewinds when an approval is reversed, so undo then re-approve no longer pays a repeatable quest twice.
- Child-driven actions are written to the audit log, and the capped log counts what it has dropped.
- Audio sniffing, upload part-scan bounds and the serving headers on images and sounds are brought in line with the photo path.
- CI: the actionlint installer is pinned and checksummed, the release workflow publishes build provenance and drops workflow-wide write permission, release-guard compares the attached zip against the tag, and `.gitignore` now carries the secret patterns that only existed in a local exclude file.

**Verification**

1881 unit tests pass (up from 1792), plus Ruff, ESLint and actionlint clean. Every change was exercised against the live ha-dev instance — including the non-admin account for the authorization paths — and ha-dev was left in exactly its pre-test state.