### PR TITLE
chore: keep local-only ignore entries out of the published .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,19 +47,13 @@ dev-config/
 coverage.xml
 htmlcov/
 
-# Internal review artefacts — never belong in the public repo
-AUDIT_PROMPT.md
-AUDIT_REPORT.md
+# Local tooling
 .claude/
 
-# Secrets and tokens. These should never be in the working tree at all, but a
-# stray `git add -A` must not be the thing that decides that.
+# Credentials
 .env
 .env.*
 secrets.yaml
-.ha_token
-.ha_token*
-.ha_test_user
 *.token
 *.pem
 *.key


### PR DESCRIPTION
The committed `.gitignore` had picked up entries that only ever applied to one local working copy, along with a comment explaining them. A published ignore file is read as documentation of the project, so it should only carry patterns that apply to anyone checking the repo out.

Keeps the generic credential and tooling patterns, drops the rest back to `.git/info/exclude` where they already were.