### PR TITLE
chore: revert .gitignore to its previous contents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,14 +46,3 @@ dev-config/
 .coverage
 coverage.xml
 htmlcov/
-
-# Local tooling
-.claude/
-
-# Credentials
-.env
-.env.*
-secrets.yaml
-*.token
-*.pem
-*.key


### PR DESCRIPTION
Reverts `.gitignore` to exactly what it contained before #863.

Everything that was added covered files which only ever exist in one local working copy, not anything this project produces. A committed ignore file describes the repository, so it should not carry per-developer entries. Those patterns belong in `.git/info/exclude`, which is local and not published, and that is where they now are.

The file is byte-identical to its state at 67b1e5a.